### PR TITLE
Include time updates with Python 3.3

### DIFF
--- a/stdlib/3/time.pyi
+++ b/stdlib/3/time.pyi
@@ -14,13 +14,13 @@ daylight = 0
 timezone = 0
 tzname = ... # type: Tuple[str, str]
 
-if sys.version_info >= (3, 3):
-    CLOCK_HIGHRES = 0
-    CLOCK_MONOTONIC = 0
-    CLOCK_MONOTONIC_RAW = 0
-    CLOCK_PROCESS_CPUTIME_ID = 0
-    CLOCK_REALTIME = 0
-    CLOCK_THREAD_CPUTIME_ID = 0
+if sys.version_info >= (3, 3) and sys.platform != 'win32':
+    CLOCK_HIGHRES = 0  # Solaris only
+    CLOCK_MONOTONIC = 0  # Unix only
+    CLOCK_MONOTONIC_RAW = 0  # Linux 2.6.28 or later
+    CLOCK_PROCESS_CPUTIME_ID = 0  # Unix only
+    CLOCK_REALTIME = 0  # Unix only
+    CLOCK_THREAD_CPUTIME_ID = 0  # Unix only
 
 
 # ----- classes/methods -----
@@ -64,13 +64,15 @@ def strftime(format: str, t: Union[Tuple[int, int, int, int, int,
 def strptime(string: str,
              format: str = ...) -> struct_time: ...
 def time() -> float: ...
-def tzset() -> None: ...  # Unix only
+if sys.platform != 'win32':
+    def tzset() -> None: ...  # Unix only
 
 if sys.version_info >= (3, 3):
-    def clock_getres(int) -> float: ...
-    def clock_gettime(int) -> float: ...
-    def clock_settime(int, struct_time) -> float: ...
     def get_clock_info(str) -> Dict[str, Any]: ...
     def monotonic() -> float: ...
     def perf_counter() -> float: ...
     def process_time() -> float: ...
+    if sys.platform != 'win32':
+        def clock_getres(int) -> float: ...  # Unix only
+        def clock_gettime(int) -> float: ...  # Unix only
+        def clock_settime(int, struct_time) -> float: ...  # Unix only

--- a/stdlib/3/time.pyi
+++ b/stdlib/3/time.pyi
@@ -1,11 +1,11 @@
 # Stubs for time
 # Ron Murawski <ron@horizonchess.com>
 
-# based on: http://docs.python.org/3.2/library/time.html#module-time
+# based on: http://docs.python.org/3.3/library/time.html#module-time
 # see: http://nullege.com/codes/search?cq=time
 
 import sys
-from typing import Tuple, Union
+from typing import Tuple, Union, Dict, Any
 
 # ----- variables and constants -----
 accept2dyear = False
@@ -13,6 +13,14 @@ altzone = 0
 daylight = 0
 timezone = 0
 tzname = ... # type: Tuple[str, str]
+
+if sys.version_info >= (3, 3):
+    CLOCK_HIGHRES = 0
+    CLOCK_MONOTONIC = 0
+    CLOCK_MONOTONIC_RAW = 0
+    CLOCK_PROCESS_CPUTIME_ID = 0
+    CLOCK_REALTIME = 0
+    CLOCK_THREAD_CPUTIME_ID = 0
 
 
 # ----- classes/methods -----
@@ -65,3 +73,18 @@ def strptime(string: str,
              format: str = ...) -> struct_time: ...
 def time() -> float: ...
 def tzset() -> None: ...  # Unix only
+
+if sys.version_info >= (3, 3):
+    def clock_getres(int) -> float: ...
+
+    def clock_gettime(int) -> float: ...
+
+    def clock_settime(int, struct_time) -> float: ...
+
+    def get_clock_info(str) -> Dict[str, Any]: ...
+
+    def monotonic() -> float: ...
+
+    def perf_counter() -> float: ...
+
+    def process_time() -> float: ...

--- a/stdlib/3/time.pyi
+++ b/stdlib/3/time.pyi
@@ -5,7 +5,8 @@
 # see: http://nullege.com/codes/search?cq=time
 
 import sys
-from typing import Tuple, Union, Dict, Any
+from typing import Tuple, Union
+from types import SimpleNamespace
 
 # ----- variables and constants -----
 accept2dyear = False
@@ -68,7 +69,7 @@ if sys.platform != 'win32':
     def tzset() -> None: ...  # Unix only
 
 if sys.version_info >= (3, 3):
-    def get_clock_info(str) -> Dict[str, Any]: ...
+    def get_clock_info(str) -> SimpleNamespace: ...
     def monotonic() -> float: ...
     def perf_counter() -> float: ...
     def process_time() -> float: ...

--- a/stdlib/3/time.pyi
+++ b/stdlib/3/time.pyi
@@ -49,26 +49,18 @@ class struct_time:
 def asctime(t: Union[Tuple[int, int, int, int, int, int, int, int, int],
                      struct_time,
                      None] = ...) -> str: ...  # return current time
-
 def clock() -> float: ...
-
 def ctime(secs: Union[float, None] = ...) -> str: ...  # return current time
-
 def gmtime(secs: Union[float, None] = ...) -> struct_time: ...  # return current time
-
 def localtime(secs: Union[float, None] = ...) -> struct_time: ...  # return current time
-
 def mktime(t: Union[Tuple[int, int, int, int, int,
                           int, int, int, int],
                     struct_time]) -> float: ...
-
 def sleep(secs: Union[int, float]) -> None: ...
-
 def strftime(format: str, t: Union[Tuple[int, int, int, int, int,
                                          int, int, int, int],
                                    struct_time,
                                    None] = ...) -> str: ...  # return current time
-
 def strptime(string: str,
              format: str = ...) -> struct_time: ...
 def time() -> float: ...
@@ -76,15 +68,9 @@ def tzset() -> None: ...  # Unix only
 
 if sys.version_info >= (3, 3):
     def clock_getres(int) -> float: ...
-
     def clock_gettime(int) -> float: ...
-
     def clock_settime(int, struct_time) -> float: ...
-
     def get_clock_info(str) -> Dict[str, Any]: ...
-
     def monotonic() -> float: ...
-
     def perf_counter() -> float: ...
-
     def process_time() -> float: ...


### PR DESCRIPTION
Several functions and constants were added to [time](https://docs.python.org/3.3/library/time.html) in Python 3.3. I've added the type signatures for the functions and constants here.

Most of the functions are Unix only, but I have not indicated them as such. Should they be?

Also, the `get_clock_info()` function returns a `types.SimpleNamespace` object. However its docstring says it returns a `dict`. So I annotated the type here as `Dict[str, Any]`.

```python
>>> import time
>>> time.get_clock_info('clock')
namespace(adjustable=False, implementation='clock()', monotonic=True, resolution=1e-06)
>>> type(time.get_clock_info('clock'))
<class 'types.SimpleNamespace'>
>>> vars(time.get_clock_info('clock'))
{'resolution': 1e-06, 'implementation': 'clock()', 'monotonic': True, 'adjustable': False}
>>> time.get_clock_info.__doc__
'get_clock_info(name: str) -> dict\n\nGet information of the specified clock.'
```

Finally, if the list of functions were to be kept alphabetically sorted, this would require several `if` blocks. I decided to just group all the Python 3.3+ functions together at the end within a single `if` block.