### PR TITLE
Make all single-constraint TypeVars to use bounds

### DIFF
--- a/stdlib/2and3/plistlib.pyi
+++ b/stdlib/2and3/plistlib.pyi
@@ -9,7 +9,7 @@ from enum import Enum
 import sys
 
 mm = MutableMapping[str, Any]
-_D = TypeVar('_D', mm)
+_D = TypeVar('_D', bound=mm)
 if sys.version_info >= (3,):
     _Path = str
 else:

--- a/stdlib/3/unittest/__init__.pyi
+++ b/stdlib/3/unittest/__init__.pyi
@@ -12,7 +12,7 @@ from contextlib import ContextManager
 
 
 _T = TypeVar('_T')
-_FT = TypeVar('_FT', Callable[[Any], Any])
+_FT = TypeVar('_FT', bound=Callable[[Any], Any])
 
 
 def skip(reason: str) -> Callable[[_FT], _FT]: ...


### PR DESCRIPTION
According to the documentation in the typing module, TypeVars cannot have only a single constraint. Attempting to do so will actually result in an exception at runtime. (However, this error is currently ignored by mypy -- see https://github.com/python/mypy/pull/2626 for a related pending pull request).

This commit changes all instances of TypeVars using a single constraint (e.g. `T = TypeVar('T', Foo)`) to use bounds instead (e.g. `T = TypeVar('T', bound=Foo)`.

This seems to be the correct fix for plistlib after reading the module docs, but it's less obvious this is correct for unittest. The unittest module originally had `_FT = TypeVar('_FT', Callable[[Any], Any])` -- an alternative fix would have been to do `_FT = Callable[[Any], Any]`.

Although I'm not entirely sure what it means to have a bound be a Callable, I decided to make the assumption that the original authors probably meant to use TypeVars instead of type aliases for a reason (possibly to handle classes implementing `__call__`?)