### PR TITLE
Allow the first argument to SequenceMatcher.__init__ to be None.

### DIFF
--- a/stdlib/2.7/difflib.pyi
+++ b/stdlib/2.7/difflib.pyi
@@ -6,13 +6,13 @@
 
 from typing import (
     TypeVar, Callable, Iterable, Iterator, List, NamedTuple, Sequence, Tuple,
-    Generic
+    Generic, Optional
 )
 
 _T = TypeVar('_T')
 
 class SequenceMatcher(Generic[_T]):
-    def __init__(self, isjunk: Callable[[_T], bool] = ...,
+    def __init__(self, isjunk: Optional[Callable[[_T], bool]] = ...,
                  a: Sequence[_T] = ..., b: Sequence[_T] = ...,
                  autojunk: bool = ...) -> None: ...
     def set_seqs(self, a: Sequence[_T], b: Sequence[_T]) -> None: ...

--- a/stdlib/3/difflib.pyi
+++ b/stdlib/3/difflib.pyi
@@ -4,13 +4,13 @@
 
 from typing import (
     TypeVar, Callable, Iterable, Iterator, List, NamedTuple, Sequence, Tuple,
-    Generic
+    Generic, Optional
 )
 
 _T = TypeVar('_T')
 
 class SequenceMatcher(Generic[_T]):
-    def __init__(self, isjunk: Callable[[_T], bool] = ...,
+    def __init__(self, isjunk: Optional[Callable[[_T], bool]] = ...,
                  a: Sequence[_T] = ..., b: Sequence[_T] = ...,
                  autojunk: bool = ...) -> None: ...
     def set_seqs(self, a: Sequence[_T], b: Sequence[_T]) -> None: ...


### PR DESCRIPTION
SequenceMatcher(None, a, b) is valid, so need to use Optional[] around Callable[].

Docs: https://docs.python.org/2/library/difflib.html#sequencematcher-objects