### PR TITLE
Change the type of BaseException.message to Any

### DIFF
--- a/stdlib/2/__builtin__.pyi
+++ b/stdlib/2/__builtin__.pyi
@@ -903,7 +903,10 @@ class memoryview(Sized, Container[bytes]):
 
 class BaseException(object):
     args = ...  # type: Tuple[Any, ...]
-    message = ...  # type: str
+    # The type for message is debatable; an ASCII-only unicode object
+    # is acceptable, but non-ASCII characters will cause the message
+    # to be replaced with '<exception str() failed>'.
+    message = ...  # type: Text
     def __init__(self, *args: object, **kwargs: object) -> None: ...
     def __getitem__(self, i: int) -> Any: ...
     def __getslice__(self, start: int, stop: int) -> Tuple[Any, ...]: ...

--- a/stdlib/2/__builtin__.pyi
+++ b/stdlib/2/__builtin__.pyi
@@ -8,7 +8,7 @@ from typing import (
     Sequence, Mapping, Tuple, List, Any, Dict, Callable, Generic, Set,
     AbstractSet, FrozenSet, Sized, Reversible, SupportsInt, SupportsFloat, SupportsAbs,
     SupportsRound, IO, BinaryIO, Union, AnyStr, MutableSequence, MutableMapping,
-    MutableSet, ItemsView, KeysView, ValuesView, Optional, Container, Type, Text,
+    MutableSet, ItemsView, KeysView, ValuesView, Optional, Container, Type
 )
 from abc import abstractmethod, ABCMeta
 from mypy_extensions import NoReturn
@@ -903,10 +903,7 @@ class memoryview(Sized, Container[bytes]):
 
 class BaseException(object):
     args = ...  # type: Tuple[Any, ...]
-    # The type for message is debatable; an ASCII-only unicode object
-    # is acceptable, but non-ASCII characters will cause the message
-    # to be replaced with '<exception str() failed>'.
-    message = ...  # type: Text
+    message = ...  # type: Any
     def __init__(self, *args: object, **kwargs: object) -> None: ...
     def __getitem__(self, i: int) -> Any: ...
     def __getslice__(self, start: int, stop: int) -> Tuple[Any, ...]: ...

--- a/stdlib/2/__builtin__.pyi
+++ b/stdlib/2/__builtin__.pyi
@@ -8,7 +8,7 @@ from typing import (
     Sequence, Mapping, Tuple, List, Any, Dict, Callable, Generic, Set,
     AbstractSet, FrozenSet, Sized, Reversible, SupportsInt, SupportsFloat, SupportsAbs,
     SupportsRound, IO, BinaryIO, Union, AnyStr, MutableSequence, MutableMapping,
-    MutableSet, ItemsView, KeysView, ValuesView, Optional, Container, Type
+    MutableSet, ItemsView, KeysView, ValuesView, Optional, Container, Type, Text,
 )
 from abc import abstractmethod, ABCMeta
 from mypy_extensions import NoReturn


### PR DESCRIPTION
This is debatable: an ASCII-only unicode object is acceptable, but
non-ASCII characters will cause the message to be replaced with
'<exception str() failed>'.  However I found some internal code that
sometimes assigns unicode objects to .message, and I'd rather not
burden that code with .encode() calls -- especially since in Python 3
this is a text string.  Note that if you pass the unicode object to
the constructor it type-checks, and ditto if you assign to .args.

**UPDATE:** Actually it should be `Any`, see later comments.