### PR TITLE
Fix ujson stubs to properly use AnyStr.

### DIFF
--- a/third_party/2and3/ujson.pyi
+++ b/third_party/2and3/ujson.pyi
@@ -1,6 +1,6 @@
 # Stubs for ujson
 # See: https://pypi.python.org/pypi/ujson
-from typing import Any, IO, Optional
+from typing import Any, AnyStr, IO, Optional
 
 __version__ = ...  # type: str
 
@@ -32,14 +32,14 @@ def dump(obj: Any,
     indent: int = ...,
     ) -> None: ...
 
-def decode(s: str,
+def decode(s: AnyStr,
     precise_float: bool = ...,
     ) -> Any: ...
 
-def loads(s: str,
+def loads(s: AnyStr,
     precise_float: bool = ...,
     ) -> Any: ...
 
-def load(fp: IO[str],
+def load(fp: IO[AnyStr],
     precise_float: bool = ...,
     ) -> Any: ...


### PR DESCRIPTION
The ujson module apparently will accept both bytes and text format
input, however, it does always output a str (both on Python 2 and
Python 3).

Some discussion in: https://github.com/python/typeshed/pull/460