### PR TITLE
Direct import for metaclass ABCMeta

### DIFF
--- a/stdlib/3/_importlib_modulespec.pyi
+++ b/stdlib/3/_importlib_modulespec.pyi
@@ -5,7 +5,7 @@
 # - Loader in importlib.abc
 # - ModuleSpec in importlib.machinery (3.4 and later only)
 
-import abc
+from abc import ABCMeta
 import sys
 from typing import Any, Optional
 
@@ -33,7 +33,7 @@ class ModuleType:
         __spec__ = ... # type: Optional[ModuleSpec]
     def __init__(self, name: str, doc: str) -> None: ...
 
-class Loader(metaclass=abc.ABCMeta):
+class Loader(metaclass=ABCMeta):
     def load_module(self, fullname: str) -> ModuleType: ...
     if sys.version_info >= (3, 3):
         def module_repr(self, module: ModuleType) -> str: ...

--- a/stdlib/3/importlib/abc.pyi
+++ b/stdlib/3/importlib/abc.pyi
@@ -1,4 +1,5 @@
 import abc
+from abc import ABCMeta
 if sys.version_info >= (3, 4):
     from _importlib_modulespec import ModuleSpec
 import sys
@@ -11,7 +12,7 @@ _Path = Union[bytes, str]
 # exists in its own stub file (with ModuleSpec and ModuleType).
 from _importlib_modulespec import Loader as Loader  # Exported
 
-class Finder(metaclass=abc.ABCMeta): ...
+class Finder(metaclass=ABCMeta): ...
     # Technically this class defines the following method, but its subclasses
     # in this module violate its signature. Since this class is deprecated, it's
     # easier to simply ignore that this method exists.

--- a/stdlib/3/importlib/abc.pyi
+++ b/stdlib/3/importlib/abc.pyi
@@ -1,5 +1,4 @@
-import abc
-from abc import ABCMeta
+from abc import ABCMeta, abstractmethod
 if sys.version_info >= (3, 4):
     from _importlib_modulespec import ModuleSpec
 import sys
@@ -16,19 +15,19 @@ class Finder(metaclass=ABCMeta): ...
     # Technically this class defines the following method, but its subclasses
     # in this module violate its signature. Since this class is deprecated, it's
     # easier to simply ignore that this method exists.
-    #@abc.abstractmethod
+    #@abstractmethod
     #def find_module(self, fullname: str,
     #                path: Sequence[_Path] = None) -> Optional[Loader]: ...
 
 class ResourceLoader(Loader):
-    @abc.abstractmethod
+    @abstractmethod
     def get_data(self, path: _Path) -> bytes: ...
 
 class InspectLoader(Loader):
     def is_package(self, fullname: str) -> bool: ...
     def get_code(self, fullname: str) -> Optional[types.CodeType]: ...
     def load_module(self, fullname: str) -> types.ModuleType: ...
-    @abc.abstractmethod
+    @abstractmethod
     def get_source(self, fullname: str) -> Optional[str]: ...
     if sys.version_info >= (3, 4):
         def exec_module(self, module: types.ModuleType) -> None: ...
@@ -41,7 +40,7 @@ class InspectLoader(Loader):
                            path: str = '<string>') -> types.CodeType: ...
 
 class ExecutionLoader(InspectLoader):
-    @abc.abstractmethod
+    @abstractmethod
     def get_filename(self, fullname: str) -> _Path: ...
     def get_code(self, fullname: str) -> Optional[types.CodeType]: ...
 


### PR DESCRIPTION
Added `from abc import ABCMeta` in importlib.

This change is needed for [mypy/#2365](https://github.com/python/mypy/pull/2365).