### PR TITLE
update shlex (python 3.6 updates)

### DIFF
--- a/stdlib/3/shlex.pyi
+++ b/stdlib/3/shlex.pyi
@@ -2,10 +2,8 @@
 
 # Based on http://docs.python.org/3.2/library/shlex.html
 
-from typing import List, Tuple, Any, TextIO, Union, Optional, TypeVar, Iterator
+from typing import List, Tuple, Any, TextIO, Union, Optional, Iterator
 import sys
-
-_T = TypeVar('_T')
 
 def split(s: str, comments: bool = ...,
           posix: bool = ...) -> List[str]: ...
@@ -13,7 +11,7 @@ def split(s: str, comments: bool = ...,
 # Added in 3.3, use (undocumented) pipes.quote in previous versions.
 def quote(s: str) -> str: ...
 
-class shlex(Iterator[_T]):
+class shlex(Iterator[str]):
     commenters = ...  # type: str
     wordchars = ...  # type: str
     whitespace = ...  # type: str
@@ -36,7 +34,7 @@ class shlex(Iterator[_T]):
                      posix: bool = ..., punctuation_chars: Union[bool, str] = ...) -> None: ...
     else:
         def __init__(self, instream: Union[str, TextIO] = ..., infile: Optional[str] = ...,
-                    posix: bool = ...) -> None: ...
+                     posix: bool = ...) -> None: ...
     def get_token(self) -> str: ...
     def push_token(self, tok: str) -> None: ...
     def read_token(self) -> str: ...

--- a/stdlib/3/shlex.pyi
+++ b/stdlib/3/shlex.pyi
@@ -2,7 +2,10 @@
 
 # Based on http://docs.python.org/3.2/library/shlex.html
 
-from typing import List, Tuple, Any, TextIO, Union, Optional
+from typing import List, Tuple, Any, TextIO, Union, Optional, TypeVar, Iterator
+import sys
+
+_T = TypeVar('_T')
 
 def split(s: str, comments: bool = ...,
           posix: bool = ...) -> List[str]: ...
@@ -10,7 +13,7 @@ def split(s: str, comments: bool = ...,
 # Added in 3.3, use (undocumented) pipes.quote in previous versions.
 def quote(s: str) -> str: ...
 
-class shlex:
+class shlex(Iterator[_T]):
     commenters = ...  # type: str
     wordchars = ...  # type: str
     whitespace = ...  # type: str
@@ -25,9 +28,15 @@ class shlex:
     lineno = 0
     token = ...  # type: str
     eof = ...  # type: str
+    if sys.version_info >= (3, 6):
+        punctuation_chars = ... # type: str
 
-    def __init__(self, instream: Union[str, TextIO] = ..., infile: Optional[str] = ...,
-                 posix: bool = ...) -> None: ...
+    if sys.version_info >= (3, 6):
+        def __init__(self, instream: Union[str, TextIO] = ..., infile: Optional[str] = ...,
+                     posix: bool = ..., punctuation_chars: Union[bool, str] = ...) -> None: ...
+    else:
+        def __init__(self, instream: Union[str, TextIO] = ..., infile: Optional[str] = ...,
+                    posix: bool = ...) -> None: ...
     def get_token(self) -> str: ...
     def push_token(self, tok: str) -> None: ...
     def read_token(self) -> str: ...

--- a/stdlib/3/shlex.pyi
+++ b/stdlib/3/shlex.pyi
@@ -29,7 +29,7 @@ class shlex(Iterator[_T]):
     token = ...  # type: str
     eof = ...  # type: str
     if sys.version_info >= (3, 6):
-        punctuation_chars = ... # type: str
+        punctuation_chars = ...  # type: str
 
     if sys.version_info >= (3, 6):
         def __init__(self, instream: Union[str, TextIO] = ..., infile: Optional[str] = ...,


### PR DESCRIPTION
Update shlex to be compatible with changes from python 3.6: https://docs.python.org/3/library/shlex.html

Those changes should fix issues I've encountered:
```
main.py:10: error: No overload variant of "list" matches argument types [shlex.shlex]
main.py:10: error: Unexpected keyword argument "punctuation_chars" for "shlex"
/usr/local/lib/mypy/typeshed/stdlib/3/shlex.pyi:29: note: "shlex" defined here
```
caused by
```python
list(shlex(string, posix=True, punctuation_chars=True))
```