### PR TITLE
Add Protocol and runtime to typing_extensions

### DIFF
--- a/third_party/2and3/typing_extensions.pyi
+++ b/third_party/2and3/typing_extensions.pyi
@@ -30,6 +30,6 @@ if sys.version_info >= (3, 5):
 if sys.version_info >= (3, 6):
     from typing import AsyncGenerator as AsyncGenerator
 
-is sys.version_info >= (3, 5, 2) or sys.version_info < (3, 5, 0):
+if sys.version_info >= (3, 5, 2) or sys.version_info < (3, 5, 0):
     def runtime(cls: _T) -> _T: ...
     Protocol: _SpecialForm = ...

--- a/third_party/2and3/typing_extensions.pyi
+++ b/third_party/2and3/typing_extensions.pyi
@@ -11,6 +11,11 @@ from typing import overload as overload
 from typing import Text as Text
 from typing import Type as Type
 from typing import TYPE_CHECKING as TYPE_CHECKING
+from typing import TypeVar, Any
+
+T = TypeVar('T')
+class _SpecialForm:
+    def __getitem__(self, typeargs: Any) -> Any: ...
 
 if sys.version_info >= (3, 3):
     from typing import ChainMap as ChainMap
@@ -24,3 +29,7 @@ if sys.version_info >= (3, 5):
 
 if sys.version_info >= (3, 6):
     from typing import AsyncGenerator as AsyncGenerator
+
+is sys.version_info >= (3, 5, 2) or sys.version_info < (3, 5, 0):
+    def runtime(cls: T) -> T: ...
+    Protocol: _SpecialForm = ...

--- a/third_party/2and3/typing_extensions.pyi
+++ b/third_party/2and3/typing_extensions.pyi
@@ -13,7 +13,7 @@ from typing import Type as Type
 from typing import TYPE_CHECKING as TYPE_CHECKING
 from typing import TypeVar, Any
 
-_T = TypeVar('_T')
+_TC = TypeVar('_TC', bound=Type[object])
 class _SpecialForm:
     def __getitem__(self, typeargs: Any) -> Any: ...
 
@@ -31,5 +31,5 @@ if sys.version_info >= (3, 6):
     from typing import AsyncGenerator as AsyncGenerator
 
 if sys.version_info >= (3, 5, 2) or sys.version_info < (3, 5, 0):
-    def runtime(cls: _T) -> _T: ...
+    def runtime(cls: _TC) -> _TC: ...
     Protocol: _SpecialForm = ...

--- a/third_party/2and3/typing_extensions.pyi
+++ b/third_party/2and3/typing_extensions.pyi
@@ -16,6 +16,8 @@ from typing import TypeVar, Any
 _TC = TypeVar('_TC', bound=Type[object])
 class _SpecialForm:
     def __getitem__(self, typeargs: Any) -> Any: ...
+def runtime(cls: _TC) -> _TC: ...
+Protocol: _SpecialForm = ...
 
 if sys.version_info >= (3, 3):
     from typing import ChainMap as ChainMap
@@ -29,7 +31,3 @@ if sys.version_info >= (3, 5):
 
 if sys.version_info >= (3, 6):
     from typing import AsyncGenerator as AsyncGenerator
-
-if sys.version_info >= (3, 5, 2) or sys.version_info < (3, 5, 0):
-    def runtime(cls: _TC) -> _TC: ...
-    Protocol: _SpecialForm = ...

--- a/third_party/2and3/typing_extensions.pyi
+++ b/third_party/2and3/typing_extensions.pyi
@@ -13,7 +13,7 @@ from typing import Type as Type
 from typing import TYPE_CHECKING as TYPE_CHECKING
 from typing import TypeVar, Any
 
-T = TypeVar('T')
+_T = TypeVar('_T')
 class _SpecialForm:
     def __getitem__(self, typeargs: Any) -> Any: ...
 
@@ -31,5 +31,5 @@ if sys.version_info >= (3, 6):
     from typing import AsyncGenerator as AsyncGenerator
 
 is sys.version_info >= (3, 5, 2) or sys.version_info < (3, 5, 0):
-    def runtime(cls: T) -> T: ...
+    def runtime(cls: _T) -> _T: ...
     Protocol: _SpecialForm = ...


### PR DESCRIPTION
This PR adds stubs for the changes to ``typing_extensions`` in https://github.com/python/typing/pull/464