### PR TITLE
Improve concurrent.futures.wait function stub

### DIFF
--- a/stdlib/3/concurrent/futures/_base.pyi
+++ b/stdlib/3/concurrent/futures/_base.pyi
@@ -1,4 +1,4 @@
-from typing import TypeVar, Generic, Any, Iterable, Iterator, Callable, Tuple, Optional
+from typing import TypeVar, Generic, Any, Iterable, Iterator, Callable, Tuple, Optional, Set
 from collections import namedtuple
 
 FIRST_COMPLETED = ... # type: Any
@@ -41,4 +41,4 @@ class Executor:
 
 def as_completed(fs: Iterable[Future], timeout: Optional[float] = ...) -> Iterator[Future]: ...
 
-def wait(fs: Iterable[Future], timeout: Optional[float] = ..., return_when: str = ...) -> Tuple[Iterable[Future], Iterable[Future]]: ...
+def wait(fs: Iterable[Future], timeout: Optional[float] = ..., return_when: str = ...) -> Tuple[Set[Future], Set[Future]]: ...


### PR DESCRIPTION
According to the doc for `concurrent.futures.wait`:
> Returns a named 2-tuple of sets. The first set, named done, contains the futures that completed (finished or were cancelled) before the wait completed. The second set, named not_done, contains uncompleted futures.

Here's my use case:
```
with ThreadPoolExecutor(threads) as e:
    running = set()  # type: Set[Future]
    while True:
        while len(running) < threads:
            future = e.submit(func)
            running.add(future)
        done, running = wait(running, return_when=FIRST_COMPLETED)
```

Mypy reports an error in the last line: `Incompatible types in assignment (expression has type Iterable[Future[Any]], variable has type Set[Future[Any]])`. This PR should fix that.