### PR TITLE
Add Arg() etc to mypy_extensions

### DIFF
--- a/third_party/2and3/mypy_extensions.pyi
+++ b/third_party/2and3/mypy_extensions.pyi
@@ -1,6 +1,24 @@
-from typing import Dict, Type, TypeVar
+from typing import Dict, Type, TypeVar, Optional, Any
 
 T = TypeVar('T')
 
 
 def TypedDict(typename: str, fields: Dict[str, Type[T]]) -> Type[dict]: ...
+
+class Arg(object):
+    def __init__(name: Optional[str]=...,
+                 typ: Type[T]=...,
+                 keyword_only: Optional[bool]=...) -> None:
+        ...
+
+class DefaultArg(object):
+    def __init__(name: Optional[str]=...,
+                 typ: Type[T]=...,
+                 keyword_only: Optional[bool]=...) -> None:
+        ...
+
+class StarArg(object):
+    def __init__(typ: Type[T]=...) -> None: ...
+
+class KwArg(object):
+    def __init__(typ: Type[T]=...) -> None: ...


### PR DESCRIPTION
This pull request is relevant to https://github.com/python/typing/issues/264 making `Callable` more flexible and able to represent more python functions.

This adds stubs for `Arg`, `DefaultArg`, `StarArg`, and `KwArg` to `mypy_extensions.pyi`.  We should merge this before the relevant pull request to `mypy` but approve them as if they're one pull request.