### PR TITLE
Fix returned decoder/encoder types in codecs

### DIFF
--- a/stdlib/2/codecs.pyi
+++ b/stdlib/2/codecs.pyi
@@ -30,7 +30,7 @@ _decode_type = Callable[[_encoded], _decoded]  # signature of Codec().decode
 _stream_reader_type = Callable[[BinaryIO], 'StreamReader']  # signature of StreamReader __init__
 _stream_writer_type = Callable[[BinaryIO], 'StreamWriter']  # signature of StreamWriter __init__
 _incremental_encoder_type = Callable[[], 'IncrementalEncoder']  # signature of IncrementalEncoder __init__
-_incremental_decode_type = Callable[[], 'IncrementalDecoder']  # signature of IncrementalDecoder __init__
+_incremental_decoder_type = Callable[[], 'IncrementalDecoder']  # signature of IncrementalDecoder __init__
 
 
 def encode(obj: _decoded, encoding: str = ..., errors: str = ...) -> _encoded:
@@ -41,22 +41,22 @@ def decode(obj: _encoded, encoding: str = ..., errors: str = ...) -> _decoded:
 def lookup(encoding: str) -> 'CodecInfo':
     ...
 class CodecInfo(Tuple[_encode_type, _decode_type, _stream_reader_type, _stream_writer_type]):
-    def __init__(self, encode: _encode_type, decode: _decode_type, streamreader: _stream_reader_type = ..., streamwriter: _stream_writer_type = ..., incrementalencoder: _incremental_encoder_type = ..., incrementaldecoder: _incremental_decode_type = ..., name: str = ...) -> None: ...
+    def __init__(self, encode: _encode_type, decode: _decode_type, streamreader: _stream_reader_type = ..., streamwriter: _stream_writer_type = ..., incrementalencoder: _incremental_encoder_type = ..., incrementaldecoder: _incremental_decoder_type = ..., name: str = ...) -> None: ...
     encode = ...  # type: _encode_type
     decode = ...  # type: _decode_type
     streamreader = ...  # type: _stream_reader_type
     streamwriter = ...  # type: _stream_writer_type
     incrementalencoder = ...  # type: _incremental_encoder_type
-    incrementaldecoder = ...  # type: _incremental_decode_type
+    incrementaldecoder = ...  # type: _incremental_decoder_type
     name = ...  # type: str
 
 def getencoder(encoding: str) -> _encode_type:
     ...
-def getdecoder(encoding: str) -> _encode_type:
+def getdecoder(encoding: str) -> _decode_type:
     ...
 def getincrementalencoder(encoding: str) -> _incremental_encoder_type:
     ...
-def getincrementaldecoder(encoding: str) -> _incremental_encoder_type:
+def getincrementaldecoder(encoding: str) -> _incremental_decoder_type:
     ...
 def getreader(encoding: str) -> _stream_reader_type:
     ...

--- a/stdlib/3/codecs.pyi
+++ b/stdlib/3/codecs.pyi
@@ -29,7 +29,7 @@ _decode_type = Callable[[_encoded], _decoded]  # signature of Codec().decode
 _stream_reader_type = Callable[[BinaryIO], 'StreamReader']  # signature of StreamReader __init__
 _stream_writer_type = Callable[[BinaryIO], 'StreamWriter']  # signature of StreamWriter __init__
 _incremental_encoder_type = Callable[[], 'IncrementalEncoder']  # signature of IncrementalEncoder __init__
-_incremental_decode_type = Callable[[], 'IncrementalDecoder']  # signature of IncrementalDecoder __init__
+_incremental_decoder_type = Callable[[], 'IncrementalDecoder']  # signature of IncrementalDecoder __init__
 
 
 def encode(obj: _decoded, encoding: str = ..., errors: str = ...) -> _encoded:
@@ -40,7 +40,7 @@ def decode(obj: _encoded, encoding: str = ..., errors: str = ...) -> _decoded:
 def lookup(encoding: str) -> 'CodecInfo':
     ...
 class CodecInfo(Tuple[_encode_type, _decode_type, _stream_reader_type, _stream_writer_type]):
-    def __init__(self, encode: _encode_type, decode: _decode_type, streamreader: _stream_reader_type = ..., streamwriter: _stream_writer_type = ..., incrementalencoder: _incremental_encoder_type = ..., incrementaldecoder: _incremental_decode_type = ..., name: str = ...) -> None:
+    def __init__(self, encode: _encode_type, decode: _decode_type, streamreader: _stream_reader_type = ..., streamwriter: _stream_writer_type = ..., incrementalencoder: _incremental_encoder_type = ..., incrementaldecoder: _incremental_decoder_type = ..., name: str = ...) -> None:
         self.encode = encode
         self.decode = decode
         self.streamreader = streamreader
@@ -51,11 +51,11 @@ class CodecInfo(Tuple[_encode_type, _decode_type, _stream_reader_type, _stream_w
 
 def getencoder(encoding: str) -> _encode_type:
     ...
-def getdecoder(encoding: str) -> _encode_type:
+def getdecoder(encoding: str) -> _decode_type:
     ...
 def getincrementalencoder(encoding: str) -> _incremental_encoder_type:
     ...
-def getincrementaldecoder(encoding: str) -> _incremental_encoder_type:
+def getincrementaldecoder(encoding: str) -> _incremental_decoder_type:
     ...
 def getreader(encoding: str) -> _stream_reader_type:
     ...


### PR DESCRIPTION
This prevents false alarms like:
```
"IncrementalEncoder" has no attribute "decode"; maybe "encode"?
```