### PR TITLE
Update configs and instructions for running tests manually.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -19,3 +19,4 @@ ignore = F401, F811, E127, E128, E301, E302, E305, E501, E701, E704, B303
 # A nice future improvement would be to provide separate .flake8
 # configurations for Python 2 and Python 3 files.
 builtins = StandardError,apply,basestring,buffer,cmp,coerce,execfile,file,intern,long,raw_input,reduce,reload,unichr,unicode,xrange
+exclude = .venv*,@*

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ analyze.py
 .*.sw?
 .vscode/
 .idea/
+.venv*/

--- a/README.md
+++ b/README.md
@@ -79,8 +79,7 @@ The tests are automatically run by Travis CI on every PR and push to
 the repo.  There are two separate sets of tests: `tests/mypy_test.py`
 runs tests against [mypy](https://github.com/python/mypy/), while
 `tests/pytype_tests.py` runs tests against
-[pytype](https://github.com/google/pytype/).  The script runtests.sh
-runs both sets of tests and flake8 over all .pyi files.
+[pytype](https://github.com/google/pytype/).
 
 Both sets of tests are shallow -- they verify that all stubs can be
 imported but they don't check whether stubs match their implementation
@@ -88,21 +87,25 @@ imported but they don't check whether stubs match their implementation
 that each set of tests has a blacklist of modules that are not tested
 at all.  The blacklists also live in the tests directory.
 
-To manually run the mypy tests, you need to have Python 3.5 or higher.
+To manually run the mypy tests, you need to have Python 3.5 or higher;
+Python 3.6.1 or higher is recommended.
 Run:
 ```
-$ python3.5 -m venv .venv3
+$ python3.6 -m venv .venv3
 $ source .venv3/bin/activate
-(.venv3)$ pip install -r requirements-tests-py3.txt
+(.venv3)$ pip3 install -r requirements-tests-py3.txt
 ```
-This will install mypy-lang, typed-ast, and flake8. You can then run
-mypy tests and flake8 tests by invoking:
+This will install mypy (you need the latest master branch from GitHub),
+typed-ast, and flake8. You can then run mypy tests and flake8 tests by
+invoking:
 ```
-(.venv3)$ python tests/mypy_test.py
+(.venv3)$ python3 tests/mypy_test.py
 ...
 (.venv3)$ flake8
 ...
 ```
+(Note that flake8 only works with Python 3.6 or higher.)
+
 To run the pytype tests, you need a separate virtual environment with
 Python 2.7. Run:
 ```
@@ -114,25 +117,6 @@ This will install pytype from its GitHub repo. You can then run pytype
 tests by running:
 ```
 (.venv2)$ python tests/pytype_test.py
-```
-
-To be able to everything with ``runtests.sh``, copy the ``pytype`` script
-from the Python 2 virtualenv to the Python 3 one:
-```
-$ cp .venv2/bin/pytype .venv3/bin/pytype
-$ source .venv3/bin/activate
-(.venv3)$ ./runtests.sh
-running mypy --python-version 3.6 --strict-optional # with 479 files
-running mypy --python-version 3.5 --strict-optional # with 469 files
-running mypy --python-version 3.4 --strict-optional # with 469 files
-running mypy --python-version 3.3 --strict-optional # with 454 files
-running mypy --python-version 3.2 --strict-optional # with 453 files
-running mypy --python-version 2.7 --strict-optional # with 502 files
-Running pytype tests...
-Ran pytype with 244 pyis, got 0 errors.
-Running flake8...
-flake8 run clean.
-(.venv3)$
 ```
 
 For mypy, if you are in the typeshed repo that is submodule of the

--- a/requirements-tests-py3.txt
+++ b/requirements-tests-py3.txt
@@ -1,4 +1,4 @@
-mypy>=0.501
+git+https://github.com/python/mypy.git@master
 typed-ast>=1.0.2
 flake8==3.3.0
 flake8-bugbear>=17.3.0

--- a/runtests.sh
+++ b/runtests.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-./tests/mypy_test.py
-./tests/pytype_test.py
-echo "Running flake8..."
-flake8 && echo "flake8 run clean."


### PR DESCRIPTION
- Switch requirements-tests-py3.txt to use mypy GitHub master.
- Exclude .venv{2,3} (suggested in README.md) in .flake8 and .gitignore.
- Update instructions in README.md to be working.
- Remove runtests.sh script and mentions of it -- I can't get it to work
  and the three steps are easily run by hand.