### PR TITLE
add from importlib import util

### DIFF
--- a/stdlib/3/importlib/__init__.pyi
+++ b/stdlib/3/importlib/__init__.pyi
@@ -1,3 +1,4 @@
+from importlib import util
 from importlib.abc import Loader
 import sys
 import types


### PR DESCRIPTION
at `typeshed/stdlib/3/importlib/__init__.pyi` added `from importlib import util` as it was missing.