### PR TITLE
Match python2 assert*IsInstance signatures with isinstance

### DIFF
--- a/stdlib/2/unittest.pyi
+++ b/stdlib/2/unittest.pyi
@@ -6,7 +6,7 @@
 
 from typing import (
     Any, Callable, Dict, Iterable, Tuple, List, TextIO, Sequence,
-    overload, Set, TypeVar, Pattern
+    overload, Set, TypeVar, Union, Pattern
 )
 from abc import abstractmethod, ABCMeta
 
@@ -123,9 +123,9 @@ class TestCase(Testable):
                  msg: object = ...) -> None: ...
     def assertNotIn(self, first: _T, second: Iterable[_T],
                     msg: object = ...) -> None: ...
-    def assertIsInstance(self, obj: Any, cls: type,
+    def assertIsInstance(self, obj: Any, cls: Union[type, Tuple[type, ...]],
                          msg: object = ...) -> None: ...
-    def assertNotIsInstance(self, obj: Any, cls: type,
+    def assertNotIsInstance(self, obj: Any, cls: Union[type, Tuple[type, ...]],
                             msg: object = ...) -> None: ...
     def fail(self, msg: object = ...) -> None: ...
     def countTestCases(self) -> int: ...


### PR DESCRIPTION
The python2 unittest `assertIsInstance` and `assertNotIsInstance` stub
did not allow using a tuple of classes, but that behavior is [in the
documentation][1]. This commit copies the type stub for the isinstance
built-in to the stubs for `assertIsInstance` and `assertNotIsInstance`

I made this commit in response to @gvanrossum's request in
python/typeshed#802 (which fixed this issue for python 3) that I apply
the same fix to python 2.

[1]: https://docs.python.org/2.7/library/unittest.html#unittest.TestCase.assertNotIsInstance