### PR TITLE
Revert "make __class__ refer to the current object's class"

### DIFF
--- a/stdlib/2/__builtin__.pyi
+++ b/stdlib/2/__builtin__.pyi
@@ -10,7 +10,7 @@ from typing import (
     SupportsRound, IO, BinaryIO, Union, AnyStr, MutableSequence, MutableMapping,
     MutableSet, ItemsView, KeysView, ValuesView, Optional, Container, Type
 )
-from abc import ABCMeta
+from abc import abstractmethod, ABCMeta
 from mypy_extensions import NoReturn
 
 _T = TypeVar('_T')
@@ -27,13 +27,10 @@ _TT = TypeVar('_TT', bound='type')
 
 class object:
     __doc__ = ...  # type: Optional[str]
+    __class__ = ...  # type: type
     __slots__ = ...  # type: Optional[Union[str, unicode, Iterable[Union[str, unicode]]]]
     __module__ = ...  # type: str
 
-    @property
-    def __class__(self: _T) -> Type[_T]: ...
-    @__class__.setter
-    def __class__(self, __type: Type[object]) -> None: ...
     def __init__(self) -> None: ...
     def __new__(cls) -> Any: ...
     def __setattr__(self, name: str, value: Any) -> None: ...

--- a/stdlib/2/types.pyi
+++ b/stdlib/2/types.pyi
@@ -90,6 +90,7 @@ class UnboundMethodType:
 
 class InstanceType:
     __doc__ = ...  # type: Optional[str]
+    __class__ = ...  # type: type
     __module__ = ...  # type: Any
 
 MethodType = UnboundMethodType

--- a/stdlib/3/builtins.pyi
+++ b/stdlib/3/builtins.pyi
@@ -29,16 +29,13 @@ _TT = TypeVar('_TT', bound='type')
 
 class object:
     __doc__ = ...  # type: Optional[str]
+    __class__ = ...  # type: type
     __dict__ = ...  # type: Dict[str, Any]
     __slots__ = ...  # type: Optional[Union[str, Iterable[str]]]
     __module__ = ...  # type: str
     if sys.version_info >= (3, 6):
         __annotations__ = ...  # type: Dict[str, Any]
 
-    @property
-    def __class__(self: _T) -> Type[_T]: ...
-    @__class__.setter
-    def __class__(self, __type: Type[object]) -> None: ...
     def __init__(self) -> None: ...
     def __new__(cls) -> Any: ...
     def __setattr__(self, name: str, value: Any) -> None: ...

--- a/stdlib/3/unittest/mock.pyi
+++ b/stdlib/3/unittest/mock.pyi
@@ -42,6 +42,7 @@ if sys.version_info >= (3, 3):
         def attach_mock(self, mock: Any, attribute: Any) -> Any: ...
         def mock_add_spec(self, spec: Any, spec_set: Any = False) -> Any: ...
         return_value = ...  # type: Any
+        __class__ = ...  # type: type
         called = ...  # type: Any
         call_count = ...  # type: Any
         call_args = ...  # type: Any


### PR DESCRIPTION
Reverts python/typeshed#1549.

See Guido's comments in the original PR.