### PR TITLE
Make typing.IO inherit Iterator, not Iterable

### DIFF
--- a/stdlib/2.7/typing.pyi
+++ b/stdlib/2.7/typing.pyi
@@ -208,7 +208,7 @@ Text = unicode
 
 TYPE_CHECKING = True
 
-class IO(Iterable[AnyStr], Generic[AnyStr]):
+class IO(Iterator[AnyStr], Generic[AnyStr]):
     # TODO detach
     # TODO use abstract properties
     @property
@@ -250,6 +250,8 @@ class IO(Iterable[AnyStr], Generic[AnyStr]):
     @abstractmethod
     def writelines(self, lines: Iterable[AnyStr]) -> None: ...
 
+    @abstractmethod
+    def next(self) -> AnyStr: ...
     @abstractmethod
     def __iter__(self) -> Iterator[AnyStr]: ...
     @abstractmethod

--- a/stdlib/3/typing.pyi
+++ b/stdlib/3/typing.pyi
@@ -267,7 +267,7 @@ Text = str
 
 TYPE_CHECKING = True
 
-class IO(Iterable[AnyStr], Generic[AnyStr]):
+class IO(Iterator[AnyStr], Generic[AnyStr]):
     # TODO detach
     # TODO use abstract properties
     @property
@@ -310,6 +310,8 @@ class IO(Iterable[AnyStr], Generic[AnyStr]):
     @abstractmethod
     def writelines(self, lines: Iterable[AnyStr]) -> None: ...
 
+    @abstractmethod
+    def __next__(self) -> AnyStr: ...
     @abstractmethod
     def __iter__(self) -> Iterator[AnyStr]: ...
     @abstractmethod


### PR DESCRIPTION
In Python, it's possible to use the `next` builtin method on file objects produced by `open`. (This is particularly useful when you want to do some pre-processing on header lines before looping over the rest of the file). This change modifies `typing.IO` so this usage will successfully typecheck.