### PR TITLE
Add stubs for pkgutils

### DIFF
--- a/stdlib/2and3/pkgutil.pyi
+++ b/stdlib/2and3/pkgutil.pyi
@@ -1,0 +1,26 @@
+# Stubs for pkgutil
+
+from typing import Any, Callable, Generator, IO, Iterable, Optional, Tuple
+from importlib.abc import Loader
+
+_YMFNI = Generator[Tuple[Any, str, bool], None, None]
+
+
+def extend_path(path: Iterable[str], name: str) -> Iterable[str]: ...
+
+class ImpImporter:
+    def __init__(self, dirname: Optional[str] = ...) -> None: ...
+
+class ImpLoader:
+    def __init__(self, fullname: str, file: IO[str], filename: str,
+                 etc: Tuple[str, str, int]) -> None: ...
+
+def find_loader(fullname: str) -> Loader: ...
+def get_importer(path_item: str) -> Any: ...  # TODO precise type
+def get_loader(module_or_name: str) -> Loader: ...
+def iter_importers(fullname: str = ...) -> Generator[Any, None, None]: ...  # TODO precise type
+def iter_modules(path: Optional[str] = ...,
+                 prefix: str = ...) -> _YMFNI: ...  # TODO precise type
+def walk_packages(path: Optional[str] = ..., prefix: str = ...,
+                  onerror: Optional[Callable[[str], None]] = ...) -> _YMFNI: ...
+def get_data(package: str, resource: str) -> bytes: ...

--- a/stdlib/2and3/pkgutil.pyi
+++ b/stdlib/2and3/pkgutil.pyi
@@ -1,7 +1,12 @@
 # Stubs for pkgutil
 
 from typing import Any, Callable, Generator, IO, Iterable, Optional, Tuple
-from importlib.abc import Loader
+import sys
+
+if sys.version_info >= (3,):
+    from importlib.abc import Loader
+else:
+    Loader = Any
 
 _YMFNI = Generator[Tuple[Any, str, bool], None, None]
 

--- a/stdlib/3/importlib.pyi
+++ b/stdlib/3/importlib.pyi
@@ -1,9 +1,0 @@
-# Stubs for importlib
-
-# NOTE: These are incomplete!
-
-from typing import Any
-
-# TODO more precise type?
-def import_module(name: str, package: str = ...) -> Any: ...
-def invalidate_caches() -> None: ...


### PR DESCRIPTION
https://docs.python.org/3/library/pkgutil.html

I was unable to find a better type than any for importers, also `ImpLoader.__init__` was mainly based on code rather than documentation (deprecated anyway, new code should be based on importlib).