### PR TITLE
Improve types for subprocess module

### DIFF
--- a/stdlib/2/subprocess.pyi
+++ b/stdlib/2/subprocess.pyi
@@ -52,8 +52,7 @@ def check_output(args: _CMD,
                  env: Mapping[_TXT, _TXT] = ...,
                  universal_newlines: bool = ...,
                  startupinfo: Any = ...,
-                 creationflags: int = ...
-                 ) -> Any: ...  # morally: _TXT
+                 creationflags: int = ...) -> bytes: ...
 
 PIPE = ...  # type: int
 STDOUT = ...  # type: int
@@ -62,13 +61,13 @@ class CalledProcessError(Exception):
     returncode = 0
     # morally: _CMD
     cmd = ...  # type: Any
-    # morally: Optional[_TXT]
+    # morally: Optional[bytes]
     output = ...  # type: Any
 
     def __init__(self,
                  returncode: int,
                  cmd: _CMD,
-                 output: Optional[_TXT] = ...) -> None: ...
+                 output: Optional[bytes] = ...) -> None: ...
 
 class Popen:
     stdin = ...  # type: Optional[IO[Any]]
@@ -95,7 +94,7 @@ class Popen:
 
     def poll(self) -> int: ...
     def wait(self) -> int: ...
-    # morally: -> Tuple[_TXT, _TXT]
+    # morally: -> Tuple[Optional[bytes], Optional[bytes]]
     def communicate(self, input: Optional[_TXT] = ...) -> Tuple[Any, Any]: ...
     def send_signal(self, signal: int) -> None: ...
     def terminate(self) -> None: ...

--- a/stdlib/2/subprocess.pyi
+++ b/stdlib/2/subprocess.pyi
@@ -57,12 +57,14 @@ STDOUT = ...  # type: int
 
 class CalledProcessError(Exception):
     returncode = 0
+    # morally: Union[bytes, Text, Sequence[bytes], Sequence[Text]]
     cmd = ...  # type: Any
+    # morally: Optional[Union[bytes, Text]]
     output = ...  # type: Any
 
     def __init__(self,
                  returncode: int,
-                 cmd: Union[bytes, Text, List[bytes], List[Text]],
+                 cmd: Union[bytes, Text, Sequence[bytes], Sequence[Text]],
                  output: Optional[Union[bytes, Text]] = ...) -> None: ...
 
 class Popen:

--- a/stdlib/2/subprocess.pyi
+++ b/stdlib/2/subprocess.pyi
@@ -53,7 +53,7 @@ def check_output(args: _CMD,
                  universal_newlines: bool = ...,
                  startupinfo: Any = ...,
                  creationflags: int = ...,
-                ) -> Any: ...  # morally: _TXT
+                 ) -> Any: ...  # morally: _TXT
 
 PIPE = ...  # type: int
 STDOUT = ...  # type: int

--- a/stdlib/2/subprocess.pyi
+++ b/stdlib/2/subprocess.pyi
@@ -5,67 +5,70 @@
 from typing import Sequence, Any, AnyStr, Mapping, Callable, Tuple, IO, Union, Optional, List, Text
 
 _FILE = Union[int, IO[Any]]
+_TXT = Union[bytes, Text]
+_CMD = Union[_TXT, Sequence[_TXT]]
 
 # Same args as Popen.__init__
