### PR TITLE
Expose pytz.UTC as an instance as opposed to as a class

### DIFF
--- a/third_party/2and3/pytz/__init__.pyi
+++ b/third_party/2and3/pytz/__init__.pyi
@@ -11,7 +11,7 @@ country_timezones = ...  # type: Dict
 country_names = ...  # type: Dict
 
 
-class __UTC(dt.tzinfo):
+class _UTCclass(dt.tzinfo):
     zone = ...  # type: str
     def fromutc(self, dt: dt.datetime) -> dt.datetime: ...
     def utcoffset(self, dt: Optional[dt.datetime]) -> dt.timedelta: ...  # type: ignore
@@ -20,7 +20,7 @@ class __UTC(dt.tzinfo):
     def localize(self, dt: dt.datetime, is_dst: bool=...) -> dt.datetime: ...
     def normalize(self, dt: dt.datetime, is_dst: bool=...) -> dt.datetime: ...
 
-utc = ...  # type: __UTC
-UTC = ...  # type: __UTC
+utc = ...  # type: _UTCclass
+UTC = ...  # type: _UTCclass
 
 def timezone(zone: str) -> dt.tzinfo: ...

--- a/third_party/2and3/pytz/__init__.pyi
+++ b/third_party/2and3/pytz/__init__.pyi
@@ -11,7 +11,7 @@ country_timezones = ...  # type: Dict
 country_names = ...  # type: Dict
 
 
-class UTC(dt.tzinfo):
+class __UTC(dt.tzinfo):
     zone = ...  # type: str
     def fromutc(self, dt: dt.datetime) -> dt.datetime: ...
     def utcoffset(self, dt: Optional[dt.datetime]) -> dt.timedelta: ...  # type: ignore
@@ -20,6 +20,7 @@ class UTC(dt.tzinfo):
     def localize(self, dt: dt.datetime, is_dst: bool=...) -> dt.datetime: ...
     def normalize(self, dt: dt.datetime, is_dst: bool=...) -> dt.datetime: ...
 
-utc = ...  # type: UTC
+utc = ...  # type: __UTC
+UTC = ...  # type: __UTC
 
-def timezone(zone: str) -> UTC: ...
+def timezone(zone: str) -> dt.tzinfo: ...


### PR DESCRIPTION
pytz shadows UTC after declaring it with a singleton:
https://github.com/newvem/pytz/blob/master/pytz/__init__.py#L135

This fixes https://github.com/python/typeshed/issues/710