### PR TITLE
Add BaseRequestHandler instance attributes

### DIFF
--- a/stdlib/3/socketserver.pyi
+++ b/stdlib/3/socketserver.pyi
@@ -1,6 +1,6 @@
 # Stubs for socketserver
 
-from typing import BinaryIO, Optional, Tuple
+from typing import Any, BinaryIO, Optional, Tuple
 from socket import SocketType
 import sys
 import types
@@ -68,7 +68,18 @@ class ForkingUDPServer(ForkingMixIn, UDPServer): ...
 class ThreadingTCPServer(ThreadingMixIn, TCPServer): ...
 class ThreadingUDPServer(ThreadingMixIn, UDPServer): ...
 
+
 class BaseRequestHandler:
+    # Those are technically of types, respectively:
+    # * Union[SocketType, Tuple[bytes, SocketType]]
+    # * Union[Tuple[str, int], str]
+    # But there are some concerns that having unions here would cause
+    # too much inconvenience to people using it (see
+    # https://github.com/python/typeshed/pull/384#issuecomment-234649696)
+    request = ...  # type: Any
+    client_address = ...  # type: Any
+
+    server = ...  # type: BaseServer
     def setup(self) -> None: ...
     def handle(self) -> None: ...
     def finish(self) -> None: ...


### PR DESCRIPTION
From the BaseRequestHandler documentation:

    handle()

    This function must do all the work required to service a request.
    The default implementation does nothing. Several instance attributes
    are available to it; the request is available as self.request; the
    client address as self.client_address; and the server instance as
    self.server, in case it needs access to per-server information.

    The type of self.request is different for datagram or stream
    services. For stream services, self.request is a socket object;
    for datagram services, self.request is a pair of string and
    socket.

I also added a union that expresses the fact that client_address can be
a string in case of using Unix domain sockets.