### PR TITLE
Add missing kwargs for create_server and create_datagram_endpoint

### DIFF
--- a/stdlib/3.4/asyncio/events.pyi
+++ b/stdlib/3.4/asyncio/events.pyi
@@ -103,24 +103,24 @@ class AbstractEventLoop(metaclass=ABCMeta):
     @abstractmethod
     @coroutine
     def create_connection(self, protocol_factory: _ProtocolFactory, host: str = ..., port: int = ..., *,
-                          ssl: _SSLContext = ..., family: int = ..., proto: int = ..., flags: int = ..., sock: socket = ...,
+                          ssl: _SSLContext = ..., family: int = ..., proto: int = ..., flags: int = ..., sock: Optional[socket] = ...,
                           local_addr: str = ..., server_hostname: str = ...) -> Generator[Any, None, _TransProtPair]: ...
     @abstractmethod
     @coroutine
     def create_server(self, protocol_factory: _ProtocolFactory, host: Union[str, Sequence[str]] = ..., port: int = ..., *,
                       family: int = ..., flags: int = ...,
-                      sock: socket = ..., backlog: int = ..., ssl: _SSLContext = ...,
+                      sock: Optional[socket] = ..., backlog: int = ..., ssl: _SSLContext = ...,
                       reuse_address: Optional[bool] = ...,
                       reuse_port: Optional[bool] = ...) -> Generator[Any, None, AbstractServer]: ...
     @abstractmethod
     @coroutine
     def create_unix_connection(self, protocol_factory: _ProtocolFactory, path: str, *,
-                               ssl: _SSLContext = ..., sock: socket = ...,
+                               ssl: _SSLContext = ..., sock: Optional[socket] = ...,
                                server_hostname: str = ...) -> Generator[Any, None, _TransProtPair]: ...
     @abstractmethod
     @coroutine
     def create_unix_server(self, protocol_factory: _ProtocolFactory, path: str, *,
-                           sock: socket = ..., backlog: int = ..., ssl: _SSLContext = ...) -> Generator[Any, None, AbstractServer]: ...
+                           sock: Optional[socket] = ..., backlog: int = ..., ssl: _SSLContext = ...) -> Generator[Any, None, AbstractServer]: ...
     @abstractmethod
     @coroutine
     def create_datagram_endpoint(self, protocol_factory: _ProtocolFactory,
@@ -128,7 +128,7 @@ class AbstractEventLoop(metaclass=ABCMeta):
                                  family: int = ..., proto: int = ..., flags: int = ...,
                                  reuse_address: Optional[bool] = ..., reuse_port: Optional[bool] = ...,
                                  allow_broadcast: Optional[bool] = ...,
-                                 sock: socket = ...) -> Generator[Any, None, _TransProtPair]: ...
+                                 sock: Optional[socket] = ...) -> Generator[Any, None, _TransProtPair]: ...
     @abstractmethod
     @coroutine
     def connect_accepted_socket(self, protocol_factory: _ProtocolFactory, sock: socket, *, ssl: _SSLContext = ...) -> Generator[Any, None, _TransProtPair]: ...

--- a/stdlib/3.4/asyncio/events.pyi
+++ b/stdlib/3.4/asyncio/events.pyi
@@ -109,7 +109,9 @@ class AbstractEventLoop(metaclass=ABCMeta):
     @coroutine
     def create_server(self, protocol_factory: _ProtocolFactory, host: str = ..., port: int = ..., *,
                       family: int = ..., flags: int = ...,
-                      sock: socket = ..., backlog: int = ..., ssl: _SSLContext = ..., reuse_address: Optional[bool] = ...) -> Generator[Any, None, AbstractServer]: ...
+                      sock: socket = ..., backlog: int = ..., ssl: _SSLContext = ...,
+                      reuse_address: Optional[bool] = ...,
+                      reuse_port: Optional[bool] = ...) -> Generator[Any, None, AbstractServer]: ...
     @abstractmethod
     @coroutine
     def create_unix_connection(self, protocol_factory: _ProtocolFactory, path: str, *,
@@ -123,7 +125,9 @@ class AbstractEventLoop(metaclass=ABCMeta):
     @coroutine
     def create_datagram_endpoint(self, protocol_factory: _ProtocolFactory,
                                  local_addr: str = ..., remote_addr: str = ..., *,
-                                 family: int = ..., proto: int = ..., flags: int = ...) -> Generator[Any, None, _TransProtPair]: ...
+                                 family: int = ..., proto: int = ..., flags: int = ...,
+                                 sock: socket = ..., reuse_address: Optional[bool] = ...,
+                                 reuse_port: Optional[bool] = ...) -> Generator[Any, None, _TransProtPair]: ...
     @abstractmethod
     @coroutine
     def connect_accepted_socket(self, protocol_factory: _ProtocolFactory, sock: socket, *, ssl: _SSLContext = ...) -> Generator[Any, None, _TransProtPair]: ...

--- a/stdlib/3.4/asyncio/events.pyi
+++ b/stdlib/3.4/asyncio/events.pyi
@@ -1,7 +1,7 @@
 from socket import socket
 import ssl
 import sys
-from typing import Any, Awaitable, Callable, Dict, Generator, List, Optional, Tuple, TypeVar, Union, overload
+from typing import Any, Awaitable, Callable, Dict, Generator, List, Optional, Sequence, Tuple, TypeVar, Union, overload
 from abc import ABCMeta, abstractmethod
 from asyncio.futures import Future
 from asyncio.coroutines import coroutine

--- a/stdlib/3.4/asyncio/events.pyi
+++ b/stdlib/3.4/asyncio/events.pyi
@@ -107,7 +107,7 @@ class AbstractEventLoop(metaclass=ABCMeta):
                           local_addr: str = ..., server_hostname: str = ...) -> Generator[Any, None, _TransProtPair]: ...
     @abstractmethod
     @coroutine
-    def create_server(self, protocol_factory: _ProtocolFactory, host: str = ..., port: int = ..., *,
+    def create_server(self, protocol_factory: _ProtocolFactory, host: Union[str, Sequence[str]] = ..., port: int = ..., *,
                       family: int = ..., flags: int = ...,
                       sock: socket = ..., backlog: int = ..., ssl: _SSLContext = ...,
                       reuse_address: Optional[bool] = ...,
@@ -126,8 +126,9 @@ class AbstractEventLoop(metaclass=ABCMeta):
     def create_datagram_endpoint(self, protocol_factory: _ProtocolFactory,
                                  local_addr: str = ..., remote_addr: str = ..., *,
                                  family: int = ..., proto: int = ..., flags: int = ...,
-                                 sock: socket = ..., reuse_address: Optional[bool] = ...,
-                                 reuse_port: Optional[bool] = ...) -> Generator[Any, None, _TransProtPair]: ...
+                                 reuse_address: Optional[bool] = ..., reuse_port: Optional[bool] = ...,
+                                 allow_broadcast: Optional[bool] = ...,
+                                 sock: socket = ...) -> Generator[Any, None, _TransProtPair]: ...
     @abstractmethod
     @coroutine
     def connect_accepted_socket(self, protocol_factory: _ProtocolFactory, sock: socket, *, ssl: _SSLContext = ...) -> Generator[Any, None, _TransProtPair]: ...


### PR DESCRIPTION
Looks like `create_server` and `create_datagram_endpoint` have supported `reuse_port`, `reuse_address`, and `sock` since 3.4.

https://docs.python.org/3.4/library/asyncio-eventloop.html
https://github.com/python/cpython/blob/ee51327a2329eb9c2bfbb6ea673cfab4299450b0/Lib/asyncio/events.py