### PR TITLE
Update configparser.ParsingError base class to match the source file

### DIFF
--- a/stdlib/3/configparser.pyi
+++ b/stdlib/3/configparser.pyi
@@ -225,7 +225,7 @@ class InterpolationSyntaxError(InterpolationError):
     pass
 
 
-class ParsingError:
+class ParsingError(Error):
     source = ...  # type: str
     errors = ...  # type: Sequence[Tuple[int, str]]
 


### PR DESCRIPTION
Fixes #1883 