### PR TITLE
Fix stub for ujson

### DIFF
--- a/third_party/2and3/ujson.pyi
+++ b/third_party/2and3/ujson.pyi
@@ -7,7 +7,7 @@ __version__ = ...  # type: str
 def encode(
     obj: Any,
     ensure_ascii: bool = ...,
-    double_precision: bool = ...,
+    double_precision: int = ...,
     encode_html_chars: bool = ...,
     escape_forward_slashes: bool = ...,
     sort_keys: bool = ...,
@@ -17,7 +17,7 @@ def encode(
 def dumps(
     obj: Any,
     ensure_ascii: bool = ...,
-    double_precision: bool = ...,
+    double_precision: int = ...,
     encode_html_chars: bool = ...,
     escape_forward_slashes: bool = ...,
     sort_keys: bool = ...,
@@ -28,7 +28,7 @@ def dump(
     obj: Any,
     fp: IO[str],
     ensure_ascii: bool = ...,
-    double_precision: bool = ...,
+    double_precision: int = ...,
     encode_html_chars: bool = ...,
     escape_forward_slashes: bool = ...,
     sort_keys: bool = ...,


### PR DESCRIPTION
Fixes #1332 

```
>>> import ujson
>>> ujson.dumps({"float": 0.123456789}, double_precision=3)
'{"float":0.123}'
>>> ujson.dumps({"float": 0.123456789}, double_precision=3.4)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: integer argument expected, got float
```