### PR TITLE
Add a tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,35 @@
+[tox]
+minversion=2.3.1
+envlist = flake,mypy,pytype
+skipsdist = True
+
+[testenv]
+whitelist_externals =
+    git
+    rm
+    cp
+    bash
+
+[testenv:mypy]
+commands =
+    pip install --upgrade -U git+git://github.com/python/mypy git+git://github.com/python/typed_ast
+    python tests/mypy_test.py
+
+[testenv:pytype]
+commands =
+    pip install --upgrade -U git+git://github.com/google/pytype
+    python tests/pytype_test.py
+
+[testenv:flake]
+commands =
+    pip install --upgrade -U git+git://github.com/ambv/flake8-pyi
+    flake8
+
+[testenv:mypytests]
+commands =
+    git clone --depth 1 git://github.com/python/mypy {envtmpdir}/mypy
+    pip install -U -r {envtmpdir}/mypy/test-requirements.txt
+    rm -rf {envtmpdir}/mypy/typeshed/stdlib {envtmpdir}/mypy/typeshed/third_party
+    cp -R stdlib {envtmpdir}/mypy/typeshed/stdlib
+    cp -R third_party {envtmpdir}/mypy/typeshed/third_party
+    bash -c 'cd {envtmpdir}/mypy/ && ./runtests.py'


### PR DESCRIPTION
Can be improved, but wanted to get this in to make it easier to test against the mypy test suite.

We should add the "mypytests" target to Travis.