### PR TITLE
Stub for tty

### DIFF
--- a/stdlib/2and3/tty.pyi
+++ b/stdlib/2and3/tty.pyi
@@ -1,0 +1,13 @@
+# Stubs for tty (Python 3.6)
+
+# XXX: Undocumented integer constants
+IFLAG = ...  # type: int
+OFLAG = ...  # type: int
+CFLAG = ...  # type: int
+LFLAG = ...  # type: int
+ISPEED = ...  # type: int
+OSPEED = ...  # type: int
+CC = ...  # type: int
+
+def setraw(fd: int, when: int = ...) -> None: ...
+def setcbreak(fd: int, when: int = ...) -> None: ...


### PR DESCRIPTION
Adds Python 2 and 3 stubs for `tty` module.  Addresses one of the missing stubs mentioned in #1019.