### PR TITLE
Add uri param for sqlite3.connect (Python 3.4+)

### DIFF
--- a/stdlib/3/sqlite3/dbapi2.pyi
+++ b/stdlib/3/sqlite3/dbapi2.pyi
@@ -6,6 +6,8 @@ from numbers import Integral
 from datetime import time, datetime
 from collections import Iterable
 
+import sys
+
 paramstyle = ...  # type: str
 threadsafety = ...  # type: int
 apilevel = ...  # type: str
@@ -66,13 +68,10 @@ version = ...  # type: str
 # TODO: adapt needs to get probed
 def adapt(obj, protocol, alternate): ...
 def complete_statement(sql: str) -> bool: ...
-def connect(database: Union[bytes, AnyStr],
-            timeout: float = ...,
-            detect_types: int = ...,
-            isolation_level: Union[str, None] = ...,
-            check_same_thread: bool = ...,
-            factory: Union[Connection, None] = ...,
-            cached_statements: int = ...) -> Connection: ...
+if sys.version_info >= (3, 4):
+    def connect(database: Union[bytes, AnyStr], timeout: float = ..., detect_types: int = ..., isolation_level: Union[str, None] = ..., check_same_thread: bool = ..., factory: Union[Connection, None] = ..., cached_statements: int = ..., uri: bool = ...) -> Connection: ...
+else:
+    def connect(database: Union[bytes, AnyStr], timeout: float = ..., detect_types: int = ..., isolation_level: Union[str, None] = ..., check_same_thread: bool = ..., factory: Union[Connection, None] = ..., cached_statements: int = ...) -> Connection: ...
 def enable_callback_tracebacks(flag: bool) -> None: ...
 def enable_shared_cache(do_enable: int) -> None: ...
 def register_adapter(type: type, callable: Any) -> None: ...


### PR DESCRIPTION
Read about the change [documented here](https://docs.python.org/3/library/sqlite3.html#sqlite3.connect).

The C code that implements it is [here](https://github.com/python/cpython/blob/3.4/Modules/_sqlite/module.c#L53-L72).