### PR TITLE
improve asyncio.AbstractEventLoop.getaddrinfo()

### DIFF
--- a/stdlib/3.4/asyncio/events.pyi
+++ b/stdlib/3.4/asyncio/events.pyi
@@ -96,7 +96,7 @@ class AbstractEventLoop(metaclass=ABCMeta):
     @coroutine
     # TODO the "Tuple[Any, ...]" should be "Union[Tuple[str, int], Tuple[str, int, int, int]]" but that triggers
     # https://github.com/python/mypy/issues/2509
-    def getaddrinfo(self, host: str, port: int, *,
+    def getaddrinfo(self, host: Optional[str], port: Union[str, int, None], *,
         family: int = ..., type: int = ..., proto: int = ..., flags: int = ...) -> Generator[Any, None, List[Tuple[int, int, int, str, Tuple[Any, ...]]]]: ...
     @abstractmethod
     @coroutine


### PR DESCRIPTION
The signature should match that of socket.getaddrinfo()

Maybe there are other APIs waiting for similar changes... I don't know.