### PR TITLE
Allow subprocess stdout + stderr to be Optional

### DIFF
--- a/stdlib/2/subprocess.pyi
+++ b/stdlib/2/subprocess.pyi
@@ -4,7 +4,7 @@
 
 from typing import Sequence, Any, Mapping, Callable, Tuple, IO, Union, Optional, List, Text
 
-_FILE = Union[int, IO[Any]]
+_FILE = Union[None, int, IO[Any]]
 _TXT = Union[bytes, Text]
 _CMD = Union[_TXT, Sequence[_TXT]]
 _ENV = Union[Mapping[bytes, _TXT], Mapping[Text, _TXT]]

--- a/stdlib/3/subprocess.pyi
+++ b/stdlib/3/subprocess.pyi
@@ -5,7 +5,7 @@ import sys
 from typing import Sequence, Any, Mapping, Callable, Tuple, IO, Optional, Union, List, Type, Text
 from types import TracebackType
 
-_FILE = Union[int, IO[Any]]
+_FILE = Union[None, int, IO[Any]]
 _TXT = Union[bytes, Text]
 _CMD = Union[_TXT, Sequence[_TXT]]
 _ENV = Union[Mapping[bytes, _TXT], Mapping[Text, _TXT]]


### PR DESCRIPTION
- Adding Optional to _FILE for stderr + stdout arguments to subprocess functions
- Sometimes you might want subprocess commands to be quiet and other time print the output
Example Code: https://pastebin.com/Ebr9qbch