### PR TITLE
Add missing enum attributes

### DIFF
--- a/stdlib/3.4/enum.pyi
+++ b/stdlib/3.4/enum.pyi
@@ -1,11 +1,16 @@
 import sys
-from typing import List, Any, TypeVar, Union, Iterable, Iterator, TypeVar, Generic, Type, Sized
+from typing import List, Any, TypeVar, Union, Iterable, Iterator, TypeVar, Generic, Type, Sized, Reversible, Container, Mapping
 
 _T = TypeVar('_T', bound=Enum)
 _S = TypeVar('_S', bound=Type[Enum])
 
-class EnumMeta(type, Iterable[Enum], Sized):
+class EnumMeta(type, Iterable[Enum], Sized, Reversible[Enum], Container[Enum]):
     def __iter__(self: Type[_T]) -> Iterator[_T]: ...  # type: ignore
+    def __reversed__(self: Type[_T]) -> Iterator[_T]: ...
+    def __contains__(self, member: Any) -> bool: ...
+    def __getitem__(self: Type[_T], name: str) -> _T: ...
+    @property
+    def __members__(self: Type[_T]) -> Mapping[str, _T]: ...
 
 class Enum(metaclass=EnumMeta):
     def __new__(cls: Type[_T], value: Any) -> _T: ...


### PR DESCRIPTION
Fixes #854 (unless there's more I'm missing).

Tested with this file:
```python
import enum

class A(enum.Enum):
    b = 1
    c = 2

reveal_type(reversed(A))
reveal_type(A.b in A)
reveal_type(A['a'])
reveal_type(A.__members__)
```
With mypy master this produces:
```
../bin/enum36.py:7: error: Revealed type is 'typing.Iterator[enum.Enum*]'
../bin/enum36.py:8: error: Revealed type is 'builtins.bool'
../bin/enum36.py:9: error: Revealed type is 'enum36.A'
../bin/enum36.py:10: error: Revealed type is 'typing.Mapping[builtins.str, enum36.A*]'
../bin/enum36.py:10: error: Invalid method type
```
The first line should be `Iterator[A]` but that's due to python/mypy#3210, and the last error is wrong but that's due to python/mypy#3223.