### PR TITLE
Support Python 3.6 PathLike Objects

### DIFF
--- a/stdlib/3/os/__init__.pyi
+++ b/stdlib/3/os/__init__.pyi
@@ -118,7 +118,7 @@ TMP_MAX = 0  # Undocumented, but used by tempfile
 if sys.version_info >= (3, 6):
     from builtins import _PathLike as PathLike  # See comment in builtins
 
-_PathType = Union[bytes, Text]
+_PathType = path._PathType
 
 if sys.version_info >= (3, 6):
     class DirEntry(PathLike[AnyStr]):

--- a/stdlib/3/os/path.pyi
+++ b/stdlib/3/os/path.pyi
@@ -10,7 +10,12 @@ from typing import (
 )
 
 _T = TypeVar('_T')
-_PathType = Union[bytes, Text]
+
+if sys.version_info >= (3, 6):
+    from builtins import _PathLike
+    _PathType = Union[bytes, Text, _PathLike]
+else:
+    _PathType = Union[bytes, Text]
 
 # ----- os.path variables -----
 supports_unicode_filenames = False


### PR DESCRIPTION
- Add support for PathLike to _PathType for Python 3.6 Unions only