### PR TITLE
add util.pyi to blacklist

### DIFF
--- a/tests/pytype_blacklist.txt
+++ b/tests/pytype_blacklist.txt
@@ -58,6 +58,7 @@ stdlib/3/imp.pyi # parse only
 stdlib/3/importlib/__init__.pyi # parse only
 stdlib/3/importlib/abc.pyi # parse only
 stdlib/3/importlib/machinery.pyi # parse only
+stdlib/3/importlib/util.pyi # parse only
 stdlib/3/io.pyi # parse only
 stdlib/3/json/__init__.pyi # parse only
 stdlib/3/multiprocessing/__init__.pyi # parse only


### PR DESCRIPTION
Fixes Travis CI, which broke with

```
Traceback (most recent call last):
  File "/home/travis/virtualenv/python2.7.14/bin/pytype", line 304, in <module>
    sys.exit(main(sys.argv) or 0)
  File "/home/travis/virtualenv/python2.7.14/bin/pytype", line 269, in main
    return _convert_to_pickle(options)
  File "/home/travis/virtualenv/python2.7.14/bin/pytype", line 249, in _convert_to_pickle
    ast = loader.load_file(options.module_name, options.input)
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/pytype/load_pytd.py", line 130, in load_file
    return self._process_module(module_name, filename, ast)
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/pytype/load_pytd.py", line 146, in _process_module
    module.ast = self._postprocess_pyi(module.ast)
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/pytype/load_pytd.py", line 100, in _postprocess_pyi
    self._load_ast_dependencies(dependencies, ast)
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/pytype/load_pytd.py", line 187, in _load_ast_dependencies
    raise BadDependencyError(error, ast_name or ast.name)
pytype.load_pytd.BadDependencyError: Can't find pyi for 'importlib.machinery', referenced from 'importlib.util'
Ran pytype with 476 pyis, got 1 errors.
--- exit status 1 ---
```
cc @matthiaskramm 