### PR TITLE
Fix Tuple being imported twice in ast.pyi

### DIFF
--- a/stdlib/2.7/ast.pyi
+++ b/stdlib/2.7/ast.pyi
@@ -1,7 +1,7 @@
 # Python 2.7 ast
 
 import typing
-from typing import Any, Tuple, Iterator, Union
+from typing import Any, Iterator, Union
 
 from _ast import (
     Add, alias, And, arguments, Assert, Assign, AST, Attribute, AugAssign,


### PR DESCRIPTION
This would break ast.Tuple, i.e. reveal_type(ast.Tuple) showed up as `object`