### PR TITLE
Make initial_indent and subsequent_indent AnyStr in wrap() and fill()

### DIFF
--- a/stdlib/2/textwrap.pyi
+++ b/stdlib/2/textwrap.pyi
@@ -39,8 +39,8 @@ class TextWrapper(object):
 def wrap(
         text: AnyStr,
         width: int = ...,
-        initial_indent: str = ...,
-        subsequent_indent: str = ...,
+        initial_indent: AnyStr = ...,
+        subsequent_indent: AnyStr = ...,
         expand_tabs: bool = ...,
         replace_whitespace: bool = ...,
         fix_sentence_endings: bool = ...,
@@ -52,8 +52,8 @@ def wrap(
 def fill(
         text: AnyStr,
         width: int =...,
-        initial_indent: str = ...,
-        subsequent_indent: str = ...,
+        initial_indent: AnyStr = ...,
+        subsequent_indent: AnyStr = ...,
         expand_tabs: bool = ...,
         replace_whitespace: bool = ...,
         fix_sentence_endings: bool = ...,


### PR DESCRIPTION
Leave them alone in TextWrap.__init__(), since I don't want to make the whole class generic.

(I promise this is the last one. I'd like to sync typeshed after this to lock in my winnings.)