### PR TITLE
Add __dict__ to object in Python 2

### DIFF
--- a/stdlib/2/__builtin__.pyi
+++ b/stdlib/2/__builtin__.pyi
@@ -28,7 +28,7 @@ _TT = TypeVar('_TT', bound='type')
 class object:
     __doc__ = ...  # type: Optional[str]
     __class__ = ...  # type: type
-    __dict__ = ...  # type: Dict[str, Any]
+    __dict__ = ...  # type: Union[Dict[str, Any], Dict[unicode, Any]]
     __slots__ = ...  # type: Optional[Union[str, unicode, Iterable[Union[str, unicode]]]]
     __module__ = ...  # type: str
 

--- a/stdlib/2/__builtin__.pyi
+++ b/stdlib/2/__builtin__.pyi
@@ -28,7 +28,7 @@ _TT = TypeVar('_TT', bound='type')
 class object:
     __doc__ = ...  # type: Optional[str]
     __class__ = ...  # type: type
-    __dict__ = ...  # type: Union[Dict[str, Any], Dict[unicode, Any]]
+    __dict__ = ...  # type: Dict[str, Any]
     __slots__ = ...  # type: Optional[Union[str, unicode, Iterable[Union[str, unicode]]]]
     __module__ = ...  # type: str
 
@@ -65,7 +65,6 @@ class type(object):
     __bases__ = ...  # type: Tuple[type, ...]
     __name__ = ...  # type: str
     __module__ = ...  # type: str
-    __dict__ = ...  # type: Dict[unicode, Any]
 
     @overload
     def __init__(self, o: object) -> None: ...

--- a/stdlib/2/__builtin__.pyi
+++ b/stdlib/2/__builtin__.pyi
@@ -28,6 +28,7 @@ _TT = TypeVar('_TT', bound='type')
 class object:
     __doc__ = ...  # type: Optional[str]
     __class__ = ...  # type: type
+    __dict__ = ...  # type: Dict[str, Any]
     __slots__ = ...  # type: Optional[Union[str, unicode, Iterable[Union[str, unicode]]]]
     __module__ = ...  # type: str
 


### PR DESCRIPTION
See also https://github.com/python/typeshed/issues/132
Follow up to https://github.com/python/typeshed/pull/134
Fixes https://github.com/python/mypy/issues/4242

This allows:
```python
class A(object):
    pass
A().__dict__
```
