### PR TITLE
add `__dict__` attribute to class instance

### DIFF
--- a/stdlib/3/builtins.pyi
+++ b/stdlib/3/builtins.pyi
@@ -28,6 +28,7 @@ property = object()
 class object:
     __doc__ = ...  # type: str
     __class__ = ...  # type: type
+    __dict__ = ...  # type: Dict[str, Any]
 
     def __init__(self) -> None: ...
     def __new__(cls) -> Any: ...


### PR DESCRIPTION
```python
class A:
    pass
A().__dict__
```
is a valid python3 statement but mypy (more a typeshed issue I guess) gives me
```
file:3: error: "A" has no attribute "__dict__"
```

This PR resolves this (more documented in #132) (not a really nice fix but a working one, in the future, it would be nicer to have mypy being aware if a class is native or not).