-def call(args: Union[str, Sequence[str]],
+def call(args: _CMD,
          bufsize: int = ...,
-         executable: str = ...,
+         executable: _TXT = ...,
          stdin: _FILE = ...,
          stdout: _FILE = ...,
          stderr: _FILE = ...,
          preexec_fn: Callable[[], Any] = ...,
          close_fds: bool = ...,
          shell: bool = ...,
-         cwd: str = ...,
-         env: Mapping[str, str] = ...,
+         cwd: _TXT = ...,
+         env: Mapping[_TXT, _TXT] = ...,
          universal_newlines: bool = ...,
          startupinfo: Any = ...,
          creationflags: int = ...) -> int: ...
 
-def check_call(args: Union[str, Sequence[str]],
+def check_call(args: _CMD,
                bufsize: int = ...,
-               executable: str = ...,
+               executable: _TXT = ...,
                stdin: _FILE = ...,
                stdout: _FILE = ...,
                stderr: _FILE = ...,
                preexec_fn: Callable[[], Any] = ...,
                close_fds: bool = ...,
                shell: bool = ...,
-               cwd: str = ...,
-               env: Mapping[str, str] = ...,
+               cwd: _TXT = ...,
+               env: Mapping[_TXT, _TXT] = ...,
                universal_newlines: bool = ...,
                startupinfo: Any = ...,
                creationflags: int = ...) -> int: ...
 
 # Same args as Popen.__init__ except for stdout
-def check_output(args: Union[str, Sequence[str]],
+def check_output(args: _CMD,
                  bufsize: int = ...,
-                 executable: str = ...,
+                 executable: _TXT = ...,
                  stdin: _FILE = ...,
                  stderr: _FILE = ...,
                  preexec_fn: Callable[[], Any] = ...,
                  close_fds: bool = ...,
                  shell: bool = ...,
-                 cwd: str = ...,
-                 env: Mapping[str, str] = ...,
+                 cwd: _TXT = ...,
+                 env: Mapping[_TXT, _TXT] = ...,
                  universal_newlines: bool = ...,
                  startupinfo: Any = ...,
-                 creationflags: int = ...) -> str: ...
+                 creationflags: int = ...,
+                ) -> Any: ...  # morally: _TXT
 
 PIPE = ...  # type: int
 STDOUT = ...  # type: int
 
 class CalledProcessError(Exception):
     returncode = 0
-    # morally: Union[bytes, Text, Sequence[bytes], Sequence[Text]]
+    # morally: _CMD
     cmd = ...  # type: Any
-    # morally: Optional[Union[bytes, Text]]
+    # morally: Optional[_TXT]
     output = ...  # type: Any
 
     def __init__(self,
                  returncode: int,
-                 cmd: Union[bytes, Text, Sequence[bytes], Sequence[Text]],
-                 output: Optional[Union[bytes, Text]] = ...) -> None: ...
+                 cmd: _CMD,
+                 output: Optional[_TXT] = ...) -> None: ...
 
 class Popen:
     stdin = ...  # type: Optional[IO[Any]]
@@ -75,32 +78,30 @@ class Popen:
     returncode = 0
 
     def __init__(self,
-                 args: Union[str, Sequence[str]],
+                 args: _CMD,
                  bufsize: int = ...,
-                 executable: Optional[str] = ...,
+                 executable: Optional[_TXT] = ...,
                  stdin: Optional[_FILE] = ...,
                  stdout: Optional[_FILE] = ...,
                  stderr: Optional[_FILE] = ...,
                  preexec_fn: Optional[Callable[[], Any]] = ...,
                  close_fds: bool = ...,
                  shell: bool = ...,
-                 cwd: Optional[str] = ...,
-                 env: Optional[Mapping[str, str]] = ...,
+                 cwd: Optional[_TXT] = ...,
+                 env: Optional[Mapping[_TXT, _TXT]] = ...,
                  universal_newlines: bool = ...,
                  startupinfo: Optional[Any] = ...,
                  creationflags: int = ...) -> None: ...
 
     def poll(self) -> int: ...
     def wait(self) -> int: ...
-    def communicate(self, input: Optional[AnyStr] = ...) -> Tuple[Optional[bytes], Optional[bytes]]: ...
+    # morally: -> Tuple[_TXT, _TXT]
+    def communicate(self, input: Optional[_TXT] = ...) -> Tuple[Any, Any]: ...
     def send_signal(self, signal: int) -> None: ...
     def terminate(self) -> None: ...
     def kill(self) -> None: ...
     def __enter__(self) -> 'Popen': ...
     def __exit__(self, type, value, traceback) -> bool: ...
-
-def getstatusoutput(cmd: str) -> Tuple[int, str]: ...
-def getoutput(cmd: str) -> str: ...
 
 # Windows-only: STARTUPINFO etc.
 

--- a/stdlib/2/subprocess.pyi
+++ b/stdlib/2/subprocess.pyi
@@ -52,7 +52,7 @@ def check_output(args: _CMD,
                  env: Mapping[_TXT, _TXT] = ...,
                  universal_newlines: bool = ...,
                  startupinfo: Any = ...,
-                 creationflags: int = ...,
+                 creationflags: int = ...
                  ) -> Any: ...  # morally: _TXT
 
 PIPE = ...  # type: int

--- a/stdlib/2/subprocess.pyi
+++ b/stdlib/2/subprocess.pyi
@@ -57,10 +57,15 @@ STDOUT = ...  # type: int
 
 class CalledProcessError(Exception):
     returncode = 0
-    cmd = ...  # type: str
-    output = ...  # type: str  # May be None
+    # morally: Union[str, bytes, List[str], List[bytes]]
+    cmd = ...  # type: Any
+    # morally: Optional[Union[str, bytes]]
+    output = ...  # type: Any
 
-    def __init__(self, returncode: int, cmd: str, output: Optional[str] = ...) -> None: ...
+    def __init__(self,
+                 returncode: int,
+                 cmd: Union[str, bytes, List[str], List[bytes]],
+                 output: Optional[Union[str, bytes]] = ...) -> None: ...
 
 class Popen:
     stdin = ...  # type: Optional[IO[Any]]

--- a/stdlib/2/subprocess.pyi
+++ b/stdlib/2/subprocess.pyi
@@ -2,7 +2,7 @@
 
 # Based on http://docs.python.org/2/library/subprocess.html and Python 3 stub
 
-from typing import Sequence, Any, AnyStr, Mapping, Callable, Tuple, IO, Union, Optional
+from typing import Sequence, Any, AnyStr, Mapping, Callable, Tuple, IO, Union, Optional, List
 
 _FILE = Union[int, IO[Any]]
 
@@ -57,15 +57,13 @@ STDOUT = ...  # type: int
 
 class CalledProcessError(Exception):
     returncode = 0
-    # morally: Union[str, bytes, List[str], List[bytes]]
     cmd = ...  # type: Any
-    # morally: Optional[Union[str, bytes]]
     output = ...  # type: Any
 
     def __init__(self,
                  returncode: int,
-                 cmd: Union[str, bytes, List[str], List[bytes]],
-                 output: Optional[Union[str, bytes]] = ...) -> None: ...
+                 cmd: Union[bytes, Text, List[bytes], List[Text]],
+                 output: Optional[Union[bytes, Text]] = ...) -> None: ...
 
 class Popen:
     stdin = ...  # type: Optional[IO[Any]]

