### PR TITLE
Add range attributes

### DIFF
--- a/stdlib/3/builtins.pyi
+++ b/stdlib/3/builtins.pyi
@@ -715,6 +715,9 @@ class enumerate(Iterator[Tuple[int, _T]], Generic[_T]):
     def __next__(self) -> Tuple[int, _T]: ...
 
 class range(Sequence[int]):
+    start = ...  # type: int
+    stop = ...  # type: int
+    step = ...  # type: int
     @overload
     def __init__(self, stop: int) -> None: ...
     @overload


### PR DESCRIPTION
This allows accessing properties on `range` (and `xrange` in py2) without an error.

https://docs.python.org/3/library/stdtypes.html#range.start