### PR TITLE
Add an alias for `ensure_future` as `async`

### DIFF
--- a/stdlib/3.4/asyncio/__init__.pyi
+++ b/stdlib/3.4/asyncio/__init__.pyi
@@ -48,6 +48,7 @@ from asyncio.tasks import (
     ALL_COMPLETED as ALL_COMPLETED,
     as_completed as as_completed,
     ensure_future as ensure_future,
+    ensure_future as async,
     gather as gather,
     run_coroutine_threadsafe as run_coroutine_threadsafe,
     shield as shield,


### PR DESCRIPTION
`async` is still present in 3.6 and `ensure_future` doesn't exist before 3.4.4