### PR TITLE
Make traceback.FrameSummary Iterable

### DIFF
--- a/stdlib/2and3/traceback.pyi
+++ b/stdlib/2and3/traceback.pyi
@@ -1,6 +1,6 @@
 # Stubs for traceback
 
-from typing import Any, Dict, Generator, IO, Iterator, List, Mapping, Optional, Tuple, Type
+from typing import Any, Dict, Generator, IO, Iterator, List, Mapping, Optional, Tuple, Type, Iterable
 from types import FrameType, TracebackType
 import sys
 
@@ -91,7 +91,7 @@ if sys.version_info >= (3, 5):
 
 
 if sys.version_info >= (3, 5):
-    class FrameSummary:
+    class FrameSummary(Iterable):
         filename: str
         lineno: int
         name: str


### PR DESCRIPTION
To make this code valid:
```python
import traceback
for filename, lineno, name, line in traceback.extract_stack(stack):
    pass
```