### PR TITLE
Add TypeAlias for OrderedDict

### DIFF
--- a/stdlib/2.7/typing.pyi
+++ b/stdlib/2.7/typing.pyi
@@ -30,6 +30,7 @@ Optional = TypeAlias(object)
 List = TypeAlias(object)
 Dict = TypeAlias(object)
 DefaultDict = TypeAlias(object)
+OrderedDict = TypeAlias(object)
 Set = TypeAlias(object)
 
 # Predefined type variables.

--- a/stdlib/2.7/typing.pyi
+++ b/stdlib/2.7/typing.pyi
@@ -31,6 +31,7 @@ List = TypeAlias(object)
 Dict = TypeAlias(object)
 DefaultDict = TypeAlias(object)
 OrderedDict = TypeAlias(object)
+
 Set = TypeAlias(object)
 
 # Predefined type variables.

--- a/stdlib/3/typing.pyi
+++ b/stdlib/3/typing.pyi
@@ -32,6 +32,7 @@ Optional = TypeAlias(object)
 List = TypeAlias(object)
 Dict = TypeAlias(object)
 DefaultDict = TypeAlias(object)
+OrderedDict = TypeAlias(object)
 Set = TypeAlias(object)
 
 # Predefined type variables.


### PR DESCRIPTION
This is needed for NamedTuple support in mypy