### PR TITLE
Add stub for SameFileError.

### DIFF
--- a/stdlib/3/shutil.pyi
+++ b/stdlib/3/shutil.pyi
@@ -1,4 +1,5 @@
 # Stubs for shutil
+import sys
 
 # Based on http://docs.python.org/3.2/library/shutil.html
 
@@ -27,6 +28,8 @@ def rmtree(path: str, ignore_errors: bool = ...,
 def move(src: str, dst: str) -> None: ...
 
 class Error(Exception): ...
+if sys.version_info >= (3, 4):
+  class SameFileError(Error): ...
 
 def make_archive(base_name: str, format: str, root_dir: str = ...,
                  base_dir: str = ..., verbose: bool = ...,


### PR DESCRIPTION
`SameFileError`: https://docs.python.org/3/library/shutil.html#shutil.SameFileError

Introduced in 3.4.

```
$ ./tests/mypy_test.py 
running mypy --python-version 3.5 --strict-optional # with 341 files
running mypy --python-version 3.4 --strict-optional # with 341 files
running mypy --python-version 3.3 --strict-optional # with 326 files
running mypy --python-version 3.2 --strict-optional # with 325 files
running mypy --python-version 2.7 --strict-optional # with 382 files
```

```
$ ./tests/pytype_test.py 
Running pytype tests...
Ran pytype with 242 pyis, got 0 errors.
```