--- a/stdlib/2/subprocess.pyi
+++ b/stdlib/2/subprocess.pyi
@@ -2,7 +2,7 @@
 
 # Based on http://docs.python.org/2/library/subprocess.html and Python 3 stub
 
-from typing import Sequence, Any, AnyStr, Mapping, Callable, Tuple, IO, Union, Optional, List
+from typing import Sequence, Any, AnyStr, Mapping, Callable, Tuple, IO, Union, Optional, List, Text
 
 _FILE = Union[int, IO[Any]]
 

--- a/stdlib/3/subprocess.pyi
+++ b/stdlib/3/subprocess.pyi
@@ -169,7 +169,7 @@ if sys.version_info >= (3, 4):
                      pass_fds: Any = ...,
                      timeout: float = ...,
                      input: _TXT = ...,
-                    ) -> Any: ...  # morally: -> _TXT
+                     ) -> Any: ...  # morally: -> _TXT
 elif sys.version_info >= (3, 3):
     # 3.3 added timeout
     def check_output(args: _CMD,
@@ -189,7 +189,7 @@ elif sys.version_info >= (3, 3):
                      start_new_session: bool = ...,
                      pass_fds: Any = ...,
                      timeout: float = ...,
-                    ) -> Any: ...  # morally: -> _TXT
+                     ) -> Any: ...  # morally: -> _TXT
 else:
     # Same args as Popen.__init__, except for stdout
     def check_output(args: _CMD,
@@ -208,7 +208,7 @@ else:
                      restore_signals: bool = ...,
                      start_new_session: bool = ...,
                      pass_fds: Any = ...,
-                    ) -> Any: ...  # morally: -> _TXT
+                     ) -> Any: ...  # morally: -> _TXT
 
 
 # TODO types
@@ -247,7 +247,7 @@ class Popen:
 
     if sys.version_info >= (3, 6):
         def __init__(self,
-                     args: _CMD],
+                     args: _CMD,
                      bufsize: int = ...,
                      executable: Optional[_TXT] = ...,
                      stdin: Optional[_FILE] = ...,
