### PR TITLE
Allow user-defined kwargs being passed to click.group

### DIFF
--- a/third_party/3.6/click/decorators.pyi
+++ b/third_party/3.6/click/decorators.pyi
@@ -57,6 +57,8 @@ def group(
     short_help: str = None,
     options_metavar: str = '[OPTIONS]',
     add_help_option: bool = True,
+    # User-defined
+    **kwargs: Any,
 ) -> _Decorator:
     ...
 


### PR DESCRIPTION
This fixes the false positive with the following:
```python
class FooGroup(click.Group):
    def __init__(self, msg, *args, **kwargs):
        super().__init__(*args, **kwargs)
        self.message = msg


@click.group(cls=FooGroup, msg='OK')
def cli():
    pass
```

That, while still raising errors for regular arguments:
```python
@click.group(cls='Unexpected string', msg='OK')
def cli():
    pass
```
```
test.py:10: error: Argument 1 to "group" has incompatible type "str"; expected "type"
```