### PR TITLE
fix example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,15 @@ of the stub files.
 The below is an excerpt from the types for the `datetime` module.
 
 ```python
+from typing import Union
+
 MAXYEAR = ...  # type: int
 MINYEAR = ...  # type: int
 
 class date(object):
     def __init__(self, year: int, month: int, day: int) -> None: ...
     @classmethod
-    def fromtimestamp(cls, timestamp: int or float) -> date: ...
+    def fromtimestamp(cls, timestamp: Union[int, float]) -> date: ...
     @classmethod
     def fromordinal(cls, ordinal: int) -> date: ...
     @classmethod


### PR DESCRIPTION
"int or float" isn't valid.

We could also just use float (that's what the datetime stub currently has), but
introducing a typing feature in the example seems useful.