@@ -297,11 +297,11 @@ class Popen:
         def communicate(self,
                         input: Optional[_TXT] = ...,
                         timeout: Optional[float] = ...,
-                       ) -> Tuple[Any, Any]: ...  # morally: -> Tuple[_TXT, _TXT]
+                        ) -> Tuple[Any, Any]: ...  # morally: -> Tuple[_TXT, _TXT]
     else:
         def communicate(self,
                         input: Optional[AnyStr] = ...,
-                       ) -> Tuple[Any, Any]: ...  # morally: -> Tuple[_TXT, _TXT]
+                        ) -> Tuple[Any, Any]: ...  # morally: -> Tuple[_TXT, _TXT]
     def send_signal(self, signal: int) -> None: ...
     def terminate(self) -> None: ...
     def kill(self) -> None: ...

--- a/stdlib/3/subprocess.pyi
+++ b/stdlib/3/subprocess.pyi
@@ -214,16 +214,19 @@ if sys.version_info >= (3, 3):
 
 class CalledProcessError(Exception):
     returncode = 0
+    # morally: Union[bytes, Text, Sequence[bytes], Sequence[Text]]
     cmd = ...  # type: Any
+    # morally: Optional[Union[bytes, Text]]
     output = ...  # type: Any
 
     if sys.version_info >= (3, 5):
+        # morally: Optional[Union[bytes, Text]]
         stdout = ...  # type: Any
         stderr = ...  # type: Any
 
     def __init__(self,
                  returncode: int,
-                 cmd: Union[bytes, Text, List[bytes], List[Text]],
+                 cmd: Union[bytes, Text, Sequence[bytes], Sequence[Text]],
                  output: Optional[Union[bytes, Text]] = ...,
                  stderr: Optional[Union[bytes, Text]] = ...) -> None: ...
 

--- a/stdlib/3/subprocess.pyi
+++ b/stdlib/3/subprocess.pyi
@@ -223,9 +223,9 @@ class CalledProcessError(Exception):
 
     def __init__(self,
                  returncode: int,
-                 cmd: Union[str, bytes, List[str], List[bytes]],
-                 output: Optional[Union[str, bytes]] = ...,
-                 stderr: Optional[Union[str, bytes]] = ...) -> None: ...
+                 cmd: Union[bytes, Text, List[bytes], List[Text]],
+                 output: Optional[Union[bytes, Text]] = ...,
+                 stderr: Optional[Union[bytes, Text]] = ...) -> None: ...
 
 class Popen:
     stdin = ...  # type: IO[Any]

--- a/stdlib/3/subprocess.pyi
+++ b/stdlib/3/subprocess.pyi
@@ -2,7 +2,7 @@
 
 # Based on http://docs.python.org/3.6/library/subprocess.html
 import sys
-from typing import Sequence, Any, AnyStr, Mapping, Callable, Tuple, IO, Optional, Union, List, Type
+from typing import Sequence, Any, AnyStr, Mapping, Callable, Tuple, IO, Optional, Union, List, Type, Text
 from types import TracebackType
 
 if sys.version_info >= (3, 5):

--- a/stdlib/3/subprocess.pyi
+++ b/stdlib/3/subprocess.pyi
@@ -214,15 +214,18 @@ if sys.version_info >= (3, 3):
 
 class CalledProcessError(Exception):
     returncode = 0
-    cmd = ...  # type: str
-    output = b''  # May be None
+    cmd = ...  # type: Any
+    output = ...  # type: Any
 
     if sys.version_info >= (3, 5):
-        stdout = b''
-        stderr = b''
+        stdout = ...  # type: Any
+        stderr = ...  # type: Any
 
-    def __init__(self, returncode: int, cmd: str, output: Optional[str] = ...,
-                 stderr: Optional[str] = ...) -> None: ...
+    def __init__(self,
+                 returncode: int,
+                 cmd: Union[str, bytes, List[str], List[bytes]],
+                 output: Optional[Union[str, bytes]] = ...,
+                 stderr: Optional[Union[str, bytes]] = ...) -> None: ...
 
 class Popen:
     stdin = ...  # type: IO[Any]

