### PR TITLE
add site

### DIFF
--- a/stdlib/2and3/site.pyi
+++ b/stdlib/2and3/site.pyi
@@ -1,0 +1,17 @@
+# Stubs for site
+
+from typing import List, Iterable, Optional
+import sys
+
+PREFIXES = ...  # type: List[str]
+ENABLE_USER_SITE = ...  # type: Optional[bool]
+USER_SITE = ...  # type: Optional[str]
+USER_BASE = ...  # type: Optional[str]
+
+if sys.version_info < (3,):
+    def main() -> None: ...
+def addsitedir(sitedir: str,
+               known_paths: Optional[Iterable[str]] = ...) -> None: ...
+def getsitepackages(prefixes: Optional[Iterable[str]] = ...) -> List[str]: ...
+def getuserbase() -> str: ...
+def getusersitepackages() -> str: ...


### PR DESCRIPTION
Add the site module.

Based on docs.python.org, `known_path` and `prefixes` are not documented but in code, can take an `Iterable`.