### PR TITLE
#538 fixing concurrent.futures.ProcessPoolExecutor

### DIFF
--- a/third_party/2/concurrent/futures/__init__.pyi
+++ b/third_party/2/concurrent/futures/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import TypeVar, Generic, Any, Iterable, Iterator, Callable, Tuple
+from typing import TypeVar, Generic, Any, Iterable, Iterator, Callable, Tuple, Union
 
 _T = TypeVar('_T')
 
@@ -26,7 +26,7 @@ class ThreadPoolExecutor(Executor):
     def __init__(self, max_workers: int) -> None: ...
 
 class ProcessPoolExecutor(Executor):
-    def __init__(self, max_workers: None) -> None: ...
+    def __init__(self, max_workers: Union[int, None] = ...) -> None: ...
 
 def wait(fs: Iterable[Future], timeout: float = ..., return_when: str = ...) -> Tuple[Iterable[Future], Iterable[Future]]: ...
 


### PR DESCRIPTION
this fixes issue #538 

I looked more at the [documentation](https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.ProcessPoolExecutor) and found that you can initialize `ProcessPoolExecutor` with an int, None, or nothing at all, as shown in the below code that runs in python 2.7.

```
from concurrent.futures import ProcessPoolExecutor

test = ProcessPoolExecutor()
test2 = ProcessPoolExecutor(4)
test3 = ProcessPoolExecutor(None)
```

Before this fix, when running mypy with the --py2 flag, I got these errors:
```
test_concurrent.py:3: error: Too few arguments for "ProcessPoolExecutor"
test_concurrent.py:4: error: Argument 1 to "ProcessPoolExecutor" has incompatible type "int"; expected None
```

With this fix, the above code is now valid and it runs fine on python2.7.