### PR TITLE
Update Num stub for typed_ast 2.7

### DIFF
--- a/third_party/3/typed_ast/ast27.pyi
+++ b/third_party/3/typed_ast/ast27.pyi
@@ -242,7 +242,7 @@ class Repr(expr):
     value = ...  # type: expr
 
 class Num(expr):
-    n = ...  # type: Union[int, float]
+    n = ...  # type: Union[int, float, complex]
 
 class Str(expr):
     s = ...  # type: bytes


### PR DESCRIPTION
Field `n` should be a `Union[int, float, complex]`, not just `Union[int, float]`.