### PR TITLE
add some types to importlib

### DIFF
--- a/stdlib/3/importlib/__init__.pyi
+++ b/stdlib/3/importlib/__init__.pyi
@@ -1,3 +1,4 @@
+from importlib.abc import Loader
 import sys
 import types
 from typing import Any, Mapping, Optional, Sequence
@@ -9,8 +10,7 @@ def __import__(name: str, globals: Mapping[str, Any] = None,
 def import_module(name: str, package: str = None) -> types.ModuleType: ...
 
 if sys.version_info >= (3, 3):
-    # Optionally returns a loader, but importlib.abc doesn't have a stub file.
-    def find_loader(name: str, path: str = None): ...
+    def find_loader(name: str, path: str = None) -> Optional[Loader]: ...
 
     def invalidate_caches() -> None: ...
 

--- a/stdlib/3/importlib/abc.pyi
+++ b/stdlib/3/importlib/abc.pyi
@@ -42,7 +42,7 @@ class InspectLoader(Loader):
                            path: str = '<string>') -> types.CodeType: ...
     elif sys.version_info >= (3, 5):
         @staticmethod
-        def source_to_code(self, data: Union[bytes, str],
+        def source_to_code(data: Union[bytes, str],
                            path: str = '<string>') -> types.CodeType: ...
 
 class ExecutionLoader(InspectLoader):


### PR DESCRIPTION
Now that `importlib.abc` is implemented, we can resolve the return type of `find_loader`.
Also, `source_to_code` is a `static_method` so it should have any `self`.