### PR TITLE
Change subprocess constants to be type int

### DIFF
--- a/stdlib/3/subprocess.pyi
+++ b/stdlib/3/subprocess.pyi
@@ -238,11 +238,10 @@ else:
                      ) -> Any: ...  # morally: -> _TXT
 
 
-# TODO types
-PIPE = ...  # type: Any
-STDOUT = ...  # type: Any
+PIPE = ...  # type: int
+STDOUT = ...  # type: int
 if sys.version_info >= (3, 3):
-    DEVNULL = ...  # type: Any
+    DEVNULL = ...  # type: int
     class SubprocessError(Exception): ...
     class TimeoutExpired(SubprocessError): ...
 


### PR DESCRIPTION
This change modifies the `PIPE`, `STDOUT`, and `DEVNULL` constants in the subprocess module to be of type 'int'.

Interestingly, the Python 2 version of the subprocess module was already typed this way, so this commit only needs to change the Python 3 version.