### PR TITLE
Added attributes for URLError and HTTPError

### DIFF
--- a/stdlib/2.7/urllib2.pyi
+++ b/stdlib/2.7/urllib2.pyi
@@ -1,10 +1,13 @@
 
-from typing import AnyStr
+from typing import AnyStr, Dict, Union
 from urllib import addinfourl
 
-class URLError(IOError): ...
+class URLError(IOError):
+    reason = ...  # type: Union[str, BaseException]
 
-class HTTPError(URLError, addinfourl): ...
+class HTTPError(URLError, addinfourl):
+    code = ...  # type: int
+    headers = ...  # type: Dict[str, str]
 
 class Request(object):
     host = ... # type: str

--- a/stdlib/3/urllib/error.pyi
+++ b/stdlib/3/urllib/error.pyi
@@ -1,5 +1,11 @@
+from typing import Any, Dict, Union
+from urllib.response import addinfourl
+
 # Stubs for urllib.error
 
-class URLError(IOError): ...
-class HTTPError(URLError): ...
+class URLError(IOError):
+    reason = ...  # type: Union[str, BaseException]
+class HTTPError(URLError, addinfourl):
+    code = ...  # type: int
+    headers = ...  # type: Dict[str, str]
 class ContentTooShortError(URLError): ...


### PR DESCRIPTION
HTTPError had the superclass of addinfourl in Python 2.7 stub but not in Python 3.