### PR TITLE
Add missing re module constants for 2.7.

### DIFF
--- a/stdlib/2.7/re.pyi
+++ b/stdlib/2.7/re.pyi
@@ -10,8 +10,6 @@ from typing import (
 )
 
 # ----- re variables and constants -----
-A = 0
-ASCII = 0
 DEBUG = 0
 I = 0
 IGNORECASE = 0
@@ -23,6 +21,10 @@ S = 0
 DOTALL = 0
 X = 0
 VERBOSE = 0
+U = 0
+UNICODE = 0
+T = 0
+TEMPLATE = 0
 
 class error(Exception): ...
 


### PR DESCRIPTION
From python 2.7 re, this should now be the correct full constants list:
```
# flags
I = IGNORECASE = sre_compile.SRE_FLAG_IGNORECASE # ignore case
L = LOCALE = sre_compile.SRE_FLAG_LOCALE # assume current 8-bit locale
U = UNICODE = sre_compile.SRE_FLAG_UNICODE # assume unicode locale
M = MULTILINE = sre_compile.SRE_FLAG_MULTILINE # make anchors look for newline
S = DOTALL = sre_compile.SRE_FLAG_DOTALL # make dot match newline
X = VERBOSE = sre_compile.SRE_FLAG_VERBOSE # ignore whitespace and comments

# sre extensions (experimental, don't rely on these)
T = TEMPLATE = sre_compile.SRE_FLAG_TEMPLATE # disable backtracking
DEBUG = sre_compile.SRE_FLAG_DEBUG # dump pattern after compilation
```