### PR TITLE
Fix click annotation syntax and add missing keyword arguments to subprocess (new in 3.76)

### DIFF
--- a/stdlib/3/subprocess.pyi
+++ b/stdlib/3/subprocess.pyi
@@ -1,10 +1,9 @@
 # Stubs for subprocess
 
-# Based on http://docs.python.org/3.5/library/subprocess.html
+# Based on http://docs.python.org/3.6/library/subprocess.html
 import sys
 from typing import Sequence, Any, AnyStr, Mapping, Callable, Tuple, IO, Optional, Union, List, Type
 from types import TracebackType
-
 
 if sys.version_info >= (3, 5):
     class CompletedProcess:
@@ -18,27 +17,52 @@ if sys.version_info >= (3, 5):
                      stderr: Union[str, bytes, None] = ...) -> None: ...
         def check_returncode(self) -> None: ...
 
-    # Nearly same args as Popen.__init__ except for timeout, input, and check
-    def run(args: Union[str, Sequence[str]],
-            timeout: float = ...,
-            input: Union[str, bytes] = ...,
-            check: bool = ...,
-            bufsize: int = ...,
-            executable: str = ...,
-            stdin: Any = ...,
-            stdout: Any = ...,
-            stderr: Any = ...,
-            preexec_fn: Callable[[], Any] = ...,
-            close_fds: bool = ...,
-            shell: bool = ...,
-            cwd: str = ...,
-            env: Mapping[str, str] = ...,
-            universal_newlines: bool = ...,
-            startupinfo: Any = ...,
-            creationflags: int = ...,
-            restore_signals: bool = ...,
-            start_new_session: bool = ...,
-            pass_fds: Any = ...) -> CompletedProcess: ...
+    if sys.version_info >= (3, 6):
+        # Nearly same args as Popen.__init__ except for timeout, input, and check
+        def run(args: Union[str, Sequence[str]],
+                timeout: float = ...,
+                input: Union[str, bytes] = ...,
+                check: bool = ...,
+                bufsize: int = ...,
+                executable: str = ...,
+                stdin: Any = ...,
+                stdout: Any = ...,
+                stderr: Any = ...,
+                preexec_fn: Callable[[], Any] = ...,
+                close_fds: bool = ...,
+                shell: bool = ...,
+                cwd: str = ...,
+                env: Mapping[str, str] = ...,
+                universal_newlines: bool = ...,
+                startupinfo: Any = ...,
+                creationflags: int = ...,
+                restore_signals: bool = ...,
+                start_new_session: bool = ...,
+                pass_fds: Any = ...,
+                encoding: str = ...,
+                errors: str = ...) -> CompletedProcess: ...
+    else:
+        # Nearly same args as Popen.__init__ except for timeout, input, and check
+        def run(args: Union[str, Sequence[str]],
+                timeout: float = ...,
+                input: Union[str, bytes] = ...,
+                check: bool = ...,
+                bufsize: int = ...,
+                executable: str = ...,
+                stdin: Any = ...,
+                stdout: Any = ...,
+                stderr: Any = ...,
+                preexec_fn: Callable[[], Any] = ...,
+                close_fds: bool = ...,
+                shell: bool = ...,
+                cwd: str = ...,
+                env: Mapping[str, str] = ...,
+                universal_newlines: bool = ...,
+                startupinfo: Any = ...,
+                creationflags: int = ...,
+                restore_signals: bool = ...,
+                start_new_session: bool = ...,
+                pass_fds: Any = ...) -> CompletedProcess: ...
 
 # Same args as Popen.__init__
 if sys.version_info >= (3, 3):
@@ -207,24 +231,46 @@ class Popen:
     pid = 0
     returncode = 0
 
