### PR TITLE
drop 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
       env: TEST_CMD="./tests/pytype_test.py --num-parallel=4"
 
 install:
-  # pytype needs py-2.7, mypy needs py-3.2+. Additional logic in runtests.py
+  # pytype needs py-2.7, mypy needs py-3.3+. Additional logic in runtests.py
   - if [[ $TRAVIS_PYTHON_VERSION == '3.6-dev' ]]; then pip install -U flake8==3.3.0 flake8-bugbear>=17.3.0 flake8-pyi>=17.1.0; fi
   - if [[ $TRAVIS_PYTHON_VERSION == '3.5' ]]; then pip install -U git+git://github.com/python/mypy git+git://github.com/python/typed_ast; fi
   - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then pip install -U git+git://github.com/google/pytype; fi

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ For information on how to use `typeshed`, read below.  Information for
 contributors can be found in [CONTRIBUTING.md](CONTRIBUTING.md).  **Please read
 it before submitting pull requests.**
 
+Typeshed supports Python versions 2.7 and 3.3 and up.
+
 ## Format
 
 Each Python module is represented by a `.pyi` "stub". This is a normal Python

--- a/tests/mypy_test.py
+++ b/tests/mypy_test.py
@@ -83,7 +83,7 @@ def main():
         print("Cannot import mypy. Did you install it?")
         sys.exit(1)
 
-    versions = [(3, 6), (3, 5), (3, 4), (3, 3), (3, 2), (2, 7)]
+    versions = [(3, 6), (3, 5), (3, 4), (3, 3), (2, 7)]
     if args.python_version:
         versions = [v for v in versions
                     if any(('%d.%d' % v).startswith(av) for av in args.python_version)]


### PR DESCRIPTION
Closes #1145

I found no explicit statement about supported Python versions, so I added it to a
prominent place in the README. Let me know if you prefer it to be put somewhere
else.