### PR TITLE
Extract WSGIEnvironment and change value type to Any

### DIFF
--- a/stdlib/2/wsgiref/types.pyi
+++ b/stdlib/2/wsgiref/types.pyi
@@ -22,9 +22,10 @@ _exc_info = Tuple[Optional[Type[BaseException]],
                   Optional[BaseException],
                   Optional[TracebackType]]
 _Text = Union[unicode, str]
+WSGIEnvironment = Dict[_Text, _Text]
 WSGIApplication = Callable[
     [
-        Dict[_Text, _Text],
+        WSGIEnvironment,
         Union[
             Callable[[_Text, List[Tuple[_Text, _Text]]], Callable[[_Text], None]],
             Callable[[_Text, List[Tuple[_Text, _Text]], _exc_info], Callable[[_Text], None]]

--- a/stdlib/2/wsgiref/types.pyi
+++ b/stdlib/2/wsgiref/types.pyi
@@ -15,7 +15,7 @@
 # you need to use 'WSGIApplication' and not simply WSGIApplication when type
 # hinting your code.  Otherwise Python will raise NameErrors.
 
-from typing import Callable, Dict, Iterable, List, Optional, Tuple, Type, Union
+from typing import Callable, Dict, Iterable, List, Optional, Tuple, Type, Union, Any
 from types import TracebackType
 
 _exc_info = Tuple[Optional[Type[BaseException]],

--- a/stdlib/2/wsgiref/types.pyi
+++ b/stdlib/2/wsgiref/types.pyi
@@ -22,7 +22,7 @@ _exc_info = Tuple[Optional[Type[BaseException]],
                   Optional[BaseException],
                   Optional[TracebackType]]
 _Text = Union[unicode, str]
-WSGIEnvironment = Dict[_Text, _Text]
+WSGIEnvironment = Dict[_Text, Any]
 WSGIApplication = Callable[
     [
         WSGIEnvironment,

--- a/stdlib/3/wsgiref/types.pyi
+++ b/stdlib/3/wsgiref/types.pyi
@@ -21,7 +21,7 @@ from types import TracebackType
 _exc_info = Tuple[Optional[Type[BaseException]],
                   Optional[BaseException],
                   Optional[TracebackType]]
-WSGIEnvironment = Dict[str, str]
+WSGIEnvironment = Dict[str, Any]
 WSGIApplication = Callable[
     [
         WSGIEnvironment,

--- a/stdlib/3/wsgiref/types.pyi
+++ b/stdlib/3/wsgiref/types.pyi
@@ -21,9 +21,10 @@ from types import TracebackType
 _exc_info = Tuple[Optional[Type[BaseException]],
                   Optional[BaseException],
                   Optional[TracebackType]]
+WSGIEnvironment = Dict[str, str]
 WSGIApplication = Callable[
     [
-        Dict[str, str],
+        WSGIEnvironment,
         Union[
             Callable[[str, List[Tuple[str, str]]], Callable[[Union[bytes, str]], None]],
             Callable[[str, List[Tuple[str, str]], _exc_info], Callable[[Union[bytes, str]], None]]

--- a/stdlib/3/wsgiref/types.pyi
+++ b/stdlib/3/wsgiref/types.pyi
@@ -15,7 +15,7 @@
 # you need to use 'WSGIApplication' and not simply WSGIApplication when type
 # hinting your code.  Otherwise Python will raise NameErrors.
 
-from typing import Callable, Dict, Iterable, List, Optional, Tuple, Type, Union
+from typing import Callable, Dict, Iterable, List, Optional, Tuple, Type, Union, Any
 from types import TracebackType
 
 _exc_info = Tuple[Optional[Type[BaseException]],


### PR DESCRIPTION
Per PEP 3333, a WSGI environment can contain anything, not just strings.

WSGIEnvironment is a useful type on its own.