### PR TITLE
 Allow `requests.post` to accept `str` for `data`.

### DIFF
--- a/third_party/2and3/requests/api.pyi
+++ b/third_party/2and3/requests/api.pyi
@@ -13,6 +13,7 @@ else:
 _ParamsMappingValueType = Union[_Text, bytes, int, float, Iterable[Union[_Text, bytes, int, float]]]
 _Data = Union[
     None,
+    _Text,
     bytes,
     MutableMapping[str, str],
     MutableMapping[str, Text],


### PR DESCRIPTION
Use case:

```python
import json

url = 'https://api.github.com/some/endpoint'
payload = {'some': 'data'}
r = requests.post(url, data=json.dumps(payload))
```