### PR TITLE
Multiprocessing fixes

### DIFF
--- a/stdlib/3/multiprocessing/__init__.pyi
+++ b/stdlib/3/multiprocessing/__init__.pyi
@@ -49,11 +49,11 @@ class Pool():
                        chunksize: Optional[int] = None) -> Iterable[Any]: ...
     def starmap(self,
                 func: Callable[..., Any],
-                iterable: Iterable[Any]=(),
+                iterable: Iterable[Iterable[Any]]=(),
                 chunksize: Optional[int] = None) -> List[Any]: ...
     def starmap_async(self,
                       func: Callable[..., Any],
-                      iterable: Iterable[Any] = (),
+                      iterable: Iterable[Iterable[Any]] = (),
                       chunksize: Optional[int] = None,
                       callback: Callable[..., None] = None,
                       error_callback: Callable[[BaseException], None] = None) -> AsyncResult: ...

--- a/stdlib/3/multiprocessing/pool.pyi
+++ b/stdlib/3/multiprocessing/pool.pyi
@@ -2,7 +2,7 @@
 
 # NOTE: These are incomplete!
 
-from typing import Any, Callable, Iterable, List, Sequence
+from typing import Any, Callable, Iterable, Mapping, Optional, Dict, List
 
 class AsyncResult():
     def get(self, timeout: float = -1) -> Any: ...
@@ -11,26 +11,48 @@ class AsyncResult():
     def successful(self) -> bool: ...
 
 class ThreadPool():
-    def __init__(self, processes: int = ...) -> None: ...
-    def apply_async(self, func: Callable[..., Any],
-                    args: Sequence[Any]=(),
-                    kwds: Dict[str, Any]={},
-                    callback: Callable[..., None] = None) -> AsyncResult: ...
-    def apply(self, func: Callable[..., Any],
-              args: Sequence[Any]=(),
+    def __init__(self, processes: Optional[int] = None,
+                 initializer: Optional[Callable[..., None]] = None,
+                 initargs: Iterable[Any] = ()) -> None: ...
+    def apply(self,
+              func: Callable[..., Any],
+              args: Iterable[Any]=(),
               kwds: Dict[str, Any]={}) -> Any: ...
-    def map(self, func: Callable[..., Any],
-            iterable: Iterable[Any]=()) -> List[Any]: ...
+    def apply_async(self,
+                func: Callable[..., Any],
+                args: Iterable[Any]=(),
+                kwds: Dict[str, Any]={},
+                callback: Callable[..., None] = None,
+                error_callback: Callable[[BaseException], None] = None) -> AsyncResult: ...
+    def map(self,
+            func: Callable[..., Any],
+            iterable: Iterable[Any]=(),
+            chunksize: Optional[int] = None) -> List[Any]: ...
     def map_async(self, func: Callable[..., Any],
                   iterable: Iterable[Any] = (),
-                  chunksize: int = -1,
-                  callback: Callable[..., None] = None) -> AsyncResult: ...
-    def imap(self, func: Callable[..., Any],
-             iterable: Iterable[Any]=()) -> Iterable[Any]: ...
-    def imap_async(self, func: Callable[..., Any],
-                   chunksize: int = -1,
-                   iterable: Iterable[Any]=(),
-                   callback: Callable[..., None] = None) -> AsyncResult: ...
+                  chunksize: Optional[int] = None,
+                  callback: Callable[..., None] = None,
+                  error_callback: Callable[[BaseException], None] = None) -> AsyncResult: ...
+    def imap(self,
+             func: Callable[..., Any],
+             iterable: Iterable[Any]=(),
+             chunksize: Optional[int] = None) -> Iterable[Any]: ...
+    def imap_unordered(self,
+                       func: Callable[..., Any],
+                       iterable: Iterable[Any]=(),
+                       chunksize: Optional[int] = None) -> Iterable[Any]: ...
+    def starmap(self,
+                func: Callable[..., Any],
+                iterable: Iterable[Any]=(),
+                chunksize: Optional[int] = None) -> List[Any]: ...
+    def starmap_async(self,
+                      func: Callable[..., Any],
+                      iterable: Iterable[Any] = (),
+                      chunksize: Optional[int] = None,
+                      callback: Callable[..., None] = None,
+                      error_callback: Callable[[BaseException], None] = None) -> AsyncResult: ...
     def close(self) -> None: ...
     def terminate(self) -> None: ...
     def join(self) -> None: ...
+    def __enter__(self) -> 'ThreadPool': ...
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None: ...

--- a/stdlib/3/multiprocessing/pool.pyi
+++ b/stdlib/3/multiprocessing/pool.pyi
@@ -43,11 +43,11 @@ class ThreadPool():
                        chunksize: Optional[int] = None) -> Iterable[Any]: ...
     def starmap(self,
                 func: Callable[..., Any],
-                iterable: Iterable[Any]=(),
+                iterable: Iterable[Iterable[Any]]=(),
                 chunksize: Optional[int] = None) -> List[Any]: ...
     def starmap_async(self,
                       func: Callable[..., Any],
-                      iterable: Iterable[Any] = (),
+                      iterable: Iterable[Iterable[Any]] = (),
                       chunksize: Optional[int] = None,
                       callback: Callable[..., None] = None,
                       error_callback: Callable[[BaseException], None] = None) -> AsyncResult: ...


### PR DESCRIPTION
1. Fix type declarations for multiprocessing.pool.ThreadPool

The existing incomplete type declarations were replaced by a copy of
multiprocessing.Pool's declarations, suitably modified.

Fixes #683.

2. Change iterable type to Iterable[Iterable[Any]] in starmap