### PR TITLE
Remove unnecessary --fast-parser flag to mypy

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ from the Python 2 virtualenv to the Python 3 one:
 $ cp .venv2/bin/pytype .venv3/bin/pytype
 $ source .venv3/bin/activate
 (.venv3)$ ./runtests.sh
-running mypy --python-version 3.6 --strict-optional --fast-parser # with 479 files
+running mypy --python-version 3.6 --strict-optional # with 479 files
 running mypy --python-version 3.5 --strict-optional # with 469 files
 running mypy --python-version 3.4 --strict-optional # with 469 files
 running mypy --python-version 3.3 --strict-optional # with 454 files

--- a/tests/mypy_test.py
+++ b/tests/mypy_test.py
@@ -124,8 +124,6 @@ def main():
             runs += 1
             flags = ['--python-version', '%d.%d' % (major, minor)]
             flags.append('--strict-optional')
-            if (major, minor) >= (3, 6):
-                flags.append('--fast-parser')
             # flags.append('--warn-unused-ignores')  # Fast parser and regular parser disagree.
             sys.argv = ['mypy'] + flags + files
             if args.verbose:


### PR DESCRIPTION
It's now on by default, and the flag will eventually be removed.