### PR TITLE
make enums support len()

### DIFF
--- a/stdlib/3.4/enum.pyi
+++ b/stdlib/3.4/enum.pyi
@@ -1,10 +1,10 @@
 import sys
-from typing import List, Any, TypeVar, Union, Iterable, Iterator, TypeVar, Generic, Type
+from typing import List, Any, TypeVar, Union, Iterable, Iterator, TypeVar, Generic, Type, Sized
 
 _T = TypeVar('_T', bound=Enum)
 _S = TypeVar('_S', bound=Type[Enum])
 
-class EnumMeta(type, Iterable[Enum]):
+class EnumMeta(type, Iterable[Enum], Sized):
     def __iter__(self: Type[_T]) -> Iterator[_T]: ...  # type: ignore
 
 class Enum(metaclass=EnumMeta):


### PR DESCRIPTION
Test with mypy:

```shell
$ cat ../bin/enumops.py 
import enum

class Foo(enum.Enum):
    a = 1
    b = 2

reveal_type(list(Foo))
reveal_type(Foo['a'])
reveal_type(Foo.a in Foo)
reveal_type(len(Foo))

$ mypy --custom-typeshed-dir . ../bin/enumops.py 
../bin/enumops.py:7: error: Revealed type is 'builtins.list[enum.Enum*]'
../bin/enumops.py:8: error: Revealed type is 'enumops.Foo'
../bin/enumops.py:9: error: Revealed type is 'builtins.bool'
../bin/enumops.py:10: error: Revealed type is 'builtins.int'
```