### PR TITLE
Fix asyncio.wait for() and missing asyncio.{Cancelled,Timeout,InvalidState}Error types

### DIFF
--- a/stdlib/3.4/asyncio/__init__.pyi
+++ b/stdlib/3.4/asyncio/__init__.pyi
@@ -37,6 +37,9 @@ from asyncio.transports import (
 )
 from asyncio.futures import (
     Future as Future,
+    CancelledError as CancelledError,
+    TimeoutError as TimeoutError,
+    InvalidStateError as InvalidStateError,
 )
 from asyncio.tasks import (
     FIRST_COMPLETED as FIRST_COMPLETED,

--- a/stdlib/3.4/asyncio/futures.pyi
+++ b/stdlib/3.4/asyncio/futures.pyi
@@ -5,6 +5,15 @@ __all__ = ... # type: str
 
 _T = TypeVar('_T')
 
+from concurrent.futures._base import (
+    Error as Error,
+)
+from concurrent.futures import (
+    CancelledError as CancelledError,
+    TimeoutError as TimeoutError,
+)
+class InvalidStateError(Error): ...
+
 class _TracebackLogger:
     __slots__ = ... # type: List[str]
     exc = ...  # type: BaseException

--- a/stdlib/3.4/asyncio/tasks.pyi
+++ b/stdlib/3.4/asyncio/tasks.pyi
@@ -28,7 +28,7 @@ def sleep(delay: float, result: _T = ..., loop: AbstractEventLoop = ...) -> Futu
 def wait(fs: List[Task[_T]], *, loop: AbstractEventLoop = ...,
     timeout: float = ...,
          return_when: str = ...) -> Future[Tuple[Set[Future[_T]], Set[Future[_T]]]]: ...
-def wait_for(fut: Union[Future[_T], Generator[Any, None, _T]], timeout: Optional[float],
+def wait_for(fut: Union[Future[_T], Generator[Any, None, _T], Awaitable[_T]], timeout: Optional[float],
              *, loop: AbstractEventLoop = ...) -> Future[_T]: ...
 
 class Task(Future[_T], Generic[_T]):


### PR DESCRIPTION
asyncio.wait for() should also accept Awaitable[_T] in the same way as asyncio.gather() does.
Maybe asyncio,ensure_future() needs to be fixed too. I didn't change it since my code did not fail there.
The asyncio.{Cancelled,Timeout,InvalidState}Error types are missing. I got the types from concurrent.futures as the implementation does - hope this is correct.