### PR TITLE
Add IOBase to types fcntl will accept as files

### DIFF
--- a/stdlib/3/fcntl.pyi
+++ b/stdlib/3/fcntl.pyi
@@ -1,4 +1,5 @@
 # Stubs for fcntl
+from io import IOBase as _IOBase
 from typing import Any, IO, Union
 
 FASYNC = ...  # type: int
@@ -74,7 +75,7 @@ LOCK_SH = ...  # type: int
 LOCK_UN = ...  # type: int
 LOCK_WRITE = ...  # type: int
 
-_AnyFile = Union[int, IO[Any]]
+_AnyFile = Union[int, IO[Any], _IOBase]
 
 # TODO All these return either int or bytes depending on the value of
 # cmd (not on the type of arg).

--- a/stdlib/3/fcntl.pyi
+++ b/stdlib/3/fcntl.pyi
@@ -1,5 +1,5 @@
 # Stubs for fcntl
-from io import IOBase as _IOBase
+from io import IOBase
 from typing import Any, IO, Union
 
 FASYNC = ...  # type: int
@@ -75,7 +75,7 @@ LOCK_SH = ...  # type: int
 LOCK_UN = ...  # type: int
 LOCK_WRITE = ...  # type: int
 
-_AnyFile = Union[int, IO[Any], _IOBase]
+_AnyFile = Union[int, IO[Any], IOBase]
 
 # TODO All these return either int or bytes depending on the value of
 # cmd (not on the type of arg).

--- a/stdlib/3/fcntl.pyi
+++ b/stdlib/3/fcntl.pyi
@@ -1,6 +1,5 @@
 # Stubs for fcntl
 from typing import Any, IO, Union
-import typing
 
 FASYNC = ...  # type: int
 FD_CLOEXEC = ...  # type: int


### PR DESCRIPTION
Anything that implements a fileno() method is acceptable (per https://github.com/python/cpython/blob/master/Objects/fileobject.c#L168-L173), and IOBase fits the bill.

Fixes #1548.