### PR TITLE
AbstractEventLoop missing methods from 3.4.2 and up. 

### DIFF
--- a/stdlib/3.4/asyncio/events.pyi
+++ b/stdlib/3.4/asyncio/events.pyi
@@ -2,7 +2,7 @@ from typing import Any, Awaitable, TypeVar, List, Callable, Tuple, Union, Dict, 
 from abc import ABCMeta, abstractmethod
 from asyncio.futures import Future
 from asyncio.coroutines import coroutine
-from asyncio.task import Task
+from asyncio.tasks import Task
 
 __all__ = ...  # type: str
 

--- a/stdlib/3.4/asyncio/events.pyi
+++ b/stdlib/3.4/asyncio/events.pyi
@@ -56,7 +56,7 @@ class AbstractEventLoop(metaclass=ABCMeta):
     @abstractmethod
     def time(self) -> float: ...
     # Future methods
-    if sys.version_info > (3, 5):
+    if sys.version_info >= (3, 5):
         @abstractmethod
         def create_future(self) -> Future[Any]: ...
     # Tasks methods

--- a/stdlib/3.4/asyncio/events.pyi
+++ b/stdlib/3.4/asyncio/events.pyi
@@ -1,7 +1,8 @@
-from typing import Any, Awaitable, TypeVar, List, Callable, Tuple, Union, Dict, Generator, overload
+from typing import Any, Awaitable, TypeVar, List, Callable, Tuple, Union, Dict, Generator, overload, Optional
 from abc import ABCMeta, abstractmethod
 from asyncio.futures import Future
 from asyncio.coroutines import coroutine
+from asyncio.task import Task
 
 __all__ = ...  # type: str
 
@@ -53,6 +54,16 @@ class AbstractEventLoop(metaclass=ABCMeta):
     def call_at(self, when: float, callback: Callable[..., Any], *args: Any) -> Handle: ...
     @abstractmethod
     def time(self) -> float: ...
+    # Future methods
+    @abstractmethod
+    def create_future(self) -> Future[Any]: ...
+    # Tasks methods
+    @abstractmethod
+    def create_task(self, coro: Union[Future[_T], Generator[Any, None, _T]]) -> Task[_T]: ...
+    @abstractmethod
+    def set_task_factory(self, factory: Optional[Callable[[AbstractEventLoop, Generator[Any, None, _T]], Future[_T]]]) -> None: ...
+    @abstractmethod
+    def get_task_factory(self) -> Optional[Callable[[AbstractEventLoop, Generator[Any, None, _T]], Future[_T]]]: ...
     # Methods for interacting with threads
     @abstractmethod
     def call_soon_threadsafe(self, callback: Callable[..., Any], *args: Any) -> Handle: ...

--- a/stdlib/3.4/asyncio/events.pyi
+++ b/stdlib/3.4/asyncio/events.pyi
@@ -1,3 +1,4 @@
+import sys
 from typing import Any, Awaitable, TypeVar, List, Callable, Tuple, Union, Dict, Generator, overload, Optional
 from abc import ABCMeta, abstractmethod
 from asyncio.futures import Future
@@ -55,8 +56,9 @@ class AbstractEventLoop(metaclass=ABCMeta):
     @abstractmethod
     def time(self) -> float: ...
     # Future methods
-    @abstractmethod
-    def create_future(self) -> Future[Any]: ...
+    if sys.version_info > (3, 5):
+        @abstractmethod
+        def create_future(self) -> Future[Any]: ...
     # Tasks methods
     @abstractmethod
     def create_task(self, coro: Union[Future[_T], Generator[Any, None, _T]]) -> Task[_T]: ...


### PR DESCRIPTION
create_future, create_task, set_task_factory, get_task_factory