### PR TITLE
Removes MyPy test for Python 3.2, as support for 3.2 has been removed.

### DIFF
--- a/tests/mypy_test.py
+++ b/tests/mypy_test.py
@@ -83,7 +83,7 @@ def main():
         print("Cannot import mypy. Did you install it?")
         sys.exit(1)
 
-    versions = [(3, 6), (3, 5), (3, 4), (3, 3), (3, 2), (2, 7)]
+    versions = [(3, 6), (3, 5), (3, 4), (3, 3), (2, 7)]
     if args.python_version:
         versions = [v for v in versions
                     if any(('%d.%d' % v).startswith(av) for av in args.python_version)]


### PR DESCRIPTION
This fixes the mypy_test by removing 3.2, as MyPy does not support this version.