### PR TITLE
Set a default value for output in CalledProcessError.__init__

### DIFF
--- a/stdlib/3/subprocess.pyi
+++ b/stdlib/3/subprocess.pyi
@@ -29,7 +29,7 @@ class CalledProcessError(Exception):
     cmd = ...  # type: str
     output = b'' # May be None
 
-    def __init__(self, returncode: int, cmd: str, output: Optional[str],
+    def __init__(self, returncode: int, cmd: str, output: Optional[str] = ...,
                  stderr: Optional[str] = ...) -> None: ...
 
 class Popen:


### PR DESCRIPTION
https://docs.python.org/3/library/subprocess.html#subprocess.CalledProcessError says that `CalledProcessError`'s `output` is `None` if not specified.

I checked the source code of [subprocess.py](https://hg.python.org/cpython/file/3.5/Lib/subprocess.py#l380) and there `CalledProcessError`'s `__init__` took a default value of `None` for the parameter `output`.