### PR TITLE
Support enum iteration

### DIFF
--- a/stdlib/3.4/enum.pyi
+++ b/stdlib/3.4/enum.pyi
@@ -1,10 +1,9 @@
-import abc
 import sys
 from typing import List, Any, TypeVar, Union, Iterable, Iterator, TypeVar, Generic, Type
 
 _T = TypeVar('_T', bound=Enum)
 
-class EnumMeta(abc.ABCMeta, Iterable[Enum]):
+class EnumMeta(type, Iterable[Enum]):
     def __iter__(self: Type[_T]) -> Iterator[_T]: ...  # type: ignore
 
 class Enum(metaclass=EnumMeta):

--- a/stdlib/3.4/enum.pyi
+++ b/stdlib/3.4/enum.pyi
@@ -1,12 +1,14 @@
-# FIXME: Stub incomplete, ommissions include:
-# * the metaclass
-# * _sunder_ methods with their transformations
-
+import abc
 import sys
-from typing import List, Any, TypeVar, Union
+from typing import List, Any, TypeVar, Union, Iterable, Iterator, TypeVar, Generic, Type
 
-class Enum:
-    def __new__(cls, value: Any) -> None: ...
+_T = TypeVar('_T', bound=Enum)
+
+class EnumMeta(abc.ABCMeta, Iterable[Enum]):
+    def __iter__(self: Type[_T]) -> Iterator[_T]: ...  # type: ignore
+
+class Enum(metaclass=EnumMeta):
+    def __new__(cls: Type[_T], value: Any) -> _T: ...
     def __repr__(self) -> str: ...
     def __str__(self) -> str: ...
     def __dir__(self) -> List[str]: ...
@@ -19,8 +21,6 @@ class Enum:
 
 class IntEnum(int, Enum):
     value = ...  # type: int
-
-_T = TypeVar('_T')
 
 def unique(enumeration: _T) -> _T: ...
 


### PR DESCRIPTION
Fixes python/mypy#2305.

Example:
```
import enum
class Colors(enum.Enum):
    RED = 0
    BLUE = 1
print([color.name for color in Colors])  # This used to fail, now it works
```

(I found this unfinished project. Maybe it was waiting for some mypy improvement, or maybe I got distracted. Anyway, it seems to work now.)