### PR TITLE
Allow Any in the tuple of lists returned by select

### DIFF
--- a/stdlib/3/select.pyi
+++ b/stdlib/3/select.pyi
@@ -22,6 +22,6 @@ class poll:
     def poll(self, timeout: int = ...) -> List[Tuple[int, int]]: ...
 
 def select(rlist: Sequence, wlist: Sequence, xlist: Sequence,
-           timeout: float = ...) -> Tuple[List[int],
-                                           List[int],
-                                           List[int]]: ...
+           timeout: float = ...) -> Tuple[List[Any],
+                                           List[Any],
+                                           List[Any]]: ...


### PR DESCRIPTION
The original type definition was incorrect, because `select.select` doesn't return a tuple of lists of integers, it returns a tuple of subsets of the sequences provided as arguments. I wasn't sure how to handle that case (the documentation isn't explicit on all the kinds of objects allowed in the sequence, but mentions sockets and file descriptors. It also says custom wrapper classes are allowed as long as they define a `fileno` method), so I made it have a definition of type Any. 

Would it be more appropriate to have a Union type of the socket and file descriptor return values?