### PR TITLE
[waiting for author] Add stubs for the statistics module

### DIFF
--- a/stdlib/3.4/statistics.pyi
+++ b/stdlib/3.4/statistics.pyi
@@ -4,14 +4,17 @@
 import sys
 from typing import Iterable, Iterator, Sequence, TypeVar, Union, overload
 from decimal import Decimal
-from fractions import Fraction
 
 # Note: according to the docs, statistics only explicitly supports
 # int, float, Decimal, and Fraction. Other types within the numeric
 # tower are not supported. It also states mixing together different
 # types results in undefined behavior, so the type signatures below
 # deliberately enforce that numeric types may not be mixed.
-_TNum = TypeVar('_TNum', int, float, Decimal, Fraction)
+#
+# TODO: Once either https://github.com/python/typeshed/pull/545 or
+# https://github.com/python/typeshed/pull/94 is accepted, add support
+# for fractions.
+_TNum = TypeVar('_TNum', int, float, Decimal)
 _T = TypeVar('_T')
 
 def mean(data: Union[Iterator[_TNum], Sequence[_TNum]]) -> _TNum: ...
@@ -26,8 +29,9 @@ if sys.version_info >= (3, 6):
 def median(data: Iterable[_TNum]) -> _TNum: ...
 def median_low(data: Iterable[_TNum]) -> _TNum: ...
 def median_high(data: Iterable[_TNum]) -> _TNum: ...
+# TODO: interval should also accept a Fraction.
 def median_grouped(data: Iterable[_TNum],
-                   interval: Union[int, float, Fraction] = 1
+                   interval: Union[int, float] = 1
                    ) -> Union[_TNum, float]: ...
 
 def mode(data: Iterable[_T]) -> _T: ...

--- a/stdlib/3.4/statistics.pyi
+++ b/stdlib/3.4/statistics.pyi
@@ -1,0 +1,40 @@
+# Stubs for statistics
+# See: http://docs.python.org/3/library/statistics.html
+
+import sys
+from typing import Iterable, Iterator, Sequence, TypeVar, Union, overload
+from decimal import Decimal
+from fractions import Fraction
+
+# Note: according to the docs, statistics only explicitly supports
+# int, float, Decimal, and Fraction. Other types within the numeric
+# tower are not supported. It also states mixing together different
+# types results in undefined behavior, so the type signatures below
+# deliberately enforce that numeric types may not be mixed.
+_TNum = TypeVar('_TNum', int, float, Decimal, Fraction)
+_T = TypeVar('_T')
+
+def mean(data: Union[Iterator[_TNum], Sequence[_TNum]]) -> _TNum: ...
+if sys.version_info >= (3, 6):
+    def geometric_mean(data: Union[Iterator[_TNum], Sequence[_TNum]]) -> _TNum: ...
+    def harmonic_mean(data: Union[Iterator[_TNum], Sequence[_TNum]]) -> _TNum: ...
+
+# Note: in CPython, the output of median_grouped may sometimes be coerced to
+# float as an implementation detail. In the interests of not breaking code
+# that relies on this implementation detail, the return type is set to the
+# Union of float and the contained numeric type.
+def median(data: Iterable[_TNum]) -> _TNum: ...
+def median_low(data: Iterable[_TNum]) -> _TNum: ...
+def median_high(data: Iterable[_TNum]) -> _TNum: ...
+def median_grouped(data: Iterable[_TNum],
+                   interval: Union[int, float, Fraction] = 1
+                   ) -> Union[_TNum, float]: ...
+
+def mode(data: Iterable[_T]) -> _T: ...
+
+def pstdev(data: Union[Iterator[_TNum], Sequence[_TNum]]) -> Union[float, Decimal]: ...
+def stdev(data: Union[Iterator[_TNum], Sequence[_TNum]]) -> Union[float, Decimal]: ...
+def pvariance(data: Union[Iterator[_TNum], Sequence[_TNum]]) -> _TNum: ...
+def variance(data: Union[Iterator[_TNum], Sequence[_TNum]]) -> _TNum: ...
+
+class StatisticsError(ValueError): pass


### PR DESCRIPTION
This pull request adds stubs for the statistics module, including the `geometric_mean` and `harmonic_mean` functions that will be added to the upcoming Python 3.6 release.

In order to reduce the number of interconnected pull requests I'm making, I've deliberately omitted using the `fractions` module in any way so that this pull request can be evaluated and merged independently of my other pending pull requests.

Once either https://github.com/python/typeshed/pull/544 or https://github.com/python/typeshed/pull/94 is merged, I'll submit a new pull request to add back support for `fractions.Fraction` to the statistics module. (The former requires https://github.com/python/typeshed/pull/545 to first be accepted, and the latter appear to be indefinitely stuck until issue https://github.com/python/mypy/issues/1264 is resolved).
