### PR TITLE
Use --strict-optional for mypy CI tests

### DIFF
--- a/tests/mypy_test.py
+++ b/tests/mypy_test.py
@@ -115,7 +115,8 @@ def main():
                                     files.append(fn)
         if files:
             runs += 1
-            flags = ['--python-version', '%d.%d' % (major, minor)]
+            flags = ['--python-version', '%d.%d' % (major, minor),
+                     '--strict-optional']
             sys.argv = ['mypy'] + flags + files
             if args.verbose:
                 print("running", ' '.join(sys.argv))


### PR DESCRIPTION
Strict optional will catch additional errors related to
optional types in stubs.

Fixes #365.