### PR TITLE
Revert "Make all single-constraint TypeVars to use bounds"

### DIFF
--- a/stdlib/2and3/plistlib.pyi
+++ b/stdlib/2and3/plistlib.pyi
@@ -9,7 +9,7 @@ from enum import Enum
 import sys
 
 mm = MutableMapping[str, Any]
-_D = TypeVar('_D', bound=mm)
+_D = TypeVar('_D', mm)
 if sys.version_info >= (3,):
     _Path = str
 else:

--- a/stdlib/3/unittest/__init__.pyi
+++ b/stdlib/3/unittest/__init__.pyi
@@ -12,7 +12,7 @@ from contextlib import ContextManager
 
 
 _T = TypeVar('_T')
-_FT = TypeVar('_FT', bound=Callable[[Any], Any])
+_FT = TypeVar('_FT', Callable[[Any], Any])
 
 
 def skip(reason: str) -> Callable[[_FT], _FT]: ...


### PR DESCRIPTION
Reverts python/typeshed#804

Reason: until https://github.com/python/mypy/issues/1551 is fixed this gives an error whenever `@skip()` is used.