### PR TITLE
Allow passing lambdas as init arguments in multiprocessing

### DIFF
--- a/stdlib/3/multiprocessing/context.pyi
+++ b/stdlib/3/multiprocessing/context.pyi
@@ -3,7 +3,6 @@
 from logging import Logger
 import multiprocessing
 import sys
-from mypy_extensions import NoReturn
 from typing import Any, Callable, Optional, List, Sequence, Tuple, Type, Union
 
 class ProcessError(Exception): ...
@@ -53,7 +52,7 @@ class BaseContext(object):
     def Pool(
         self,
         processes: Optional[int] = ...,
-        initializer: Optional[Callable[..., NoReturn]] = ...,
+        initializer: Optional[Callable[..., Any]] = ...,
         initargs: Tuple = ...,
         maxtasksperchild: Optional[int] = ...
     ) -> multiprocessing.Pool: ...

--- a/stdlib/3/multiprocessing/context.pyi
+++ b/stdlib/3/multiprocessing/context.pyi
@@ -3,6 +3,7 @@
 from logging import Logger
 import multiprocessing
 import sys
+from mypy_extensions import NoReturn
 from typing import Any, Callable, Optional, List, Sequence, Tuple, Type, Union
 
 class ProcessError(Exception): ...
@@ -49,14 +50,13 @@ class BaseContext(object):
     def JoinableQueue(self, maxsize: int = ...) -> Any: ...
     # TODO: change return to SimpleQueue once a stub exists in multiprocessing.queues
     def SimpleQueue(self) -> Any: ...
-    # TODO: change return to Pool once a stub exists in multiprocessing.pool
     def Pool(
         self,
         processes: Optional[int] = ...,
-        initializer: Optional[Callable[..., Any]] = ...,
+        initializer: Optional[Callable[..., NoReturn]] = ...,
         initargs: Tuple = ...,
         maxtasksperchild: Optional[int] = ...
-    ) -> Any: ...
+    ) -> multiprocessing.Pool: ...
     # TODO: typecode_or_type param is a ctype with a base class of _SimpleCData or array.typecode Need to figure out
     # how to handle the ctype
     # TODO: change return to RawValue once a stub exists in multiprocessing.sharedctypes

--- a/stdlib/3/multiprocessing/managers.pyi
+++ b/stdlib/3/multiprocessing/managers.pyi
@@ -4,6 +4,7 @@
 
 import queue
 import threading
+from mypy_extensions import NoReturn
 from typing import (
     Any, Callable, Dict, Iterable, List, Mapping, Optional, Sequence, TypeVar
 )
@@ -19,7 +20,7 @@ _Namespace = Namespace
 class BaseManager:
     def register(self, typeid: str, callable: Any = ...) -> None: ...
     def shutdown(self) -> None: ...
-    def start(self, initializer: Optional[Callable[..., None]] = ...,
+    def start(self, initializer: Optional[Callable[..., NoReturn]] = ...,
               initargs: Iterable[Any] = ...) -> None: ...
     def __enter__(self) -> 'BaseManager': ...
     def __exit__(self, exc_type, exc_value, tb) -> None: ...

--- a/stdlib/3/multiprocessing/managers.pyi
+++ b/stdlib/3/multiprocessing/managers.pyi
@@ -4,7 +4,6 @@
 
 import queue
 import threading
-from mypy_extensions import NoReturn
 from typing import (
     Any, Callable, Dict, Iterable, List, Mapping, Optional, Sequence, TypeVar
 )
@@ -20,7 +19,7 @@ _Namespace = Namespace
 class BaseManager:
     def register(self, typeid: str, callable: Any = ...) -> None: ...
     def shutdown(self) -> None: ...
-    def start(self, initializer: Optional[Callable[..., NoReturn]] = ...,
+    def start(self, initializer: Optional[Callable[..., Any]] = ...,
               initargs: Iterable[Any] = ...) -> None: ...
     def __enter__(self) -> 'BaseManager': ...
     def __exit__(self, exc_type, exc_value, tb) -> None: ...

--- a/stdlib/3/multiprocessing/pool.pyi
+++ b/stdlib/3/multiprocessing/pool.pyi
@@ -2,7 +2,6 @@
 
 # NOTE: These are incomplete!
 
-from mypy_extensions import NoReturn
 from typing import Any, Callable, Iterable, Mapping, Optional, Dict, List
 
 class AsyncResult():
@@ -13,7 +12,7 @@ class AsyncResult():
 
 class ThreadPool():
     def __init__(self, processes: Optional[int] = None,
-                 initializer: Optional[Callable[..., NoReturn]] = None,
+                 initializer: Optional[Callable[..., Any]] = None,
                  initargs: Iterable[Any] = ...) -> None: ...
     def apply(self,
               func: Callable[..., Any],

--- a/stdlib/3/multiprocessing/pool.pyi
+++ b/stdlib/3/multiprocessing/pool.pyi
@@ -2,6 +2,7 @@
 
 # NOTE: These are incomplete!
 
+from mypy_extensions import NoReturn
 from typing import Any, Callable, Iterable, Mapping, Optional, Dict, List
 
 class AsyncResult():
@@ -12,7 +13,7 @@ class AsyncResult():
 
 class ThreadPool():
     def __init__(self, processes: Optional[int] = None,
-                 initializer: Optional[Callable[..., None]] = None,
+                 initializer: Optional[Callable[..., NoReturn]] = None,
                  initargs: Iterable[Any] = ...) -> None: ...
     def apply(self,
               func: Callable[..., Any],


### PR DESCRIPTION
This will enable passing lambda expressions as init functions:

```
import signal
from multiprocessing import Manager

m = Manager()
m.start(lambda: signal.signal(signal.SIGINT, signal.SIG_IGN))

test.py:6: error: Argument 1 to "start" of "BaseManager" has incompatible type Callable[[], Union[Callable[[Signals, FrameType], None], int, Handlers]]; expected Callable[..., None]
```