### PR TITLE
Better stub for contextlib.contextmanager.

### DIFF
--- a/stdlib/2.7/contextlib.pyi
+++ b/stdlib/2.7/contextlib.pyi
@@ -2,14 +2,16 @@
 
 # NOTE: These are incomplete!
 
-from typing import Any, TypeVar, Generic
-
-# TODO more precise type?
-def contextmanager(func: Any) -> Any: ...
+from typing import Callable, Generic, Iterator, TypeVar
 
 _T = TypeVar('_T')
 
-class closing(Generic[_T]):
-    def __init__(self, thing: _T) -> None: ...
+class ContextManager(Generic[_T]):
     def __enter__(self) -> _T: ...
     def __exit__(self, *exc_info) -> None: ...
+
+# TODO this doesn't capture the relationship that the returned function's args are the same as func's.
+def contextmanager(func: Callable[..., Iterator[_T]]) -> Callable[..., ContextManager[_T]]: ...
+
+class closing(ContextManager[_T], Generic[_T]):
+    def __init__(self, thing: _T) -> None: ...

--- a/stdlib/3/contextlib.pyi
+++ b/stdlib/3/contextlib.pyi
@@ -2,14 +2,16 @@
 
 # NOTE: These are incomplete!
 
-from typing import Any, TypeVar, Generic
-
-# TODO more precise type?
-def contextmanager(func: Any) -> Any: ...
+from typing import Callable, Generic, Iterator, TypeVar
 
 _T = TypeVar('_T')
 
-class closing(Generic[_T]):
-    def __init__(self, thing: _T) -> None: ...
+class ContextManager(Generic[_T]):
     def __enter__(self) -> _T: ...
     def __exit__(self, *exc_info) -> None: ...
+
+# TODO this doesn't capture the relationship that the returned function's args are the same as func's.
+def contextmanager(func: Callable[..., Iterator[_T]]) -> Callable[..., ContextManager[_T]]: ...
+
+class closing(ContextManager[_T], Generic[_T]):
+    def __init__(self, thing: _T) -> None: ...


### PR DESCRIPTION
This reflects the fact that `contextlib.contextmanager` should be applied to functions that return an iterator and returns a function that makes a context manager.

I'm not sure where the best place is to put this ContextManager[T] concept.