### PR TITLE
add typing.AsyncContextManager and contextlib.asynccontextmanager

### DIFF
--- a/stdlib/2and3/contextlib.pyi
+++ b/stdlib/2and3/contextlib.pyi
@@ -9,6 +9,9 @@ import sys
 # Aliased here for backwards compatibility; TODO eventually remove this
 from typing import ContextManager as ContextManager
 
+if sys.version_info >= (3, 5):
+    from typing import AsyncContextManager, AsyncIterator
+
 if sys.version_info >= (3, 6):
     from typing import ContextManager as AbstractContextManager
 
@@ -25,6 +28,9 @@ if sys.version_info >= (3, 2):
     def contextmanager(func: Callable[..., Iterator[_T]]) -> Callable[..., GeneratorContextManager[_T]]: ...
 else:
     def contextmanager(func: Callable[..., Iterator[_T]]) -> Callable[..., ContextManager[_T]]: ...
+
+if sys.version_info >= (3, 7):
+    def asynccontextmanager(func: Callable[..., AsyncIterator[_T]]) -> Callable[..., AsyncContextManager[_T]]: ...
 
 if sys.version_info < (3,):
     def nested(*mgr: ContextManager[Any]) -> ContextManager[Iterable[Any]]: ...

--- a/stdlib/3/typing.pyi
+++ b/stdlib/3/typing.pyi
@@ -291,6 +291,13 @@ class ContextManager(Generic[_T_co]):
                  exc_value: Optional[BaseException],
                  traceback: Optional[TracebackType]) -> Optional[bool]: ...
 
+if sys.version_info >= (3, 5):
+    class AsyncContextManager(Generic[_T_co]):
+        def __aenter__(self) -> Awaitable[_T_co]: ...
+        def __aexit__(self, exc_type: Optional[Type[BaseException]],
+                      exc_value: Optional[BaseException],
+                      traceback: Optional[TracebackType]) -> Awaitable[Optional[bool]]: ...
+
 class Mapping(_Collection[_KT], Generic[_KT, _VT_co]):
     # TODO: We wish the key type could also be covariant, but that doesn't work,
     # see discussion in https: //github.com/python/typing/pull/273.


### PR DESCRIPTION
Implements:
- https://github.com/python/typing/pull/438
- https://github.com/python/cpython/pull/360

https://github.com/python/cpython/pull/1412, which adds
contextlib.AbstractAsyncContextManager, has not yet been merged.

cc @ilevkivskyi 