### PR TITLE
Adds logging PlaceHolder class and Logger attributes

### DIFF
--- a/stdlib/2and3/logging/__init__.pyi
+++ b/stdlib/2and3/logging/__init__.pyi
@@ -19,7 +19,12 @@ _FilterType = Union['Filter', Callable[[LogRecord], int]]
 
 
 class Logger:
+    name = ...  # type: str
+    level = ...  # type: int
+    parent = ...  # type: Union[Logger, PlaceHolder]
     propagate = ...  # type: bool
+    handlers = ... # type: List[Handler]
+    disabled = ... # type: int
     def setLevel(self, lvl: Union[int, str]) -> None: ...
     def isEnabledFor(self, lvl: int) -> None: ...
     def getEffectiveLevel(self) -> int: ...
@@ -334,3 +339,8 @@ class FileHandler(Handler):
 
 
 class NullHandler(Handler): ...
+
+
+class PlaceHolder:
+    def __init__(self, alogger: Logger) -> None: ...
+    def append(self, alogger: Logger) -> None: ...


### PR DESCRIPTION
Adds several attributes which were missing from the Logger types,
including "name", "level", and "parent". Because the type of "parent"
is a union of Logger and PlaceHolder, we also define types for
PlaceHolder and all of it's methods.