### PR TITLE
requests.post data arg accepts an iterable of tuples

### DIFF
--- a/third_party/2and3/requests/api.pyi
+++ b/third_party/2and3/requests/api.pyi
@@ -5,7 +5,7 @@ from typing import Optional, Union, Any, Iterable, Mapping, MutableMapping, Tupl
 from .models import Response
 
 _ParamsMappingValueType = Union[Text, bytes, int, float, Iterable[Union[Text, bytes, int, float]]]
-_Data = Union[None, bytes, MutableMapping[Text, Text], IO]
+_Data = Union[None, bytes, MutableMapping[Text, Text], Iterable[Tuple[Text, Text]], IO]
 
 def request(method: str, url: str, **kwargs) -> Response: ...
 def get(url: Union[Text, bytes],


### PR DESCRIPTION
It's not obvious from the documentation, but the data argument for post, put and push also accepts an iterable of tuples. It also says so in the docs for requests.request function that post, put and push are aliases for.
http://docs.python-requests.org/en/master/api/