### PR TITLE
RawConfigParser.items

### DIFF
--- a/stdlib/3/configparser.pyi
+++ b/stdlib/3/configparser.pyi
@@ -104,6 +104,9 @@ class RawConfigParser(_parser):
     def get(self, section: str, option: str, *, raw: bool = ..., vars: _section = ..., fallback: str = ...) -> str:  # type: ignore
         ...
 
+    # This is incompatible with Mapping so we ignore the type.
+    def items(self, section: str, raw: bool = ..., vars: _section = ...) -> Iterable[Tuple[str, str]]: ...  # type: ignore
+
     def set(self, section: str, option: str, value: str) -> None: ...
 
     def write(self,


### PR DESCRIPTION
The corresponding line is already present in the Python 2 ConfigParser stubs.