### PR TITLE
Add List to the typing imports and order the imports

### DIFF
--- a/stdlib/3/_importlib_modulespec.pyi
+++ b/stdlib/3/_importlib_modulespec.pyi
@@ -7,7 +7,7 @@
 
 from abc import ABCMeta
 import sys
-from typing import Dict, Any, Optional
+from typing import Any, Dict, List, Optional
 
 if sys.version_info >= (3, 4):
     class ModuleSpec:


### PR DESCRIPTION
List is used but not imported. According to PEP-484 "Suggested syntax for Python 2.7 and straddling code" it should be imports. 

"Like other type comments, any names used in the annotations must be imported or defined by the module containing the annotation.".

Also order the typing import list, because it looks nicer.