### PR TITLE
Enhance type information for lru_cache

### DIFF
--- a/stdlib/3/functools.pyi
+++ b/stdlib/3/functools.pyi
@@ -3,7 +3,7 @@
 # NOTE: These are incomplete!
 
 from abc import ABCMeta, abstractmethod
-from typing import Any, Callable, Generic, Dict, Iterator, Optional, Sequence, Tuple, TypeVar
+from typing import Any, Callable, Generic, Dict, Iterator, Optional, Sequence, Tuple, TypeVar, NamedTuple
 from collections import namedtuple
 
 _AnyCallable = Callable[..., Any]
@@ -12,9 +12,21 @@ _T = TypeVar("_T")
 def reduce(function: Callable[[_T], _T],
            sequence: Iterator[_T], initial: Optional[_T] = ...) -> _T: ...
 
-# TODO implement as class; more precise typing
-# TODO cache_info and __wrapped__ attributes
-def lru_cache(maxsize: Optional[int] = ...) -> Callable[[Any], Any]: ...
+
+class CacheInfo(NamedTuple('CacheInfo', [
+    ('hits', int), ('misses', int), ('maxsize', int), ('currsize', int)])):
+     pass
+
+class _lru_cache_wrapper(Generic[_T]):
+    __wrapped__ = ... # type: Callable[..., _T]
+    def __call__(self, *args: Any, **kwargs: Any) -> _T: ...
+    def cache_info(self) -> CacheInfo: ...
+
+class lru_cache():
+    def __init__(self, maxsize: int = ..., typed: bool = ...) -> None:
+        pass
+    def __call__(self, f: Callable[..., _T]) -> _lru_cache_wrapper[_T]: ...
+
 
 WRAPPER_ASSIGNMENTS = ... # type: Sequence[str]
 WRAPPER_UPDATES = ... # type: Sequence[str]


### PR DESCRIPTION
Implements two "TODO" notes in `functools.pyi`.
- "TODO implement as class; more precise typing"
- "TODO cache_info and `__wrapped__` attributes"

But I wasn't able to figure out how to type the `Callable` as precisely as I would have liked, because you really want the signature to match callables of arbitrary arity and then have a callable of that arity as the return value.

PEP484 [says](https://www.python.org/dev/peps/pep-0484/#callable):
> Since using callbacks with keyword arguments is not perceived as a common use case, there is currently no support for specifying keyword arguments with Callable . Similarly, there is no support for specifying callback signatures with a variable number of argument of a specific type.

I'm not 100% sure, but I interpret this as ruling out the ability to type the callable more specifically.