### PR TITLE
use PEP 526-style annotations in os stubs

### DIFF
--- a/stdlib/2/os/__init__.pyi
+++ b/stdlib/2/os/__init__.pyi
@@ -11,93 +11,94 @@ from mypy_extensions import NoReturn
 
 _T = TypeVar('_T')
 
-SEEK_SET = 0
-SEEK_CUR = 0
-SEEK_END = 0
+SEEK_SET: int
+SEEK_CUR: int
+SEEK_END: int
 
 # More constants, copied from stdlib/3/os/__init__.pyi
-O_RDONLY = 0
-O_WRONLY = 0
-O_RDWR = 0
-O_APPEND = 0
-O_CREAT = 0
-O_EXCL = 0
-O_TRUNC = 0
-O_DSYNC = 0    # Unix only
-O_RSYNC = 0    # Unix only
-O_SYNC = 0     # Unix only
-O_NDELAY = 0   # Unix only
-O_NONBLOCK = 0  # Unix only
-O_NOCTTY = 0   # Unix only
-O_SHLOCK = 0   # Unix only
-O_EXLOCK = 0   # Unix only
-O_BINARY = 0     # Windows only
-O_NOINHERIT = 0  # Windows only
-O_SHORT_LIVED = 0  # Windows only
-O_TEMPORARY = 0  # Windows only
-O_RANDOM = 0     # Windows only
-O_SEQUENTIAL = 0  # Windows only
-O_TEXT = 0       # Windows only
-O_ASYNC = 0      # Gnu extension if in C library
-O_DIRECT = 0     # Gnu extension if in C library
-O_DIRECTORY = 0  # Gnu extension if in C library
-O_NOFOLLOW = 0   # Gnu extension if in C library
-O_NOATIME = 0    # Gnu extension if in C library
-O_LARGEFILE = 0  # Gnu extension if in C library
+O_RDONLY: int
+O_WRONLY: int
+O_RDWR: int
+O_APPEND: int
+O_CREAT: int
+O_EXCL: int
+O_TRUNC: int
+O_DSYNC: int    # Unix only
+O_RSYNC: int    # Unix only
+O_SYNC: int     # Unix only
+O_NDELAY: int   # Unix only
+O_NONBLOCK: int  # Unix only
+O_NOCTTY: int   # Unix only
+O_SHLOCK: int   # Unix only
+O_EXLOCK: int   # Unix only
+O_BINARY: int     # Windows only
+O_NOINHERIT: int  # Windows only
+O_SHORT_LIVED: int  # Windows only
+O_TEMPORARY: int  # Windows only
+O_RANDOM: int     # Windows only
+O_SEQUENTIAL: int  # Windows only
+O_TEXT: int       # Windows only
+O_ASYNC: int      # Gnu extension if in C library
+O_DIRECT: int     # Gnu extension if in C library
+O_DIRECTORY: int  # Gnu extension if in C library
+O_NOFOLLOW: int   # Gnu extension if in C library
+O_NOATIME: int    # Gnu extension if in C library
+O_LARGEFILE: int  # Gnu extension if in C library
 
-curdir = ...  # type: str
-pardir = ...  # type: str
-sep = ...  # type: str
-altsep = ...  # type: str
-extsep = ...  # type: str
-pathsep = ...  # type: str
-defpath = ...  # type: str
-linesep = ...  # type: str
-devnull = ...  # type: str
-name = ...  # type: str
+curdir: str
+pardir: str
+sep: str
+altsep: str
+extsep: str
+pathsep: str
+defpath: str
+linesep: str
+devnull: str
+name: str
 
-F_OK = 0
-R_OK = 0
-W_OK = 0
-X_OK = 0
+F_OK: int
+R_OK: int
+W_OK: int
+X_OK: int
 
 class _Environ(MutableMapping[AnyStr, AnyStr], Generic[AnyStr]):
     def copy(self) -> Dict[AnyStr, AnyStr]: ...
 
-environ = ...  # type: _Environ[str]
+environ: _Environ[str]
 
