### PR TITLE
Fixes to subprocess.CompletedProcess

### DIFF
--- a/stdlib/3/subprocess.pyi
+++ b/stdlib/3/subprocess.pyi
@@ -8,14 +8,14 @@ from types import TracebackType
 
 if sys.version_info >= (3, 5):
     class CompletedProcess:
-        args = ...  # type: Union[List, str]
+        args = ...  # type: Union[Sequence[str], str]
         returncode = ...  # type: int
-        stdout = ...  # type: Any
-        stderr = ...  # type: Any
+        stdout = ...  # type: Union[str, bytes, None]
+        stderr = ...  # type: Union[str, bytes, None]
         def __init__(self, args: Union[List, str],
                      returncode: int,
-                     stdout: Union[str, bytes],
-                     stderr: Union[str, bytes]) -> None: ...
+                     stdout: Union[str, bytes, None] = ...,
+                     stderr: Union[str, bytes, None] = ...) -> None: ...
         def check_returncode(self) -> None: ...
 
     # Nearly same args as Popen.__init__ except for timeout, input, and check

--- a/stdlib/3/subprocess.pyi
+++ b/stdlib/3/subprocess.pyi
@@ -10,8 +10,8 @@ if sys.version_info >= (3, 5):
     class CompletedProcess:
         args = ...  # type: Union[Sequence[str], str]
         returncode = ...  # type: int
-        stdout = ...  # type: Union[str, bytes, None]
-        stderr = ...  # type: Union[str, bytes, None]
+        stdout = ...  # type: Any
+        stderr = ...  # type: Any
         def __init__(self, args: Union[List, str],
                      returncode: int,
                      stdout: Union[str, bytes, None] = ...,


### PR DESCRIPTION
- The stdout and stderr arguments are optional and default to None.
- args can be any sequence that was passed in to run(), but it is always a sequence of strings. (Actually it seems like it can also be bytes, but I'd prefer to change that in another PR since it would affect a bunch of other functions in this module.)
- The stdout and stderr attributes of CompletedProcess are the same type as the constructor arguments.

For reference: https://github.com/python/cpython/blob/master/Lib/subprocess.py#L339

```
In [32]: subprocess.run(('true',))
Out[32]: CompletedProcess(args=('true',), returncode=0)

In [33]: cp = subprocess.run(('true',))

In [34]: cp.args
Out[34]: ('true',)

In [35]: cp.stdout

In [36]: cp.stderr

In [37]: cp.returncode
Out[37]: 0
```