### PR TITLE
Fixes to os.environ

### DIFF
--- a/stdlib/2.7/os/__init__.pyi
+++ b/stdlib/2.7/os/__init__.pyi
@@ -1,11 +1,17 @@
 # created from https://docs.python.org/2/library/os.html
 
-from typing import List, Tuple, Union, Sequence, Mapping, IO, Any, Optional, AnyStr, MutableMapping, Iterator
+from typing import (
+    List, Tuple, Union, Sequence, Mapping, IO, Any, Optional, AnyStr, Iterator, MutableMapping
+)
 import os.path as path
 
 error = OSError
 name = ... # type: str
-environ = ... # type: MutableMapping[str, str]
+
+class _Environ(MutableMapping[str, str]):
+    def copy(self) -> Dict[str, str]: ...
+
+environ = ... # type: _Environ
 
 def chdir(path: unicode) -> None: ...
 def fchdir(fd: int) -> None: ...

--- a/stdlib/3/os/__init__.pyi
+++ b/stdlib/3/os/__init__.pyi
@@ -62,7 +62,7 @@ W_OK = 0
 X_OK = 0
 
 class _Environ(MutableMapping[AnyStr, AnyStr], Generic[AnyStr]):
-    def copy(self) -> _Environ[AnyStr]: ...
+    def copy(self) -> Dict[AnyStr, AnyStr]: ...
 
 environ = ...  # type: _Environ[str]
 environb = ...  # type: _Environ[bytes]


### PR DESCRIPTION
Add os.environ.copy() to Python 2 stubs. Fix return
type of os.environ.copy().