### PR TITLE
review exported names in collections stubs

### DIFF
--- a/stdlib/2/collections.pyi
+++ b/stdlib/2/collections.pyi
@@ -2,16 +2,28 @@
 
 # Based on http://docs.python.org/2.7/library/collections.html
 
-# TODO more abstract base classes (interfaces in mypy)
+# These are not exported.
+from typing import Any, Dict, Generic, TypeVar, Tuple, overload, Type, Optional, List, Union, Reversible
 
-# NOTE: These are incomplete!
-
+# These are exported.
 from typing import (
-    Any, Container, Dict, Generic, TypeVar, Iterable, Tuple, Callable, Mapping, overload,
-    Iterator, Type, Sized, Optional, List, Set, Sequence, Union, Reversible,
-    MutableMapping, MutableSet, MutableSequence,
+    Callable as Callable,
+    Container as Container,
+    Hashable as Hashable,
+    ItemsView as ItemsView,
+    Iterable as Iterable,
+    Iterator as Iterator,
+    KeysView as KeysView,
+    Mapping as Mapping,
+    MappingView as MappingView,
+    MutableMapping as MutableMapping,
+    MutableSequence as MutableSequence,
+    MutableSet as MutableSet,
+    Sequence as Sequence,
+    AbstractSet as Set,
+    Sized as Sized,
+    ValuesView as ValuesView,
 )
-import typing
 
 _T = TypeVar('_T')
 _KT = TypeVar('_KT')

--- a/stdlib/3/collections/__init__.pyi
+++ b/stdlib/3/collections/__init__.pyi
@@ -2,18 +2,18 @@
 
 # Based on http://docs.python.org/3.2/library/collections.html
 
-# TODO more abstract base classes (interfaces in mypy)
-
 # These are not exported.
 import sys
 import typing
 from typing import (
     TypeVar, Generic, Dict, overload, List, Tuple,
-    Callable, Any, Type, Optional, Union
+    Any, Type, Optional, Union
 )
 # These are exported.
-# TODO reexport more.
+from . import abc
+
 from typing import (
+    Callable as Callable,
     Container as Container,
     Hashable as Hashable,
     Iterable as Iterable,
@@ -21,10 +21,6 @@ from typing import (
     Sized as Sized,
     Generator as Generator,
     ByteString as ByteString,
-    Awaitable as Awaitable,
-    Coroutine as Coroutine,
-    AsyncIterable as AsyncIterable,
-    AsyncIterator as AsyncIterator,
     Reversible as Reversible,
     Mapping as Mapping,
     MappingView as MappingView,
@@ -41,6 +37,13 @@ if sys.version_info >= (3, 6):
     from typing import (
         Collection as Collection,
         AsyncGenerator as AsyncGenerator,
+    )
+if sys.version_info >= (3, 5):
+    from typing import (
+        Awaitable as Awaitable,
+        Coroutine as Coroutine,
+        AsyncIterable as AsyncIterable,
+        AsyncIterator as AsyncIterator,
     )
 
 _T = TypeVar('_T')


### PR DESCRIPTION
Fixes #709

I looked at dir(collections) in 2.7 and 3.6 and made sure the list of names matched the stubs.