### PR TITLE
argparse stub fix: allow subclasses of Action in add_argument(action=...)

### DIFF
--- a/stdlib/2and3/argparse.pyi
+++ b/stdlib/2and3/argparse.pyi
@@ -7,7 +7,7 @@ from typing import (
 import sys
 
 _T = TypeVar('_T')
-
+_AT = TypeVar('_AT', bound=Action)
 
 ONE_OR_MORE = ...  # type: str
 OPTIONAL = ...  # type: str
@@ -48,7 +48,7 @@ class ArgumentParser:
                      add_help: bool = ...) -> None: ...
     def add_argument(self,
                      *name_or_flags: Union[str, Sequence[str]],
-                     action: Union[str, Action] = ...,
+                     action: Union[str, Type[_AT]] = ...,
                      nargs: Union[int, str] = ...,
                      const: Any = ...,
                      default: Any = ...,
@@ -132,7 +132,7 @@ class FileType:
 class _ArgumentGroup:
     def add_argument(self,
                      *name_or_flags: Union[str, Sequence[str]],
-                     action: Union[str, Action] = ...,
+                     action: Union[str, Type[_AT]] = ...,
                      nargs: Union[int, str] = ...,
                      const: Any = ...,
                      default: Any = ...,

--- a/stdlib/2and3/argparse.pyi
+++ b/stdlib/2and3/argparse.pyi
@@ -8,6 +8,7 @@ import sys
 
 _T = TypeVar('_T')
 
+
 ONE_OR_MORE = ...  # type: str
 OPTIONAL = ...  # type: str
 PARSER = ...  # type: str

--- a/stdlib/2and3/argparse.pyi
+++ b/stdlib/2and3/argparse.pyi
@@ -7,7 +7,6 @@ from typing import (
 import sys
 
 _T = TypeVar('_T')
-_AT = TypeVar('_AT', bound=Action)
 
 ONE_OR_MORE = ...  # type: str
 OPTIONAL = ...  # type: str
@@ -48,7 +47,7 @@ class ArgumentParser:
                      add_help: bool = ...) -> None: ...
     def add_argument(self,
                      *name_or_flags: Union[str, Sequence[str]],
-                     action: Union[str, Type[_AT]] = ...,
+                     action: Union[str, Type[Action]] = ...,
                      nargs: Union[int, str] = ...,
                      const: Any = ...,
                      default: Any = ...,
@@ -132,7 +131,7 @@ class FileType:
 class _ArgumentGroup:
     def add_argument(self,
                      *name_or_flags: Union[str, Sequence[str]],
-                     action: Union[str, Type[_AT]] = ...,
+                     action: Union[str, Type[Action]] = ...,
                      nargs: Union[int, str] = ...,
                      const: Any = ...,
                      default: Any = ...,


### PR DESCRIPTION
Currently the following code produces an error:

```py
import argparse

from typing import Any


class TestAction(argparse.Action):
    pass

if __name__ == "__main__":
    p = argparse.ArgumentParser()
    p.add_argument("--test", action=TestAction)
```

The error message is:

```
test.py:11: error: Argument 2 to "add_argument" of "ArgumentParser" has incompatible type "TestAction"; expected "Union[str, Action]"
```

Imho the current stub in `stdlib/2and3/argparse.pyi` is wrong by declaring `action: Union[str, Action]` since that disallows subclasses of `Action`. This PR fixes that by using a bound TypeVar.