### PR TITLE
Add stubs for *path.pyi in Python 3 stdlib

### DIFF
--- a/stdlib/3/macpath.pyi
+++ b/stdlib/3/macpath.pyi
@@ -1,0 +1,1 @@
+posixpath.pyi

--- a/stdlib/3/ntpath.pyi
+++ b/stdlib/3/ntpath.pyi
@@ -1,0 +1,1 @@
+posixpath.pyi


### PR DESCRIPTION
Similar to #1166 but for python 3.