### PR TITLE
Remove subclass IOBase from TextIOBase.

### DIFF
--- a/stdlib/2/fcntl.pyi
+++ b/stdlib/2/fcntl.pyi
@@ -1,4 +1,4 @@
-from typing import Any, Union
+from typing import Any, Union, IO
 import io
 
 FASYNC = ...  # type: int
@@ -72,7 +72,7 @@ LOCK_SH = ...  # type: int
 LOCK_UN = ...  # type: int
 LOCK_WRITE = ...  # type: int
 
-_ANYFILE = Union[int, io.IOBase]
+_ANYFILE = Union[int, IO]
 
 # TODO All these return either int or bytes depending on the value of
 # cmd (not on the type of arg).

--- a/stdlib/2/io.pyi
+++ b/stdlib/2/io.pyi
@@ -39,5 +39,7 @@ class RawIOBase(_io._RawIOBase, IOBase):
 class BufferedIOBase(_io._BufferedIOBase, IOBase):
     pass
 
-class TextIOBase(_io._TextIOBase, IOBase):  # type: ignore
+# Note: In the actual io.py, TextIOBase subclasses IOBase.
+# (Which we don't do here because we don't want to subclass both TextIO and BinaryIO.)
+class TextIOBase(_io._TextIOBase):
     pass


### PR DESCRIPTION
This used to cause TextIOBase to subclass both BinaryIO and TextIO, even
though those two are incompatible.