### PR TITLE
Update pbkdf2_hmac argument names for 3.4+

### DIFF
--- a/stdlib/3/hashlib.pyi
+++ b/stdlib/3/hashlib.pyi
@@ -37,8 +37,6 @@ def new(name: str, data: _DataType = ...) -> Hash: ...
 algorithms_guaranteed = ...  # type: AbstractSet[str]
 algorithms_available = ...  # type: AbstractSet[str]
 
-# New in version 3.4, rounds renamed to iterations in 3.5
-if sys.version_info >= (3, 5):
+# New in version 3.4
+if sys.version_info >= (3, 4):
     def pbkdf2_hmac(hash_name: str, password: _DataType, salt: _DataType, iterations: int, dklen: Optional[int] = ...) -> bytes: ...
-else:
-    def pbkdf2_hmac(name: str, password: _DataType, salt: _DataType, rounds: int, dklen: Optional[int] = ...) -> bytes: ...

--- a/stdlib/3/hashlib.pyi
+++ b/stdlib/3/hashlib.pyi
@@ -1,7 +1,8 @@
 # Stubs for hashlib
 
+import sys
 from abc import abstractmethod, ABCMeta
-from typing import AbstractSet, Union
+from typing import AbstractSet, Optional, Union
 
 _DataType = Union[bytes, bytearray, memoryview]
 
@@ -36,5 +37,8 @@ def new(name: str, data: _DataType = ...) -> Hash: ...
 algorithms_guaranteed = ...  # type: AbstractSet[str]
 algorithms_available = ...  # type: AbstractSet[str]
 
-# New in version 3.4
-def pbkdf2_hmac(name: str, password: _DataType, salt: _DataType, rounds: int, dklen: int = ...) -> bytes: ...
+# New in version 3.4, rounds renamed to iterations in 3.5
+if sys.version_info >= (3, 5):
+    def pbkdf2_hmac(hash_name: str, password: _DataType, salt: _DataType, iterations: int, dklen: Optional[int] = ...) -> bytes: ...
+else:
+    def pbkdf2_hmac(name: str, password: _DataType, salt: _DataType, rounds: int, dklen: Optional[int] = ...) -> bytes: ...


### PR DESCRIPTION
- Use `iterations` instead of `rounds` if running on 3.5
- Change `dklen` to `Optional`

Python 3.5 source:
https://github.com/python/cpython/blob/3626a505dbffc5539888bfdb596dc20560f0d2a1/Lib/hashlib.py#L157