### PR TITLE
Fix some problems introduced by recent commits.

### DIFF
--- a/stdlib/3/builtins.pyi
+++ b/stdlib/3/builtins.pyi
@@ -948,7 +948,7 @@ class OSError(Exception):
     if sys.version_info >= (3, 4):
         filename2 = ...  # type: Any
     if sys.platform == 'win32':
-        winerror = 0
+        winerror = ...  # type: int
 IOError = OSError
 EnvironmentError = OSError
 WindowsError = OSError

--- a/stdlib/3/builtins.pyi
+++ b/stdlib/3/builtins.pyi
@@ -947,11 +947,10 @@ class OSError(Exception):
     filename = ...  # type: Any
     if sys.version_info >= (3, 4):
         filename2 = ...  # type: Any
-    if sys.platform == 'win32':
-        winerror = ...  # type: int
 IOError = OSError
 EnvironmentError = OSError
-WindowsError = OSError
+class WindowsError(OSError):
+    winerror = ...  # type: int
 class LookupError(Exception): ...
 class RuntimeError(Exception): ...
 class ValueError(Exception): ...

--- a/stdlib/3/multiprocessing/__init__.pyi
+++ b/stdlib/3/multiprocessing/__init__.pyi
@@ -12,7 +12,7 @@ from multiprocessing.context import (
     ProcessError, BufferTooShort, TimeoutError, AuthenticationError)
 from multiprocessing.managers import SyncManager
 from multiprocessing.process import current_process as current_process
-from multiprocessing.queues import Queue, SimpleQueue, JoinableQueue
+from multiprocessing.queues import Queue as Queue, SimpleQueue as SimpleQueue, JoinableQueue as JoinableQueue
 import sys
 
 # N.B. The functions below are generated at runtime by partially applying


### PR DESCRIPTION
* The problem in `multiprocessing` was just overlooked
* The change to `OSError`, while being technically correct, is problematic because conditional platform checks are sometimes hard to recognize.