### PR TITLE
Add 'message' to click.decorators.version_option

### DIFF
--- a/third_party/2and3/click/decorators.pyi
+++ b/third_party/2and3/click/decorators.pyi
@@ -174,6 +174,7 @@ def version_option(
     cls: Type[Option] = ...,
     # Option
     prog_name: Optional[str] = ...,
+    message: Optional[str] = ...,
     show_default: bool = ...,
     prompt: Union[bool, Text] = ...,
     confirmation_prompt: bool = ...,


### PR DESCRIPTION
Click's version_option decorator allows the caller to specify the version message (http://click.pocoo.org/5/api/). This optional string option is missing in typeshed. If accepted, this also fixes #1773.