### PR TITLE
also run pytype tests for Python 3 modules

### DIFF
--- a/tests/pytype_blacklist.txt
+++ b/tests/pytype_blacklist.txt
@@ -1,9 +1,58 @@
 # Pytype blacklist. Files will not be tested with pytype.
 
+# pytype has its own version of these files, and thus doesn't mind if it
+# can't parse the typeshed version:
 stdlib/2/__builtin__.pyi
 stdlib/2/builtins.pyi
 stdlib/2/typing.pyi
+stdlib/3/builtins.pyi
+stdlib/3/typing.pyi
 
 # Because of 'from . import path':
 stdlib/2/os/__init__.pyi
 stdlib/3/os/__init__.pyi
+
+# We've not been running the pytype tests under Python 3, for quite a while.
+# The below are files that have regressed and need fixing:
+stdlib/3/calendar.pyi
+stdlib/3/collections/__init__.pyi
+stdlib/3/collections/abc.pyi
+stdlib/3/concurrent/futures/__init__.pyi
+stdlib/3/concurrent/futures/_base.pyi
+stdlib/3/concurrent/futures/process.pyi
+stdlib/3/concurrent/futures/thread.pyi
+stdlib/3/email/headerregistry.pyi
+stdlib/3/email/message.pyi
+stdlib/3/email/policy.pyi
+stdlib/3/fileinput.pyi
+stdlib/3/gzip.pyi
+stdlib/3/http/__init__.pyi
+stdlib/3/http/cookiejar.pyi
+stdlib/3/importlib/__init__.pyi
+stdlib/3/importlib/abc.pyi
+stdlib/3/inspect.pyi
+stdlib/3/json/__init__.pyi
+stdlib/3/json/decoder.pyi
+stdlib/3/json/encoder.pyi
+stdlib/3/multiprocessing/__init__.pyi
+stdlib/3/multiprocessing/pool.pyi
+stdlib/3/ssl.pyi
+stdlib/3/subprocess.pyi
+stdlib/3/sys.pyi
+stdlib/3/textwrap.pyi
+stdlib/3/time.pyi
+stdlib/3/tkinter/__init__.pyi
+stdlib/3/types.pyi
+stdlib/3/unittest/__init__.pyi
+stdlib/3/unittest/mock.pyi
+stdlib/3/urllib/parse.pyi
+stdlib/3/urllib/request.pyi
+stdlib/3/wsgiref/types.pyi
+stdlib/3.4/asyncio/events.pyi
+stdlib/3.4/asyncio/futures.pyi
+stdlib/3.4/asyncio/locks.pyi
+stdlib/3.4/asyncio/queues.pyi
+stdlib/3.4/asyncio/streams.pyi
+stdlib/3.4/asyncio/subprocess.pyi
+stdlib/3.4/asyncio/tasks.pyi
+stdlib/3.4/enum.pyi

--- a/tests/pytype_test.py
+++ b/tests/pytype_test.py
@@ -70,7 +70,7 @@ def pytype_test(args):
         print("Cannot run pytd. Did you install pytype?")
         return 0, 0
 
-    wanted = re.compile(r"stdlib/(2|2\.7|2and3)/.*\.pyi$")
+    wanted = re.compile(r"stdlib/.*\.pyi$")
     skipped = re.compile("(%s)$" % "|".join(load_blacklist()))
     files = []
 


### PR DESCRIPTION
For reasons I don't remember, we've only been running pytype on the Python 2 sources (`stdlib/2`). Now that we're looking into Python 3 compatibility more earnestly, let's also run pytype on `stdlib/3*`.