### PR TITLE
Make PY2 enum more like PY3 enum, fixing bug in unique()

### DIFF
--- a/third_party/2/enum.pyi
+++ b/third_party/2/enum.pyi
@@ -1,8 +1,20 @@
-from typing import List, Any, TypeVar, Type, Iterable, Iterator
+from typing import List, Any, TypeVar, Union, Iterable, Iterator, TypeVar, Generic, Type, Sized, Reversible, Container, Mapping
+from abc import ABCMeta
 
 _T = TypeVar('_T', bound=Enum)
-class EnumMeta(type, Iterable[Enum]):
-    def __iter__(self: Type[_T]) -> Iterator[_T]: ...  # type: ignore
+_S = TypeVar('_S', bound=Type[Enum])
+
+# Note: EnumMeta actually subclasses type directly, not ABCMeta.
+# This is a temporary workaround to allow multiple creation of enums with builtins
+# such as str as mixins, which due to the handling of ABCs of builtin types, cause
+# spurious inconsistent metaclass structure. See #1595.
+class EnumMeta(ABCMeta, Iterable[Enum], Sized, Reversible[Enum], Container[Enum]):
+    def __iter__(self: Type[_T]) -> Iterator[_T]: ...
+    def __reversed__(self: Type[_T]) -> Iterator[_T]: ...
+    def __contains__(self, member: Any) -> bool: ...
+    def __getitem__(self: Type[_T], name: str) -> _T: ...
+    @property
+    def __members__(self: Type[_T]) -> Mapping[str, _T]: ...
 
 class Enum(metaclass=EnumMeta):
     def __new__(cls: Type[_T], value: Any) -> _T: ...
@@ -18,4 +30,4 @@ class Enum(metaclass=EnumMeta):
 
 class IntEnum(int, Enum): ...
 
-def unique(enumeration: _T) -> _T: ...
+def unique(enumeration: _S) -> _S: ...


### PR DESCRIPTION
Test program:
```py
import enum
@enum.unique
class MoveReason(enum.IntEnum):
    ALLOWED = 0
    TEAM_FOLDER_MOVE = 1
    REMOVE_FROM_TEAM_FOLDER = 2
all_reason = list(MoveReason)  # Error here
```
This gave a confusing error **when run with `mypy -2`:**
```
__tmp__.py:7: error: No overload variant of "list" matches argument types [Overload(def (x: typing.SupportsInt =) -> __tmp__.MoveReason, def (x: Union[builtins.str, builtins.unicode, builtins.bytearray], base: builtins.int =) -> __tmp__.MoveReason)]
```
Some research suggested that `unique()` had the wrong signature in the PY2 stub. Just fixing that didn't seem to change anything, so I just copied the metaclass from the PY3.4 stub. Now the error is the same as for that code in PY3:
```
__tmp__.py:7: error: Need type annotation for variable
__tmp__.py:7: error: Argument 1 to "list" has incompatible type "Type[MoveReason]"; expected "Iterable[<nothing>]"
```
Searching a bit, those errors are due to deeper problems with metaclasses than I care about today.