### PR TITLE
Fix the definitions of BadZip{f,F}ile.

### DIFF
--- a/stdlib/2and3/zipfile.pyi
+++ b/stdlib/2and3/zipfile.pyi
@@ -9,10 +9,11 @@ _SZI = Union[str, ZipInfo]
 _DT = Tuple[int, int, int, int, int, int]
 
 
-class BadZipFile(Exception): ...
-
 if sys.version_info >= (3,):
+    class BadZipFile(Exception): ...
     BadZipfile = BadZipFile
+else:
+    class BadZipfile(Exception): ...
 
 class LargeZipFile(Exception): ...
 


### PR DESCRIPTION
In 2.7, only BadZipfile exists. In 3.x, both exist.