### PR TITLE
fix typo in dateutil.tz importing tzutc as tzutz in python 2

### DIFF
--- a/third_party/2/dateutil/tz/__init__.pyi
+++ b/third_party/2/dateutil/tz/__init__.pyi
@@ -1,5 +1,5 @@
 from .tz import (
-    tzutc as tzutz,
+    tzutc as tzutc,
     tzoffset as tzoffset,
     tzlocal as tzlocal,
     tzfile as tzfile,


### PR DESCRIPTION
Typo introduced in #1669 (#1673 fixed this for python 3 only)