### PR TITLE
[review] Add multiprocessing.Pool

### DIFF
--- a/stdlib/3/multiprocessing/__init__.pyi
+++ b/stdlib/3/multiprocessing/__init__.pyi
@@ -19,7 +19,7 @@ class Pool():
                  initializer: Optional[Callable[..., None]] = None,
                  initargs: Iterable[Any] = (),
                  maxtasksperchild: Optional[int] = None,
-                 context: Optional[Callable[[Any], Any]] = None) -> None: ...
+                 context: Any = None) -> None: ...
     def apply(self,
               func: Callable[..., Any],
               args: Iterable[Any]=(),

--- a/stdlib/3/multiprocessing/__init__.pyi
+++ b/stdlib/3/multiprocessing/__init__.pyi
@@ -1,12 +1,65 @@
 # Stubs for multiprocessing
 
-from typing import Any, Callable, Iterable, Mapping
+from typing import Any, Callable, Iterable, Mapping, Optional, Dict, List
 
 from multiprocessing.process import current_process as current_process
 
 class Lock():
     def acquire(self, block: bool = ..., timeout: int = ...) -> None: ...
     def release(self) -> None: ...
+
+class AsyncResult():
+    def get(self, timeout: float = -1) -> Any: ...
+    def wait(self, timeout: float = -1) -> None: ...
+    def ready(self) -> bool: ...
+    def successful(self) -> bool: ...
+
+class Pool():
+    def __init__(self, processes: Optional[int] = None,
+                 initializer: Optional[Callable[..., None]] = None,
+                 initargs: Iterable[Any] = (),
+                 maxtasksperchild: Optional[int] = None,
+                 context: Optional[Callable[[Any], Any]] = None) -> None: ...
+    def apply(self,
+              func: Callable[..., Any],
+              args: Iterable[Any]=(),
+              kwds: Dict[str, Any]={}) -> Any: ...
+    def apply_async(self,
+                func: Callable[..., Any],
+                args: Iterable[Any]=(),
+                kwds: Dict[str, Any]={},
+                callback: Callable[..., None] = None,
+                error_callback: Callable[[BaseException], None] = None) -> AsyncResult: ...
+    def map(self,
+            func: Callable[..., Any],
+            iterable: Iterable[Any]=(),
+            chunksize: Optional[int] = None) -> List[Any]: ...
+    def map_async(self, func: Callable[..., Any],
+                  iterable: Iterable[Any] = (),
+                  chunksize: Optional[int] = None,
+                  callback: Callable[..., None] = None,
+                  error_callback: Callable[[BaseException], None] = None) -> AsyncResult: ...
+    def imap(self,
+             func: Callable[..., Any],
+             iterable: Iterable[Any]=(),
+             chunksize: Optional[int] = None) -> Iterable[Any]: ...
+    def imap_unordered(self,
+                       func: Callable[..., Any],
+                       iterable: Iterable[Any]=(),
+                       chunksize: Optional[int] = None) -> Iterable[Any]: ...
+    def starmap(self,
+                func: Callable[..., Any],
+                iterable: Iterable[Any]=(),
+                chunksize: Optional[int] = None) -> List[Any]: ...
+    def starmap_async(self,
+                      func: Callable[..., Any],
+                      iterable: Iterable[Any] = (),
+                      chunksize: Optional[int] = None,
+                      callback: Callable[..., None] = None,
+                      error_callback: Callable[[BaseException], None] = None) -> AsyncResult: ...
+    def close(self) -> None: ...
+    def terminate(self) -> None: ...
+    def join(self) -> None: ...
 
 class Process():
     # TODO: set type of group to None


### PR DESCRIPTION
I'm not sure how to test stub files (does mypy download them automatically? I couldn't see anything in `mypy --help` about using stubs) so this is untested, but I'm aiming to fix this error:

```
$ cat test.py
import multiprocessing
multiprocessing.Pool()
$ mypy test.py
test.py:2: error: "module" has no attribute "Pool"
```
