### PR TITLE
Remove undesired type variable from lxml.objectify

### DIFF
--- a/third_party/3/lxml/objectify.pyi
+++ b/third_party/3/lxml/objectify.pyi
@@ -1,13 +1,13 @@
 # Hand-written stub, incomplete
 
-from typing import AnyStr
+from typing import Union
 
 from lxml.etree import ElementBase, XMLParser
 
 class ObjectifiedElement(ElementBase):
     pass
 
-def fromstring(text: AnyStr,
+def fromstring(text: Union[bytes, str],
                parser: XMLParser = ...,
                *,
-               base_url: AnyStr = ...) -> ObjectifiedElement: ...
+               base_url: Union[bytes, str] = ...) -> ObjectifiedElement: ...


### PR DESCRIPTION
typing.AnyStr usage here was a mistake that I noticed too late,
from a GitHub comment[1]:

    AnyStr is a type variable so in your version of
    objectify.fromstring() the types if text and base_url have to
    correspond -- but with unions they can each be either str or bytes,
    and that's how the rest of the API is defined.

[1] https://github.com/python/typeshed/pull/436#issuecomment-237708512