### PR TITLE
Add missing attributes: asyncio.subprocess.Process

### DIFF
--- a/stdlib/3.4/asyncio/subprocess.pyi
+++ b/stdlib/3.4/asyncio/subprocess.pyi
@@ -21,6 +21,10 @@ class SubprocessStreamProtocol(streams.FlowControlMixin,
 
 
 class Process:
+    stdin = ...  # type: Optional[streams.StreamWriter]
+    stdout = ...  # type: Optional[streams.StreamReader]
+    stderr = ...  # type: Optional[streams.StreamReader]
+    pid = ...  # type: int
     def __init__(self,
             transport: transports.BaseTransport,
             protocol: protocols.BaseProtocol,

--- a/stdlib/3.4/asyncio/subprocess.pyi
+++ b/stdlib/3.4/asyncio/subprocess.pyi
@@ -13,6 +13,9 @@ DEVNULL = ...  # type: int
 
 class SubprocessStreamProtocol(streams.FlowControlMixin,
                                protocols.SubprocessProtocol):
+    stdin = ...  # type: Optional[streams.StreamWriter]
+    stdout = ...  # type: Optional[streams.StreamReader]
+    stderr = ...  # type: Optional[streams.StreamReader]
     def __init__(self, limit: int, loop: events.AbstractEventLoop) -> None: ...
     def connection_made(self, transport: transports.BaseTransport) -> None: ...
     def pipe_data_received(self, fd: int, data: AnyStr) -> None: ...


### PR DESCRIPTION
Add typehints for the following `asyncio.subprocess.Process` attributes:

- `stdin`: `Optional[asyncio.streams.StreamWriter]`
- `stdout`: `Optional[asyncio.streams.StreamReader]`
- `stderr`: `Optional[asyncio.streams.StreamReader]`
- `pid`: `int`