### PR TITLE
move os.stat_result into posix stub

### DIFF
--- a/stdlib/3/os/__init__.pyi
+++ b/stdlib/3/os/__init__.pyi
@@ -1,15 +1,18 @@
 # Stubs for os
 # Ron Murawski <ron@horizonchess.com>
 
-from builtins import OSError as error
 from io import TextIOWrapper as _TextIOWrapper
 import sys
 from typing import (
     Mapping, MutableMapping, Dict, List, Any, Tuple, IO, Iterable, Iterator, overload, Union, AnyStr,
     Optional, Generic, Set, Callable, Text, Sequence, NamedTuple, TypeVar, ContextManager
 )
-from . import path as path
 from mypy_extensions import NoReturn
+
+# Re-exported names from other modules.
+from builtins import OSError as error
+from posix import stat_result as stat_result
+from . import path as path
 
 _T = TypeVar('_T')
 
@@ -215,49 +218,6 @@ elif sys.version_info >= (3, 5):
         def is_symlink(self) -> bool: ...
         def stat(self) -> stat_result: ...
 
-
-class stat_result:
-    # For backward compatibility, the return value of stat() is also
-    # accessible as a tuple of at least 10 integers giving the most important
-    # (and portable) members of the stat structure, in the order st_mode,
-    # st_ino, st_dev, st_nlink, st_uid, st_gid, st_size, st_atime, st_mtime,
-    # st_ctime. More items may be added at the end by some implementations.
-
-    st_mode: int  # protection bits,
-    st_ino: int  # inode number,
-    st_dev: int  # device,
-    st_nlink: int  # number of hard links,
-    st_uid: int  # user id of owner,
-    st_gid: int  # group id of owner,
-    st_size: int  # size of file, in bytes,
-    st_atime: float  # time of most recent access,
-    st_mtime: float  # time of most recent content modification,
-    st_ctime: float  # platform dependent (time of most recent metadata change on Unix, or the time of creation on Windows)
-
-    if sys.version_info >= (3, 3):
-        st_atime_ns: int  # time of most recent access, in nanoseconds
-        st_mtime_ns: int  # time of most recent content modification in nanoseconds
-        st_ctime_ns: int  # platform dependent (time of most recent metadata change on Unix, or the time of creation on Windows) in nanoseconds
-
-    # not documented
-    def __init__(self, tuple: Tuple[int, ...]) -> None: ...
-
-    # On some Unix systems (such as Linux), the following attributes may also
-    # be available:
-    st_blocks: int  # number of blocks allocated for file
-    st_blksize: int  # filesystem blocksize
-    st_rdev: int  # type of device if an inode device
-    st_flags: int  # user defined flags for file
-
-    # On other Unix systems (such as FreeBSD), the following attributes may be
-    # available (but may be only filled out if root tries to use them):
-    st_gen: int  # file generation number
-    st_birthtime: int  # time of file creation
-
-    # On Mac OS systems, the following attributes may also be available:
-    st_rsize: int
-    st_creator: int
-    st_type: int
 
 class statvfs_result:  # Unix only
     f_bsize: int

--- a/stdlib/3/posix.pyi
+++ b/stdlib/3/posix.pyi
@@ -4,8 +4,50 @@
 
 import sys
 import typing
-from os import stat_result
-from typing import NamedTuple
+from typing import NamedTuple, Tuple
+
+class stat_result:
+    # For backward compatibility, the return value of stat() is also
+    # accessible as a tuple of at least 10 integers giving the most important
+    # (and portable) members of the stat structure, in the order st_mode,
+    # st_ino, st_dev, st_nlink, st_uid, st_gid, st_size, st_atime, st_mtime,
+    # st_ctime. More items may be added at the end by some implementations.
+
+    st_mode: int  # protection bits,
+    st_ino: int  # inode number,
+    st_dev: int  # device,
+    st_nlink: int  # number of hard links,
+    st_uid: int  # user id of owner,
+    st_gid: int  # group id of owner,
+    st_size: int  # size of file, in bytes,
+    st_atime: float  # time of most recent access,
+    st_mtime: float  # time of most recent content modification,
+    st_ctime: float  # platform dependent (time of most recent metadata change on Unix, or the time of creation on Windows)
+
+    if sys.version_info >= (3, 3):
+        st_atime_ns: int  # time of most recent access, in nanoseconds
+        st_mtime_ns: int  # time of most recent content modification in nanoseconds
+        st_ctime_ns: int  # platform dependent (time of most recent metadata change on Unix, or the time of creation on Windows) in nanoseconds
+
+    # not documented
+    def __init__(self, tuple: Tuple[int, ...]) -> None: ...
+
+    # On some Unix systems (such as Linux), the following attributes may also
+    # be available:
+    st_blocks: int  # number of blocks allocated for file
+    st_blksize: int  # filesystem blocksize
+    st_rdev: int  # type of device if an inode device
+    st_flags: int  # user defined flags for file
+
+    # On other Unix systems (such as FreeBSD), the following attributes may be
+    # available (but may be only filled out if root tries to use them):
+    st_gen: int  # file generation number
+    st_birthtime: int  # time of file creation
+
+    # On Mac OS systems, the following attributes may also be available:
+    st_rsize: int
+    st_creator: int
+    st_type: int
 
 if sys.version_info >= (3, 3):
     uname_result = NamedTuple('uname_result', [('sysname', str), ('nodename', str),


### PR DESCRIPTION
This removes the circular dependency between the os and posix stub, which
is somehow triggering python/mypy#4442. We should ideally fix the mypy bug,
but since it's easy enough to fix the import cycle, we might as well do that
too.