### PR TITLE
Add NoReturn type to typing stubs

### DIFF
--- a/stdlib/2/typing.pyi
+++ b/stdlib/2/typing.pyi
@@ -24,6 +24,11 @@ ClassVar: _SpecialForm = ...
 
 class GenericMeta(type): ...
 
+# Return type that indicates a function does not return.
+# This type is equivalent to the None type, but the no-op Union is necessary to
+# distinguish the None type from the None value.
+NoReturn = Union[None]
+
 # Type aliases and type constructors
 
 class TypeAlias:

--- a/stdlib/3/typing.pyi
+++ b/stdlib/3/typing.pyi
@@ -25,6 +25,11 @@ ClassVar: _SpecialForm = ...
 
 class GenericMeta(type): ...
 
+# Return type that indicates a function does not return.
+# This type is equivalent to the None type, but the no-op Union is necessary to
+# distinguish the None type from the None value.
+NoReturn = Union[None]
+
 # Type aliases and type constructors
 
 class TypeAlias:


### PR DESCRIPTION
The `NoReturn` type is in PEP 484 and in the actual typing module, so should probably exist in the typing stubs.

I copied the definition and comment from `mypy_extensions.pyi`.