### PR TITLE
Fix type stubs in typing.pyi

### DIFF
--- a/stdlib/2/typing.pyi
+++ b/stdlib/2/typing.pyi
@@ -385,7 +385,8 @@ class Pattern(Generic[AnyStr]):
 
 # Functions
 
-def get_type_hints(obj: Callable) -> dict[str, Any]: ...
+def get_type_hints(obj: Callable, globalns: Optional[dict],
+                   localns: Optional[dict]) -> dict[str, Any]: ...
 
 def cast(tp: Type[_T], obj: Any) -> _T: ...
 

--- a/stdlib/2/typing.pyi
+++ b/stdlib/2/typing.pyi
@@ -385,8 +385,8 @@ class Pattern(Generic[AnyStr]):
 
 # Functions
 
-def get_type_hints(obj: Callable, globalns: Optional[dict[AnyStr, Any]],
-                   localns: Optional[dict[AnyStr, Any]]) -> dict[AnyStr, Any]: ...
+def get_type_hints(obj: Callable, globalns: Optional[dict[Text, Any]] = ...,
+                   localns: Optional[dict[Text, Any]] = ...) -> None: ...
 
 def cast(tp: Type[_T], obj: Any) -> _T: ...
 

--- a/stdlib/2/typing.pyi
+++ b/stdlib/2/typing.pyi
@@ -385,8 +385,8 @@ class Pattern(Generic[AnyStr]):
 
 # Functions
 
-def get_type_hints(obj: Callable, globalns: Optional[dict],
-                   localns: Optional[dict]) -> dict[str, Any]: ...
+def get_type_hints(obj: Callable, globalns: Optional[dict[AnyStr, Any]],
+                   localns: Optional[dict[AnyStr, Any]]) -> dict[AnyStr, Any]: ...
 
 def cast(tp: Type[_T], obj: Any) -> _T: ...
 

--- a/stdlib/3/typing.pyi
+++ b/stdlib/3/typing.pyi
@@ -486,8 +486,8 @@ class Pattern(Generic[AnyStr]):
 
 # Functions
 
-def get_type_hints(obj: Callable, globalns: Optional[dict],
-                   localns: Optional[dict]) -> dict[str, Any]: ...
+def get_type_hints(obj: Callable, globalns: Optional[dict[AnyStr, Any]],
+                   localns: Optional[dict[AnyStr, Any]]) -> dict[AnyStr, Any]: ...
 
 def cast(tp: Type[_T], obj: Any) -> _T: ...
 

--- a/stdlib/3/typing.pyi
+++ b/stdlib/3/typing.pyi
@@ -486,8 +486,8 @@ class Pattern(Generic[AnyStr]):
 
 # Functions
 
-def get_type_hints(obj: Callable, globalns: Optional[dict[AnyStr, Any]],
-                   localns: Optional[dict[AnyStr, Any]]) -> dict[AnyStr, Any]: ...
+def get_type_hints(obj: Callable, globalns: Optional[dict[str, Any]] = ...,
+                   localns: Optional[dict[str, Any]] = ...) -> dict[str, Any]: ...
 
 def cast(tp: Type[_T], obj: Any) -> _T: ...
 

--- a/stdlib/3/typing.pyi
+++ b/stdlib/3/typing.pyi
@@ -486,7 +486,8 @@ class Pattern(Generic[AnyStr]):
 
 # Functions
 
-def get_type_hints(obj: Callable) -> dict[str, Any]: ...
+def get_type_hints(obj: Callable, globalns: Optional[dict],
+                   localns: Optional[dict]) -> dict[str, Any]: ...
 
 def cast(tp: Type[_T], obj: Any) -> _T: ...
 


### PR DESCRIPTION
Signature for `get_type_hints` function looks like `obj, globalns=None, localns=None`