### PR TITLE
Define three argument type() overload (Python 3)

### DIFF
--- a/stdlib/3/builtins.pyi
+++ b/stdlib/3/builtins.pyi
@@ -44,7 +44,10 @@ class type:
     __module__ = ...  # type: str
     __dict__ = ...  # type: Dict[str, Any]
 
+    @overload
     def __init__(self, o: object) -> None: ...
+    @overload
+    def __init__(self, name: str, bases: Tuple[type, ...], dict: Dict[str, Any]) -> None: ...
     @staticmethod
     def __new__(cls, name: str, bases: Tuple[type, ...], namespace: Dict[str, Any]) -> type: ...
 


### PR DESCRIPTION
This was missing for some reason while the Python 2.7 stubs have it.

Sample test code:

```
% cat testtype.py
A = type('A', (), {})
print(A.__name__)
```

Results before:

```
% python -m mypy --py2 testtype.py
% python -m mypy testtype.py
testtype.py:1: error: Too many arguments for "type"
%
```

Results after: type checking passes in both modes.