### PR TITLE
Add stubs for *path.pyi in Python 2.7 stdlib

### DIFF
--- a/stdlib/2/macpath.pyi
+++ b/stdlib/2/macpath.pyi
@@ -1,0 +1,1 @@
+posixpath.pyi

--- a/stdlib/2/ntpath.pyi
+++ b/stdlib/2/ntpath.pyi
@@ -1,0 +1,1 @@
+posixpath.pyi

--- a/stdlib/2/os2emxpath.pyi
+++ b/stdlib/2/os2emxpath.pyi
@@ -1,0 +1,1 @@
+posixpath.pyi


### PR DESCRIPTION
Stubs are just soft links to posixpath.pyi, since the interfaces are identical.