### PR TITLE
Fix tests to work with newest version of pytype

### DIFF
--- a/tests/pytype_test.py
+++ b/tests/pytype_test.py
@@ -67,7 +67,7 @@ class BinaryRun(object):
         if dry_run:
             self.results = (0, '', '')
         else:
-            if env:
+            if env is not None:
                 full_env = os.environ.copy()
                 full_env.update(env)
             else:
@@ -127,7 +127,8 @@ def pytype_test(args):
                 test_run = BinaryRun(
                     ['pytype',
                      '--module-name=%s' % _get_module_name(f),
-                     '--parse-pyi', f],
+                     '--parse-pyi',
+                     f],
                     dry_run=args.dry_run,
                     env={"TYPESHED_HOME": os.getcwd()})
             elif f in pytd_run:

--- a/tests/pytype_test.py
+++ b/tests/pytype_test.py
@@ -60,19 +60,23 @@ def load_blacklist():
 
 
 class BinaryRun(object):
-    def __init__(self, args, dry_run=False):
+    def __init__(self, args, dry_run=False, env=None):
         self.args = args
-
-        self.dry_run = dry_run
         self.results = None
 
         if dry_run:
             self.results = (0, '', '')
         else:
+            if env:
+                full_env = os.environ.copy()
+                full_env.update(env)
+            else:
+                full_env = None
             self.proc = subprocess.Popen(
                 self.args,
                 stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE)
+                stderr=subprocess.PIPE,
+                env=full_env)
 
     def communicate(self):
         if self.results:
@@ -122,11 +126,10 @@ def pytype_test(args):
             if f in pytype_run:
                 test_run = BinaryRun(
                     ['pytype',
-                     '--typeshed-location=%s' % os.getcwd(),
                      '--module-name=%s' % _get_module_name(f),
-                     '--convert-to-pickle=%s' % os.devnull,
-                     f],
-                    dry_run=args.dry_run)
+                     '--parse-pyi', f],
+                    dry_run=args.dry_run,
+                    env={"TYPESHED_HOME": os.getcwd()})
             elif f in pytd_run:
                 test_run = BinaryRun(['pytd', f], dry_run=args.dry_run)
             else:


### PR DESCRIPTION
We removed some flags. In particular, the typeshed location is now passed via the environment.