### PR TITLE
Typing.AsyncIterable should have __aiter__, not __anext__

### DIFF
--- a/stdlib/3/typing.pyi
+++ b/stdlib/3/typing.pyi
@@ -155,7 +155,7 @@ class AwaitableGenerator(Generator[_T_co, _T_contra, _V_co], Awaitable[_V_co],
 
 class AsyncIterable(Generic[_T_co]):
     @abstractmethod
-    def __anext__(self) -> Awaitable[_T_co]: ...
+    def __aiter__(self) -> 'AsyncIterator[_T_co]': ...
 
 class AsyncIterator(AsyncIterable[_T_co],
                     Generic[_T_co]):


### PR DESCRIPTION
Fixes #1396.

As requested in the issue #1396, here's an example demonstrating how the current stub is wrong:

```py
import asyncio
from typing import AsyncIterable


async def aproduce() -> AsyncIterable[int]:
    for i in range(10):
        yield i


class MyAsyncIterable(AsyncIterable[int]):

    def __aiter__(self) -> AsyncIterable[int]:
        print('PYTHON async for CALLED __aiter__')
        return aproduce()


async def aconsume() -> None:
    consumed = []
    async for i in MyAsyncIterable():
        consumed.append(i)
    assert consumed == list(range(10))


if __name__ == '__main__':
    loop = asyncio.get_event_loop()
    loop.run_until_complete(aconsume())
```

When executed using CPython 3.6.1 it works, but `mypy` generates the failure:

```
t.py:19: error: Cannot instantiate abstract class 'MyAsyncIterable' with abstract attribute '__anext__'
```

The Python iterator protocol is as follows:

Iterable: ``__aiter__`` returns `Iterator`
Iterator: ``__aiter__`` returns self, ``__next__`` returns next value in iterator.

The same goes for AsyncIterable/AsyncIterator, but typeshed deviates from all of the other sources I could find in having AsyncIterator have an ``__anext__`` method instead of ``__aiter__``.