### PR TITLE
Add stubs for typing_extensions module

### DIFF
--- a/third_party/2and3/typing_extensions.pyi
+++ b/third_party/2and3/typing_extensions.pyi
@@ -1,20 +1,26 @@
 import sys
 import typing
-from typing import (
-    ClassVar, ContextManager, Counter, DefaultDict, Deque,
-    NewType, overload, Text, TYPE_CHECKING,
-)
+from typing import ClassVar as ClassVar
+from typing import ContextManager as ContextManager
+from typing import Counter as Counter
+from typing import DefaultDict as DefaultDict
+from typing import Deque as Deque
+from typing import NewType as NewType
+from typing import overload as overload
+from typing import Text as Text
+from typing import TYPE_CHECKING as TYPE_CHECKING
 
 if sys.version_info >= (3, 3):
-    from typing import ChainMap
+    from typing import ChainMap as ChainMap
 
 if sys.version_info >= (3, 5):
-    from typing import (
-        AsyncIterable, AsyncIterator, AsyncContextManager, Coroutine,
-    )
+    from typing import AsyncIterable as AsyncIterable
+    from typing import AsyncIterator as AsyncIterator
+    from typing import AsyncContextManager as AsyncContextManager
+    from typing import Coroutine as Coroutine
 
 if sys.version_info >= (3, 6):
-    from typing import AsyncGenerator
+    from typing import AsyncGenerator as AsyncGenerator
 
 # Return type that indicates a function does not return.
 # This type is equivalent to the None type, but the no-op Union is necessary to

--- a/third_party/2and3/typing_extensions.pyi
+++ b/third_party/2and3/typing_extensions.pyi
@@ -6,6 +6,7 @@ from typing import Counter as Counter
 from typing import DefaultDict as DefaultDict
 from typing import Deque as Deque
 from typing import NewType as NewType
+from typing import NoReturn as NoReturn
 from typing import overload as overload
 from typing import Text as Text
 from typing import Type as Type
@@ -24,10 +25,3 @@ if sys.version_info >= (3, 5):
 if sys.version_info >= (3, 6):
     from typing import AsyncGenerator as AsyncGenerator
 
-# Return type that indicates a function does not return.
-# This type is equivalent to the None type, but the no-op Union is necessary to
-# distinguish the None type from the None value.
-#
-# TODO: Replace with direct import from typing once NoReturn is added to
-# typing.pyi.
-NoReturn = typing.Union[None]

--- a/third_party/2and3/typing_extensions.pyi
+++ b/third_party/2and3/typing_extensions.pyi
@@ -8,6 +8,7 @@ from typing import Deque as Deque
 from typing import NewType as NewType
 from typing import overload as overload
 from typing import Text as Text
+from typing import Type as Type
 from typing import TYPE_CHECKING as TYPE_CHECKING
 
 if sys.version_info >= (3, 3):
@@ -17,6 +18,7 @@ if sys.version_info >= (3, 5):
     from typing import AsyncIterable as AsyncIterable
     from typing import AsyncIterator as AsyncIterator
     from typing import AsyncContextManager as AsyncContextManager
+    from typing import Awaitable as Awaitable
     from typing import Coroutine as Coroutine
 
 if sys.version_info >= (3, 6):
@@ -25,4 +27,7 @@ if sys.version_info >= (3, 6):
 # Return type that indicates a function does not return.
 # This type is equivalent to the None type, but the no-op Union is necessary to
 # distinguish the None type from the None value.
+#
+# TODO: Replace with direct import from typing once NoReturn is added to
+# typing.pyi.
 NoReturn = typing.Union[None]

--- a/third_party/2and3/typing_extensions.pyi
+++ b/third_party/2and3/typing_extensions.pyi
@@ -24,4 +24,3 @@ if sys.version_info >= (3, 5):
 
 if sys.version_info >= (3, 6):
     from typing import AsyncGenerator as AsyncGenerator
-

--- a/third_party/2and3/typing_extensions.pyi
+++ b/third_party/2and3/typing_extensions.pyi
@@ -1,0 +1,32 @@
+import sys
+import typing
+from typing import (
+    ClassVar, ContextManager, Counter, DefaultDict, Deque,
+    NewType, overload, Text, TYPE_CHECKING,
+)
+
+if sys.version_info >= (3, 3):
+    from typing import ChainMap
+
+if sys.version_info >= (3, 5):
+    from typing import (
+        AsyncIterable, AsyncIterator, AsyncContextManager, Coroutine,
+    )
+
+if sys.version_info >= (3, 6):
+    from typing import AsyncGenerator
+
+if sys.version_info >= (3, 6):
+    from typing import Collection
+else:
+    _T_co = typing.TypeVar('_T_co', covariant=True)
+    class Collection(typing.Sized,
+                     typing.Iterable[_T_co],
+                     typing.Container[_T_co],
+                     typing.Generic[_T_co]):
+        ...
+
+# Return type that indicates a function does not return.
+# This type is equivalent to the None type, but the no-op Union is necessary to
+# distinguish the None type from the None value.
+NoReturn = typing.Union[None]

--- a/third_party/2and3/typing_extensions.pyi
+++ b/third_party/2and3/typing_extensions.pyi
@@ -16,16 +16,6 @@ if sys.version_info >= (3, 5):
 if sys.version_info >= (3, 6):
     from typing import AsyncGenerator
 
-if sys.version_info >= (3, 6):
-    from typing import Collection
-else:
-    _T_co = typing.TypeVar('_T_co', covariant=True)
-    class Collection(typing.Sized,
-                     typing.Iterable[_T_co],
-                     typing.Container[_T_co],
-                     typing.Generic[_T_co]):
-        ...
-
 # Return type that indicates a function does not return.
 # This type is equivalent to the None type, but the no-op Union is necessary to
 # distinguish the None type from the None value.


### PR DESCRIPTION
This pull request adds stubs for the [`typing_extensions` module](https://github.com/python/typing/pull/443). The module is currently being reviewed, but its contents are mostly finalized at this point so I figured I might as well make this pull request now.