### PR TITLE
add calendar data attributes

### DIFF
--- a/stdlib/2/calendar.pyi
+++ b/stdlib/2/calendar.pyi
@@ -1,4 +1,4 @@
-from typing import Any, Iterable, Optional, Tuple
+from typing import Any, Iterable, Optional, Tuple, Sequence
 import datetime
 
 LocaleType = Tuple[Optional[str], Optional[str]]
@@ -73,6 +73,12 @@ def setfirstweekday(firstweekday: int) -> None: ...
 def format(cols: int, colwidth: int = ..., spacing: int = ...) -> str: ...
 def formatstring(cols: int, colwidth: int = ..., spacing: int = ...) -> str: ...
 def timegm(tuple: Tuple[int, ...]) -> int: ...
+
+# Data attributes
+day_name = ...  # type: Sequence[str]
+day_abbr = ...  # type: Sequence[str]
+month_name = ...  # type: Sequence[str]
+month_abbr = ...  # type: Sequence[str]
 
 # Below constants are not in docs or __all__, but enough people have used them
 # they are now effectively public.

--- a/stdlib/3/calendar.pyi
+++ b/stdlib/3/calendar.pyi
@@ -1,4 +1,4 @@
-from typing import Any, Iterable, Optional, Tuple
+from typing import Any, Iterable, Optional, Tuple, Sequence
 import datetime
 
 LocaleType = Tuple[Optional[str], Optional[str]]
@@ -73,6 +73,12 @@ def setfirstweekday(firstweekday: int) -> None: ...
 def format(cols: int, colwidth: int = ..., spacing: int = ...) -> str: ...
 def formatstring(cols: int, colwidth: int = ..., spacing: int = ...) -> str: ...
 def timegm(tuple: Tuple[int, ...]) -> int: ...
+
+# Data attributes
+day_name = ...  # type: Sequence[str]
+day_abbr = ...  # type: Sequence[str]
+month_name = ...  # type: Sequence[str]
+month_abbr = ...  # type: Sequence[str]
 
 # Below constants are not in docs or __all__, but enough people have used them
 # they are now effectively public.


### PR DESCRIPTION
Fixes #692

The calendar stub is not in 2and3 but has duplicates in 2 and 3, so I updated both.

As far as I can understand, the right type for those is Sequence (implements __len__ and __getitem__).