### PR TITLE
Support named attributes in `os.uname()` result

### DIFF
--- a/stdlib/3/os/__init__.pyi
+++ b/stdlib/3/os/__init__.pyi
@@ -254,7 +254,11 @@ def setsid() -> None: ...  # Unix only
 def setuid(uid: int) -> None: ...  # Unix only
 def strerror(code: int) -> str: ...
 def umask(mask: int) -> int: ...
-def uname() -> Tuple[str, str, str, str, str]: ...  # Unix only
+if sys.version_info >= (3, 3):
+    from posix import uname_result
+    def uname() -> uname_result: ...  # Unix only
+else:
+    def uname() -> Tuple[str, str, str, str, str]: ...  # Unix only
 
 @overload
 def getenv(key: Text) -> Optional[str]: ...

--- a/stdlib/3/posix.pyi
+++ b/stdlib/3/posix.pyi
@@ -2,5 +2,11 @@
 
 # NOTE: These are incomplete!
 
+import sys
 import typing
 from os import stat_result
+from typing import NamedTuple
+
+if sys.version_info >= (3, 3):
+    uname_result = NamedTuple('uname_result', [('sysname', str), ('nodename', str),
+        ('release', str), ('version', str), ('machine', str)])


### PR DESCRIPTION
`os.uname` changed in version 3.3: Return type changed from a tuple to
a tuple-like object with named attributes.