### PR TITLE
Stubs for collections.abc module

### DIFF
--- a/stdlib/3/collections/abc.pyi
+++ b/stdlib/3/collections/abc.pyi
@@ -1,0 +1,13 @@
+# Stubs for collections.abc (introduced from Python 3.3)
+#
+# https://docs.python.org/3.3/whatsnew/3.3.html#collections
+import sys
+
+if sys.version_info >= (3, 3):
+    from . import (
+        Container as Container,
+        MutableMapping as MutableMapping,
+        Sequence as Sequence,
+        MutableSequence as MutableSequence,
+        Set as Set,
+    )


### PR DESCRIPTION
[Abstract base classes have been moved in a `collections.abc` module since Python 3.3.][1]

[1]: https://docs.python.org/3.3/whatsnew/3.3.html#collections