### PR TITLE
Enable typing.DefaultDict as an alias for collections.defaultdict

### DIFF
--- a/stdlib/2.7/typing.pyi
+++ b/stdlib/2.7/typing.pyi
@@ -1,6 +1,7 @@
 # Stubs for typing (Python 2.7)
 
 from abc import abstractmethod, ABCMeta
+import collections
 
 # Definitions of special type checking related constructs.  Their definition
 # are not used, so their value does not matter.
@@ -27,6 +28,7 @@ Union = TypeAlias(object)
 Optional = TypeAlias(object)
 List = TypeAlias(object)
 Dict = TypeAlias(object)
+DefaultDict = collections.defaultdict
 Set = TypeAlias(object)
 
 # Predefined type variables.

--- a/stdlib/3/typing.pyi
+++ b/stdlib/3/typing.pyi
@@ -1,6 +1,7 @@
 # Stubs for typing
 
 from abc import abstractmethod, ABCMeta
+import collections
 
 # Definitions of special type checking related constructs.  Their definition
 # are not used, so their value does not matter.
@@ -28,6 +29,7 @@ Union = TypeAlias(object)
 Optional = TypeAlias(object)
 List = TypeAlias(object)
 Dict = TypeAlias(object)
+DefaultDict = collections.defaultdict
 Set = TypeAlias(object)
 
 # Predefined type variables.


### PR DESCRIPTION
following https://github.com/python/typing/issues/179

I didn't add tests, because it looks like everything is checked automatically by typeshed/runtests.py