### PR TITLE
Fix missing colon in StreamHandler.stream type annotation

### DIFF
--- a/stdlib/2and3/logging/__init__.pyi
+++ b/stdlib/2and3/logging/__init__.pyi
@@ -366,7 +366,7 @@ if sys.version_info >= (3,):
 
 
 class StreamHandler(Handler):
-    stream = ...  # type IO[str]
+    stream = ...  # type: IO[str]
     if sys.version_info >= (3,):
         terminator = ...  # type: str
     def __init__(self, stream: Optional[IO[str]] = ...) -> None: ...


### PR DESCRIPTION
The missing colon in the variable type annotation means that the type of stream is currently incorrectly determined to be of type ellipsis, rather than IO[str].