--- a/stdlib/3/subprocess.pyi
+++ b/stdlib/3/subprocess.pyi
@@ -5,34 +5,39 @@ import sys
 from typing import Sequence, Any, AnyStr, Mapping, Callable, Tuple, IO, Optional, Union, List, Type, Text
 from types import TracebackType
 
+_FILE = Union[int, IO[Any]]
+_TXT = Union[bytes, Text]
+_CMD = Union[_TXT, Sequence[_TXT]]
+
 if sys.version_info >= (3, 5):
     class CompletedProcess:
-        args = ...  # type: Union[Sequence[str], str]
+        # morally: _CMD
+        args = ...  # type: Any
         returncode = ...  # type: int
         stdout = ...  # type: Any
         stderr = ...  # type: Any
-        def __init__(self, args: Union[List, str],
+        def __init__(self, args: _CMD,
                      returncode: int,
-                     stdout: Union[str, bytes, None] = ...,
-                     stderr: Union[str, bytes, None] = ...) -> None: ...
+                     stdout: Optional[_TXT] = ...,
+                     stderr: Optional[_TXT] = ...) -> None: ...
         def check_returncode(self) -> None: ...
 
     if sys.version_info >= (3, 6):
         # Nearly same args as Popen.__init__ except for timeout, input, and check
