### PR TITLE
All `loop` kwargs in asyncio.streams are optional

### DIFF
--- a/stdlib/3.4/asyncio/streams.pyi
+++ b/stdlib/3.4/asyncio/streams.pyi
@@ -22,7 +22,7 @@ def open_connection(
     host: str = ...,
     port: int = ...,
     *,
-    loop: events.AbstractEventLoop = ...,
+    loop: Optional[events.AbstractEventLoop] = ...,
     limit: int = ...,
     **kwds: Any
 ) -> Generator[Any, None, Tuple[StreamReader, StreamWriter]]: ...
@@ -33,7 +33,7 @@ def start_server(
     host: str = ...,
     port: int = ...,
     *,
-    loop: events.AbstractEventLoop = ...,
+    loop: Optional[events.AbstractEventLoop] = ...,
     limit: int = ...,
     **kwds: Any
 ) -> Generator[Any, None, events.AbstractServer]: ...
@@ -43,7 +43,7 @@ if sys.platform != 'win32':
     def open_unix_connection(
         path: str = ...,
         *,
-        loop: events.AbstractEventLoop = ...,
+        loop: Optional[events.AbstractEventLoop] = ...,
         limit: int = ...,
         **kwds: Any
     ) -> Generator[Any, None, Tuple[StreamReader, StreamWriter]]: ...
@@ -63,7 +63,7 @@ class StreamReaderProtocol(FlowControlMixin, protocols.Protocol):
     def __init__(self,
             stream_reader: StreamReader,
             client_connected_cb: _ClientConnectedCallback = ...,
-            loop: events.AbstractEventLoop = ...) -> None: ...
+            loop: Optional[events.AbstractEventLoop] = ...) -> None: ...
     def connection_made(self, transport: transports.BaseTransport) -> None: ...
     def connection_lost(self, exc: Exception) -> None: ...
     def data_received(self, data: bytes) -> None: ...
@@ -89,7 +89,7 @@ class StreamWriter:
 class StreamReader:
     def __init__(self,
             limit: int = ...,
-            loop: events.AbstractEventLoop = ...) -> None: ...
+            loop: Optional[events.AbstractEventLoop] = ...) -> None: ...
     def exception(self) -> Exception: ...
     def set_exception(self, exc: Exception) -> None: ...
     def set_transport(self, transport: transports.BaseTransport) -> None: ...


### PR DESCRIPTION
I verified this with the module source code. All these loop arguments default to `None` and are set with events.get_event_loop()` if this is the case.

For quick reference:

https://github.com/python/cpython/blob/9b47af65375fab9318e88ccb061394a36c8c6c33/Lib/asyncio/streams.py#L70-L71