### PR TITLE
Clean out the pytype blacklist

### DIFF
--- a/stdlib/3.4/asyncio/futures.pyi
+++ b/stdlib/3.4/asyncio/futures.pyi
@@ -1,5 +1,5 @@
 import sys
-from typing import Any, Union, Callable, TypeVar, List, Generic, Iterable, Generator, Awaitable
+from typing import Any, Union, Callable, TypeVar, Type, List, Generic, Iterable, Generator, Awaitable
 from .events import AbstractEventLoop
 from concurrent.futures import (
     CancelledError as CancelledError,
@@ -31,7 +31,7 @@ class Future(Iterable[_T], Awaitable[_T], Generic[_T]):
     _exception = ...  # type: BaseException
     _blocking = False
     _log_traceback = False
-    _tb_logger = _TracebackLogger
+    _tb_logger = ...  # type: Type[_TracebackLogger]
     def __init__(self, *, loop: AbstractEventLoop = ...) -> None: ...
     def __repr__(self) -> str: ...
     def __del__(self) -> None: ...

--- a/stdlib/3/collections/__init__.pyi
+++ b/stdlib/3/collections/__init__.pyi
@@ -215,15 +215,18 @@ class deque(MutableSequence[_T], Generic[_T]):
     @overload
     def __getitem__(self, index: int) -> _T: ...
     @overload
-    def __getitem__(self, s: slice) -> Sequence[_T]: raise TypeError
+    def __getitem__(self, s: slice) -> Sequence[_T]:
+      raise TypeError
     @overload
     def __setitem__(self, i: int, x: _T) -> None: ...
     @overload
-    def __setitem__(self, s: slice, o: Iterable[_T]) -> None: raise TypeError
+    def __setitem__(self, s: slice, o: Iterable[_T]) -> None:
+      raise TypeError
     @overload
     def __delitem__(self, i: int) -> None: ...
     @overload
-    def __delitem__(self, s: slice) -> None: raise TypeError
+    def __delitem__(self, s: slice) -> None:
+      raise TypeError
 
     def __contains__(self, o: object) -> bool: ...
     def __reversed__(self) -> Iterator[_T]: ...

--- a/stdlib/3/collections/__init__.pyi
+++ b/stdlib/3/collections/__init__.pyi
@@ -216,17 +216,17 @@ class deque(MutableSequence[_T], Generic[_T]):
     def __getitem__(self, index: int) -> _T: ...
     @overload
     def __getitem__(self, s: slice) -> Sequence[_T]:
-      raise TypeError
+        raise TypeError
     @overload
     def __setitem__(self, i: int, x: _T) -> None: ...
     @overload
     def __setitem__(self, s: slice, o: Iterable[_T]) -> None:
-      raise TypeError
+        raise TypeError
     @overload
     def __delitem__(self, i: int) -> None: ...
     @overload
     def __delitem__(self, s: slice) -> None:
-      raise TypeError
+        raise TypeError
 
     def __contains__(self, o: object) -> bool: ...
     def __reversed__(self) -> Iterator[_T]: ...

--- a/stdlib/3/concurrent/futures/_base.pyi
+++ b/stdlib/3/concurrent/futures/_base.pyi
@@ -1,5 +1,4 @@
-from typing import TypeVar, Generic, Any, Iterable, Iterator, Callable, Tuple, Optional, Set
-from collections import namedtuple
+from typing import TypeVar, Generic, Any, Iterable, Iterator, Callable, Tuple, Optional, Set, NamedTuple
 
 FIRST_COMPLETED = ...  # type: str
 FIRST_EXCEPTION = ...  # type: str
@@ -15,7 +14,7 @@ class Error(Exception): ...
 class CancelledError(Error): ...
 class TimeoutError(Error): ...
 
-DoneAndNotDoneFutures = namedtuple('DoneAndNotDoneFutures', 'done not_done')
+DoneAndNotDoneFutures = NamedTuple('DoneAndNotDoneFutures', [('done', Future[Any]), ('not_done', Future[Any])])
 
 _T = TypeVar('_T')
 

--- a/stdlib/3/http/__init__.pyi
+++ b/stdlib/3/http/__init__.pyi
@@ -5,9 +5,10 @@ from enum import IntEnum
 if sys.version_info >= (3, 5):
     class HTTPStatus(IntEnum):
 
-        def __init__(self, *a) -> None:
-            self.phrase = ...  # type: str
-            self.description = ...  # type: str
+        def __init__(self, *a) -> None: ...
+
+        phrase = ...  # type: str
+        description = ...  # type: str
 
         CONTINUE = ...  # type: HTTPStatus
         SWITCHING_PROTOCOLS = ...  # type: HTTPStatus

--- a/stdlib/3/wsgiref/types.pyi
+++ b/stdlib/3/wsgiref/types.pyi
@@ -29,5 +29,5 @@ WSGIApplication = Callable[
             Callable[[str, List[Tuple[str, str]], _exc_info], Callable[[Union[bytes, str]], None]]
         ]
     ],
