### PR TITLE
add types to socketserver for py2

### DIFF
--- a/stdlib/2.7/SocketServer.pyi
+++ b/stdlib/2.7/SocketServer.pyi
@@ -1,0 +1,1 @@
+../3/socketserver.pyi

--- a/stdlib/3/socketserver.pyi
+++ b/stdlib/3/socketserver.pyi
@@ -1,6 +1,6 @@
-# Stubs for socketserver (Python 3.4)
+# Stubs for socketserver
 
-from typing import Optional, Tuple
+from typing import BinaryIO, Optional, Tuple
 from socket import SocketType
 import sys
 import types
@@ -73,5 +73,10 @@ class BaseRequestHandler:
     def handle(self) -> None: ...
     def finish(self) -> None: ...
 
-class StreamRequestHandler(BaseRequestHandler): ...
-class DatagramRequestHandler(BaseRequestHandler): ...
+class StreamRequestHandler(BaseRequestHandler):
+    rfile = ...  # type: BinaryIO
+    wfile = ...  # type: BinaryIO
+
+class DatagramRequestHandler(BaseRequestHandler):
+    rfile = ...  # type: BinaryIO
+    wfile = ...  # type: BinaryIO


### PR DESCRIPTION
See #238.

Simply moved to `2and3`, also found some missing attributes.