### PR TITLE
Require warning categories to be subclasses of Warning (#343)

### DIFF
--- a/stdlib/2/_warnings.pyi
+++ b/stdlib/2/_warnings.pyi
@@ -1,11 +1,11 @@
-from typing import Any, List
+from typing import Any, List, Optional, Type
 
 default_action = ...  # type: str
 filters = ...  # type: List[tuple]
 once_registry = ...  # type: dict
 
-def warn(message: Warning, category: type = ..., stacklevel: int = ...) -> None: ...
-def warn_explicit(message: Warning, category: type,
+def warn(message: Warning, category: Optional[Type[Warning]] = ..., stacklevel: int = ...) -> None: ...
+def warn_explicit(message: Warning, category: Optional[Type[Warning]],
                   filename: str, lineno: int,
                   module: Any = ..., registry: dict = ...,
                   module_globals: dict = ...) -> None: ...

--- a/stdlib/3/_warnings.pyi
+++ b/stdlib/3/_warnings.pyi
@@ -1,11 +1,11 @@
-from typing import Any, List
+from typing import Any, List, Optional, Type
 
 _defaultaction = ...  # type: str
 _onceregistry = ...  # type: dict
 filters = ...  # type: List[tuple]
 
-def warn(message: Warning, category: type = ..., stacklevel: int = ...) -> None: ...
-def warn_explicit(message: Warning, category: type,
+def warn(message: Warning, category: Optional[Type[Warning]] = ..., stacklevel: int = ...) -> None: ...
+def warn_explicit(message: Warning, category: Optional[Type[Warning]],
                   filename: str, lineno: int,
                   module: Any = ..., registry: dict = ...,
                   module_globals: dict = ...) -> None: ...


### PR DESCRIPTION
CPython _warnings module implementation accepts Warning subclasses and None, but not any subclass of BaseException
specified in the stub. The stub for warnings is correct.