### PR TITLE
Bug: Fix the typing for clock_settime

### DIFF
--- a/stdlib/3/time.pyi
+++ b/stdlib/3/time.pyi
@@ -91,4 +91,4 @@ if sys.version_info >= (3, 3):
     if sys.platform != 'win32':
         def clock_getres(clk_id: int) -> float: ...  # Unix only
         def clock_gettime(clk_id: int) -> float: ...  # Unix only
-        def clock_settime(clk_id: int, time: struct_time) -> float: ...  # Unix only
+        def clock_settime(clk_id: int, time: float) -> None: ...  # Unix only


### PR DESCRIPTION
clock_settime expects a float as parameter, and returns nothing.

It would make sense that the "settime" function accepts what the "gettime" function returns.
It also returns nothing as experimentation shows.

In python 3.4:
```
>>> time.clock_settime(time.CLOCK_REALTIME, time.gmtime())
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: an integer is required (got type time.struct_time)
>>> time.clock_settime(time.CLOCK_REALTIME, time.clock_gettime(time.CLOCK_REALTIME))
>>>
```
(Note that it accepts both a float and int, but figured the typing of a float makes more sense)