### PR TITLE
Add a tox.ini to make running all tests easier

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,24 @@
+[tox]
+envlist = mypy,mypy-selftest,pytype
+skipsdist = True
+
+[testenv]
+basepython=python3
+
+[testenv:mypy]
+deps=
+    git+git://github.com/python/mypy
+    git+git://github.com/python/typed_ast
+commands=
+    python ./tests/mypy_test.py --no-implicit-optional
+
+[testenv:mypy-selftest]
+commands=
+    python ./tests/mypy_selftest.py --no-impicit-optional
+
+[testenv:pytype]
+basepython=python2.7
+deps=
+    git+git://github.com/google/pytype
+commands=
+    python ./tests/pytype_test.py --num-parallel=4


### PR DESCRIPTION
I've been using this for a while now and it solves a couple of problems
for me.  Firstly, I was never running the pytype tests because it's
Python 2.7 which introduces manual switching when I'm primarily testing
with mypy; tox automates the creation and switching of the virtualenv.
Secondly, I was sometimes pushing broken code because of local changes
to mypy which was used when I was running the tests; tox creates a
pristine virtualenv using upstream mypy, which avoids this.