### PR TITLE
make xml.etree.ElementTree.Element a Sequence

### DIFF
--- a/stdlib/2.7/xml/etree/ElementTree.pyi
+++ b/stdlib/2.7/xml/etree/ElementTree.pyi
@@ -21,7 +21,7 @@ class ParseError(SyntaxError): ...
 
 def iselement(element: 'Element') -> bool: ...
 
-class Element:
+class Element(Sequence['Element']):
     tag = ... # type: _str_or_bytes
     attrib = ... # type: Dict[_str_or_bytes, _str_or_bytes]
     text = ... # type: Optional[_str_or_bytes]

--- a/stdlib/3.2/xml/etree/ElementTree.pyi
+++ b/stdlib/3.2/xml/etree/ElementTree.pyi
@@ -21,7 +21,7 @@ class ParseError(SyntaxError): ...
 
 def iselement(element: 'Element') -> bool: ...
 
-class Element:
+class Element(Sequence['Element']):
     tag = ... # type: _str_or_bytes
     attrib = ... # type: Dict[_str_or_bytes, _str_or_bytes]
     text = ... # type: Optional[_str_or_bytes]

--- a/stdlib/3.3/xml/etree/ElementTree.pyi
+++ b/stdlib/3.3/xml/etree/ElementTree.pyi
@@ -15,7 +15,7 @@ _Ss = TypeVar('_Ss', str, bytes)
 _T = TypeVar('_T')
 _str_or_bytes = Union[str, bytes]
 
-class Element:
+class Element(Sequence['Element']):
     tag = ... # type: _str_or_bytes
     attrib = ... # type: Dict[_str_or_bytes, _str_or_bytes]
     text = ... # type: Optional[_str_or_bytes]

--- a/stdlib/3.4/xml/etree/ElementTree.pyi
+++ b/stdlib/3.4/xml/etree/ElementTree.pyi
@@ -15,7 +15,7 @@ _Ss = TypeVar('_Ss', str, bytes)
 _T = TypeVar('_T')
 _str_or_bytes = Union[str, bytes]
 
-class Element:
+class Element(Sequence['Element']):
     tag = ... # type: _str_or_bytes
     attrib = ... # type: Dict[_str_or_bytes, _str_or_bytes]
     text = ... # type: Optional[_str_or_bytes]

--- a/stdlib/3.5/xml/etree/ElementTree.pyi
+++ b/stdlib/3.5/xml/etree/ElementTree.pyi
@@ -15,7 +15,7 @@ _Ss = TypeVar('_Ss', str, bytes)
 _T = TypeVar('_T')
 _str_or_bytes = Union[str, bytes]
 
-class Element:
+class Element(Sequence['Element']):
     tag = ... # type: _str_or_bytes
     attrib = ... # type: Dict[_str_or_bytes, _str_or_bytes]
     text = ... # type: Optional[_str_or_bytes]

--- a/stdlib/3/xml/etree/ElementTree.pyi
+++ b/stdlib/3/xml/etree/ElementTree.pyi
@@ -11,7 +11,7 @@ _Ss = TypeVar('_Ss', str, bytes)
 _T = TypeVar('_T')
 _str_or_bytes = Union[str, bytes]
 
-class _ElementInterface:
+class _ElementInterface(Sequence['_ElementInterface']):
     tag = ... # type: _str_or_bytes
     attrib = ... # type: Dict[_str_or_bytes, _str_or_bytes]
     text = ... # type: Optional[_str_or_bytes]


### PR DESCRIPTION
`xml.etree.ElementTree.Element`s can be iterated over, yielding their children. They're a `Sequence` since they use `__getitem__` as opposed to `__iter__`.

Presently there is no indication that this is the case in typeshed, so iterating over an `Element` gives an error on typechecking.

We ran into this in https://github.com/zulip/zulip/pull/875 (you can see the relevant error in the travis build [here](https://travis-ci.org/zulip/zulip/jobs/135110548)).

This PR adds the information that `Elements` are `Sequence`s to the stub, fixing this. The only thing I'm not quite sure about is if I did the right thing with `_ElementInterface ` under `3`.

cc @gnprice, who I talked about this with earlier. also @timabbott.