### PR TITLE
Fix missing 'type: ' in opcode.pyi

### DIFF
--- a/stdlib/2and3/opcode.pyi
+++ b/stdlib/2and3/opcode.pyi
@@ -12,7 +12,7 @@ hascompare = ...  # type: List[int]
 hasfree = ...  # type: List[int]
 opname = ...  # type: List[str]
 
-opmap = ...  # Dict[str, int]
+opmap = ...  # type: Dict[str, int]
 HAVE_ARGUMENT = ...  # type: int
 EXTENDED_ARG = ...  # type: int
 


### PR DESCRIPTION
Fixes `error: Value of type "ellipsis" is not indexable` when trying to index into `opcode.opmap`.