### PR TITLE
Added private method _basic_auth_str

### DIFF
--- a/third_party/2and3/requests/auth.pyi
+++ b/third_party/2and3/requests/auth.pyi
@@ -1,6 +1,6 @@
 # Stubs for requests.auth (Python 3)
 
-from typing import Any, AnyStr, Union
+from typing import Any, Text, Union
 from . import compat
 from . import cookies
 from . import utils

--- a/third_party/2and3/requests/auth.pyi
+++ b/third_party/2and3/requests/auth.pyi
@@ -1,6 +1,6 @@
 # Stubs for requests.auth (Python 3)
 
-from typing import Any
+from typing import Any, AnyStr, Union
 from . import compat
 from . import cookies
 from . import utils
@@ -13,6 +13,8 @@ codes = status_codes.codes
 
 CONTENT_TYPE_FORM_URLENCODED = ...  # type: Any
 CONTENT_TYPE_MULTI_PART = ...  # type: Any
+
+def _basic_auth_str(username: Union[bytes, Text], password: Union[bytes, Text]) -> str: ...
 
 class AuthBase:
     def __call__(self, r): ...


### PR DESCRIPTION
Adds signature for [`_basic_auth_str`](https://github.com/requests/requests/blob/master/requests/auth.py#L28).

As the comment within its definition says *this behaviour is dumb but we need to preserve it because people are relying on it*, there's no reason to not add it as people surely use it.

Not handling random types like `int` though as the support for them will be eventually removed, hence no point in allowing them.