### PR TITLE
fix six.{string,integer,class}_types

### DIFF
--- a/third_party/3/six/__init__.pyi
+++ b/third_party/3/six/__init__.pyi
@@ -34,9 +34,9 @@ PY2 = False
 PY3 = True
 PY34 = ...  # type: bool
 
-string_types = str,
-integer_types = int,
-class_types = type,
+string_types = str
+integer_types = int
+class_types = type
 text_type = str
 binary_type = bytes
 


### PR DESCRIPTION
```python
import six

class A: pass

a = ''  # type: six.string_types
b = 1  # type: six.integer_types
c = A  # type: six.class_types
d = ''  # type: six.text_type
e = b'' # type: six.binary_type
```

gives

```
asd.py:5: error: Invalid type "six.string_types"
asd.py:6: error: Invalid type "six.integer_types"
asd.py:7: error: Invalid type "six.class_types"
```

because `six.string_types`, `six.integer_types` and `six.class_types` are written as tuple and not `Union`. As we only have a single element, we just remove the tuple notation.