### PR TITLE
Indicate that `float()` accepts `Real` objects

### DIFF
--- a/stdlib/2and3/numbers.pyi
+++ b/stdlib/2and3/numbers.pyi
@@ -5,7 +5,7 @@
 # Note: these stubs are incomplete. The more complex type
 # signatures are currently omitted.
 
-from typing import Any, Optional, TypeVar
+from typing import Any, Optional, TypeVar, SupportsFloat
 from abc import ABCMeta, abstractmethod
 import sys
 
@@ -59,7 +59,7 @@ class Complex(Number):
     if sys.version_info < (3, 0):
         def __ne__(self, other: object) -> bool: ...
 
-class Real(Complex):
+class Real(Complex, SupportsFloat):
     @abstractmethod
     def __float__(self) -> float: ...
     @abstractmethod


### PR DESCRIPTION
This contradicts CPython, in `Lib/numbers.py`, because `Real` does not
actually inherit from `SupportsFloat`. But it suppresses errors from
mypy when passing sub-classes like `fractions.Fraction` to `float()`.