### PR TITLE
Second param of islice should allow None.

### DIFF
--- a/stdlib/2/itertools.pyi
+++ b/stdlib/2/itertools.pyi
@@ -40,7 +40,7 @@ def groupby(iterable: Iterable[_T],
 @overload
 def islice(iterable: Iterable[_T], stop: int) -> Iterator[_T]: ...
 @overload
-def islice(iterable: Iterable[_T], start: int, stop: Optional[int],
+def islice(iterable: Iterable[_T], start: Optional[int], stop: Optional[int],
            step: int = ...) -> Iterator[_T]: ...
 
 _T1 = TypeVar('_T1')


### PR DESCRIPTION
Hello, I suspect this issue also should have a documentation fix for python both 2 and 3. Here's the fix for the type declaration though.

The relevant case to repro is over at: https://github.com/python/mypy/issues/3953

Here's the inconsistency in the stdlib docs too: 

![selection_003](https://user-images.githubusercontent.com/229943/30403706-4540419a-9926-11e7-97bb-57c8f292c1e4.png)

![selection_002](https://user-images.githubusercontent.com/229943/30403710-48c37850-9926-11e7-912d-4b1271029d41.png)

