### PR TITLE
Adjust "ast" imports to make pytype happy.

### DIFF
--- a/stdlib/2/ast.pyi
+++ b/stdlib/2/ast.pyi
@@ -4,6 +4,7 @@ import typing
 from typing import Any, Iterator, Union
 
 from _ast import *
+from _ast import AST, Module
 
 __version__ = ...  # type: str
 PyCF_ONLY_AST = ...  # type: int


### PR DESCRIPTION
Turns out that pytype is a bit more finicky about imports, and differentiates between `*` imports for export, and imports for use in the local pyi. This adjusts `ast.pyi` to make pytype understand it again, after https://github.com/python/typeshed/pull/1515