### PR TITLE
Function bodies should be empty

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,6 +127,7 @@ Style conventions for stub files are different from PEP 8. The general
 rule is that they should be as concise as possible.  Specifically:
 * there is no line length limit;
 * prefer long lines over elaborate indentation;
+* all function bodies should be empty;
 * prefer ``...`` over ``pass``;
 * prefer ``...`` on the same line as the class/function signature;
 * avoid vertical whitespace between consecutive module-level functions,


### PR DESCRIPTION
I've seen some stubs like

```
class X:
    def __init__(self, x: str) -> None:
        self.x = x
        self.y = 0
```
I think this should be written instead as
```
class X:
    x: str
    y: int
    def __init__(self, x: str) -> None: ...
```
If the first style is preferred we should mention that in `CONTRIBUTING` instead.