### PR TITLE
Removed 'function' not present in builtins

### DIFF
--- a/stdlib/2/__builtin__.pyi
+++ b/stdlib/2/__builtin__.pyi
@@ -488,11 +488,6 @@ class tuple(Sequence[_T_co], Generic[_T_co]):
     def count(self, x: Any) -> int: ...
     def index(self, x: Any) -> int: ...
 
-class function:
-    # TODO name of the class (corresponds to Python 'function' class)
-    __name__ = ...  # type: str
-    __module__ = ...  # type: str
-
 class list(MutableSequence[_T], Generic[_T]):
     @overload
     def __init__(self) -> None: ...

--- a/stdlib/3/builtins.pyi
+++ b/stdlib/3/builtins.pyi
@@ -508,13 +508,6 @@ class tuple(Sequence[_T_co], Generic[_T_co]):
     else:
         def index(self, x: Any) -> int: ...
 
-class function:
-    # TODO not defined in builtins!
-    __name__ = ...  # type: str
-    __qualname__ = ...  # type: str
-    __module__ = ...  # type: str
-    __code__ = ...  # type: Any
-
 class list(MutableSequence[_T], Generic[_T]):
     @overload
     def __init__(self) -> None: ...


### PR DESCRIPTION
If you need it, use `types.FunctionType` instead.