### PR TITLE
Make FunctionType and MethodType Callable.

### DIFF
--- a/stdlib/3/collections/abc.pyi
+++ b/stdlib/3/collections/abc.pyi
@@ -5,6 +5,7 @@ import sys
 
 if sys.version_info >= (3, 3):
     from . import (
+        Callable as Callable,
         Container as Container,
         Hashable as Hashable,
         Iterable as Iterable,

--- a/stdlib/3/types.pyi
+++ b/stdlib/3/types.pyi
@@ -9,6 +9,12 @@ from typing import (
     Union, overload
 )
 
+if sys.version_info >= (3, 3):
+   from collections.abc import Callable as CallableABC
+else:
+   from collections import Callable as CallableABC
+
+
 # ModuleType is exported from this module, but for circular import
 # reasons exists in its own stub file (with ModuleSpec and Loader).
 from _importlib_modulespec import ModuleType as ModuleType  # Exported
@@ -20,7 +26,7 @@ _VT = TypeVar('_VT')
 class _Cell:
     cell_contents = ...  # type: Any
 
-class FunctionType(Callable):
+class FunctionType(CallableABC):
     __closure__ = ...  # type: Optional[Tuple[_Cell, ...]]
     __code__ = ...  # type: CodeType
     __defaults__ = ...  # type: Optional[Tuple[Any, ...]]
@@ -104,7 +110,7 @@ class CoroutineType:
     @overload
     def throw(self, typ: type, val: BaseException = ..., tb: 'TracebackType' = ...) -> Any: ...
 
-class MethodType(Callable):
+class MethodType(CallableABC):
     __func__ = ...  # type: FunctionType
     __self__ = ...  # type: object
     def __call__(self, *args: Any, **kwargs: Any) -> Any: ...

--- a/stdlib/3/types.pyi
+++ b/stdlib/3/types.pyi
@@ -20,7 +20,7 @@ _VT = TypeVar('_VT')
 class _Cell:
     cell_contents = ...  # type: Any
 
-class FunctionType:
+class FunctionType(Callable):
     __closure__ = ...  # type: Optional[Tuple[_Cell, ...]]
     __code__ = ...  # type: CodeType
     __defaults__ = ...  # type: Optional[Tuple[Any, ...]]
@@ -104,7 +104,7 @@ class CoroutineType:
     @overload
     def throw(self, typ: type, val: BaseException = ..., tb: 'TracebackType' = ...) -> Any: ...
 
-class MethodType:
+class MethodType(Callable):
     __func__ = ...  # type: FunctionType
     __self__ = ...  # type: object
     def __call__(self, *args: Any, **kwargs: Any) -> Any: ...


### PR DESCRIPTION
Currently instances of `FunctionType` and `MethodType` do not satisfy `Callable`.