### PR TITLE
Add collections import in typing for type aliases to always work

### DIFF
--- a/stdlib/2/typing.pyi
+++ b/stdlib/2/typing.pyi
@@ -2,6 +2,7 @@
 
 from abc import abstractmethod, ABCMeta
 from types import CodeType, FrameType, TracebackType
+import collections  # Needed by aliases like DefaultDict, Deque, etc.
 
 # Definitions of special type checking related constructs.  Their definitions
 # are not used, so their value does not matter.

--- a/stdlib/2/typing.pyi
+++ b/stdlib/2/typing.pyi
@@ -2,7 +2,7 @@
 
 from abc import abstractmethod, ABCMeta
 from types import CodeType, FrameType, TracebackType
-import collections  # Needed by aliases like DefaultDict, Deque, etc.
+import collections  # Needed by aliases like DefaultDict, see mypy issue 2986
 
 # Definitions of special type checking related constructs.  Their definitions
 # are not used, so their value does not matter.

--- a/stdlib/3/typing.pyi
+++ b/stdlib/3/typing.pyi
@@ -3,6 +3,7 @@
 import sys
 from abc import abstractmethod, ABCMeta
 from types import CodeType, FrameType, TracebackType
+import collections  # Needed by aliases like DefaultDict, Deque, etc.
 
 # Definitions of special type checking related constructs.  Their definition
 # are not used, so their value does not matter.

--- a/stdlib/3/typing.pyi
+++ b/stdlib/3/typing.pyi
@@ -3,7 +3,7 @@
 import sys
 from abc import abstractmethod, ABCMeta
 from types import CodeType, FrameType, TracebackType
-import collections  # Needed by aliases like DefaultDict, Deque, etc.
+import collections  # Needed by aliases like DefaultDict, see mypy issue 2986
 
 # Definitions of special type checking related constructs.  Their definition
 # are not used, so their value does not matter.


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/2986

This is a simplest fix, and all other fixes will require complicated manual loading of ``collections`` (since it contains the actual class definitions for ``DefaultDict``, ``Deque`` etc).

The problem is that if ``collections`` are not in checked modules, then ``DefaultDict``, ``Deque`` etc. are automatically translated to ``Any`` thus potentially hiding some errors, see https://github.com/python/mypy/issues/2986 for an example.