### PR TITLE
Re-export names in 3/dateutil.tz

### DIFF
--- a/third_party/3/dateutil/tz/__init__.pyi
+++ b/third_party/3/dateutil/tz/__init__.pyi
@@ -1,1 +1,12 @@
-from .tz import tzutc, tzoffset, tzlocal, tzfile, tzrange, tzstr, tzical, gettz, datetime_exists, datetime_ambiguous
+from .tz import (
+    tzutc as tzutc,
+    tzoffset as tzoffset,
+    tzlocal as tzlocal,
+    tzfile as tzfile,
+    tzrange as tzrange,
+    tzstr as tzstr,
+    tzical as tzical,
+    gettz as gettz,
+    datetime_exists as datetime_exists,
+    datetime_ambiguous as datetime_ambiguous
+)


### PR DESCRIPTION
This was missed in #1669, and should completely fix #1665.