### PR TITLE
Add __version__ to requests

### DIFF
--- a/third_party/2.7/requests/__init__.pyi
+++ b/third_party/2.7/requests/__init__.pyi
@@ -12,6 +12,7 @@ __title__ = ...  # type: Any
 __build__ = ...  # type: Any
 __license__ = ...  # type: Any
 __copyright__ = ...  # type: Any
+__version__ = ... # type: Any
 
 Request = models.Request
 Response = models.Response

--- a/third_party/3/requests/__init__.pyi
+++ b/third_party/3/requests/__init__.pyi
@@ -12,6 +12,7 @@ __title__ = ...  # type: Any
 __build__ = ...  # type: Any
 __license__ = ...  # type: Any
 __copyright__ = ...  # type: Any
+__version__ = ...  # type: Any
 
 Request = models.Request
 Response = models.Response


### PR DESCRIPTION
Not having `__version__` in requests' stub file was giving a mypy error [here](https://github.com/zulip/zulip/blob/5f053e0047f1f96303f0fe6498bada48aa444454/api/zulip/__init__.py#L49).

I haven't yet taken permission from requests' maintainers about this pull request.