### PR TITLE
Fix AwaitableGenerator inheritance

### DIFF
--- a/stdlib/3/typing.pyi
+++ b/stdlib/3/typing.pyi
@@ -135,7 +135,7 @@ class Coroutine(Awaitable[_V_co], Generic[_T_co, _T_contra, _V_co]):
 
 # NOTE: This type does not exist in typing.py or PEP 484.
 # The parameters corrrespond to Generator, but the 4th is the original type.
-class AwaitableGenerator(Generator[_T_co, _T_contra, _V_co], Awaitable[_T_co],
+class AwaitableGenerator(Generator[_T_co, _T_contra, _V_co], Awaitable[_V_co],
                          Generic[_T_co, _T_contra, _V_co, _S]):
     pass
 


### PR DESCRIPTION
Awaitable is the return value, not the yielded value.