-confstr_names = ...  # type: Dict[str, int]  # Unix only
-pathconf_names = ...  # type: Dict[str, int]  # Unix only
-sysconf_names = ...  # type: Dict[str, int]  # Unix only
+confstr_names: Dict[str, int]  # Unix only
+pathconf_names: Dict[str, int]  # Unix only
+sysconf_names: Dict[str, int]  # Unix only
 
-EX_OK = 0        # Unix only
-EX_USAGE = 0     # Unix only
-EX_DATAERR = 0   # Unix only
-EX_NOINPUT = 0   # Unix only
-EX_NOUSER = 0    # Unix only
-EX_NOHOST = 0    # Unix only
-EX_UNAVAILABLE = 0  # Unix only
-EX_SOFTWARE = 0  # Unix only
-EX_OSERR = 0     # Unix only
-EX_OSFILE = 0    # Unix only
-EX_CANTCREAT = 0  # Unix only
-EX_IOERR = 0     # Unix only
-EX_TEMPFAIL = 0  # Unix only
-EX_PROTOCOL = 0  # Unix only
-EX_NOPERM = 0    # Unix only
-EX_CONFIG = 0    # Unix only
-P_NOWAIT = 0
-P_NOWAITO = 0
-P_WAIT = 0
-# P_DETACH = 0  # Windows only
-# P_OVERLAY = 0  # Windows only
+EX_OK: int        # Unix only
+EX_USAGE: int     # Unix only
+EX_DATAERR: int   # Unix only
+EX_NOINPUT: int   # Unix only
+EX_NOUSER: int    # Unix only
+EX_NOHOST: int    # Unix only
+EX_UNAVAILABLE: int  # Unix only
+EX_SOFTWARE: int  # Unix only
+EX_OSERR: int     # Unix only
+EX_OSFILE: int    # Unix only
+EX_CANTCREAT: int  # Unix only
+EX_IOERR: int     # Unix only
+EX_TEMPFAIL: int  # Unix only
+EX_PROTOCOL: int  # Unix only
+EX_NOPERM: int    # Unix only
+EX_CONFIG: int    # Unix only
+P_NOWAIT: int
+P_NOWAITO: int
+P_WAIT: int
+if sys.platform == 'win32':
+    P_DETACH: int  # Windows only
+    P_OVERLAY: int  # Windows only
 
 # wait()/waitpid() options
-WNOHANG = 0  # Unix only
-WCONTINUED = 0  # some Unix systems
-WUNTRACED = 0  # Unix only
+WNOHANG: int  # Unix only
+WCONTINUED: int  # some Unix systems
+WUNTRACED: int  # Unix only
 
