### PR TITLE
Fix signature for reduce in some files.

### DIFF
--- a/stdlib/2.7/_functools.pyi
+++ b/stdlib/2.7/_functools.pyi
@@ -1,15 +1,16 @@
 """Stub file for the '_functools' module."""
 
-from typing import Any, Callable, Dict, Iterator, Optional, TypeVar, Tuple, overload
+from typing import Any, Callable, Dict, Iterable, Optional, TypeVar, Tuple, overload
 
 _T = TypeVar("_T")
+_S = TypeVar("_S")
 
 @overload
 def reduce(function: Callable[[_T, _T], _T],
-           sequence: Iterator[_T]) -> _T: ...
+           sequence: Iterable[_T]) -> _T: ...
 @overload
-def reduce(function: Callable[[_T, _T], _T],
-           sequence: Iterator[_T], initial: _T) -> _T: ...
+def reduce(function: Callable[[_T, _S], _T],
+           sequence: Iterable[_S], initial: _T) -> _T: ...
 
 class partial(object):
     func = ...  # type: Callable[..., Any]

--- a/stdlib/2.7/functools.pyi
+++ b/stdlib/2.7/functools.pyi
@@ -3,14 +3,19 @@
 # NOTE: These are incomplete!
 
 from abc import ABCMeta, abstractmethod
-from typing import Any, Callable, Generic, Dict, Iterator, Optional, Sequence, Tuple, TypeVar
+from typing import Any, Callable, Generic, Dict, Iterable, Optional, Sequence, Tuple, TypeVar, overload
 from collections import namedtuple
 
 _AnyCallable = Callable[..., Any]
 
 _T = TypeVar("_T")
-def reduce(function: Callable[[_T], _T],
-           sequence: Iterator[_T], initial: Optional[_T] = ...) -> _T: ...
+_S = TypeVar("_S")
+@overload
+def reduce(function: Callable[[_T, _T], _T],
+           sequence: Iterable[_T]) -> _T: ...
+@overload
+def reduce(function: Callable[[_T, _S], _T],
+           sequence: Iterable[_S], initial: _T) -> _T: ...
 
 WRAPPER_ASSIGNMENTS = ... # type: Sequence[str]
 WRAPPER_UPDATES = ... # type: Sequence[str]


### PR DESCRIPTION
I believe that the signature in stdlib/3/functools.pyi is the correct model
for all versions of reduce.