### PR TITLE
Expansion of unions inside `params` definition

### DIFF
--- a/third_party/2/requests/api.pyi
+++ b/third_party/2/requests/api.pyi
@@ -1,18 +1,22 @@
 # Stubs for requests.api (Python 2)
 
-from typing import Union, Optional, Iterable, Dict, Tuple
+from typing import Union, Optional, Iterable, Mapping, Tuple
 
 from .models import Response
 
-def request(method: str, url: str, **kwargs) -> Response: ...
+ParamsMappingValueType = Union[str, unicode, int, float, Iterable[Union[str, unicode, int, float]]]
 
+def request(method: str, url: str, **kwargs) -> Response: ...
 def get(url: Union[str, unicode],
         params: Optional[
-            Union[Dict[Union[str, unicode, int, float], Union[str, unicode, int, float, Iterable[Union[str, unicode, int, float]]]],
+            Union[Mapping[Union[str, unicode, int, float], ParamsMappingValueType],
                   Union[str, unicode],
-                  Tuple[Union[str, unicode, int, float], Union[str, unicode, int, float, Iterable[Union[str, unicode, int, float]]]]]] = None,
+                  Tuple[Union[str, unicode, int, float], ParamsMappingValueType],
+                  Mapping[str, ParamsMappingValueType],
+                  Mapping[unicode, ParamsMappingValueType],
+                  Mapping[int, ParamsMappingValueType],
+                  Mapping[float, ParamsMappingValueType]]] = None,
         **kwargs) -> Response: ...
-
 def options(url: Union[str, unicode], **kwargs) -> Response: ...
 def head(url: Union[str, unicode], **kwargs) -> Response: ...
 def post(url: Union[str, unicode], data=..., json=...,

--- a/third_party/3/requests/api.pyi
+++ b/third_party/3/requests/api.pyi
@@ -4,12 +4,19 @@ from typing import Optional, Union, Any, Iterable, Mapping, Tuple
 
 from .models import Response
 
+ParametersMappingValueType = Union[str, bytes, int, float, Iterable[Union[str, bytes, int, float]]]
+
 def request(method: str, url: str, **kwargs) -> Response: ...
 def get(url: Union[str, bytes],
-        params: Optional[Union[str, bytes, Mapping[Union[str, bytes], Union[str, bytes]], Mapping[str, str], Mapping[str, bytes], Mapping[bytes, str], Mapping[bytes, bytes]]]=None,
-                Dict[Union[str, bytes, int, float], Union[str, bytes, int, float, Iterable[Union[str, bytes, int, float]]]],
+        params: Optional[
+            Union[
+                Mapping[Union[str, bytes, int, float], ParametersMappingValueType],
                 Union[str, bytes],
-                Tuple[Union[str, bytes, int, float], Union[str, bytes, int, float, Iterable[Union[str, bytes, int, float]]]]]] = None,
+                Tuple[Union[str, bytes, int, float], ParametersMappingValueType],
+                Mapping[str, ParametersMappingValueType],
+                Mapping[bytes, ParametersMappingValueType],
+                Mapping[int, ParametersMappingValueType],
+                Mapping[float, ParametersMappingValueType]]]=None,
         **kwargs) -> Response: ...
 def options(url: str, **kwargs) -> Response: ...
 def head(url: str, **kwargs) -> Response: ...

--- a/third_party/3/requests/api.pyi
+++ b/third_party/3/requests/api.pyi
@@ -4,19 +4,19 @@ from typing import Optional, Union, Any, Iterable, Mapping, Tuple
 
 from .models import Response
 
-ParametersMappingValueType = Union[str, bytes, int, float, Iterable[Union[str, bytes, int, float]]]
+ParamsMappingValueType = Union[str, bytes, int, float, Iterable[Union[str, bytes, int, float]]]
 
 def request(method: str, url: str, **kwargs) -> Response: ...
 def get(url: Union[str, bytes],
         params: Optional[
             Union[
-                Mapping[Union[str, bytes, int, float], ParametersMappingValueType],
+                Mapping[Union[str, bytes, int, float], ParamsMappingValueType],
                 Union[str, bytes],
-                Tuple[Union[str, bytes, int, float], ParametersMappingValueType],
-                Mapping[str, ParametersMappingValueType],
-                Mapping[bytes, ParametersMappingValueType],
-                Mapping[int, ParametersMappingValueType],
-                Mapping[float, ParametersMappingValueType]]]=None,
+                Tuple[Union[str, bytes, int, float], ParamsMappingValueType],
+                Mapping[str, ParamsMappingValueType],
+                Mapping[bytes, ParamsMappingValueType],
+                Mapping[int, ParamsMappingValueType],
+                Mapping[float, ParamsMappingValueType]]]=None,
         **kwargs) -> Response: ...
 def options(url: str, **kwargs) -> Response: ...
 def head(url: str, **kwargs) -> Response: ...

--- a/third_party/3/requests/api.pyi
+++ b/third_party/3/requests/api.pyi
@@ -1,6 +1,6 @@
 # Stubs for requests.api (Python 3)
 
-from typing import Optional, Union, Any, Iterable, Dict, Tuple
+from typing import Optional, Union, Any, Iterable, Mapping, Tuple
 
 from .models import Response
 
@@ -11,6 +11,12 @@ def get(url: Union[str, bytes],
                 Dict[Union[str, bytes, int, float], Union[str, bytes, int, float, Iterable[Union[str, bytes, int, float]]]],
                 Union[str, bytes],
                 Tuple[Union[str, bytes, int, float], Union[str, bytes, int, float, Iterable[Union[str, bytes, int, float]]]]]] = None,
+                               Mapping[Union[str, bytes], Union[str, bytes]],
+                               Mapping[str, str],
+                               Mapping[str, bytes],
+                               Mapping[bytes, str],
+                               Mapping[bytes, bytes]
+                               ]]=None,
         **kwargs) -> Response: ...
 def options(url: str, **kwargs) -> Response: ...
 def head(url: str, **kwargs) -> Response: ...

--- a/third_party/3/requests/api.pyi
+++ b/third_party/3/requests/api.pyi
@@ -6,17 +6,10 @@ from .models import Response
 
 def request(method: str, url: str, **kwargs) -> Response: ...
 def get(url: Union[str, bytes],
-        params: Optional[
-            Union[
+        params: Optional[Union[str, bytes, Mapping[Union[str, bytes], Union[str, bytes]], Mapping[str, str], Mapping[str, bytes], Mapping[bytes, str], Mapping[bytes, bytes]]]=None,
                 Dict[Union[str, bytes, int, float], Union[str, bytes, int, float, Iterable[Union[str, bytes, int, float]]]],
                 Union[str, bytes],
                 Tuple[Union[str, bytes, int, float], Union[str, bytes, int, float, Iterable[Union[str, bytes, int, float]]]]]] = None,
-                               Mapping[Union[str, bytes], Union[str, bytes]],
-                               Mapping[str, str],
-                               Mapping[str, bytes],
-                               Mapping[bytes, str],
-                               Mapping[bytes, bytes]
-                               ]]=None,
         **kwargs) -> Response: ...
 def options(url: str, **kwargs) -> Response: ...
 def head(url: str, **kwargs) -> Response: ...


### PR DESCRIPTION
Due to `Dict` / `Mapping` type invariance it's necessary to include other variants of `Union[str, bytes], Union[str, bytes]`. Also I changed from `Dict` to `Mapping` as `requests` should not modify passed mapping