### PR TITLE
Add required to click.option decorator

### DIFF
--- a/third_party/2and3/click/decorators.pyi
+++ b/third_party/2and3/click/decorators.pyi
@@ -103,6 +103,7 @@ def option(
     help: str = None,
     # Parameter
     default: Any = None,
+    required: bool = False,
     callback: Optional[_Callback] = ...,
     nargs: int = None,
     metavar: str = None,


### PR DESCRIPTION
`click.option` creates `Option` instance which is a subclass of `Parameter` https://github.com/pallets/click/blob/master/click/core.py#L1477

As `Parameter` supports `required` so do `Option`.