### PR TITLE
Make flake8 not complain about star imports

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -14,7 +14,7 @@
 #    34 E127 continuation line over-indented for visual indent
 
 [flake8]
-ignore = F401, F811, E127, E128, E301, E302, E305, E501, E701, E704, B303
+ignore = F401, F403, F405, F811, E127, E128, E301, E302, E305, E501, E701, E704, B303
 # We are checking with Python 3 but many of the stubs are Python 2 stubs.
 # A nice future improvement would be to provide separate .flake8
 # configurations for Python 2 and Python 3 files.


### PR DESCRIPTION
This commit disables following flake8 errors:
* F403: `‘from module import *’ used; unable to detect undefined names`
* F405: `name may be undefined, or defined from star imports: module`

We don't need to worry about flake8 not reporting undefined names since running mypy_test.py
should detect undefined names anyway.