### PR TITLE
click.echo message arg type to follow click's documentation

### DIFF
--- a/third_party/2and3/click/utils.pyi
+++ b/third_party/2and3/click/utils.pyi
@@ -1,5 +1,4 @@
-from typing import Any, Callable, Iterator, IO, List, Optional, TypeVar, Union
-
+from typing import Any, Callable, Iterator, IO, List, Optional, TypeVar, Union, Text
 
 _T = TypeVar('_T')
 _Decorator = Callable[[_T], _T]
@@ -74,7 +73,7 @@ class KeepOpenFile:
 
 
 def echo(
-    message: Optional[str] = None,
+    message: Optional[Text] = None,
     file: Optional[IO] = None,
     nl: bool = True,
     err: bool = False,

--- a/third_party/2and3/click/utils.pyi
+++ b/third_party/2and3/click/utils.pyi
@@ -73,7 +73,7 @@ class KeepOpenFile:
 
 
 def echo(
-    message: Optional[Text] = None,
+    message: Optional[Union[bytes, Text]] = None,
     file: Optional[IO] = None,
     nl: bool = True,
     err: bool = False,


### PR DESCRIPTION
str is not unicode on Python 2 while Text is a proper alias
for unicode on python 2 and str on python 3

closes #1691
    