### PR TITLE
[waiting for author] New type hints for ssl module.

### DIFF
--- a/stdlib/3/ssl.pyi
+++ b/stdlib/3/ssl.pyi
@@ -46,6 +46,17 @@ if sys.version_info >= (3, 4):
                                capath: Optional[str] = ...,
                                cadata: Optional[str] = ...) -> 'SSLContext': ...
 
+if sys.version_info >= (3, 4, 3):
+    def _create_unverified_context(protocol: int = ..., *,
+                                   cert_reqs: int = ...,
+                                   check_hostname: bool = ...,
+                                   purpose: Any = ...,
+                                   certfile: Optional[str] = ...,
+                                   keyfile: Optional[str] = ...,
+                                   cafile: Optional[str] = ...,
+                                   capath: Optional[str] = ...,
+                                   cadata: Optional[str] = ...) -> 'SSLContext': ...
+    _create_default_https_context = ... # type: Callable[..., 'SSLContext']
 
 def RAND_bytes(num: int) -> bytes: ...
 def RAND_pseudo_bytes(num: int) -> Tuple[bytes, bool]: ...


### PR DESCRIPTION
- `_create_default_https_context`
- `_create_unverified_context`

See https://github.com/python/typeshed/issues/582

```
$ ./tests/mypy_test.py 
running mypy --python-version 3.5 --strict-optional # with 341 files
running mypy --python-version 3.4 --strict-optional # with 341 files
running mypy --python-version 3.3 --strict-optional # with 326 files
running mypy --python-version 3.2 --strict-optional # with 325 files
running mypy --python-version 2.7 --strict-optional # with 382 files
```

```
$ ./tests/pytype_test.py --num-parallel=4
Running pytype tests...
Ran pytype with 242 pyis, got 0 errors.
```