### PR TITLE
logging.Formatter attributes fixed

### DIFF
--- a/stdlib/2and3/logging/__init__.pyi
+++ b/stdlib/2and3/logging/__init__.pyi
@@ -1,10 +1,11 @@
 ## Stubs for logging (Python 3.4)
 
 from typing import (
-    Any, Callable, Iterable, Mapping, MutableMapping, Optional, IO, Tuple,
-    Text, Union,
-    overload,
+    Any, Callable, Dict, Iterable, Mapping, MutableMapping, Optional, IO,
+    Tuple, Text, Union, overload,
 )
+from string import Template
+from time import struct_time
 from types import TracebackType
 import sys
 
@@ -26,7 +27,7 @@ class Logger:
     handlers = ... # type: List[Handler]
     disabled = ... # type: int
     def setLevel(self, lvl: Union[int, str]) -> None: ...
-    def isEnabledFor(self, lvl: int) -> Union[int, bool]: ...
+    def isEnabledFor(self, lvl: int) -> bool: ...
     def getEffectiveLevel(self) -> int: ...
     def getChild(self, suffix: str) -> 'Logger': ...
     if sys.version_info > (3,):
@@ -135,6 +136,14 @@ class Handler:
 
 
 class Formatter:
+    converter = ...  # type: Callable[[Optional[float]], struct_time]
+    _fmt = ...  # type: Optional[str]
+    datefmt = ...  # type: Optional[str]
+    if sys.version_info >= (3,):
+        _style = ...  # type: PercentStyle
+        default_time_format = ...  # type: str
+        default_msec_format = ...  # type: str
+
     if sys.version_info >= (3,):
         def __init__(self, fmt: Optional[str] = ...,
                      datefmt: Optional[str] =...,
@@ -143,6 +152,7 @@ class Formatter:
         def __init__(self,
                      fmt: Optional[str] = ...,
                      datefmt: Optional[str] =...) -> None: ...
+
     def format(self, record: LogRecord) -> str: ...
     def formatTime(self, record: LogRecord, datefmt: str = ...) -> str: ...
     def formatException(self, exc_info: _SysExcInfoType) -> str: ...
@@ -240,7 +250,7 @@ class LoggerAdapter:
         def log(self,
                 lvl: int, msg: Text, *args: Any, exc_info: _ExcInfoType = ...,
                 extra: Dict[str, Any] = ..., **kwargs: Any) -> None: ...
-    def isEnabledFor(self, lvl: int) -> Union[int, bool]: ...
+    def isEnabledFor(self, lvl: int) -> bool: ...
     if sys.version_info >= (3,):
         def getEffectiveLevel(self) -> int: ...
         def setLevel(self, lvl: Union[int, str]) -> None: ...
@@ -353,3 +363,24 @@ class RootLogger(Logger):
     pass
 
 root = ...  # type: RootLogger
+
+
+if sys.version_info >= (3,):
+    class PercentStyle(object):
+        default_format = ...  # type: str
+        asctime_format = ...  # type: str
+        asctime_search = ...  # type: str
+        _fmt = ...  # type: str
+
+        def __init__(self, fmt) -> None: ...
+        def usesTime(self) -> bool: ...
+        def format(self, record: Any) -> str: ...
+
+    class StrFormatStyle(PercentStyle):
+        ...
+
+    class StringTemplateStyle(PercentStyle):
+        _tpl = ...  # type: Template
+
+    BASIC_FORMAT = ...  # type: str
+    _STYLES = ...  # type: Dict[str, Tuple[PercentStyle, str]]

--- a/stdlib/3/time.pyi
+++ b/stdlib/3/time.pyi
@@ -5,7 +5,7 @@
 # see: http://nullege.com/codes/search?cq=time
 
 import sys
-from typing import Tuple, Union
+from typing import Any, NamedTuple, Tuple, Union
 from types import SimpleNamespace
 
 TimeTuple = Tuple[int, int, int, int, int, int, int, int, int]
@@ -26,27 +26,36 @@ if sys.version_info >= (3, 3) and sys.platform != 'win32':
     CLOCK_THREAD_CPUTIME_ID = 0  # Unix only
 
 
-# ----- classes/methods -----
-class struct_time:
-    # this is supposed to be a namedtuple object
-    # namedtuple is not yet implemented (see file: mypy/stubs/collections.py)
-    # see: http://docs.python.org/3.2/library/time.html#time.struct_time
-    # see: http://nullege.com/codes/search/time.struct_time
-    # TODO: namedtuple() object problem
-    #namedtuple __init__(self, int, int, int, int, int, int, int, int, int):
-    #    ...
-    tm_year = 0
-    tm_mon = 0
-    tm_mday = 0
-    tm_hour = 0
-    tm_min = 0
-    tm_sec = 0
-    tm_wday = 0
-    tm_yday = 0
-    tm_isdst = 0
-    if sys.version_info >= (3, 3):
-        tm_gmtoff = 0
-        tm_zone = 'GMT'
+if sys.version_info >= (3, 3):
+    class struct_time(
+        NamedTuple(
+            '_struct_time',
+             [('tm_year', int), ('tm_mon', int), ('tm_mday', int),
+              ('tm_hour', int), ('tm_min', int), ('tm_sec', int),
+              ('tm_wday', int), ('tm_yday', int), ('tm_isdst', int),
+              ('tm_zone', str), ('tm_gmtoff', int)]
+        )
+    ):
+        def __init__(
+            self,
+            o: Union[
+                Tuple[int, int, int, int, int, int, int, int, int],
+                Tuple[int, int, int, int, int, int, int, int, int, str],
+                Tuple[int, int, int, int, int, int, int, int, int, str, int]
+            ],
+            _arg: Any = ...,
+        ) -> None: ...
+else:
+    class struct_time(
+        NamedTuple(
+            '_struct_time',
+             [('tm_year', int), ('tm_mon', int), ('tm_mday', int),
+              ('tm_hour', int), ('tm_min', int), ('tm_sec', int),
+              ('tm_wday', int), ('tm_yday', int), ('tm_isdst', int)]
+        )
+    ):
+        def __init__(self, o: TimeTuple, _arg: Any = ...) -> None: ...
+
 
 # ----- functions -----
 def asctime(t: Union[TimeTuple, struct_time, None] = ...) -> str: ...  # return current time


### PR DESCRIPTION
Fixes #720.

Related changes: used a NamedTuple for time.struct_time on Python 3, used
sys.version selectors for proper typing of #716, added missing *Style classes
to logging on Python 3.