-    def __init__(self,
-                  args: Union[str, Sequence[str]],
-                  bufsize: int = ...,
-                  executable: Optional[str] = ...,
-                  stdin: Optional[Any] = ...,
-                  stdout: Optional[Any] = ...,
-                  stderr: Optional[Any] = ...,
-                  preexec_fn: Optional[Callable[[], Any]] = ...,
-                  close_fds: bool = ...,
-                  shell: bool = ...,
-                  cwd: Optional[str] = ...,
-                  env: Optional[Mapping[str, str]] = ...,
-                  universal_newlines: bool = ...,
-                  startupinfo: Optional[Any] = ...,
-                  creationflags: int = ...,
-                  restore_signals: bool = ...,
-                  start_new_session: bool = ...,
-                  pass_fds: Any = ...) -> None: ...
+    if sys.version_info >= (3, 6):
+        def __init__(self,
+                     args: Union[str, Sequence[str]],
+                     bufsize: int = ...,
+                     executable: Optional[str] = ...,
+                     stdin: Optional[Any] = ...,
+                     stdout: Optional[Any] = ...,
+                     stderr: Optional[Any] = ...,
+                     preexec_fn: Optional[Callable[[], Any]] = ...,
+                     close_fds: bool = ...,
+                     shell: bool = ...,
+                     cwd: Optional[str] = ...,
+                     env: Optional[Mapping[str, str]] = ...,
+                     universal_newlines: bool = ...,
+                     startupinfo: Optional[Any] = ...,
+                     creationflags: int = ...,
+                     restore_signals: bool = ...,
+                     start_new_session: bool = ...,
+                     pass_fds: Any = ...,
+                     encoding: str = ...,
+                     errors: str = ...) -> None: ...
+    else:
+        def __init__(self,
+                     args: Union[str, Sequence[str]],
+                     bufsize: int = ...,
+                     executable: Optional[str] = ...,
+                     stdin: Optional[Any] = ...,
+                     stdout: Optional[Any] = ...,
+                     stderr: Optional[Any] = ...,
+                     preexec_fn: Optional[Callable[[], Any]] = ...,
+                     close_fds: bool = ...,
+                     shell: bool = ...,
+                     cwd: Optional[str] = ...,
+                     env: Optional[Mapping[str, str]] = ...,
+                     universal_newlines: bool = ...,
+                     startupinfo: Optional[Any] = ...,
+                     creationflags: int = ...,
+                     restore_signals: bool = ...,
+                     start_new_session: bool = ...,
+                     pass_fds: Any = ...) -> None: ...
 
     def poll(self) -> int: ...
     if sys.version_info >= (3, 3):

