### PR TITLE
Add collections.abc.Collection

### DIFF
--- a/stdlib/3/collections/__init__.pyi
+++ b/stdlib/3/collections/__init__.pyi
@@ -38,7 +38,10 @@ from typing import (
     AbstractSet as Set,
 )
 if sys.version_info >= (3, 6):
-    from typing import AsyncGenerator as AsyncGenerator
+    from typing import (
+        Collection as Collection,
+        AsyncGenerator as AsyncGenerator,
+    )
 
 _T = TypeVar('_T')
 _KT = TypeVar('_KT')

--- a/stdlib/3/collections/abc.pyi
+++ b/stdlib/3/collections/abc.pyi
@@ -34,6 +34,7 @@ if sys.version_info >= (3, 5):
 
 if sys.version_info >= (3, 6):
     from . import (
+        Collection as Collection,
         Reversible as Reversible,
         AsyncGenerator as AsyncGenerator,
     )


### PR DESCRIPTION
This was missing for some reason. I'm pretty sure it needs to be added under the `>=3.6` section since it appears to have been added in 3.6.