### PR TITLE
Fix imports to expose error classes in multiprocessing module

### DIFF
--- a/stdlib/3/multiprocessing/__init__.pyi
+++ b/stdlib/3/multiprocessing/__init__.pyi
@@ -9,7 +9,7 @@ from logging import Logger
 from multiprocessing import connection, pool, synchronize
 from multiprocessing.context import (
     BaseContext,
-    ProcessError, BufferTooShort, TimeoutError, AuthenticationError)
+    ProcessError as ProcessError, BufferTooShort as BufferTooShort, TimeoutError as TimeoutError, AuthenticationError as AuthenticationError)
 from multiprocessing.managers import SyncManager
 from multiprocessing.process import current_process as current_process
 from multiprocessing.queues import Queue as Queue, SimpleQueue as SimpleQueue, JoinableQueue as JoinableQueue


### PR DESCRIPTION
Fixes #1923.

Modules should import explicitly with `as X` to expose `X` in mypy (https://github.com/python/mypy/blob/8bbfef12d173303e3f4f9511901b88d23a10526f/mypy/semanal.py#L1440), but error classes such as `TimeoutError` in `multiprocessing` module in Python 3 stub lacks `as X` part, which was the cause of #1923. This PR adds missing `as X` to these imports.