### PR TITLE
add some missing names to abc.pyi

### DIFF
--- a/stdlib/3/abc.pyi
+++ b/stdlib/3/abc.pyi
@@ -1,18 +1,24 @@
-from typing import Any, Type, TypeVar
+from typing import Any, Callable, Type, TypeVar
 import sys
 # Stubs for abc.
 
 _T = TypeVar('_T')
+_FuncT = TypeVar('_FuncT', bound=Callable[..., Any])
 
-# Thesee definitions have special processing in type checker.
+# Thesee definitions have special processing in mypy
 class ABCMeta(type):
     if sys.version_info >= (3, 3):
         def register(cls: "ABCMeta", subclass: Type[_T]) -> Type[_T]: ...
     else:
         def register(cls: "ABCMeta", subclass: Type[Any]) -> None: ...
-abstractmethod = object()
-abstractproperty = object()
+
+def abstractmethod(callable: _FuncT) -> _FuncT: ...
+def abstractproperty(callable: _FuncT) -> _FuncT: ...
+# These two are deprecated and not supported by mypy
+def abstractstaticmethod(callable: _FuncT) -> _FuncT: ...
+def abstractclassmethod(callable: _FuncT) -> _FuncT: ...
 
 if sys.version_info >= (3, 4):
     class ABC(metaclass=ABCMeta):
         pass
+    def get_cache_token() -> object: ...


### PR DESCRIPTION
Fixes #304 

Also made the @abstractmethod stub slightly more meaningful. (It doesn't matter to mypy.)