### PR TITLE
Add _taskqueue to MP Pool

### DIFF
--- a/stdlib/3/multiprocessing/pool.pyi
+++ b/stdlib/3/multiprocessing/pool.pyi
@@ -2,9 +2,10 @@
 
 # NOTE: These are incomplete!
 
+from queue import Queue
 from typing import (
     Any, Callable, ContextManager, Iterable, Mapping, Optional, Dict, List,
-    TypeVar,
+    Tuple, TypeVar
 )
 
 _T = TypeVar('_T', bound='Pool')
@@ -16,6 +17,7 @@ class AsyncResult():
     def successful(self) -> bool: ...
 
 class Pool(ContextManager[Pool]):
+    _taskqueue: Queue[Tuple]
     def __init__(self, processes: Optional[int] = ...,
                  initializer: Optional[Callable[..., None]] = ...,
                  initargs: Iterable[Any] = ...,


### PR DESCRIPTION
Make the following snippet work correctly with mypy:

```
from multiprocessing import Pool
pool = Pool(1)
print(pool._taskqueue.empty())
```