### PR TITLE
Correct a typo in stdlib/2/symbol.pyi

### DIFF
--- a/stdlib/2/symbol.pyi
+++ b/stdlib/2/symbol.pyi
@@ -88,4 +88,4 @@ testlist1 = ...  # type: int
 encoding_decl = ...  # type: int
 yield_expr = ...  # type: int
 
-symbol = ...  # type: Dict[int, str]
+sym_name = ...  # type: Dict[int, str]


### PR DESCRIPTION
The `sym_name` dictionary was accidentally named `symbol`.  (https://docs.python.org/2/library/symbol.html)