### PR TITLE
Add a __new__ method to datetime.datetime.

### DIFF
--- a/stdlib/2/datetime.pyi
+++ b/stdlib/2/datetime.pyi
@@ -143,6 +143,9 @@ class datetime(object):
     def __init__(self, year: int, month: int, day: int, hour: int = ...,
                  minute: int = ..., second: int = ..., microseconds: int = ...,
                  tzinfo: tzinfo = ...) -> None: ...
+    def __new__(cls, year: int, month: int, day: int, hour: int = ...,
+                minute: int = ..., second: int = ..., microseconds: int = ...,
+                tzinfo: tzinfo = ...) -> datetime: ...
 
     @property
     def year(self) -> int: ...


### PR DESCRIPTION
datetime_tz subclasses datetime.datetime and overrides __new__ (https://github.com/mithro/python-datetime-tz/blob/master/datetime_tz/__init__.py#L415), so for pytype to analyze datetime_tz correctly, datetime.datetime.__new__ needs to be in the pyi file.