### PR TITLE
revert unnecessary change to mypy_test from previous commit

### DIFF
--- a/tests/mypy_test.py
+++ b/tests/mypy_test.py
@@ -22,7 +22,7 @@ parser = argparse.ArgumentParser(description="Test runner for typeshed. "
 parser.add_argument('-v', '--verbose', action='count', default=0, help="More output")
 parser.add_argument('-n', '--dry-run', action='store_true', help="Don't actually run mypy")
 parser.add_argument('-x', '--exclude', type=str, nargs='*', help="Exclude pattern")
-parser.add_argument('-p', '--python-version', type=str, action='append',
+parser.add_argument('-p', '--python-version', type=str, nargs='*',
                     help="These versions only (major[.minor])")
 parser.add_argument('filter', type=str, nargs='*', help="Include pattern (default all)")
 


### PR DESCRIPTION
this reverts a change I introduced in 63cbe2dc3cde25109f2ad212dbf32aa21e3329c6

original flag change was just confusion on my part