### PR TITLE
Add missing MutableSet abstract base class

### DIFF
--- a/stdlib/3/collections/abc.pyi
+++ b/stdlib/3/collections/abc.pyi
@@ -10,4 +10,5 @@ if sys.version_info >= (3, 3):
         Sequence as Sequence,
         MutableSequence as MutableSequence,
         Set as Set,
+        MutableSet as MutableSet,
     )


### PR DESCRIPTION
[`MutableSet`][1] is a mutable version of [`Set`][2].

[1]: https://docs.python.org/3/library/collections.abc.html#collections.abc.MutableSet
[2]: https://docs.python.org/3/library/collections.abc.html#collections.abc.Set