### PR TITLE
builtins: Remove Exception.message.

### DIFF
--- a/stdlib/3/builtins.pyi
+++ b/stdlib/3/builtins.pyi
@@ -751,7 +751,6 @@ Ellipsis = ...  # type: ellipsis
 
 class BaseException:
     args = ...  # type: Any
-    message = ...  # type: str
     def __init__(self, *args: Any) -> None: ...
     def with_traceback(self, tb: Any) -> BaseException: ...
 


### PR DESCRIPTION
The `message` attribute of `Exception` has been deprecated since python 2.6. It has been removed from python 3 afaik.