### PR TITLE
Add stub for os.get_terminal_size in python3

### DIFF
--- a/stdlib/3/os/__init__.pyi
+++ b/stdlib/3/os/__init__.pyi
@@ -382,5 +382,7 @@ if sys.version_info >= (3, 3):
               dir_fd: int = ...) -> Iterator[Tuple[AnyStr, List[AnyStr],
                                              List[AnyStr], int]]: ...  # Unix only
 
+    def get_terminal_size(fd: int) -> Tuple[int, int]: ...
+
 if sys.version_info >= (3, 4):
     def cpu_count() -> Optional[int]: ...


### PR DESCRIPTION
This PR adds a stub for `os.get_terminal_size`. A quick search on the [typeshed repo](https://github.com/python/typeshed/search?utf8=%E2%9C%93&q=get_terminal_size) shows that its currently missing. The API has been available [since 3.3](https://docs.python.org/3/library/os.html#os.get_terminal_size).

Notice that the function actually returns `os.terminal_size`, a subclass of `Tuple`, but I wasn't sure if that should be stubbed out, too or if the simple `Tuple[int, int]` was enough. Let me know and I'll make changes accordingly.