### PR TITLE
Add ns accurate times in os.stat_result

### DIFF
--- a/stdlib/3/os/__init__.pyi
+++ b/stdlib/3/os/__init__.pyi
@@ -138,6 +138,12 @@ class stat_result:
     st_ctime = 0.0 # platform dependent (time of most recent metadata change
                    # on  Unix, or the time of creation on Windows)
 
+    if sys.version_info >= (3, 3):
+        st_atime_ns = 0 # time of most recent access, in nanoseconds
+        st_mtime_ns = 0 # time of most recent content modification in nanoseconds
+        st_ctime_ns = 0 # platform dependent (time of most recent metadata change
+                        # on  Unix, or the time of creation on Windows) in nanoseconds
+
     # not documented
     def __init__(self, tuple: Tuple[int, ...]) -> None: ...
 


### PR DESCRIPTION
This isn't entirely correct because adding the fields should be conditional on 3.3 or later (http://bugs.python.org/issue14127). Is there a way to do that without repeating the entire stat_result definition?