### PR TITLE
Remove trailing commas, pytype doesn't like them

### DIFF
--- a/stdlib/2/wsgiref/types.pyi
+++ b/stdlib/2/wsgiref/types.pyi
@@ -27,7 +27,7 @@ WSGIApplication = Callable[
         Dict[_Text, _Text],
         Union[
             Callable[[_Text, List[Tuple[_Text, _Text]]], Callable[[_Text], None]],
-            Callable[[_Text, List[Tuple[_Text, _Text]], _exc_info], Callable[[_Text], None]],
+            Callable[[_Text, List[Tuple[_Text, _Text]], _exc_info], Callable[[_Text], None]]
         ]
     ],
     Iterable[_Text]

--- a/stdlib/3/wsgiref/types.pyi
+++ b/stdlib/3/wsgiref/types.pyi
@@ -26,7 +26,7 @@ WSGIApplication = Callable[
         Dict[str, str],
         Union[
             Callable[[str, List[Tuple[str, str]]], Callable[[Union[bytes, str]], None]],
-            Callable[[str, List[Tuple[str, str]], _exc_info], Callable[[Union[bytes, str]], None]],
+            Callable[[str, List[Tuple[str, str]], _exc_info], Callable[[Union[bytes, str]], None]]
         ]
     ],
     Iterable[Union[bytes, str]],


### PR DESCRIPTION
Fix a bug I introduced when attempting to clean up #825.