### PR TITLE
TestCase.assertSetEqual() does not accept frozenset

### DIFF
--- a/stdlib/2/unittest.pyi
+++ b/stdlib/2/unittest.pyi
@@ -6,7 +6,7 @@
 
 from typing import (
     Any, Callable, Dict, Iterable, Tuple, List, TextIO, Sequence,
-    overload, Set, TypeVar, Union, Pattern, Type
+    overload, Set, TypeVar, Union, Pattern, Type, AbstractSet
 )
 from abc import abstractmethod, ABCMeta
 
@@ -101,7 +101,7 @@ class TestCase(Testable):
                         msg: object = ...) -> None: ...
     def assertTupleEqual(self, first: Tuple[Any, ...], second: Tuple[Any, ...],
                          msg: object = ...) -> None: ...
-    def assertSetEqual(self, first: Set[Any], second: Set[Any],
+    def assertSetEqual(self, first: AbstractSet[Any], second: AbstractSet[Any],
                        msg: object = ...) -> None: ...
     def assertDictEqual(self, first: Dict[Any, Any], second: Dict[Any, Any],
                         msg: object = ...) -> None: ...

--- a/stdlib/3/unittest/__init__.pyi
+++ b/stdlib/3/unittest/__init__.pyi
@@ -2,7 +2,7 @@
 
 from typing import (
     Any, Callable, Dict, Iterable, Iterator, List, Optional, Pattern, Sequence,
-    Set, TextIO, Tuple, Type, TypeVar, Union,
+    Set, TextIO, Tuple, Type, TypeVar, Union, AbstractSet,
     overload,
 )
 import logging
@@ -130,7 +130,7 @@ class TestCase:
                         msg: Any = ...) -> None: ...
     def assertTupleEqual(self, first: Tuple[Any, ...], second: Tuple[Any, ...],
                          msg: Any = ...) -> None: ...
-    def assertSetEqual(self, first: Set[Any], second: Set[Any],
+    def assertSetEqual(self, first: AbstractSet[Any], second: AbstractSet[Any],
                        msg: Any = ...) -> None: ...
     def assertDictEqual(self, first: Dict[Any, Any], second: Dict[Any, Any],
                         msg: Any = ...) -> None: ...


### PR DESCRIPTION
I believe `AbstractSet` is the correct type for the arguments, since the method works with `frozenset`s or user-defined set types.