### PR TITLE
Fix ClientConnectedCallback in asyncio.stream

### DIFF
--- a/stdlib/3.4/asyncio/streams.pyi
+++ b/stdlib/3.4/asyncio/streams.pyi
@@ -1,12 +1,12 @@
 import socket
-from typing import Any, Callable, Generator, Iterable, Tuple
+from typing import Any, Awaitable, Callable, Generator, Iterable, Optional, Tuple
 
 from . import coroutines
 from . import events
 from . import protocols
 from . import transports
 
-ClientConnectedCallback = Callable[[Tuple[StreamReader, StreamWriter]], None]
+ClientConnectedCallback = Callable[[StreamReader, StreamWriter], Optional[Awaitable[None]]]
 
 
 __all__ = ...  # type: str


### PR DESCRIPTION
According to [`asyncio.start_server` doc](https://docs.python.org/3/library/asyncio-stream.html#asyncio.start_server)
> The client_connected_cb parameter is called with two parameters: client_reader, client_writer. client_reader is a StreamReader object, while client_writer is a StreamWriter object. The client_connected_cb parameter can either be a plain callback function or a coroutine function; [...].

With this change the following code passes.

```
import asyncio

MSG = b'hello'

def f1(reader: asyncio.StreamReader,
       writer: asyncio.StreamWriter):
    writer.write(MSG)

@asyncio.coroutine
def f2(reader: asyncio.StreamReader,
       writer: asyncio.StreamWriter):
    writer.write(MSG)
    yield from writer.drain()

async def f3(reader: asyncio.StreamReader,
             writer: asyncio.StreamWriter):
    writer.write(MSG)
    await writer.drain()

asyncio.start_server(f1, '127.0.0.1', 8081)
asyncio.start_server(f2, '127.0.0.1', 8082)
asyncio.start_server(f3, '127.0.0.1', 8083)
```