### PR TITLE
Add Iterable base class to tarfile.TarFile

### DIFF
--- a/stdlib/2and3/tarfile.pyi
+++ b/stdlib/2and3/tarfile.pyi
@@ -1,7 +1,7 @@
 ## Stubs for tarfile
 
 from typing import (
-    Callable, IO, Iterator, List, Mapping, Optional, Type,
+    Callable, IO, Iterable, Iterator, List, Mapping, Optional, Type,
     Union,
 )
 import sys
@@ -41,7 +41,7 @@ def open(name: Optional[str] = ..., mode: str = ...,
         errorlevel: Optional[int] = ...) -> TarFile: ...
 
 
-class TarFile:
+class TarFile(Iterable[TarInfo]):
     name = ...  # type: Optional[str]
     mode = ...  # type: str
     fileobj = ...  # type: Optional[IO[bytes]]


### PR DESCRIPTION
Allows this example from the [Python documentation](https://docs.python.org/3/library/tarfile.html#examples) to type check:

```python
import tarfile
tar = tarfile.open("sample.tar.gz", "r:gz")
for tarinfo in tar:
    print(tarinfo.name, "is", tarinfo.size, "bytes in size and is", end="")
    if tarinfo.isreg():
        print("a regular file.")
    elif tarinfo.isdir():
        print("a directory.")
    else:
        print("something else.")
tar.close()
```
