### PR TITLE
Update type of six.string_types to Union[str, unicode]

### DIFF
--- a/third_party/2/six/__init__.pyi
+++ b/third_party/2/six/__init__.pyi
@@ -27,7 +27,7 @@ PY2 = True
 PY3 = False
 PY34 = False
 
-string_types = Union[str, unicode],
+string_types = (str, unicode)
 integer_types = (int, long)
 class_types = (type, types.ClassType)
 text_type = unicode

--- a/third_party/2/six/__init__.pyi
+++ b/third_party/2/six/__init__.pyi
@@ -27,7 +27,7 @@ PY2 = True
 PY3 = False
 PY34 = False
 
-string_types = basestring,
+string_types = Union[str, unicode],
 integer_types = (int, long)
 class_types = (type, types.ClassType)
 text_type = unicode


### PR DESCRIPTION
This PR updates the type stub for `six.string_types` to `(Union[str, unicode], )`. This is _technically_ inaccurate, since `six.string_types[0] is basestring`, but as @JukkaL pointed out [here](https://github.com/python/typeshed/pull/138#issuecomment-219526689), expressing `basestring` as a union better expresses its semantics. 

While the caveats raised in #138 are valid, I think none of them apply to the six stub, since `text_type` already does not mention `basestring`.  See also https://github.com/python/mypy/issues/1537

## Testing

```
$ cat getattr_six.py 
import six
from typing import Any

def c(a, b):  # type: (Any, Any) -> int
    if isinstance(a, six.string_types):
        return getattr(b, a)
    else:
        return b[a]

$ mypy --py2 getattr_six.py --custom-typeshed-dir=/Users/lucaswiman/opensource/typeshed
$ mypy --py2 getattr_six.py 
getattr_six.py: note: In function "c":
getattr_six.py:6: error: Argument 2 to "getattr" has incompatible type "basestring"; expected "unicode"
```

cc @benjaminp (author of `six`)