### PR TITLE
Improved annotations for select.select()

### DIFF
--- a/stdlib/2/select.pyi
+++ b/stdlib/2/select.pyi
@@ -1,6 +1,6 @@
 """Stubs for the 'select' module."""
 
-from typing import Any, Optional, Tuple, Iterable, List
+from typing import Any, Optional, Tuple, Iterable, List, Sequence, TypeVar
 
 EPOLLERR = ...  # type: int
 EPOLLET = ...  # type: int
@@ -66,7 +66,11 @@ POLLWRBAND = ...  # type: int
 POLLWRNORM = ...  # type: int
 
 def poll() -> epoll: ...
-def select(rlist, wlist, xlist, timeout: float = None) -> Tuple[List, List, List]: ...
+
+_R = TypeVar("_R")
+_W = TypeVar("_W")
+_X = TypeVar("_X")
+def select(rlist: Sequence[_R], wlist: Sequence[_W], xlist: Sequence[_X], timeout: float = None) -> Tuple[List[_R], List[_W], List[_X]]: ...
 
 class error(Exception): ...
 

--- a/stdlib/3/select.pyi
+++ b/stdlib/3/select.pyi
@@ -27,7 +27,4 @@ class poll:
 _R = TypeVar("_R")
 _W = TypeVar("_W")
 _X = TypeVar("_X")
-def select(rlist: Sequence[_R], wlist: Sequence[_W], xlist: Sequence[_X],
-           timeout: float = ...) -> Tuple[List[_R],
-                                           List[_W],
-                                           List[_X]]: ...
+def select(rlist: Sequence[_R], wlist: Sequence[_W], xlist: Sequence[_X], timeout: float = ...) -> Tuple[List[_R], List[_W], List[_X]]: ...

--- a/stdlib/3/select.pyi
+++ b/stdlib/3/select.pyi
@@ -2,7 +2,7 @@
 
 # NOTE: These are incomplete!
 
-from typing import Any, Tuple, List, Sequence
+from typing import Any, Tuple, List, Sequence, TypeVar
 
 class error(Exception): ...
 
@@ -21,7 +21,13 @@ class poll:
     def unregister(self, fd: Any) -> None: ...
     def poll(self, timeout: int = ...) -> List[Tuple[int, int]]: ...
 
-def select(rlist: Sequence, wlist: Sequence, xlist: Sequence,
-           timeout: float = ...) -> Tuple[List[Any],
-                                           List[Any],
-                                           List[Any]]: ...
+# Not the canonical naming choices, but these map to the select arguments. We
+# need 3 because nothing in select prevents the read set from being socket
+# objects and the write set from being file descriptors.
+_R = TypeVar("_R")
+_W = TypeVar("_W")
+_X = TypeVar("_X")
+def select(rlist: Sequence[_R], wlist: Sequence[_W], xlist: Sequence[_X],
+           timeout: float = ...) -> Tuple[List[_R],
+                                           List[_W],
+                                           List[_X]]: ...


### PR DESCRIPTION
The TypeVars allow mypy to enforce that the returned lists are subsets of the arguments.