### PR TITLE
make type aliases in lxml.etree private

### DIFF
--- a/third_party/3/lxml/etree.pyi
+++ b/third_party/3/lxml/etree.pyi
@@ -11,10 +11,10 @@ from typing import Iterable, Iterator, SupportsBytes
 # unnecessary constraint. It seems reasonable to constrain each
 # List/Dict argument to use one type consistently, though, and it is
 # necessary in order to keep these brief.
-AnyStr = Union[str, bytes]
-ListAnyStr = Union[List[str], List[bytes]]
-DictAnyStr = Union[Dict[str, str], Dict[bytes, bytes]]
-Dict_Tuple2AnyStr_Any = Union[Dict[Tuple[str, str], Any], Tuple[bytes, bytes], Any]
+_AnyStr = Union[str, bytes]
+_ListAnyStr = Union[List[str], List[bytes]]
+_DictAnyStr = Union[Dict[str, str], Dict[bytes, bytes]]
+_Dict_Tuple2AnyStr_Any = Union[Dict[Tuple[str, str], Any], Tuple[bytes, bytes], Any]
 
 
 class ElementChildIterator(Iterator['_Element']):
@@ -22,23 +22,21 @@ class ElementChildIterator(Iterator['_Element']):
     def __next__(self) -> '_Element': ...
 
 class _Element(Iterable['_Element']):
-    def addprevious(self, element: '_Element') -> None:
-        ...
+    def addprevious(self, element: '_Element') -> None: ...
 
     attrib = ...  # type: MutableMapping[str, str]
-    text = ...  # type: AnyStr
+    text = ...  # type: _AnyStr
     tag = ...  # type: str
     def append(self, element: '_Element') -> '_Element': ...
     def __iter__(self) -> ElementChildIterator: ...
 
-class ElementBase(_Element):
-    ...
+class ElementBase(_Element): ...
 
 class _ElementTree:
     def write(self,
-              file: Union[AnyStr, typing.IO],
-              encoding: AnyStr = ...,
-              method: AnyStr = ...,
+              file: Union[_AnyStr, typing.IO],
+              encoding: _AnyStr = ...,
+              method: _AnyStr = ...,
               pretty_print: bool = ...,
               xml_declaration: Any = ...,
               with_tail: Any = ...,
@@ -46,80 +44,54 @@ class _ElementTree:
               compression: int = ...,
               exclusive: bool = ...,
               with_comments: bool = ...,
-              inclusive_ns_prefixes: ListAnyStr = ...) -> None:
-        ...
+              inclusive_ns_prefixes: _ListAnyStr = ...) -> None: ...
 
-class _XSLTResultTree(SupportsBytes):
-    ...
+class _XSLTResultTree(SupportsBytes): ...
 
-class _XSLTQuotedStringParam:
-    ...
+class _XSLTQuotedStringParam: ...
 
-class XMLParser:
-    ...
+class XMLParser: ...
 
 class XMLSchema:
     def __init__(self,
                  etree: Union[_Element, _ElementTree] = ...,
-                 file: Union[AnyStr, typing.IO] = ...) -> None:
-        ...
+                 file: Union[_AnyStr, typing.IO] = ...) -> None: ...
+    def assertValid(self, etree: Union[_Element, _ElementTree]) -> None: ...
 
-    def assertValid(self,
-                    etree: Union[_Element, _ElementTree]) -> None:
-        ...
-
-class XSLTAccessControl:
-    ...
+class XSLTAccessControl: ...
 
 class XSLT:
     def __init__(self,
                  xslt_input: Union[_Element, _ElementTree],
-                 extensions: Dict_Tuple2AnyStr_Any = ...,
+                 extensions: _Dict_Tuple2AnyStr_Any = ...,
                  regexp: bool = ...,
-                 access_control: XSLTAccessControl = ...) -> None:
-        ...
-
+                 access_control: XSLTAccessControl = ...) -> None: ...
     def __call__(self,
                  _input: Union[_Element, _ElementTree],
                  profile_run: bool = ...,
-                 **kwargs: Union[AnyStr, _XSLTQuotedStringParam]) -> _XSLTResultTree:
-        ...
-
+                 **kwargs: Union[_AnyStr, _XSLTQuotedStringParam]) -> _XSLTResultTree: ...
     @staticmethod
