### PR TITLE
add Counter, Deque, ChainMap

### DIFF
--- a/stdlib/2/typing.pyi
+++ b/stdlib/2/typing.pyi
@@ -30,6 +30,8 @@ List = TypeAlias(object)
 Dict = TypeAlias(object)
 DefaultDict = TypeAlias(object)
 Set = TypeAlias(object)
+Counter = TypeAlias(object)
+Deque = TypeAlias(object)
 
 # Predefined type variables.
 AnyStr = TypeVar('AnyStr', str, unicode)

--- a/stdlib/3/typing.pyi
+++ b/stdlib/3/typing.pyi
@@ -32,6 +32,10 @@ List = TypeAlias(object)
 Dict = TypeAlias(object)
 DefaultDict = TypeAlias(object)
 Set = TypeAlias(object)
+Counter = TypeAlias(object)
+Deque = TypeAlias(object)
+if sys.version_info >= (3, 3):
+    ChainMap = TypeAlias(object)
 
 # Predefined type variables.
 AnyStr = TypeVar('AnyStr', str, bytes)


### PR DESCRIPTION
From https://github.com/python/typing/pull/366, cc @ilevkivskyi. Deque was missing too; it was added to typing recently.

This will presumably also need some changes in mypy and pytype; I'll work on mypy next.