### PR TITLE
distutils.core.setup fixes

### DIFF
--- a/stdlib/2and3/distutils/core.pyi
+++ b/stdlib/2and3/distutils/core.pyi
@@ -36,12 +36,14 @@ def setup(name: str = ...,
           command_packages: List[str] = ...,
           command_options: Mapping[str, Mapping[str, Tuple[Any, Any]]] = ...,
           package_data: Mapping[str, List[str]] = ...,
+          include_package_data: bool = ...,
           libraries: List[str] = ...,
           headers: List[str] = ...,
           ext_package: str = ...,
           include_dirs: List[str] = ...,
           password: str = ...,
-          fullname: str = ...) -> None: ...
+          fullname: str = ...,
+          **attrs: Any) -> None: ...
 
 def run_setup(script_name: str,
               script_args: Optional[List[str]] = ...,


### PR DESCRIPTION
- add include_package_data (which setuptools accepts)
- allow arbitrary other kwargs, because distutils.core.setup allows arbitrary kwargs and just passes them through to commands