### PR TITLE
Treat all pynamodb Numbers as `floats`

### DIFF
--- a/third_party/2and3/pynamodb/attributes.pyi
+++ b/third_party/2and3/pynamodb/attributes.pyi
@@ -6,7 +6,6 @@ _T = TypeVar('_T')
 _KT = TypeVar('_KT')
 _VT = TypeVar('_VT')
 _MT = TypeVar('_MT', bound='MapAttribute')
-Number = Union[int, float]
 
 class Attribute(Generic[_T]):
     attr_name: Optional[Text]
@@ -48,11 +47,11 @@ class LegacyBooleanAttribute(Attribute[bool]):
 class BooleanAttribute(Attribute[bool]):
     def __get__(self, instance: Any, owner: Any) -> bool: ...
 
-class NumberSetAttribute(SetMixin, Attribute[Set[Number]]):
-    def __get__(self, instance: Any, owner: Any) -> Set[Number]: ...
+class NumberSetAttribute(SetMixin, Attribute[Set[float]]):
+    def __get__(self, instance: Any, owner: Any) -> Set[float]: ...
 
-class NumberAttribute(Attribute[Number]):
-    def __get__(self, instance: Any, owner: Any) -> Number: ...
+class NumberAttribute(Attribute[float]):
+    def __get__(self, instance: Any, owner: Any) -> float: ...
 
 class UTCDateTimeAttribute(Attribute[datetime]):
     def __get__(self, instance: Any, owner: Any) -> datetime: ...


### PR DESCRIPTION
Previously we specified this as a Union type, which caused more problems than it helped with, namely when reading data off a Pynamo property
We still had to cast to the appropriate type.  Pynamo simply reads the type out of Dynamo, which more closely models a float as it can be an int or a float -

https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html