### PR TITLE
Have frozenset inherit from FrozenSet

### DIFF
--- a/stdlib/2/__builtin__.pyi
+++ b/stdlib/2/__builtin__.pyi
@@ -6,7 +6,7 @@
 from typing import (
     TypeVar, Iterator, Iterable, overload,
     Sequence, Mapping, Tuple, List, Any, Dict, Callable, Generic, Set,
-    AbstractSet, Sized, Reversible, SupportsInt, SupportsFloat, SupportsAbs,
+    AbstractSet, FrozenSet, Sized, Reversible, SupportsInt, SupportsFloat, SupportsAbs,
     SupportsRound, IO, BinaryIO, Union, AnyStr, MutableSequence, MutableMapping,
     MutableSet, ItemsView, KeysView, ValuesView, Optional, Container,
 )
@@ -602,7 +602,7 @@ class set(MutableSet[_T], Generic[_T]):
     def __gt__(self, s: AbstractSet[Any]) -> bool: ...
     # TODO more set operations
 
-class frozenset(AbstractSet[_T], Generic[_T]):
+class frozenset(FrozenSet[_T], Generic[_T]):
     @overload
     def __init__(self) -> None: ...
     @overload

--- a/stdlib/3/builtins.pyi
+++ b/stdlib/3/builtins.pyi
@@ -3,8 +3,9 @@
 from typing import (
     TypeVar, Iterator, Iterable, overload, Container,
     Sequence, MutableSequence, Mapping, MutableMapping, Tuple, List, Any, Dict, Callable, Generic,
-    Set, AbstractSet, MutableSet, Sized, Reversible, SupportsInt, SupportsFloat, SupportsBytes,
-    SupportsAbs, SupportsRound, IO, Union, ItemsView, KeysView, ValuesView, ByteString, Optional
+    Set, AbstractSet, FrozenSet, MutableSet, Sized, Reversible, SupportsInt, SupportsFloat,
+    SupportsBytes, SupportsAbs, SupportsRound, IO, Union, ItemsView, KeysView, ValuesView,
+    ByteString, Optional
 )
 from abc import abstractmethod, ABCMeta
 from types import TracebackType
@@ -610,7 +611,7 @@ class set(MutableSet[_T], Generic[_T]):
     def __gt__(self, s: AbstractSet[Any]) -> bool: ...
     # TODO more set operations
 
-class frozenset(AbstractSet[_T], Generic[_T]):
+class frozenset(FrozenSet[_T], Generic[_T]):
     def __init__(self, iterable: Iterable[_T] = ...) -> None: ...
     def copy(self) -> frozenset[_T]: ...
     def difference(self, *s: Iterable[Any]) -> frozenset[_T]: ...


### PR DESCRIPTION
This fixes the problem that a function like this:

    def f(fs):
        # type: (FrozenSet[str]) -> None
        fs = frozenset(['a'])

would result in an error like this:

    frozenset.py: note: In function "f":
    frozenset.py:5: error: Incompatible types in assignment (expression has type frozenset[str], variable has type FrozenSet[str])

Originally reported at python/mypy#2514