### PR TITLE
Fix the return type of textwrap.wrap

### DIFF
--- a/stdlib/2/textwrap.pyi
+++ b/stdlib/2/textwrap.pyi
@@ -46,7 +46,7 @@ def wrap(
         fix_sentence_endings: bool = ...,
         break_long_words: bool = ...,
         drop_whitespace: bool = ...,
-        break_on_hyphens: bool = ...) -> AnyStr:
+        break_on_hyphens: bool = ...) -> List[AnyStr]:
     ...
 
 def fill(


### PR DESCRIPTION
wrap() returns  a list of strings: https://docs.python.org/2/library/textwrap.html#textwrap.wrap