### PR TITLE
Fix requests session hooks type

### DIFF
--- a/third_party/2and3/requests/sessions.pyi
+++ b/third_party/2and3/requests/sessions.pyi
@@ -1,6 +1,6 @@
 # Stubs for requests.sessions (Python 3)
 
-from typing import Any, Union, MutableMapping, Text, Optional, IO, Tuple, Callable
+from typing import Any, Union, List, MutableMapping, Text, Optional, IO, Tuple, Callable, Iterable
 from . import adapters
 from . import auth as _auth
 from . import compat
@@ -56,7 +56,10 @@ class SessionRedirectMixin:
     def rebuild_proxies(self, prepared_request, proxies): ...
 
 _Data = Union[None, bytes, MutableMapping[Text, Text], IO]
-_Hooks = MutableMapping[Text, Callable[[Response], Any]]
+
+_Hook = Callable[[Response], Any]
+_Hooks = MutableMapping[Text, List[_Hook]]
+_HooksInput = MutableMapping[Text, Union[Iterable[_Hook], _Hook]]
 
 class Session(SessionRedirectMixin):
     __attrs__ = ...  # type: Any
@@ -87,7 +90,7 @@ class Session(SessionRedirectMixin):
                 timeout: Union[None, float, Tuple[float, float]] = ...,
                 allow_redirects: Optional[bool] = ...,
                 proxies: Optional[MutableMapping[Text, Text]] = ...,
-                hooks: Optional[_Hooks] = ...,
+                hooks: Optional[_HooksInput] = ...,
                 stream: Optional[bool] = ...,
                 verify: Union[None, bool, Text] = ...,
                 cert: Union[Text, Tuple[Text, Text], None] = ...,


### PR DESCRIPTION
Each key in `hooks` is a list, not a callable directly. Current error when using hooks is:

```
mypy: Callable[[Response], Any] has no attribute "append" (E)
```

https://github.com/requests/requests/blob/24092b11d74af0a766d9cc616622f38adb0044b9/requests/hooks.py#L18