### PR TITLE
make itertools.product more precise

### DIFF
--- a/stdlib/2/itertools.pyi
+++ b/stdlib/2/itertools.pyi
@@ -121,13 +121,13 @@ def product(iter1: Iterable[_T1],
             iter5: Iterable[_T5],
             iter6: Iterable[_T6]) -> Iterator[Tuple[_T1, _T2, _T3, _T4, _T5, _T6]]: ...
 @overload
-def product(iter1: Iterable[_T1],
-            iter2: Iterable[_T2],
-            iter3: Iterable[_T3],
-            iter4: Iterable[_T4],
-            iter5: Iterable[_T5],
-            iter6: Iterable[_T6],
-            iter7: Iterable[_T7], *iterables: Iterable) -> Iterator[Tuple]: ...
+def product(iter1: Iterable[Any],
+            iter2: Iterable[Any],
+            iter3: Iterable[Any],
+            iter4: Iterable[Any],
+            iter5: Iterable[Any],
+            iter6: Iterable[Any],
+            iter7: Iterable[Any], *iterables: Iterable) -> Iterator[Tuple]: ...
 
 def permutations(iterable: Iterable[_T],
                  r: int = ...) -> Iterator[Sequence[_T]]: ...

--- a/stdlib/2/itertools.pyi
+++ b/stdlib/2/itertools.pyi
@@ -93,9 +93,41 @@ def izip(iter1: Iterable[Any], iter2: Iterable[Any],
 def izip_longest(*p: Iterable[Any],
                  fillvalue: Any = ...) -> Iterator[Any]: ...
 
-# TODO: Return type should be Iterator[Tuple[..]], but unknown tuple shape.
-#       Iterator[Sequence[_T]] loses this type information.
-def product(*p: Iterable[_T], repeat: int = ...) -> Iterator[Sequence[_T]]: ...
+@overload
+def product(iter1: Iterable[_T1]) -> Iterator[Tuple[_T1]]: ...
+@overload
+def product(iter1: Iterable[_T1],
+            iter2: Iterable[_T2]) -> Iterator[Tuple[_T1, _T2]]: ...
+@overload
+def product(iter1: Iterable[_T1],
+            iter2: Iterable[_T2],
+            iter3: Iterable[_T3]) -> Iterator[Tuple[_T1, _T2, _T3]]: ...
+@overload
+def product(iter1: Iterable[_T1],
+            iter2: Iterable[_T2],
+            iter3: Iterable[_T3],
+            iter4: Iterable[_T4]) -> Iterator[Tuple[_T1, _T2, _T3, _T4]]: ...
+@overload
+def product(iter1: Iterable[_T1],
+            iter2: Iterable[_T2],
+            iter3: Iterable[_T3],
+            iter4: Iterable[_T4],
+            iter5: Iterable[_T5]) -> Iterator[Tuple[_T1, _T2, _T3, _T4, _T5]]: ...
+@overload
+def product(iter1: Iterable[_T1],
+            iter2: Iterable[_T2],
+            iter3: Iterable[_T3],
+            iter4: Iterable[_T4],
+            iter5: Iterable[_T5],
+            iter6: Iterable[_T6]) -> Iterator[Tuple[_T1, _T2, _T3, _T4, _T5, _T6]]: ...
+@overload
+def product(iter1: Iterable[_T1],
+            iter2: Iterable[_T2],
+            iter3: Iterable[_T3],
+            iter4: Iterable[_T4],
+            iter5: Iterable[_T5],
+            iter6: Iterable[_T6],
+            iter7: Iterable[_T7], *iterables: Iterable) -> Iterator[Tuple]: ...
 
 def permutations(iterable: Iterable[_T],
                  r: int = ...) -> Iterator[Sequence[_T]]: ...

--- a/stdlib/3/itertools.pyi
+++ b/stdlib/3/itertools.pyi
@@ -60,29 +60,29 @@ _T6 = TypeVar('_T6')
 
 @overload
 def product(iter1: Iterable[_T1], *,
-            repeat:int = ...) -> Iterator[Tuple[_T1]]: ...
+            repeat: int = ...) -> Iterator[Tuple[_T1]]: ...
 @overload
 def product(iter1: Iterable[_T1],
             iter2: Iterable[_T2], *,
-            repeat:int = ...) -> Iterator[Tuple[_T1, _T2]]: ...
+            repeat: int = ...) -> Iterator[Tuple[_T1, _T2]]: ...
 @overload
 def product(iter1: Iterable[_T1],
             iter2: Iterable[_T2],
             iter3: Iterable[_T3], *,
-            repeat:int = ...) -> Iterator[Tuple[_T1, _T2, _T3]]: ...
+            repeat: int = ...) -> Iterator[Tuple[_T1, _T2, _T3]]: ...
 @overload
 def product(iter1: Iterable[_T1],
             iter2: Iterable[_T2],
             iter3: Iterable[_T3],
             iter4: Iterable[_T4], *,
-            repeat:int = ...) -> Iterator[Tuple[_T1, _T2, _T3, _T4]]: ...
+            repeat: int = ...) -> Iterator[Tuple[_T1, _T2, _T3, _T4]]: ...
 @overload
 def product(iter1: Iterable[_T1],
             iter2: Iterable[_T2],
             iter3: Iterable[_T3],
             iter4: Iterable[_T4],
             iter5: Iterable[_T5], *,
-            repeat:int = ...) -> Iterator[Tuple[_T1, _T2, _T3, _T4, _T5]]: ...
+            repeat: int = ...) -> Iterator[Tuple[_T1, _T2, _T3, _T4, _T5]]: ...
 @overload
 def product(iter1: Iterable[_T1],
             iter2: Iterable[_T2],
@@ -90,7 +90,7 @@ def product(iter1: Iterable[_T1],
             iter4: Iterable[_T4],
             iter5: Iterable[_T5],
             iter6: Iterable[_T6], *,
-            repeat:int = ...) -> Iterator[Tuple[_T1, _T2, _T3, _T4, _T5, _T6]]: ...
+            repeat: int = ...) -> Iterator[Tuple[_T1, _T2, _T3, _T4, _T5, _T6]]: ...
 @overload
 def product(iter1: Iterable[Any],
             iter2: Iterable[Any],
@@ -99,7 +99,7 @@ def product(iter1: Iterable[Any],
             iter5: Iterable[Any],
             iter6: Iterable[Any],
             iter7: Iterable[Any], *iterables: Iterable,
-            repeat:int = ...) -> Iterator[Tuple]: ...
+            repeat: int = ...) -> Iterator[Tuple]: ...
 
 def permutations(iterable: Iterable[_T],
                  r: Optional[int] = ...) -> Iterator[Tuple[_T, ...]]: ...

