### PR TITLE
Don't reference long in types.pyi

### DIFF
--- a/stdlib/2/types.pyi
+++ b/stdlib/2/types.pyi
@@ -13,7 +13,7 @@ TypeType = type
 ObjectType = object
 
 IntType = int
-LongType = long
+LongType = int  # Really long, but can't reference that due to a mypy import cycle
 FloatType = float
 BooleanType = bool
 ComplexType = complex


### PR DESCRIPTION
(It's a type alias for int anyway, and it will cause a problem in the
initial import cycle once #886 is merged.)