### PR TITLE
change 'path' import syntax

### DIFF
--- a/stdlib/2.7/os/__init__.pyi
+++ b/stdlib/2.7/os/__init__.pyi
@@ -4,7 +4,6 @@ from typing import (
     List, Tuple, Union, Sequence, Mapping, IO, Any, Optional, AnyStr, Iterator,
     MutableMapping, NamedTuple, overload
 )
-from os import path
 
 error = OSError
 name = ... # type: str

--- a/stdlib/2.7/os/__init__.pyi
+++ b/stdlib/2.7/os/__init__.pyi
@@ -4,6 +4,7 @@ from typing import (
     List, Tuple, Union, Sequence, Mapping, IO, Any, Optional, AnyStr, Iterator,
     MutableMapping, NamedTuple, overload
 )
+from . import path
 
 error = OSError
 name = ... # type: str

--- a/stdlib/3/os/__init__.pyi
+++ b/stdlib/3/os/__init__.pyi
@@ -9,7 +9,7 @@ from typing import (
 )
 import sys
 from builtins import OSError as error
-import os.path as path
+from . import path
 
 # ----- os variables -----
 

--- a/tests/pytype_blacklist.txt
+++ b/tests/pytype_blacklist.txt
@@ -5,3 +5,7 @@ stdlib/2.7/builtins.pyi
 stdlib/2.7/types.pyi
 stdlib/2.7/typing.pyi
 stdlib/2and3/webbrowser.pyi
+
+# Because of 'from . import path':
+stdlib/2.7/os/__init__.pyi
+stdlib/3/os/__init__.pyi


### PR DESCRIPTION
`os/` is a package, hence we don't need to declare `path` in `__init__.pyi`
for mypy or pytype to find `os/path.pyi`.