-    Iterable[Union[bytes, str]],
+    Iterable[Union[bytes, str]]
 ]

--- a/tests/pytype_blacklist.txt
+++ b/tests/pytype_blacklist.txt
@@ -8,39 +8,9 @@ stdlib/2/typing.pyi
 stdlib/3/builtins.pyi
 stdlib/3/typing.pyi
 
-# pytype doesn't yet support "# type: ignore" after decorators, sometimes
-# used when overriding methods, especially those inherited from container
-# abstract base classes:
-stdlib/3/array.pyi
-
-# Because of 'from . import path':
-stdlib/2/os/__init__.pyi
-stdlib/3/os/__init__.pyi
-
-# We've not been running the pytype tests under Python 3, for quite a while.
-# The below are files that have regressed and need fixing:
+# pytype doesn't yet support 'raise' annotations
 stdlib/3/collections/__init__.pyi
-stdlib/3/collections/abc.pyi
-stdlib/3/concurrent/futures/__init__.pyi
-stdlib/3/concurrent/futures/_base.pyi
-stdlib/3/concurrent/futures/process.pyi
-stdlib/3/concurrent/futures/thread.pyi
-stdlib/3/http/__init__.pyi
-stdlib/3/http/cookiejar.pyi
-stdlib/3/inspect.pyi
-stdlib/3/json/__init__.pyi
-stdlib/3/ssl.pyi
-stdlib/3/subprocess.pyi
-stdlib/3/sys.pyi
-stdlib/3/textwrap.pyi
-stdlib/3/time.pyi
-stdlib/3/types.pyi
-stdlib/3/unittest/__init__.pyi
-stdlib/3/wsgiref/types.pyi
-stdlib/3.4/asyncio/events.pyi
-stdlib/3.4/asyncio/futures.pyi
-stdlib/3.4/asyncio/locks.pyi
-stdlib/3.4/asyncio/queues.pyi
-stdlib/3.4/asyncio/streams.pyi
-stdlib/3.4/asyncio/subprocess.pyi
+
+# pytype doesn't yet support aliases with implicit type parameters
+# (e.g., here, FutureT = Future[T])
 stdlib/3.4/asyncio/tasks.pyi

--- a/tests/pytype_blacklist.txt
+++ b/tests/pytype_blacklist.txt
@@ -8,9 +8,6 @@ stdlib/2/typing.pyi
 stdlib/3/builtins.pyi
 stdlib/3/typing.pyi
 
-# pytype doesn't yet support 'raise' annotations
-stdlib/3/collections/__init__.pyi
-
 # pytype doesn't yet support aliases with implicit type parameters
 # (e.g., here, FutureT = Future[T])
 stdlib/3.4/asyncio/tasks.pyi


### PR DESCRIPTION
Removes most of tests/pytype_blacklist

* Removes a lot of files that pytype has now added support for
* Modifies some typeshed files to use a pytype-friendly syntax
* Adds more explicit comments for the two files we still blacklist