### PR TITLE
Export Connection and TableConnection from pynamodb.connection

### DIFF
--- a/third_party/2and3/pynamodb/connection/__init__.pyi
+++ b/third_party/2and3/pynamodb/connection/__init__.pyi
@@ -1,2 +1,2 @@
-from pynamodb.connection.base import Connection
-from pynamodb.connection.table import TableConnection
+from pynamodb.connection.base import Connection as Connection
+from pynamodb.connection.table import TableConnection as TableConnection


### PR DESCRIPTION
It looks like in recent versions of mypy this stopped being exported.