### PR TITLE
Use explicit Optional[] on argument types with default None

### DIFF
--- a/stdlib/3/_importlib_modulespec.pyi
+++ b/stdlib/3/_importlib_modulespec.pyi
@@ -12,8 +12,8 @@ from typing import Dict, Any, Optional
 if sys.version_info >= (3, 4):
     class ModuleSpec:
         def __init__(self, name: str, loader: Optional['Loader'], *,
-                     origin: str = None, loader_state: Any = None,
-                     is_package: bool = None) -> None: ...
+                     origin: Optional[str] = None, loader_state: Any = None,
+                     is_package: Optional[bool] = None) -> None: ...
         name = ...  # type: str
         loader = ...  # type: Optional[Loader]
         origin = ...  # type: Optional[str]


### PR DESCRIPTION
I'm sure there are many more like this, but this one drew my attention (maybe because it's part of the initial import cycle).