### PR TITLE
Add missing attributes to urllib.response.addinfourl

### DIFF
--- a/stdlib/3/urllib/response.pyi
+++ b/stdlib/3/urllib/response.pyi
@@ -4,5 +4,8 @@ from typing import BinaryIO, Mapping, Optional
 from types import TracebackType
 
 class addinfourl(BinaryIO):
+    headers = ...  # type: Mapping[str, str]
+    url = ...  # type: str
+    code = ...  # type: int
     def info(self) -> Mapping[str, str]: ...
     def geturl(self) -> str: ...


### PR DESCRIPTION
`urllib.response.addinfourl` has several attributes.  Although these are undocumented, [many people][1] [have used][2] [it.][3]

[1]: https://github.com/search?utf8=%E2%9C%93&q=urlopen+resp.url+language%3Apython&type=Code&ref=searchresults
[2]: https://github.com/search?utf8=%E2%9C%93&q=urlopen%28%29.headers+language%3Apython&type=Code&ref=searchresults
[3]: https://github.com/search?utf8=%E2%9C%93&q=urlopen%28%29.code+language%3Apython&type=Code&ref=searchresults