### PR TITLE
Remove unnecessary optionality for requests.Session

### DIFF
--- a/third_party/2and3/requests/sessions.pyi
+++ b/third_party/2and3/requests/sessions.pyi
@@ -64,13 +64,13 @@ class Session(SessionRedirectMixin):
     auth = ...  # type: Union[None, Tuple[Text, Text], Callable[[Request], Request]]
     proxies = ...  # type: MutableMapping[Text, Text]
     hooks = ...  # type: _Hooks
-    params = ...  # type: Union[None, bytes, MutableMapping[Text, Text]]
+    params = ...  # type: Union[bytes, MutableMapping[Text, Text]]
     stream = ...  # type: bool
     verify = ...  # type: bool
     cert = ...  # type: Union[None, Text, Tuple[Text, Text]]
     max_redirects = ...  # type: int
     trust_env = ...  # type: bool
-    cookies = ...  # type: Union[None, RequestsCookieJar, MutableMapping[Text, Text]]
+    cookies = ...  # type: Union[RequestsCookieJar, MutableMapping[Text, Text]]
     adapters = ...  # type: MutableMapping
     redirect_cache = ...  # type: RecentlyUsedContainer
     def __init__(self) -> None: ...


### PR DESCRIPTION
Current code that initializes the things I've changed, to demonstrate that the
object is initialized this way:

* headers: https://github.com/requests/requests/blob/9713289e74/requests/sessions.py#L345
* proxies: https://github.com/requests/requests/blob/9713289e74/requests/sessions.py#L354
* hooks: https://github.com/requests/requests/blob/9713289e74/requests/sessions.py#L357
* params: https://github.com/requests/requests/blob/9713289e74/requests/sessions.py#L362
* cookies: https://github.com/requests/requests/blob/9713289e74/requests/sessions.py#L388

from what I can tell nothing in the official requests API ever creates a
session other than through `__init__`.

I suppose I should cc @kennethreitz since I'm making an assertion about his API.