### PR TITLE
Fix werkzeug environ type

### DIFF
--- a/third_party/2/werkzeug/wrappers.pyi
+++ b/third_party/2/werkzeug/wrappers.pyi
@@ -1,5 +1,5 @@
 from typing import (
-    Any, Iterable, Mapping, Optional, Sequence, Tuple, Type, Union,
+    Any, Iterable, Mapping, Optional, Sequence, Tuple, Type, Union, Dict,
 )
 
 from .datastructures import (
@@ -18,9 +18,9 @@ class BaseRequest:
     form_data_parser_class = ...  # type: Type
     trusted_hosts = ...  # type: Optional[Sequence[unicode]]
     disable_data_descriptor = ...  # type: Any
-    environ = ...  # type: Mapping[str, object]
+    environ = ...  # type: Dict[str, Any]
     shallow = ...  # type: Any
-    def __init__(self, environ: Mapping[basestring, object], populate_request: bool = ..., shallow: bool = ...) -> None: ...
+    def __init__(self, environ: Dict[str, Any], populate_request: bool = ..., shallow: bool = ...) -> None: ...
     @property
     def url_charset(self) -> str: ...
     @classmethod

--- a/third_party/2/werkzeug/wrappers.pyi
+++ b/third_party/2/werkzeug/wrappers.pyi
@@ -18,9 +18,9 @@ class BaseRequest:
     form_data_parser_class = ...  # type: Type
     trusted_hosts = ...  # type: Optional[Sequence[unicode]]
     disable_data_descriptor = ...  # type: Any
-    environ = ...  # type: Dict[str, Any]
+    environ = ...  # type: Dict[Union[str, unicode], Any]
     shallow = ...  # type: Any
-    def __init__(self, environ: Dict[str, Any], populate_request: bool = ..., shallow: bool = ...) -> None: ...
+    def __init__(self, environ: Dict[Union[str, unicode], Any], populate_request: bool = ..., shallow: bool = ...) -> None: ...
     @property
     def url_charset(self) -> str: ...
     @classmethod

--- a/third_party/3/werkzeug/wrappers.pyi
+++ b/third_party/3/werkzeug/wrappers.pyi
@@ -1,5 +1,5 @@
 from typing import (
-    Any, Iterable, Mapping, Optional, Sequence, Tuple, Type, Union,
+    Any, Iterable, Mapping, Optional, Sequence, Tuple, Type, Union, Dict,
 )
 
 from .datastructures import (
@@ -18,9 +18,9 @@ class BaseRequest:
     form_data_parser_class = ...  # type: Type
     trusted_hosts = ...  # type: Optional[Sequence[str]]
     disable_data_descriptor = ...  # type: Any
-    environ = ...  # type: Mapping[str, object]
+    environ = ...  # type: Dict[str, Any]
     shallow = ...  # type: Any
-    def __init__(self, environ: Mapping[str, object], populate_request: bool = ..., shallow: bool = ...) -> None: ...
+    def __init__(self, environ: Dict[str, Any], populate_request: bool = ..., shallow: bool = ...) -> None: ...
     @property
     def url_charset(self) -> str: ...
     @classmethod


### PR DESCRIPTION
PEP 3333 explicitly calls for environ to be a built-in dict. Using a
Mapping will not only prevent the dict from being modified (which is
explicitly allowed by PEP 3333), it will also cause interaction
problems when the environment is passed to other WSGI handlers.

Also change the value type from object to Any for convenience. By
definition, the values can be anything and can't be type checked.
Using object instead of Any forces us to explicitly cast the value
whenever we access it.