-        def run(args: Union[str, Sequence[str]],
+        def run(args: _CMD,
                 timeout: float = ...,
-                input: Union[str, bytes] = ...,
+                input: _TXT = ...,
                 check: bool = ...,
                 bufsize: int = ...,
-                executable: str = ...,
-                stdin: Any = ...,
-                stdout: Any = ...,
-                stderr: Any = ...,
+                executable: _TXT = ...,
+                stdin: _FILE = ...,
+                stdout: _FILE = ...,
+                stderr: _FILE = ...,
                 preexec_fn: Callable[[], Any] = ...,
                 close_fds: bool = ...,
                 shell: bool = ...,
-                cwd: str = ...,
-                env: Mapping[str, str] = ...,
+                cwd: _TXT = ...,
+                env: Mapping[_TXT, _TXT] = ...,
                 universal_newlines: bool = ...,
                 startupinfo: Any = ...,
                 creationflags: int = ...,
@@ -43,20 +48,20 @@ if sys.version_info >= (3, 5):
                 errors: str = ...) -> CompletedProcess: ...
     else:
         # Nearly same args as Popen.__init__ except for timeout, input, and check
-        def run(args: Union[str, Sequence[str]],
+        def run(args: _CMD,
                 timeout: float = ...,
-                input: Union[str, bytes] = ...,
+                input: _TXT = ...,
                 check: bool = ...,
                 bufsize: int = ...,
-                executable: str = ...,
-                stdin: Any = ...,
-                stdout: Any = ...,
-                stderr: Any = ...,
+                executable: _TXT = ...,
+                stdin: _FILE = ...,
+                stdout: _FILE = ...,
+                stderr: _FILE = ...,
                 preexec_fn: Callable[[], Any] = ...,
                 close_fds: bool = ...,
                 shell: bool = ...,
-                cwd: str = ...,
-                env: Mapping[str, str] = ...,
+                cwd: _TXT = ...,
+                env: Mapping[_TXT, _TXT] = ...,
                 universal_newlines: bool = ...,
                 startupinfo: Any = ...,
                 creationflags: int = ...,
@@ -67,17 +72,17 @@ if sys.version_info >= (3, 5):
 # Same args as Popen.__init__
 if sys.version_info >= (3, 3):
     # 3.3 added timeout
-    def call(args: Union[str, Sequence[str]],
+    def call(args: _CMD,
              bufsize: int = ...,
-             executable: str = ...,
-             stdin: Any = ...,
-             stdout: Any = ...,
-             stderr: Any = ...,
+             executable: _TXT = ...,
+             stdin: _FILE = ...,
+             stdout: _FILE = ...,
+             stderr: _FILE = ...,
              preexec_fn: Callable[[], Any] = ...,
              close_fds: bool = ...,
              shell: bool = ...,
-             cwd: str = ...,
-             env: Mapping[str, str] = ...,
+             cwd: _TXT = ...,
+             env: Mapping[_TXT, _TXT] = ...,
              universal_newlines: bool = ...,
              startupinfo: Any = ...,
              creationflags: int = ...,
@@ -86,17 +91,17 @@ if sys.version_info >= (3, 3):
              pass_fds: Any = ...,
              timeout: float = ...) -> int: ...
 else:
-    def call(args: Union[str, Sequence[str]],
+    def call(args: _CMD,
              bufsize: int = ...,
-             executable: str = ...,
-             stdin: Any = ...,
-             stdout: Any = ...,
-             stderr: Any = ...,
+             executable: _TXT = ...,
+             stdin: _FILE = ...,
+             stdout: _FILE = ...,
+             stderr: _FILE = ...,
              preexec_fn: Callable[[], Any] = ...,
              close_fds: bool = ...,
              shell: bool = ...,
-             cwd: str = ...,
-             env: Mapping[str, str] = ...,
+             cwd: _TXT = ...,
+             env: Mapping[_TXT, _TXT] = ...,
              universal_newlines: bool = ...,
              startupinfo: Any = ...,
              creationflags: int = ...,
@@ -107,17 +112,17 @@ else:
 # Same args as Popen.__init__
 if sys.version_info >= (3, 3):
     # 3.3 added timeout
-    def check_call(args: Union[str, Sequence[str]],
+    def check_call(args: _CMD,
                    bufsize: int = ...,
-                   executable: str = ...,
-                   stdin: Any = ...,
-                   stdout: Any = ...,
-                   stderr: Any = ...,
+                   executable: _TXT = ...,
+                   stdin: _FILE = ...,
+                   stdout: _FILE = ...,
+                   stderr: _FILE = ...,
                    preexec_fn: Callable[[], Any] = ...,
                    close_fds: bool = ...,
                    shell: bool = ...,
-                   cwd: str = ...,
-                   env: Mapping[str, str] = ...,
+                   cwd: _TXT = ...,
+                   env: Mapping[_TXT, _TXT] = ...,
                    universal_newlines: bool = ...,
                    startupinfo: Any = ...,
                    creationflags: int = ...,
@@ -126,17 +131,17 @@ if sys.version_info >= (3, 3):
                    pass_fds: Any = ...,
                    timeout: float = ...) -> int: ...
 else:
-    def check_call(args: Union[str, Sequence[str]],
+    def check_call(args: _CMD,
                    bufsize: int = ...,
-                   executable: str = ...,
-                   stdin: Any = ...,
-                   stdout: Any = ...,
-                   stderr: Any = ...,
+                   executable: _TXT = ...,
+                   stdin: _FILE = ...,
+                   stdout: _FILE = ...,
+                   stderr: _FILE = ...,
                    preexec_fn: Callable[[], Any] = ...,
                    close_fds: bool = ...,
                    shell: bool = ...,
-                   cwd: str = ...,
-                   env: Mapping[str, str] = ...,
+                   cwd: _TXT = ...,
+                   env: Mapping[_TXT, _TXT] = ...,
                    universal_newlines: bool = ...,
                    startupinfo: Any = ...,
                    creationflags: int = ...,
@@ -146,16 +151,16 @@ else:
 
 if sys.version_info >= (3, 4):
     # 3.4 added input
-    def check_output(args: Union[str, Sequence[str]],
+    def check_output(args: _CMD,
                      bufsize: int = ...,
-                     executable: str = ...,
-                     stdin: Any = ...,
-                     stderr: Any = ...,
+                     executable: _TXT = ...,
+                     stdin: _FILE = ...,
+                     stderr: _FILE = ...,
                      preexec_fn: Callable[[], Any] = ...,
                      close_fds: bool = ...,
                      shell: bool = ...,
-                     cwd: str = ...,
-                     env: Mapping[str, str] = ...,
+                     cwd: _TXT = ...,
+                     env: Mapping[_TXT, _TXT] = ...,
                      universal_newlines: bool = ...,
                      startupinfo: Any = ...,
                      creationflags: int = ...,
@@ -163,44 +168,47 @@ if sys.version_info >= (3, 4):
                      start_new_session: bool = ...,
                      pass_fds: Any = ...,
                      timeout: float = ...,
-                     input: Union[str, bytes] = ...) -> Any: ...
+                     input: _TXT = ...,
+                    ) -> Any: ...  # morally: -> _TXT
 elif sys.version_info >= (3, 3):
     # 3.3 added timeout
-    def check_output(args: Union[str, Sequence[str]],
+    def check_output(args: _CMD,
                      bufsize: int = ...,
-                     executable: str = ...,
-                     stdin: Any = ...,
-                     stderr: Any = ...,
+                     executable: _TXT = ...,
+                     stdin: _FILE = ...,
+                     stderr: _FILE = ...,
                      preexec_fn: Callable[[], Any] = ...,
                      close_fds: bool = ...,
                      shell: bool = ...,
-                     cwd: str = ...,
-                     env: Mapping[str, str] = ...,
+                     cwd: _TXT = ...,
+                     env: Mapping[_TXT, _TXT] = ...,
                      universal_newlines: bool = ...,
                      startupinfo: Any = ...,
                      creationflags: int = ...,
                      restore_signals: bool = ...,
                      start_new_session: bool = ...,
                      pass_fds: Any = ...,
-                     timeout: float = ...) -> Any: ...
+                     timeout: float = ...,
+                    ) -> Any: ...  # morally: -> _TXT
 else:
     # Same args as Popen.__init__, except for stdout
-    def check_output(args: Union[str, Sequence[str]],
+    def check_output(args: _CMD,
                      bufsize: int = ...,
-                     executable: str = ...,
-                     stdin: Any = ...,
-                     stderr: Any = ...,
+                     executable: _TXT = ...,
+                     stdin: _FILE = ...,
+                     stderr: _FILE = ...,
                      preexec_fn: Callable[[], Any] = ...,
                      close_fds: bool = ...,
                      shell: bool = ...,
-                     cwd: str = ...,
-                     env: Mapping[str, str] = ...,
+                     cwd: _TXT = ...,
+                     env: Mapping[_TXT, _TXT] = ...,
                      universal_newlines: bool = ...,
                      startupinfo: Any = ...,
                      creationflags: int = ...,
                      restore_signals: bool = ...,
                      start_new_session: bool = ...,
-                     pass_fds: Any = ...) -> Any: ...
+                     pass_fds: Any = ...,
+                    ) -> Any: ...  # morally: -> _TXT
 
 
 # TODO types
@@ -214,21 +222,21 @@ if sys.version_info >= (3, 3):
 
 class CalledProcessError(Exception):
     returncode = 0
-    # morally: Union[bytes, Text, Sequence[bytes], Sequence[Text]]
+    # morally: _CMD
     cmd = ...  # type: Any
-    # morally: Optional[Union[bytes, Text]]
+    # morally: Optional[_TXT]
     output = ...  # type: Any
 
     if sys.version_info >= (3, 5):
-        # morally: Optional[Union[bytes, Text]]
+        # morally: Optional[_TXT]
         stdout = ...  # type: Any
         stderr = ...  # type: Any
 
     def __init__(self,
                  returncode: int,
-                 cmd: Union[bytes, Text, Sequence[bytes], Sequence[Text]],
-                 output: Optional[Union[bytes, Text]] = ...,
-                 stderr: Optional[Union[bytes, Text]] = ...) -> None: ...
+                 cmd: _CMD,
+                 output: Optional[_TXT] = ...,
+                 stderr: Optional[_TXT] = ...) -> None: ...
 
 class Popen:
     stdin = ...  # type: IO[Any]
@@ -239,17 +247,17 @@ class Popen:
 
     if sys.version_info >= (3, 6):
         def __init__(self,
-                     args: Union[str, Sequence[str]],
+                     args: _CMD],
                      bufsize: int = ...,
-                     executable: Optional[str] = ...,
-                     stdin: Optional[Any] = ...,
-                     stdout: Optional[Any] = ...,
-                     stderr: Optional[Any] = ...,
+                     executable: Optional[_TXT] = ...,
+                     stdin: Optional[_FILE] = ...,
+                     stdout: Optional[_FILE] = ...,
+                     stderr: Optional[_FILE] = ...,
                      preexec_fn: Optional[Callable[[], Any]] = ...,
                      close_fds: bool = ...,
                      shell: bool = ...,
-                     cwd: Optional[str] = ...,
-                     env: Optional[Mapping[str, str]] = ...,
+                     cwd: Optional[_TXT] = ...,
+                     env: Optional[Mapping[_TXT, _TXT]] = ...,
                      universal_newlines: bool = ...,
                      startupinfo: Optional[Any] = ...,
                      creationflags: int = ...,
@@ -260,17 +268,17 @@ class Popen:
                      errors: str = ...) -> None: ...
     else:
         def __init__(self,
-                     args: Union[str, Sequence[str]],
+                     args: _CMD,
                      bufsize: int = ...,
-                     executable: Optional[str] = ...,
-                     stdin: Optional[Any] = ...,
-                     stdout: Optional[Any] = ...,
-                     stderr: Optional[Any] = ...,
+                     executable: Optional[_TXT] = ...,
+                     stdin: Optional[_FILE] = ...,
+                     stdout: Optional[_FILE] = ...,
+                     stderr: Optional[_FILE] = ...,
                      preexec_fn: Optional[Callable[[], Any]] = ...,
                      close_fds: bool = ...,
                      shell: bool = ...,
-                     cwd: Optional[str] = ...,
-                     env: Optional[Mapping[str, str]] = ...,
+                     cwd: Optional[_TXT] = ...,
+                     env: Optional[Mapping[_TXT, _TXT]] = ...,
                      universal_newlines: bool = ...,
                      startupinfo: Optional[Any] = ...,
                      creationflags: int = ...,
@@ -286,16 +294,22 @@ class Popen:
         def wait(self) ->int: ...
     # Return str/bytes
     if sys.version_info >= (3, 3):
-        def communicate(self, input: Optional[AnyStr] = ..., timeout: Optional[float] = ...) -> Tuple[Any, Any]: ...
+        def communicate(self,
+                        input: Optional[_TXT] = ...,
+                        timeout: Optional[float] = ...,
+                       ) -> Tuple[Any, Any]: ...  # morally: -> Tuple[_TXT, _TXT]
     else:
-        def communicate(self, input: Optional[AnyStr] = ...) -> Tuple[Any, Any]: ...
+        def communicate(self,
+                        input: Optional[AnyStr] = ...,
+                       ) -> Tuple[Any, Any]: ...  # morally: -> Tuple[_TXT, _TXT]
     def send_signal(self, signal: int) -> None: ...
     def terminate(self) -> None: ...
     def kill(self) -> None: ...
     def __enter__(self) -> 'Popen': ...
     def __exit__(self, type: Optional[Type[BaseException]], value: Optional[BaseException], traceback: Optional[TracebackType]) -> bool: ...
 
-def getstatusoutput(cmd: str) -> Tuple[int, str]: ...
-def getoutput(cmd: str) -> str: ...
+# The result really is always a str.
+def getstatusoutput(cmd: _TXT) -> Tuple[int, str]: ...
+def getoutput(cmd: _TXT) -> str: ...
 
 # Windows-only: STARTUPINFO etc.

--- a/stdlib/3/subprocess.pyi
+++ b/stdlib/3/subprocess.pyi
@@ -14,6 +14,7 @@ if sys.version_info >= (3, 5):
         # morally: _CMD
         args = ...  # type: Any
         returncode = ...  # type: int
+        # morally: Optional[_TXT]
         stdout = ...  # type: Any
         stderr = ...  # type: Any
         def __init__(self, args: _CMD,
@@ -297,11 +298,13 @@ class Popen:
         def communicate(self,
                         input: Optional[_TXT] = ...,
                         timeout: Optional[float] = ...,
-                        ) -> Tuple[Any, Any]: ...  # morally: -> Tuple[_TXT, _TXT]
+                        # morally: -> Tuple[Optional[_TXT], Optional[_TXT]]
+                        ) -> Tuple[Any, Any]: ...
     else:
         def communicate(self,
-                        input: Optional[AnyStr] = ...,
-                        ) -> Tuple[Any, Any]: ...  # morally: -> Tuple[_TXT, _TXT]
+                        input: Optional[_TXT] = ...,
+                        # morally: -> Tuple[Optional[_TXT], Optional[_TXT]]
+                        ) -> Tuple[Any, Any]: ...
     def send_signal(self, signal: int) -> None: ...
     def terminate(self) -> None: ...
     def kill(self) -> None: ...


### PR DESCRIPTION
This adds union types in the constructor to account for parameters that
might be either byte strings or unicode strings. At the same time, this
*removes* specific types from the user-accessible fields, to avoid the
need for users to at every use site specify which types their particular
instance was instantiated with.

Fixes #1004