--- a/third_party/3.6/click/core.pyi
+++ b/third_party/3.6/click/core.pyi
@@ -43,32 +43,32 @@ def iter_params_for_processing(
 
 
 class Context:
-    parent: Optional['Context']
-    command: 'Command'
-    info_name: Optional[str]
-    params: Dict
-    args: List[str]
-    protected_args: List[str]
-    obj: Any
-    default_map: Mapping[str, Any]
-    invoked_subcommand: Optional[str]
-    terminal_width: Optional[int]
-    max_content_width: Optional[int]
-    allow_extra_args: bool
-    allow_interspersed_args: bool
-    ignore_unknown_options: bool
-    help_option_names: List[str]
-    token_normalize_func: Optional[Callable[[str], str]]
-    resilient_parsing: bool
-    auto_envvar_prefix: Optional[str]
-    color: Optional[bool]
-    _meta: Dict[str, Any]
-    _close_callbacks: List
-    _depth: int
+    parent = ...  # type: Optional['Context']
+    command = ...  # type: 'Command'
+    info_name = ...  # type: Optional[str]
+    params = ...  # type: Dict
+    args = ...  # type: List[str]
+    protected_args = ...  # type: List[str]
+    obj = ...  # type: Any
+    default_map = ...  # type: Mapping[str, Any]
+    invoked_subcommand = ...  # type: Optional[str]
+    terminal_width = ...  # type: Optional[int]
+    max_content_width = ...  # type: Optional[int]
+    allow_extra_args = ...  # type: bool
+    allow_interspersed_args = ...  # type: bool
+    ignore_unknown_options = ...  # type: bool
+    help_option_names = ...  # type: List[str]
+    token_normalize_func = ...  # type: Optional[Callable[[str], str]]
+    resilient_parsing = ...  # type: bool
+    auto_envvar_prefix = ...  # type: Optional[str]
+    color = ...  # type: Optional[bool]
+    _meta = ...  # type: Dict[str, Any]
+    _close_callbacks = ...  # type: List
+    _depth = ...  # type: int
 
     # properties
-    meta: Dict[str, Any]
-    command_path: str
+    meta = ...  # type: Dict[str, Any]
+    command_path = ...  # type: str
 
     def __init__(
         self,
@@ -141,11 +141,11 @@ class Context:
         ...
 
 class BaseCommand:
-    allow_extra_args: bool
-    allow_interspersed_args: bool
-    ignore_unknown_options: bool
-    name: str
-    context_settings: Dict
+    allow_extra_args = ...  # type: bool
+    allow_interspersed_args = ...  # type: bool
+    ignore_unknown_options = ...  # type: bool
+    name = ...  # type: str
+    context_settings = ...  # type: Dict
 
     def __init__(self, name: str, context_settings: Dict = None) -> None:
         ...
@@ -182,13 +182,13 @@ class BaseCommand:
 
 
 class Command(BaseCommand):
-    callback: Optional[Callable]
-    params: List['Parameter']
-    help: Optional[str]
-    epilog: Optional[str]
-    short_help: Optional[str]
-    options_metavar: str
-    add_help_option: bool
+    callback = ...  # type: Optional[Callable]
+    params = ...  # type: List['Parameter']
+    help = ...  # type: Optional[str]
+    epilog = ...  # type: Optional[str]
+    short_help = ...  # type: Optional[str]
+    options_metavar = ...  # type: str
+    add_help_option = ...  # type: bool
 
     def __init__(
         self,
@@ -244,11 +244,11 @@ _Decorator = Callable[[_T], _T]
 
 
 class MultiCommand(Command):
-    no_args_is_help: bool
-    invoke_without_command: bool
-    subcommand_metavar: str
-    chain: bool
-    result_callback: Callable
+    no_args_is_help = ...  # type: bool
+    invoke_without_command = ...  # type: bool
+    subcommand_metavar = ...  # type: str
+    chain = ...  # type: bool
+    result_callback = ...  # type: Callable
 
     def __init__(
         self,
@@ -283,7 +283,7 @@ class MultiCommand(Command):
 
 
 class Group(MultiCommand):
-    commands: Dict[str, Command]
+    commands = ...  # type: Dict[str, Command]
 
     def __init__(
         self, name: str = None, commands: Dict[str, Command] = None, **attrs
@@ -301,7 +301,7 @@ class Group(MultiCommand):
 
 
 class CommandCollection(MultiCommand):
-    sources: List[MultiCommand]
+    sources = ...  # type: List[MultiCommand]
 
     def __init__(
         self, name: str = None, sources: List[MultiCommand] = None, **attrs
@@ -313,22 +313,22 @@ class CommandCollection(MultiCommand):
 
 
 class Parameter:
-    param_type_name: str
-    name: str
-    opts: List[str]
-    secondary_opts: List[str]
-    type: 'ParamType'
-    required: bool
-    callback: Optional[Callable[[Context, 'Parameter', str], Any]]
-    nargs: int
-    multiple: bool
-    expose_value: bool
-    default: Any
-    is_eager: bool
-    metavar: Optional[str]
-    envvar: Union[str, List[str], None]
+    param_type_name = ...  # type: str
+    name = ...  # type: str
+    opts = ...  # type: List[str]
+    secondary_opts = ...  # type: List[str]
+    type = ...  # type: 'ParamType'
+    required = ...  # type: bool
+    callback = ...  # type: Optional[Callable[[Context, 'Parameter', str], Any]]
+    nargs = ...  # type: int
+    multiple = ...  # type: bool
+    expose_value = ...  # type: bool
+    default = ...  # type: Any
+    is_eager = ...  # type: bool
+    metavar = ...  # type: Optional[str]
+    envvar = ...  # type: Union[str, List[str], None]
     # properties
-    human_readable_name: str
+    human_readable_name = ...  # type: str
 
     def __init__(
         self,
@@ -388,17 +388,17 @@ class Parameter:
 
 
 class Option(Parameter):
-    prompt: str  # sic
-    confirmation_prompt: bool
-    hide_input: bool
-    is_flag: bool
-    flag_value: Any
-    is_bool_flag: bool
-    count: bool
-    multiple: bool
-    allow_from_autoenv: bool
-    help: Optional[str]
-    show_default: bool
+    prompt = ...  # type: str  # sic
+    confirmation_prompt = ...  # type: bool
+    hide_input = ...  # type: bool
+    is_flag = ...  # type: bool
+    flag_value = ...  # type: Any
+    is_bool_flag = ...  # type: bool
+    count = ...  # type: bool
+    multiple = ...  # type: bool
+    allow_from_autoenv = ...  # type: bool
+    help = ...  # type: Optional[str]
+    show_default = ...  # type: bool
 
     def __init__(
         self,

--- a/third_party/3.6/click/exceptions.pyi
+++ b/third_party/3.6/click/exceptions.pyi
@@ -4,8 +4,8 @@ from click.core import Context, Parameter
 
 
 class ClickException(Exception):
-    exit_code: int
-    message: str
+    exit_code = ...  # type: int
+    message = ...  # type: str
 
     def __init__(self, message: str) -> None:
         ...
@@ -18,7 +18,7 @@ class ClickException(Exception):
 
 
 class UsageError(ClickException):
-    ctx: Optional[Context]
+    ctx = ...  # type: Optional[Context]
 
     def __init__(self, message: str, ctx: Context = None) -> None:
         ...
@@ -28,8 +28,8 @@ class UsageError(ClickException):
 
 
 class BadParameter(UsageError):
-    param: Optional[Parameter]
-    param_hint: Optional[str]
+    param = ...  # type: Optional[Parameter]
+    param_hint = ...  # type: Optional[str]
 
     def __init__(
         self,
@@ -42,7 +42,7 @@ class BadParameter(UsageError):
 
 
 class MissingParameter(BadParameter):
-    param_type: str  # valid values: 'parameter', 'option', 'argument'
+    param_type = ...  # type: str  # valid values: 'parameter', 'option', 'argument'
 
     def __init__(
         self,
@@ -56,8 +56,8 @@ class MissingParameter(BadParameter):
 
 
 class NoSuchOption(UsageError):
-    option_name: str
-    possibilities: Optional[List[str]]
+    option_name = ...  # type: str
+    possibilities = ...  # type: Optional[List[str]]
 
     def __init__(
         self,
@@ -80,8 +80,8 @@ class BadArgumentUsage(UsageError):
 
 
 class FileError(ClickException):
-    ui_filename: str
-    filename: str
+    ui_filename = ...  # type: str
+    filename = ...  # type: str
 
     def __init__(self, filename: str, hint: str = None) -> None:
         ...

--- a/third_party/3.6/click/formatting.pyi
+++ b/third_party/3.6/click/formatting.pyi
@@ -2,7 +2,7 @@ from contextlib import contextmanager
 from typing import Generator, Iterable, List, Optional, Tuple
 
 
-FORCED_WIDTH: Optional[int]
+FORCED_WIDTH = ...  # type: Optional[int]
 
 
 def measure_table(rows: Iterable[Iterable[str]]) -> Tuple[int, ...]:
@@ -26,10 +26,10 @@ def wrap_text(
 
 
 class HelpFormatter:
-    indent_increment: int
-    width: Optional[int]
-    current_indent: int
-    buffer: List[str]
+    indent_increment = ...  # type: int
+    width = ...  # type: Optional[int]
+    current_indent = ...  # type: int
+    buffer = ...  # type: List[str]
 
     def __init__(
         self,

--- a/third_party/3.6/click/parser.pyi
+++ b/third_party/3.6/click/parser.pyi
@@ -22,16 +22,16 @@ def split_arg_string(string: str) -> List[str]:
 
 
 class Option:
-    dest: str
-    action: str
-    nargs: int
-    const: Any
-    obj: Any
-    prefixes: Set[str]
-    _short_opts: List[str]
-    _long_opts: List[str]
+    dest = ...  # type: str
+    action = ...  # type: str
+    nargs = ...  # type: int
+    const = ...  # type: Any
+    obj = ...  # type: Any
+    prefixes = ...  # type: Set[str]
+    _short_opts = ...  # type: List[str]
+    _long_opts = ...  # type: List[str]
     # properties
-    takes_value: bool
+    takes_value = ...  # type: bool
 
     def __init__(
         self,
@@ -49,9 +49,9 @@ class Option:
 
 
 class Argument:
-    dest: str
-    nargs: int
-    obj: Any
+    dest = ...  # type: str
+    nargs = ...  # type: int
+    obj = ...  # type: Any
 
     def __init__(self, dest: str, nargs: int = 1, obj: Any = None) -> None:
         ...
@@ -61,23 +61,23 @@ class Argument:
 
 
 class ParsingState:
-    opts: Dict[str, Any]
-    largs: List[str]
-    rargs: List[str]
-    order: List[Any]
+    opts = ...  # type: Dict[str, Any]
+    largs = ...  # type: List[str]
+    rargs = ...  # type: List[str]
+    order = ...  # type: List[Any]
 
     def __init__(self, rargs: List[str]) -> None:
         ...
 
 
 class OptionParser:
-    ctx: Optional[Context]
-    allow_interspersed_args: bool
-    ignore_unknown_options: bool
-    _short_opt: Dict[str, Option]
-    _long_opt: Dict[str, Option]
-    _opt_prefixes: Set[str]
-    _args: List[Argument]
+    ctx = ...  # type: Optional[Context]
+    allow_interspersed_args = ...  # type: bool
+    ignore_unknown_options = ...  # type: bool
+    _short_opt = ...  # type: Dict[str, Option]
+    _long_opt = ...  # type: Dict[str, Option]
+    _opt_prefixes = ...  # type: Set[str]
+    _args = ...  # type: List[Argument]
 
     def __init__(self, ctx: Context = None) -> None:
         ...

--- a/third_party/3.6/click/types.pyi
+++ b/third_party/3.6/click/types.pyi
@@ -5,9 +5,9 @@ from click.core import Context, Parameter
 
 
 class ParamType:
-    name: str
-    is_composite: bool
-    envvar_list_splitter: Optional[str]
+    name = ...  # type: str
+    is_composite = ...  # type: bool
+    envvar_list_splitter = ...  # type: Optional[str]
 
     def __call__(
         self,
@@ -57,11 +57,11 @@ class BoolParamType(ParamType):
 
 
 class CompositeParamType(ParamType):
-    arity: int
+    arity = ...  # type: int
 
 
 class Choice(ParamType):
-    choices: Iterable[str]
+    choices = ...  # type: Iterable[str]
     def __init__(self, choices: Iterable[str]) -> None:
         ...
 
@@ -124,7 +124,7 @@ _Func = Callable[[Optional[str]], _F]
 
 
 class FuncParamType(ParamType):
-    func: _Func
+    func = ...  # type: _Func
 
     def __init__(self, func: _Func) -> None:
         ...
@@ -226,7 +226,7 @@ class StringParamType(ParamType):
 
 
 class Tuple(CompositeParamType):
-    types: List[ParamType]
+    types = ...  # type: List[ParamType]
 
     def __init__(self, types: Iterable[Any]) -> None:
         ...

--- a/third_party/3.6/click/utils.pyi
+++ b/third_party/3.6/click/utils.pyi
@@ -22,11 +22,11 @@ def make_default_short_help(help: str, max_length: int = 45):
 
 
 class LazyFile:
-    name: str
-    mode: str
-    encoding: Optional[str]
-    errors: str
-    atomic: bool
+    name = ...  # type: str
+    mode = ...  # type: str
+    encoding = ...  # type: Optional[str]
+    errors = ...  # type: str
+    atomic = ...  # type: bool
 
     def __init__(
         self,
@@ -58,7 +58,7 @@ class LazyFile:
 
 
 class KeepOpenFile(object):
-    _file: IO
+    _file = ...  # type: IO
 
     def __init__(self, file: IO) -> None:
         ...


### PR DESCRIPTION
* Fix click annotation syntax.
* Add the errors and encoding keyword argument to run and Popen in subprocess, those were added in python 3.6