### PR TITLE
`month`, `day` parameters to `datetime.datetime` are required

### DIFF
--- a/stdlib/3/datetime.pyi
+++ b/stdlib/3/datetime.pyi
@@ -150,7 +150,7 @@ class datetime:
     max = ...  # type: datetime
     resolution = ...  # type: timedelta
 
-    def __init__(self, year: int, month: int = ..., day: int = ..., hour: int = ...,
+    def __init__(self, year: int, month: int, day: int, hour: int = ...,
                  minute: int = ..., second: int = ..., microsecond: int = ...,
                  tzinfo: Optional[tzinfo] = ...) -> None: ...
 


### PR DESCRIPTION
As per the documentation for the latest version of Python 3: https://docs.python.org/3/library/datetime.html