### PR TITLE
Decrease Mypy concurrent process count

### DIFF
--- a/tests/mypy_selftest.py
+++ b/tests/mypy_selftest.py
@@ -19,7 +19,7 @@ if __name__ == '__main__':
         shutil.copytree('stdlib', str(dirpath / 'mypy/typeshed/stdlib'))
         shutil.copytree('third_party', str(dirpath / 'mypy/typeshed/third_party'))
         try:
-            subprocess.run(['./runtests.py'], cwd=str(dirpath / 'mypy'), check=True)
+            subprocess.run(['./runtests.py', '-j12'], cwd=str(dirpath / 'mypy'), check=True)
         except subprocess.CalledProcessError as e:
             print('mypy tests failed', file=sys.stderr)
             sys.exit(e.returncode)


### PR DESCRIPTION
Mypy has issues with running its test suite with many processes
concurrently. This should reduce travis test failures, if not completely
resolve failures. See issue https://github.com/python/mypy/issues/3543