-TMP_MAX = 0  # Undocumented, but used by tempfile
+TMP_MAX: int  # Undocumented, but used by tempfile
 _PathType = Union[bytes, Text]
 _StatVFS = NamedTuple('_StatVFS', [('f_bsize', int), ('f_frsize', int), ('f_blocks', int),
                                    ('f_bfree', int), ('f_bavail', int), ('f_files', int),
@@ -275,6 +276,6 @@ def tmpfile() -> IO[Any]: ...
 def tmpnam() -> str: ...
 def tempnam(dir: str = ..., prefix: str = ...) -> str: ...
 
-P_ALL = 0
-WEXITED = 0
-WNOWAIT = 0
+P_ALL: int
+WEXITED: int
+WNOWAIT: int

--- a/stdlib/3/os/__init__.pyi
+++ b/stdlib/3/os/__init__.pyi
@@ -17,102 +17,103 @@ _T = TypeVar('_T')
 
 # ----- os variables -----
 
-supports_bytes_environ = False  # TODO: True when bytes implemented?
+supports_bytes_environ: bool
 
 if sys.version_info >= (3, 3):
-    supports_dir_fd = ...  # type: Set[Callable[..., Any]]
-    supports_fd = ...  # type: Set[Callable[..., Any]]
-    supports_effective_ids = ...  # type: Set[Callable[..., Any]]
-    supports_follow_symlinks = ...  # type: Set[Callable[..., Any]]
+    supports_dir_fd: Set[Callable[..., Any]]
+    supports_fd: Set[Callable[..., Any]]
+    supports_effective_ids: Set[Callable[..., Any]]
+    supports_follow_symlinks: Set[Callable[..., Any]]
 
-SEEK_SET = 0
-SEEK_CUR = 0
-SEEK_END = 0
+SEEK_SET: int
+SEEK_CUR: int
+SEEK_END: int
 
-O_RDONLY = 0
-O_WRONLY = 0
-O_RDWR = 0
-O_APPEND = 0
-O_CREAT = 0
-O_EXCL = 0
-O_TRUNC = 0
-O_DSYNC = 0    # Unix only
-O_RSYNC = 0    # Unix only
-O_SYNC = 0     # Unix only
-O_NDELAY = 0   # Unix only
-O_NONBLOCK = 0  # Unix only
-O_NOCTTY = 0   # Unix only
-O_SHLOCK = 0   # Unix only
-O_EXLOCK = 0   # Unix only
-O_BINARY = 0     # Windows only
-O_NOINHERIT = 0  # Windows only
-O_SHORT_LIVED = 0  # Windows only
-O_TEMPORARY = 0  # Windows only
-O_RANDOM = 0     # Windows only
-O_SEQUENTIAL = 0  # Windows only
-O_TEXT = 0       # Windows only
-O_ASYNC = 0      # Gnu extension if in C library
-O_DIRECT = 0     # Gnu extension if in C library
-O_DIRECTORY = 0  # Gnu extension if in C library
-O_NOFOLLOW = 0   # Gnu extension if in C library
-O_NOATIME = 0    # Gnu extension if in C library
+O_RDONLY: int
+O_WRONLY: int
+O_RDWR: int
+O_APPEND: int
+O_CREAT: int
+O_EXCL: int
+O_TRUNC: int
+O_DSYNC: int    # Unix only
+O_RSYNC: int    # Unix only
+O_SYNC: int     # Unix only
+O_NDELAY: int   # Unix only
+O_NONBLOCK: int  # Unix only
+O_NOCTTY: int   # Unix only
+O_SHLOCK: int   # Unix only
+O_EXLOCK: int   # Unix only
+O_BINARY: int     # Windows only
+O_NOINHERIT: int  # Windows only
+O_SHORT_LIVED: int  # Windows only
+O_TEMPORARY: int  # Windows only
+O_RANDOM: int     # Windows only
+O_SEQUENTIAL: int  # Windows only
+O_TEXT: int       # Windows only
+O_ASYNC: int      # Gnu extension if in C library
+O_DIRECT: int     # Gnu extension if in C library
+O_DIRECTORY: int  # Gnu extension if in C library
+O_NOFOLLOW: int   # Gnu extension if in C library
+O_NOATIME: int    # Gnu extension if in C library
 
-curdir = ...  # type: str
-pardir = ...  # type: str
-sep = ...  # type: str
-altsep = ...  # type: str
-extsep = ...  # type: str
-pathsep = ...  # type: str
-defpath = ...  # type: str
-linesep = ...  # type: str
-devnull = ...  # type: str
-name = ...  # type: str
+curdir: str
+pardir: str
+sep: str
+altsep: str
+extsep: str
+pathsep: str
+defpath: str
+linesep: str
+devnull: str
+name: str
 
-F_OK = 0
-R_OK = 0
-W_OK = 0
-X_OK = 0
+F_OK: int
+R_OK: int
+W_OK: int
+X_OK: int
 
 class _Environ(MutableMapping[AnyStr, AnyStr], Generic[AnyStr]):
     def copy(self) -> Dict[AnyStr, AnyStr]: ...
 
-environ = ...  # type: _Environ[str]
-environb = ...  # type: _Environ[bytes]
+environ: _Environ[str]
+environb: _Environ[bytes]
 
-confstr_names = ...  # type: Dict[str, int]  # Unix only
-pathconf_names = ...  # type: Dict[str, int]  # Unix only
-sysconf_names = ...  # type: Dict[str, int]  # Unix only
+confstr_names: Dict[str, int]  # Unix only
+pathconf_names: Dict[str, int]  # Unix only
+sysconf_names: Dict[str, int]  # Unix only
 
-EX_OK = 0        # Unix only
-EX_USAGE = 0     # Unix only
-EX_DATAERR = 0   # Unix only
-EX_NOINPUT = 0   # Unix only
-EX_NOUSER = 0    # Unix only
-EX_NOHOST = 0    # Unix only
-EX_UNAVAILABLE = 0  # Unix only
-EX_SOFTWARE = 0  # Unix only
-EX_OSERR = 0     # Unix only
-EX_OSFILE = 0    # Unix only
-EX_CANTCREAT = 0  # Unix only
-EX_IOERR = 0     # Unix only
-EX_TEMPFAIL = 0  # Unix only
-EX_PROTOCOL = 0  # Unix only
-EX_NOPERM = 0    # Unix only
-EX_CONFIG = 0    # Unix only
-EX_NOTFOUND = 0  # Unix only
+EX_OK: int        # Unix only
+EX_USAGE: int     # Unix only
+EX_DATAERR: int   # Unix only
+EX_NOINPUT: int   # Unix only
+EX_NOUSER: int    # Unix only
+EX_NOHOST: int    # Unix only
+EX_UNAVAILABLE: int  # Unix only
+EX_SOFTWARE: int  # Unix only
+EX_OSERR: int     # Unix only
+EX_OSFILE: int    # Unix only
+EX_CANTCREAT: int  # Unix only
+EX_IOERR: int     # Unix only
+EX_TEMPFAIL: int  # Unix only
+EX_PROTOCOL: int  # Unix only
+EX_NOPERM: int    # Unix only
+EX_CONFIG: int    # Unix only
+EX_NOTFOUND: int  # Unix only
 
-P_NOWAIT = 0
-P_NOWAITO = 0
-P_WAIT = 0
-# P_DETACH = 0  # Windows only
-# P_OVERLAY = 0  # Windows only
+P_NOWAIT: int
+P_NOWAITO: int
+P_WAIT: int
+if sys.platform == 'win32':
+    P_DETACH: int  # Windows only
+    P_OVERLAY: int  # Windows only
 
 # wait()/waitpid() options
-WNOHANG = 0  # Unix only
-# WCONTINUED = 0  # some Unix systems
-# WUNTRACED = 0  # Unix only
+WNOHANG: int  # Unix only
+WCONTINUED: int  # some Unix systems
+WUNTRACED: int  # Unix only
 
-TMP_MAX = 0  # Undocumented, but used by tempfile
+TMP_MAX: int  # Undocumented, but used by tempfile
 
 # ----- os classes (structures) -----
 if sys.version_info >= (3, 6):
@@ -125,8 +126,8 @@ if sys.version_info >= (3, 6):
         # This is what the scandir interator yields
         # The constructor is hidden
 
-        name = ...  # type: AnyStr
-        path = ...  # type: AnyStr
+        name: AnyStr
+        path: AnyStr
         def inode(self) -> int: ...
         def is_dir(self, follow_symlinks: bool = ...) -> bool: ...
         def is_file(self, follow_symlinks: bool = ...) -> bool: ...
@@ -139,8 +140,8 @@ elif sys.version_info >= (3, 5):
         # This is what the scandir interator yields
         # The constructor is hidden
 
-        name = ...  # type: AnyStr
-        path = ...  # type: AnyStr
+        name: AnyStr
+        path: AnyStr
         def inode(self) -> int: ...
         def is_dir(self, follow_symlinks: bool = ...) -> bool: ...
         def is_file(self, follow_symlinks: bool = ...) -> bool: ...
@@ -155,53 +156,53 @@ class stat_result:
     # st_ino, st_dev, st_nlink, st_uid, st_gid, st_size, st_atime, st_mtime,
     # st_ctime. More items may be added at the end by some implementations.
 
-    st_mode = 0  # protection bits,
-    st_ino = 0  # inode number,
-    st_dev = 0  # device,
-    st_nlink = 0  # number of hard links,
-    st_uid = 0  # user id of owner,
-    st_gid = 0  # group id of owner,
-    st_size = 0  # size of file, in bytes,
-    st_atime = 0.0  # time of most recent access,
-    st_mtime = 0.0  # time of most recent content modification,
-    st_ctime = 0.0  # platform dependent (time of most recent metadata change on Unix, or the time of creation on Windows)
+    st_mode: int  # protection bits,
+    st_ino: int  # inode number,
+    st_dev: int  # device,
+    st_nlink: int  # number of hard links,
+    st_uid: int  # user id of owner,
+    st_gid: int  # group id of owner,
+    st_size: int  # size of file, in bytes,
+    st_atime: float  # time of most recent access,
+    st_mtime: float  # time of most recent content modification,
+    st_ctime: float  # platform dependent (time of most recent metadata change on Unix, or the time of creation on Windows)
 
     if sys.version_info >= (3, 3):
-        st_atime_ns = 0  # time of most recent access, in nanoseconds
-        st_mtime_ns = 0  # time of most recent content modification in nanoseconds
-        st_ctime_ns = 0  # platform dependent (time of most recent metadata change on Unix, or the time of creation on Windows) in nanoseconds
+        st_atime_ns: int  # time of most recent access, in nanoseconds
+        st_mtime_ns: int  # time of most recent content modification in nanoseconds
+        st_ctime_ns: int  # platform dependent (time of most recent metadata change on Unix, or the time of creation on Windows) in nanoseconds
 
     # not documented
     def __init__(self, tuple: Tuple[int, ...]) -> None: ...
 
     # On some Unix systems (such as Linux), the following attributes may also
     # be available:
-    st_blocks = 0  # number of blocks allocated for file
-    st_blksize = 0  # filesystem blocksize
-    st_rdev = 0  # type of device if an inode device
-    st_flags = 0  # user defined flags for file
+    st_blocks: int  # number of blocks allocated for file
+    st_blksize: int  # filesystem blocksize
+    st_rdev: int  # type of device if an inode device
+    st_flags: int  # user defined flags for file
 
     # On other Unix systems (such as FreeBSD), the following attributes may be
     # available (but may be only filled out if root tries to use them):
-    st_gen = 0  # file generation number
-    st_birthtime = 0  # time of file creation
+    st_gen: int  # file generation number
+    st_birthtime: int  # time of file creation
 
     # On Mac OS systems, the following attributes may also be available:
-    st_rsize = 0
-    st_creator = 0
-    st_type = 0
+    st_rsize: int
+    st_creator: int
+    st_type: int
 
 class statvfs_result:  # Unix only
-    f_bsize = 0
-    f_frsize = 0
-    f_blocks = 0
-    f_bfree = 0
-    f_bavail = 0
-    f_files = 0
-    f_ffree = 0
-    f_favail = 0
-    f_flag = 0
-    f_namemax = 0
+    f_bsize: int
+    f_frsize: int
+    f_blocks: int
+    f_bfree: int
+    f_bavail: int
+    f_files: int
+    f_ffree: int
+    f_favail: int
+    f_flag: int
+    f_namemax: int
 
 # ----- os function stubs -----
 if sys.version_info >= (3, 6):
@@ -417,11 +418,11 @@ def urandom(n: int) -> bytes: ...
 
 def sched_getaffinity(id: int) -> Set[int]: ...
 class waitresult:
-    si_pid = 0
+    si_pid: int
 def waitid(idtype: int, id: int, options: int) -> waitresult: ...
-P_ALL = 0
-WEXITED = 0
-WNOWAIT = 0
+P_ALL: int
+WEXITED: int
+WNOWAIT: int
 
 if sys.version_info >= (3, 3):
     def sync() -> None: ...  # Unix only


### PR DESCRIPTION
And fix some TODOs.

This will help me check these stubs with my stubcheck tool, and is better for consistency anyway.

Part of #1427.