### PR TITLE
Add missing `type_comments` attr to ast27.arguments

### DIFF
--- a/third_party/3/typed_ast/ast27.pyi
+++ b/third_party/3/typed_ast/ast27.pyi
@@ -347,6 +347,7 @@ class arguments(AST):
     vararg = ...  # type: Optional[identifier]
     kwarg = ...  # type: Optional[identifier]
     defaults = ...  # type: typing.List[expr]
+    type_comments = ...  # type: typing.List[str]
 
 class keyword(AST):
     arg = ...  # type: identifier


### PR DESCRIPTION
This pull request adds a missing attribute from the `ast27.arguments` class.