--- a/stdlib/3/itertools.pyi
+++ b/stdlib/3/itertools.pyi
@@ -57,7 +57,6 @@ _T3 = TypeVar('_T3')
 _T4 = TypeVar('_T4')
 _T5 = TypeVar('_T5')
 _T6 = TypeVar('_T6')
-_T7 = TypeVar('_T7')
 
 @overload
 def product(iter1: Iterable[_T1], *,
@@ -93,13 +92,13 @@ def product(iter1: Iterable[_T1],
             iter6: Iterable[_T6], *,
             repeat:int = ...) -> Iterator[Tuple[_T1, _T2, _T3, _T4, _T5, _T6]]: ...
 @overload
-def product(iter1: Iterable[_T1],
-            iter2: Iterable[_T2],
-            iter3: Iterable[_T3],
-            iter4: Iterable[_T4],
-            iter5: Iterable[_T5],
-            iter6: Iterable[_T6],
-            iter7: Iterable[_T7], *iterables: Iterable,
+def product(iter1: Iterable[Any],
+            iter2: Iterable[Any],
+            iter3: Iterable[Any],
+            iter4: Iterable[Any],
+            iter5: Iterable[Any],
+            iter6: Iterable[Any],
+            iter7: Iterable[Any], *iterables: Iterable,
             repeat:int = ...) -> Iterator[Tuple]: ...
 
 def permutations(iterable: Iterable[_T],

--- a/stdlib/3/itertools.pyi
+++ b/stdlib/3/itertools.pyi
@@ -51,7 +51,56 @@ def tee(iterable: Iterable[_T], n: int = ...) -> Tuple[Iterator[_T], ...]: ...
 def zip_longest(*p: Iterable[Any],
                 fillvalue: Any = ...) -> Iterator[Any]: ...
 
-def product(*p: Iterable[_T], repeat: int = ...) -> Iterator[Tuple[_T, ...]]: ...
+_T1 = TypeVar('_T1')
+_T2 = TypeVar('_T2')
+_T3 = TypeVar('_T3')
+_T4 = TypeVar('_T4')
+_T5 = TypeVar('_T5')
+_T6 = TypeVar('_T6')
+_T7 = TypeVar('_T7')
+
+@overload
+def product(iter1: Iterable[_T1], *,
+            repeat:int = ...) -> Iterator[Tuple[_T1]]: ...
+@overload
+def product(iter1: Iterable[_T1],
+            iter2: Iterable[_T2], *,
+            repeat:int = ...) -> Iterator[Tuple[_T1, _T2]]: ...
+@overload
+def product(iter1: Iterable[_T1],
+            iter2: Iterable[_T2],
+            iter3: Iterable[_T3], *,
+            repeat:int = ...) -> Iterator[Tuple[_T1, _T2, _T3]]: ...
+@overload
+def product(iter1: Iterable[_T1],
+            iter2: Iterable[_T2],
+            iter3: Iterable[_T3],
+            iter4: Iterable[_T4], *,
+            repeat:int = ...) -> Iterator[Tuple[_T1, _T2, _T3, _T4]]: ...
+@overload
+def product(iter1: Iterable[_T1],
+            iter2: Iterable[_T2],
+            iter3: Iterable[_T3],
+            iter4: Iterable[_T4],
+            iter5: Iterable[_T5], *,
+            repeat:int = ...) -> Iterator[Tuple[_T1, _T2, _T3, _T4, _T5]]: ...
+@overload
+def product(iter1: Iterable[_T1],
+            iter2: Iterable[_T2],
+            iter3: Iterable[_T3],
+            iter4: Iterable[_T4],
+            iter5: Iterable[_T5],
+            iter6: Iterable[_T6], *,
+            repeat:int = ...) -> Iterator[Tuple[_T1, _T2, _T3, _T4, _T5, _T6]]: ...
+@overload
+def product(iter1: Iterable[_T1],
+            iter2: Iterable[_T2],
+            iter3: Iterable[_T3],
+            iter4: Iterable[_T4],
+            iter5: Iterable[_T5],
+            iter6: Iterable[_T6],
+            iter7: Iterable[_T7], *iterables: Iterable,
+            repeat:int = ...) -> Iterator[Tuple]: ...
 
 def permutations(iterable: Iterable[_T],
                  r: Optional[int] = ...) -> Iterator[Tuple[_T, ...]]: ...


### PR DESCRIPTION
This fixes typechecking of code like e.g.

```
import itertools
itertools.product([1], [u""])
```

which currently reports a type error.