### PR TITLE
Fix a parameter type in threading.Thread.__init__

### DIFF
--- a/stdlib/2and3/threading.pyi
+++ b/stdlib/2and3/threading.pyi
@@ -54,14 +54,14 @@ class Thread:
         def __init__(self, group: None = ...,
                      target: Optional[Callable[..., None]] = ...,
                      name: Optional[str] = ...,
-                     args: Tuple[Any, ...] = ...,
+                     args: Iterable = ...,
                      kwargs: Mapping[str, Any] = ...,
                      *, daemon: Optional[bool] = ...) -> None: ...
     else:
         def __init__(self, group: None = ...,
                      target: Optional[Callable[..., None]] = ...,
                      name: Optional[str] = ...,
-                     args: Tuple[Any, ...] = ...,
+                     args: Iterable = ...,
                      kwargs: Mapping[str, Any] = ...) -> None: ...
     def start(self) -> None: ...
     def run(self) -> None: ...


### PR DESCRIPTION
The 'args' argument to `threading.Thread.__init__` can be anything that can be expanded with *.
(https://github.com/python/cpython/blob/master/Lib/threading.py#L865)