### PR TITLE
Added os.sync, os.truncate and os.fwalk for Python version >= 3.3

### DIFF
--- a/stdlib/3/os/__init__.pyi
+++ b/stdlib/3/os/__init__.pyi
@@ -341,3 +341,16 @@ def waitid(idtype: int, id: int, options: int) -> waitresult: ...
 P_ALL = 0
 WEXITED = 0
 WNOWAIT = 0
+
+if sys.version_info >= (3, 3):
+    def sync() -> None: ...  # Unix only
+
+    if sys.version_info >= (3, 5):
+        def truncate(path: Union[AnyStr, int], length: int) -> None: ...
+    else:
+        def truncate(path: Union[AnyStr, int], length: int) -> None: ...  # Unix only
+
+    def fwalk(top: AnyStr = '.', topdown: bool = True,
+              onerror: Callable = None, *, follow_symlinks: bool = False,
+              dir_fd: int = None) -> Iterator[Tuple[AnyStr, List[AnyStr],
+                                              List[AnyStr], int]]: ...  # Unix only

--- a/stdlib/3/os/__init__.pyi
+++ b/stdlib/3/os/__init__.pyi
@@ -345,10 +345,7 @@ WNOWAIT = 0
 if sys.version_info >= (3, 3):
     def sync() -> None: ...  # Unix only
 
-    if sys.version_info >= (3, 5):
-        def truncate(path: Union[AnyStr, int], length: int) -> None: ...
-    else:
-        def truncate(path: Union[AnyStr, int], length: int) -> None: ...  # Unix only
+    def truncate(path: Union[AnyStr, int], length: int) -> None: ...  # Unix only up to version 3.4
 
     def fwalk(top: AnyStr = ..., topdown: bool = ...,
               onerror: Callable = ..., *, follow_symlinks: bool = ...,

--- a/stdlib/3/os/__init__.pyi
+++ b/stdlib/3/os/__init__.pyi
@@ -5,7 +5,7 @@
 
 from typing import (
     Mapping, MutableMapping, Dict, List, Any, Tuple, Iterator, overload, Union, AnyStr,
-    Optional, Generic, Set
+    Optional, Generic, Set, Callable
 )
 import sys
 from builtins import OSError as error
@@ -350,7 +350,7 @@ if sys.version_info >= (3, 3):
     else:
         def truncate(path: Union[AnyStr, int], length: int) -> None: ...  # Unix only
 
-    def fwalk(top: AnyStr = '.', topdown: bool = True,
-              onerror: Callable = None, *, follow_symlinks: bool = False,
-              dir_fd: int = None) -> Iterator[Tuple[AnyStr, List[AnyStr],
-                                              List[AnyStr], int]]: ...  # Unix only
+    def fwalk(top: AnyStr = ..., topdown: bool = ...,
+              onerror: Callable = ..., *, follow_symlinks: bool = ...,
+              dir_fd: int = ...) -> Iterator[Tuple[AnyStr, List[AnyStr],
+                                             List[AnyStr], int]]: ...  # Unix only


### PR DESCRIPTION
Using `sys.version_info` to define the stubs depending on the version.