### PR TITLE
Use specific types in dateutil.relativedelta stubs

### DIFF
--- a/third_party/3/dateutil/relativedelta.pyi
+++ b/third_party/3/dateutil/relativedelta.pyi
@@ -1,4 +1,4 @@
-from typing import Any, Optional, Union
+from typing import Optional, overload, Union
 from datetime import date, datetime, timedelta
 
 __all__ = ...  # type: List[str]
@@ -51,17 +51,43 @@ class relativedelta(object):
 
     def normalized(self) -> 'relativedelta': ...
 
-    def __add__(
-        self,
-        other: Union['relativedelta', timedelta, date, datetime]) -> 'relativedelta': ...
+    # TODO: use Union when mypy will handle it properly in overloaded operator
+    # methods (#2129, #1442, #1264 in mypy)
+    @overload
+    def __add__(self, other: 'relativedelta') -> 'relativedelta': ...
 
-    def __radd__(
-        self,
-        other: Any) -> 'relativedelta': ...
+    @overload
+    def __add__(self, other: timedelta) -> 'relativedelta': ...
 
-    def __rsub__(
-        self,
-        other: Any) -> 'relativedelta': ...
+    @overload
+    def __add__(self, other: date) -> date: ...
+
+    @overload
+    def __add__(self, other: datetime) -> datetime: ...
+
+    @overload
+    def __radd__(self, other: 'relativedelta') -> 'relativedelta': ...
+
+    @overload
+    def __radd__(self, other: timedelta) -> 'relativedelta': ...
+
+    @overload
+    def __radd__(self, other: date) -> date: ...
+
+    @overload
+    def __radd__(self, other: datetime) -> datetime: ...
+
+    @overload
+    def __rsub__(self, other: 'relativedelta') -> 'relativedelta': ...
+
+    @overload
+    def __rsub__(self, other: timedelta) -> 'relativedelta': ...
+
+    @overload
+    def __rsub__(self, other: date) -> date: ...
+
+    @overload
+    def __rsub__(self, other: datetime) -> datetime: ...
 
     def __sub__(self, other: 'relativedelta') -> 'relativedelta': ...
 


### PR DESCRIPTION
Improve operator methods for `dateutil.relativedelta` stubs:
* `__add__` operator method could return other types than `relativedelta` (`datetime.date` or `datetime.datetime`)
* use specific types of operators args instead of `Any`
* mypy currently does not handle `Union` in op methods (see python/mypy#2129, python/mypy#1442, python/mypy#1264 for details), so I've overloaded it directly