-    def strparam(s: AnyStr) -> _XSLTQuotedStringParam:
-        ...
+    def strparam(s: _AnyStr) -> _XSLTQuotedStringParam: ...
 
-def Element(_tag: AnyStr,
-            attrib: DictAnyStr = ...,
-            nsmap: DictAnyStr = ...,
-            **extra: AnyStr) -> _Element:
-    ...
-
-def SubElement(_parent: _Element, _tag: AnyStr,
-               attrib: DictAnyStr = ...,
-               nsmap: DictAnyStr = ...,
-               **extra: AnyStr) -> _Element:
-    ...
-
+def Element(_tag: _AnyStr,
+            attrib: _DictAnyStr = ...,
+            nsmap: _DictAnyStr = ...,
+            **extra: _AnyStr) -> _Element: ...
+def SubElement(_parent: _Element, _tag: _AnyStr,
+               attrib: _DictAnyStr = ...,
+               nsmap: _DictAnyStr = ...,
+               **extra: _AnyStr) -> _Element: ...
 def ElementTree(element: _Element = ...,
-                file: Union[AnyStr, typing.IO] = ...,
-                parser: XMLParser = ...) -> _ElementTree:
-    ...
-
-def ProcessingInstruction(target: AnyStr, text: AnyStr = ...) -> _Element:
-    ...
-
-def parse(source: Union[AnyStr, typing.IO],
+                file: Union[_AnyStr, typing.IO] = ...,
+                parser: XMLParser = ...) -> _ElementTree: ...
+def ProcessingInstruction(target: _AnyStr, text: _AnyStr = ...) -> _Element: ...
+def parse(source: Union[_AnyStr, typing.IO],
           parser: XMLParser = ...,
-          base_url: AnyStr = ...) -> _ElementTree:
-    ...
-
-
-def fromstring(text: AnyStr,
+          base_url: _AnyStr = ...) -> _ElementTree: ...
+def fromstring(text: _AnyStr,
                parser: XMLParser = ...,
                *,
-               base_url: AnyStr = ...) -> _Element: ...
-
+               base_url: _AnyStr = ...) -> _Element: ...
 def tostring(element_or_tree: Union[_Element, _ElementTree],
              encoding: Union[str, type] = ...,
              method: str = ...,
@@ -130,39 +102,26 @@ def tostring(element_or_tree: Union[_Element, _ElementTree],
              doctype: str = ...,
              exclusive: bool = ...,
              with_comments: bool = ...,
-             inclusive_ns_prefixes: Any = ...) -> AnyStr: ...
+             inclusive_ns_prefixes: Any = ...) -> _AnyStr: ...
 
+class _ErrorLog: ...
 
-class _ErrorLog:
-    ...
-
-
-class Error(Exception):
-    ...
+class Error(Exception): ...
 
 class LxmlError(Error):
     def __init__(self, message: Any, error_log: _ErrorLog = ...) -> None: ...
     error_log = ...  # type: _ErrorLog
 
-class DocumentInvalid(LxmlError):
-    ...
+class DocumentInvalid(LxmlError): ...
+class LxmlSyntaxError(LxmlError, SyntaxError): ...
+class ParseError(LxmlSyntaxError): ...
+class XMLSyntaxError(ParseError): ...
 
-class LxmlSyntaxError(LxmlError, SyntaxError):
-    ...
-
-class ParseError(LxmlSyntaxError):
-    ...
-
-class XMLSyntaxError(ParseError):
-    ...
-
-
-class _Validator:
-    ...
+class _Validator: ...
 
 class DTD(_Validator):
     def __init__(self,
-                 file: Union[AnyStr, typing.IO] = ...,
+                 file: Union[_AnyStr, typing.IO] = ...,
                  *,
                  external_id: Any = ...) -> None: ...
 


### PR DESCRIPTION
Naming the alias "AnyStr" isn't a great idea since AnyStr normally means
the typevar.

Also removed some whitespace in accordance with typeshed style.