### PR TITLE
textwrap for py3: fixed stubs to include 'text' param

### DIFF
--- a/stdlib/3/textwrap.pyi
+++ b/stdlib/3/textwrap.pyi
@@ -79,6 +79,7 @@ def wrap(
     ...
 
 def fill(
+        text: str,
         width: int = ...,
         *,
         initial_indent: str = ...,
@@ -96,6 +97,7 @@ def fill(
     ...
 
 def shorten(
+        text: str,
         width: int,
         *,
         initial_indent: str = ...,


### PR DESCRIPTION
Compare with https://docs.python.org/3/library/textwrap.html .