### PR TITLE
make os.scandir work as a context manager

### DIFF
--- a/stdlib/3/os/__init__.pyi
+++ b/stdlib/3/os/__init__.pyi
@@ -6,7 +6,7 @@ from io import TextIOWrapper as _TextIOWrapper
 import sys
 from typing import (
     Mapping, MutableMapping, Dict, List, Any, Tuple, IO, Iterable, Iterator, overload, Union, AnyStr,
-    Optional, Generic, Set, Callable, Text, Sequence, NamedTuple, TypeVar
+    Optional, Generic, Set, Callable, Text, Sequence, NamedTuple, TypeVar, ContextManager
 )
 from . import path as path
 from mypy_extensions import NoReturn
@@ -487,10 +487,12 @@ if sys.version_info >= (3, 3):
 else:
     def rmdir(path: _PathType) -> None: ...
 if sys.version_info >= (3, 6):
+    class _ScandirIterator(Iterator[DirEntry[AnyStr]], ContextManager[_ScandirIterator[AnyStr]]):
+        def close(self) -> None: ...
     @overload
-    def scandir() -> Iterator[DirEntry[str]]: ...
+    def scandir() -> _ScandirIterator[str]: ...
     @overload
-    def scandir(path: Union[AnyStr, PathLike[AnyStr]]) -> Iterator[DirEntry[AnyStr]]: ...
+    def scandir(path: Union[AnyStr, PathLike[AnyStr]]) -> _ScandirIterator[AnyStr]: ...
 elif sys.version_info >= (3, 5):
     @overload
     def scandir() -> Iterator[DirEntry[str]]: ...


### PR DESCRIPTION
Rework of #1583. Fixes #1573.

See documentation in https://docs.python.org/3/library/os.html#os.scandir.

To test this, I used the following file:
```python
import os
with os.scandir() as it:
    reveal_type(it)  # _ScandirIterator[str]
    for f in it:
        reveal_type(f)  # DirEntry[str]
with os.scandir(b'.') as bit:
    reveal_type(bit)  # _ScandirIterator[bytes]
    for bf in bit:
        reveal_type(bf)  # DirEntry[bytes]
class BytesPath(os.PathLike[bytes]):
    def __fspath__(self) -> bytes:
        return b'ytes'
with os.scandir(BytesPath()) as bpit:
    reveal_type(bpit)  # _ScandirIterator[bytes]
    for bpf in bpit:
        reveal_type(bpf)  # DirEntry[bytes]
```
I got
```
$ mypy --custom-typeshed-dir . samples/scandir.py
samples/scandir.py:3: error: Revealed type is 'os._ScandirIterator*[builtins.str*]'
samples/scandir.py:5: error: Revealed type is 'os.DirEntry*[builtins.str*]'
samples/scandir.py:7: error: Revealed type is 'os._ScandirIterator*[builtins.bytes*]'
samples/scandir.py:9: error: Revealed type is 'os.DirEntry*[builtins.bytes*]'
samples/scandir.py:13: error: Argument 1 to "scandir" has incompatible type "BytesPath"; expected "Union[str, _PathLike[str]]"
samples/scandir.py:14: error: Revealed type is 'os._ScandirIterator*[builtins.str*]'
samples/scandir.py:16: error: Revealed type is 'os.DirEntry*[builtins.str*]'
```
The error on line 13 is unexpected, but it also appears without this PR. I'll file a bug to mypy for it. (Edit: it's python/mypy#3644.)