### PR TITLE
Add __annotations__ to Python 3

### DIFF
--- a/stdlib/3/builtins.pyi
+++ b/stdlib/3/builtins.pyi
@@ -36,7 +36,7 @@ class object:
     __slots__ = ...  # type: Optional[Union[str, Iterable[str]]]
     __module__ = ...  # type: str
     if sys.version_info >= (3, 6):
-        __annotations__ = ... # type: Dict[str, Any]
+        __annotations__ = ...  # type: Dict[str, Any]
 
     def __init__(self) -> None: ...
     def __new__(cls) -> Any: ...
@@ -554,7 +554,7 @@ class function:
     __qualname__ = ...  # type: str
     __module__ = ...  # type: str
     __code__ = ...  # type: Any
-    __annotations__ = ... # type: Dict[str, Any]
+    __annotations__ = ...  # type: Dict[str, Any]
 
 class list(MutableSequence[_T], Generic[_T]):
     @overload

--- a/stdlib/3/builtins.pyi
+++ b/stdlib/3/builtins.pyi
@@ -35,6 +35,8 @@ class object:
     __dict__ = ...  # type: Dict[str, Any]
     __slots__ = ...  # type: Optional[Union[str, Iterable[str]]]
     __module__ = ...  # type: str
+    if sys.version_info >= (3, 6):
+        __annotations__ = ... # type: Dict[str, Any]
 
     def __init__(self) -> None: ...
     def __new__(cls) -> Any: ...
@@ -552,6 +554,7 @@ class function:
     __qualname__ = ...  # type: str
     __module__ = ...  # type: str
     __code__ = ...  # type: Any
+    __annotations__ = ... # type: Dict[str, Any]
 
 class list(MutableSequence[_T], Generic[_T]):
     @overload


### PR DESCRIPTION
Otherwise mypy complains about ``MyClass.__annotations__`` etc.
(this is also necessary to typecheck mypy tests)