### PR TITLE
TestCase.assertSetEqual() should accept frozenset

### DIFF
--- a/stdlib/2/unittest.pyi
+++ b/stdlib/2/unittest.pyi
@@ -6,7 +6,7 @@
 
 from typing import (
     Any, Callable, Dict, Iterable, Tuple, List, TextIO, Sequence,
-    overload, Set, TypeVar, Union, Pattern, Type
+    overload, Set, FrozenSet, TypeVar, Union, Pattern, Type
 )
 from abc import abstractmethod, ABCMeta
 
@@ -101,8 +101,8 @@ class TestCase(Testable):
                         msg: object = ...) -> None: ...
     def assertTupleEqual(self, first: Tuple[Any, ...], second: Tuple[Any, ...],
                          msg: object = ...) -> None: ...
-    def assertSetEqual(self, first: Set[Any], second: Set[Any],
-                       msg: object = ...) -> None: ...
+    def assertSetEqual(self, first: Union[Set[Any], FrozenSet[Any]],
+                       second: Union[Set[Any], FrozenSet[Any]], msg: object = ...) -> None: ...
     def assertDictEqual(self, first: Dict[Any, Any], second: Dict[Any, Any],
                         msg: object = ...) -> None: ...
     def assertLess(self, first: Any, second: Any,

--- a/stdlib/3/unittest/__init__.pyi
+++ b/stdlib/3/unittest/__init__.pyi
@@ -2,7 +2,7 @@
 
 from typing import (
     Any, Callable, Dict, Iterable, Iterator, List, Optional, Pattern, Sequence,
-    Set, TextIO, Tuple, Type, TypeVar, Union, Generic,
+    Set, FrozenSet, TextIO, Tuple, Type, TypeVar, Union, Generic,
     overload,
 )
 import logging
@@ -131,8 +131,8 @@ class TestCase:
                         msg: Any = ...) -> None: ...
     def assertTupleEqual(self, first: Tuple[Any, ...], second: Tuple[Any, ...],
                          msg: Any = ...) -> None: ...
-    def assertSetEqual(self, first: Set[Any], second: Set[Any],
-                       msg: Any = ...) -> None: ...
+    def assertSetEqual(self, first: Union[Set[Any], FrozenSet[Any]],
+                       second: Union[Set[Any], FrozenSet[Any]], msg: Any = ...) -> None: ...
     def assertDictEqual(self, first: Dict[Any, Any], second: Dict[Any, Any],
                         msg: Any = ...) -> None: ...
     def fail(self, msg: Any = ...) -> None: ...


### PR DESCRIPTION
This declares the method to take the union of Set and FrozenSet rather than AbstractSet since that is where `difference()` (used by `assertSetEqual()`) is defined.