### PR TITLE
Fix click stubs for python2 use

### DIFF
--- a/third_party/2and3/click/core.pyi
+++ b/third_party/2and3/click/core.pyi
@@ -10,6 +10,7 @@ from typing import (
     Optional,
     Sequence,
     Set,
+    Text,
     Tuple,
     TypeVar,
     Union,
@@ -20,10 +21,10 @@ from click.parser import OptionParser
 
 
 def invoke_param_callback(
-    callback: Callable[['Context', 'Parameter', Optional[str]], Any],
+    callback: Callable[['Context', 'Parameter', Optional[Text]], Any],
     ctx: 'Context',
     param: 'Parameter',
-    value: Optional[str]
+    value: Optional[Text]
 ) -> Any:
     ...
 
@@ -45,47 +46,47 @@ def iter_params_for_processing(
 class Context:
     parent: Optional['Context']
     command: 'Command'
-    info_name: Optional[str]
+    info_name: Optional[Text]
     params: Dict
-    args: List[str]
-    protected_args: List[str]
+    args: List[Text]
+    protected_args: List[Text]
     obj: Any
-    default_map: Mapping[str, Any]
-    invoked_subcommand: Optional[str]
+    default_map: Mapping[Text, Any]
+    invoked_subcommand: Optional[Text]
     terminal_width: Optional[int]
     max_content_width: Optional[int]
     allow_extra_args: bool
     allow_interspersed_args: bool
     ignore_unknown_options: bool
-    help_option_names: List[str]
-    token_normalize_func: Optional[Callable[[str], str]]
+    help_option_names: List[Text]
+    token_normalize_func: Optional[Callable[[Text], Text]]
     resilient_parsing: bool
-    auto_envvar_prefix: Optional[str]
+    auto_envvar_prefix: Optional[Text]
     color: Optional[bool]
-    _meta: Dict[str, Any]
+    _meta: Dict[Text, Any]
     _close_callbacks: List
     _depth: int
 
     # properties
-    meta: Dict[str, Any]
-    command_path: str
+    meta: Dict[Text, Any]
+    command_path: Text
 
     def __init__(
         self,
         command: 'Command',
         parent: Optional['Context'] = ...,
-        info_name: Optional[str] = ...,
+        info_name: Optional[Text] = ...,
         obj: Optional[Any] = ...,
-        auto_envvar_prefix: Optional[str] = ...,
-        default_map: Optional[Mapping[str, Any]] = ...,
+        auto_envvar_prefix: Optional[Text] = ...,
+        default_map: Optional[Mapping[Text, Any]] = ...,
         terminal_width: Optional[int] = ...,
         max_content_width: Optional[int] = ...,
         resilient_parsing: bool = ...,
         allow_extra_args: Optional[bool] = ...,
         allow_interspersed_args: Optional[bool] = ...,
         ignore_unknown_options: Optional[bool] = ...,
-        help_option_names: Optional[List[str]] = ...,
-        token_normalize_func: Optional[Callable[[str], str]] = ...,
+        help_option_names: Optional[List[Text]] = ...,
+        token_normalize_func: Optional[Callable[[Text], Text]] = ...,
         color: Optional[bool] = ...
     ) -> None:
         ...
@@ -112,22 +113,22 @@ class Context:
     def ensure_object(self, object_type: type) -> Any:
         ...
 
-    def lookup_default(self, name: str) -> Any:
+    def lookup_default(self, name: Text) -> Any:
         ...
 
-    def fail(self, message: str) -> None:
+    def fail(self, message: Text) -> None:
         ...
 
     def abort(self) -> None:
         ...
 
-    def exit(self, code: Union[int, str] = ...) -> None:
+    def exit(self, code: Union[int, Text] = ...) -> None:
         ...
 
-    def get_usage(self) -> str:
+    def get_usage(self) -> Text:
         ...
 
-    def get_help(self) -> str:
+    def get_help(self) -> Text:
         ...
 
     def invoke(
@@ -144,24 +145,24 @@ class BaseCommand:
     allow_extra_args: bool
     allow_interspersed_args: bool
     ignore_unknown_options: bool
-    name: str
+    name: Text
     context_settings: Dict
 
-    def __init__(self, name: str, context_settings: Optional[Dict] = ...) -> None:
+    def __init__(self, name: Text, context_settings: Optional[Dict] = ...) -> None:
         ...
 
-    def get_usage(self, ctx: Context) -> str:
+    def get_usage(self, ctx: Context) -> Text:
         ...
 
-    def get_help(self, ctx: Context) -> str:
+    def get_help(self, ctx: Context) -> Text:
         ...
 
     def make_context(
-        self, info_name: str, args: List[str], parent: Optional[Context] = ..., **extra
+        self, info_name: Text, args: List[Text], parent: Optional[Context] = ..., **extra
     ) -> Context:
         ...
 
-    def parse_args(self, ctx: Context, args: List[str]) -> List[str]:
+    def parse_args(self, ctx: Context, args: List[Text]) -> List[Text]:
         ...
 
     def invoke(self, ctx: Context) -> Any:
@@ -169,9 +170,9 @@ class BaseCommand:
 
     def main(
         self,
-        args: Optional[List[str]] = ...,
-        prog_name: Optional[str] = ...,
-        complete_var: Optional[str] = ...,
+        args: Optional[List[Text]] = ...,
+        prog_name: Optional[Text] = ...,
+        complete_var: Optional[Text] = ...,
         standalone_mode: bool = ...,
         **extra
     ) -> Any:
@@ -184,22 +185,22 @@ class BaseCommand:
 class Command(BaseCommand):
     callback: Optional[Callable]
     params: List['Parameter']
-    help: Optional[str]
-    epilog: Optional[str]
-    short_help: Optional[str]
-    options_metavar: str
+    help: Optional[Text]
+    epilog: Optional[Text]
+    short_help: Optional[Text]
+    options_metavar: Text
     add_help_option: bool
 
     def __init__(
         self,
-        name: str,
+        name: Text,
         context_settings: Optional[Dict] = ...,
         callback: Optional[Callable] = ...,
         params: Optional[List['Parameter']] = ...,
-        help: Optional[str] = ...,
-        epilog: Optional[str] = ...,
-        short_help: Optional[str] = ...,
-        options_metavar: str = ...,
+        help: Optional[Text] = ...,
+        epilog: Optional[Text] = ...,
+        short_help: Optional[Text] = ...,
+        options_metavar: Text = ...,
         add_help_option: bool = ...
     ) -> None:
         ...
@@ -214,10 +215,10 @@ class Command(BaseCommand):
     ) -> None:
         ...
 
-    def collect_usage_pieces(self, ctx: Context) -> List[str]:
+    def collect_usage_pieces(self, ctx: Context) -> List[Text]:
         ...
 
-    def get_help_option_names(self, ctx: Context) -> Set[str]:
+    def get_help_option_names(self, ctx: Context) -> Set[Text]:
         ...
 
     def get_help_option(self, ctx: Context) -> Optional['Option']:
@@ -246,16 +247,16 @@ _Decorator = Callable[[_T], _T]
 class MultiCommand(Command):
     no_args_is_help: bool
     invoke_without_command: bool
-    subcommand_metavar: str
+    subcommand_metavar: Text
     chain: bool
     result_callback: Callable
 
     def __init__(
         self,
-        name: Optional[str] = ...,
+        name: Optional[Text] = ...,
         invoke_without_command: bool = ...,
         no_args_is_help: Optional[bool] = ...,
-        subcommand_metavar: Optional[str] = ...,
+        subcommand_metavar: Optional[Text] = ...,
         chain: bool = ...,
         result_callback: Optional[Callable] = ...,
         **attrs
@@ -271,11 +272,11 @@ class MultiCommand(Command):
         ...
 
     def resolve_command(
-        self, ctx: Context, args: List[str]
-    ) -> Tuple[str, Command, List[str]]:
+        self, ctx: Context, args: List[Text]
+    ) -> Tuple[Text, Command, List[Text]]:
         ...
 
-    def get_command(self, ctx: Context, cmd_name: str) -> Optional[Command]:
+    def get_command(self, ctx: Context, cmd_name: Text) -> Optional[Command]:
         ...
 
     def list_commands(self, ctx: Context) -> Iterable[Command]:
@@ -283,14 +284,14 @@ class MultiCommand(Command):
 
 
 class Group(MultiCommand):
-    commands: Dict[str, Command]
+    commands: Dict[Text, Command]
 
     def __init__(
-        self, name: Optional[str] = ..., commands: Optional[Dict[str, Command]] = ..., **attrs
+        self, name: Optional[Text] = ..., commands: Optional[Dict[Text, Command]] = ..., **attrs
     ) -> None:
         ...
 
-    def add_command(self, cmd: Command, name: Optional[str] = ...):
+    def add_command(self, cmd: Command, name: Optional[Text] = ...):
         ...
 
     def command(self, *args, **kwargs) -> _Decorator:
@@ -304,7 +305,7 @@ class CommandCollection(MultiCommand):
     sources: List[MultiCommand]
 
     def __init__(
-        self, name: Optional[str] = ..., sources: Optional[List[MultiCommand]] = ..., **attrs
+        self, name: Optional[Text] = ..., sources: Optional[List[MultiCommand]] = ..., **attrs
     ) -> None:
         ...
 
@@ -313,39 +314,39 @@ class CommandCollection(MultiCommand):
 
 
 class Parameter:
-    param_type_name: str
-    name: str
-    opts: List[str]
-    secondary_opts: List[str]
+    param_type_name: Text
+    name: Text
+    opts: List[Text]
+    secondary_opts: List[Text]
     type: 'ParamType'
     required: bool
-    callback: Optional[Callable[[Context, 'Parameter', str], Any]]
+    callback: Optional[Callable[[Context, 'Parameter', Text], Any]]
     nargs: int
     multiple: bool
     expose_value: bool
     default: Any
     is_eager: bool
-    metavar: Optional[str]
-    envvar: Union[str, List[str], None]
+    metavar: Optional[Text]
+    envvar: Union[Text, List[Text], None]
     # properties
-    human_readable_name: str
+    human_readable_name: Text
 
     def __init__(
         self,
-        param_decls: Optional[List[str]] = ...,
+        param_decls: Optional[List[Text]] = ...,
         type: Optional[Union[type, 'ParamType']] = ...,
         required: bool = ...,
         default: Optional[Any] = ...,
-        callback: Optional[Callable[[Context, 'Parameter', str], Any]] = ...,
+        callback: Optional[Callable[[Context, 'Parameter', Text], Any]] = ...,
         nargs: Optional[int] = ...,
-        metavar: Optional[str] = ...,
+        metavar: Optional[Text] = ...,
         expose_value: bool = ...,
         is_eager: bool = ...,
-        envvar: Optional[Union[str, List[str]]] = ...
+        envvar: Optional[Union[Text, List[Text]]] = ...
     ) -> None:
         ...
 
-    def make_metavar(self) -> str:
+    def make_metavar(self) -> Text:
         ...
 
     def get_default(self, ctx: Context) -> Any:
@@ -354,7 +355,7 @@ class Parameter:
     def add_to_parser(self, parser: OptionParser, ctx: Context) -> None:
         ...
 
-    def consume_value(self, ctx: Context, opts: Dict[str, Any]) -> Any:
+    def consume_value(self, ctx: Context, opts: Dict[Text, Any]) -> Any:
         ...
 
     def type_cast_value(self, ctx: Context, value: Any) -> Any:
@@ -369,26 +370,26 @@ class Parameter:
     def full_process_value(self, ctx: Context, value: Any) -> Any:
         ...
 
-    def resolve_envvar_value(self, ctx: Context) -> str:
+    def resolve_envvar_value(self, ctx: Context) -> Text:
         ...
 
-    def value_from_envvar(self, ctx: Context) -> Union[str, List[str]]:
+    def value_from_envvar(self, ctx: Context) -> Union[Text, List[Text]]:
         ...
 
     def handle_parse_result(
-        self, ctx: Context, opts: Dict[str, Any], args: List[str]
-    ) -> Tuple[Any, List[str]]:
+        self, ctx: Context, opts: Dict[Text, Any], args: List[Text]
+    ) -> Tuple[Any, List[Text]]:
         ...
 
-    def get_help_record(self, ctx: Context) -> Tuple[str, str]:
+    def get_help_record(self, ctx: Context) -> Tuple[Text, Text]:
         ...
 
-    def get_usage_pieces(self, ctx: Context) -> List[str]:
+    def get_usage_pieces(self, ctx: Context) -> List[Text]:
         ...
 
 
 class Option(Parameter):
-    prompt: str  # sic
+    prompt: Text  # sic
     confirmation_prompt: bool
     hide_input: bool
     is_flag: bool
@@ -397,14 +398,14 @@ class Option(Parameter):
     count: bool
     multiple: bool
     allow_from_autoenv: bool
-    help: Optional[str]
+    help: Optional[Text]
     show_default: bool
 
     def __init__(
         self,
-        param_decls: Optional[List[str]] = ...,
+        param_decls: Optional[List[Text]] = ...,
         show_default: bool = ...,
-        prompt: Union[bool, str] = ...,
+        prompt: Union[bool, Text] = ...,
         confirmation_prompt: bool = ...,
         hide_input: bool = ...,
         is_flag: Optional[bool] = ...,
@@ -413,7 +414,7 @@ class Option(Parameter):
         count: bool = ...,
         allow_from_autoenv: bool = ...,
         type: Optional[Union[type, 'ParamType']] = ...,
-        help: Optional[str] = ...,
+        help: Optional[Text] = ...,
         **attrs
     ) -> None:
         ...
@@ -425,7 +426,7 @@ class Option(Parameter):
 class Argument(Parameter):
     def __init__(
         self,
-        param_decls: Optional[List[str]] = ...,
+        param_decls: Optional[List[Text]] = ...,
         required: Optional[bool] = ...,
         **attrs
     ) -> None:

--- a/third_party/2and3/click/decorators.pyi
+++ b/third_party/2and3/click/decorators.pyi
@@ -1,5 +1,5 @@
 from distutils.version import Version
-from typing import Any, Callable, Dict, List, Optional, Type, TypeVar, Union, Text
+from typing import Any, Callable, Dict, List, Optional, Text, Type, TypeVar, Union
 
 from click.core import Command, Group, Argument, Option, Parameter, Context
 from click.types import ParamType
@@ -8,7 +8,7 @@ _T = TypeVar('_T')
 _Decorator = Callable[[_T], _T]
 
 _Callback = Callable[
-    [Context, Union[Option, Parameter], Union[bool, int, str]],
+    [Context, Union[Option, Parameter], Union[bool, int, Text]],
     Any
 ]
 
@@ -30,14 +30,14 @@ def make_pass_decorator(
 # arguments from core.pyi to help with type checking.
 
 def command(
-    name: Optional[str] = ...,
+    name: Optional[Text] = ...,
     cls: Optional[Type[Command]] = ...,
     # Command
     context_settings: Optional[Dict] = ...,
-    help: Optional[str] = ...,
-    epilog: Optional[str] = ...,
-    short_help: Optional[str] = ...,
-    options_metavar: str = ...,
+    help: Optional[Text] = ...,
+    epilog: Optional[Text] = ...,
+    short_help: Optional[Text] = ...,
+    options_metavar: Text = ...,
     add_help_option: bool = ...,
 ) -> _Decorator:
     ...
@@ -46,21 +46,21 @@ def command(
 # This inherits attrs from Group, MultiCommand and Command.
 
 def group(
-    name: Optional[str] = ...,
+    name: Optional[Text] = ...,
     cls: Type[Command] = ...,
     # Group
-    commands: Optional[Dict[str, Command]] = ...,
+    commands: Optional[Dict[Text, Command]] = ...,
     # MultiCommand
     invoke_without_command: bool = ...,
     no_args_is_help: Optional[bool] = ...,
-    subcommand_metavar: Optional[str] = ...,
+    subcommand_metavar: Optional[Text] = ...,
     chain: bool = ...,
     result_callback: Optional[Callable] = ...,
     # Command
-    help: Optional[str] = ...,
-    epilog: Optional[str] = ...,
-    short_help: Optional[str] = ...,
-    options_metavar: str = ...,
+    help: Optional[Text] = ...,
+    epilog: Optional[Text] = ...,
+    short_help: Optional[Text] = ...,
+    options_metavar: Text = ...,
     add_help_option: bool = ...,
     # User-defined
     **kwargs: Any,
@@ -69,7 +69,7 @@ def group(
 
 
 def argument(
-    *param_decls: str,
+    *param_decls: Text,
     cls: Type[Argument] = ...,
     # Argument
     required: Optional[bool] = ...,
@@ -78,16 +78,16 @@ def argument(
     default: Optional[Any] = ...,
     callback: Optional[_Callback] = ...,
     nargs: Optional[int] = ...,
-    metavar: Optional[str] = ...,
+    metavar: Optional[Text] = ...,
     expose_value: bool = ...,
     is_eager: bool = ...,
-    envvar: Optional[Union[str, List[str]]] = ...
+    envvar: Optional[Union[Text, List[Text]]] = ...
 ) -> _Decorator:
     ...
 
 
 def option(
-    *param_decls: str,
+    *param_decls: Text,
     cls: Type[Option] = ...,
     # Option
     show_default: bool = ...,
@@ -100,22 +100,22 @@ def option(
     count: bool = ...,
     allow_from_autoenv: bool = ...,
     type: Optional[Union[type, ParamType]] = ...,
-    help: Optional[str] = ...,
+    help: Optional[Text] = ...,
     # Parameter
     default: Optional[Any] = ...,
     required: bool = ...,
     callback: Optional[_Callback] = ...,
     nargs: Optional[int] = ...,
-    metavar: Optional[str] = ...,
+    metavar: Optional[Text] = ...,
     expose_value: bool = ...,
     is_eager: bool = ...,
-    envvar: Optional[Union[str, List[str]]] = ...
+    envvar: Optional[Union[Text, List[Text]]] = ...
 ) -> _Decorator:
     ...
 
 
 def confirmation_option(
-    *param_decls: str,
+    *param_decls: Text,
     cls: Type[Option] = ...,
     # Option
     show_default: bool = ...,
@@ -128,21 +128,21 @@ def confirmation_option(
     count: bool = ...,
     allow_from_autoenv: bool = ...,
     type: Optional[Union[type, ParamType]] = ...,
-    help: str = ...,
+    help: Text = ...,
     # Parameter
     default: Optional[Any] = ...,
     callback: Optional[_Callback] = ...,
     nargs: Optional[int] = ...,
-    metavar: Optional[str] = ...,
+    metavar: Optional[Text] = ...,
     expose_value: bool = ...,
     is_eager: bool = ...,
-    envvar: Optional[Union[str, List[str]]] = ...
+    envvar: Optional[Union[Text, List[Text]]] = ...
 ) -> _Decorator:
     ...
 
 
 def password_option(
-    *param_decls: str,
+    *param_decls: Text,
     cls: Type[Option] = ...,
     # Option
     show_default: bool = ...,
@@ -155,26 +155,26 @@ def password_option(
     count: bool = ...,
     allow_from_autoenv: bool = ...,
     type: Optional[Union[type, ParamType]] = ...,
-    help: Optional[str] = ...,
+    help: Optional[Text] = ...,
     # Parameter
     default: Optional[Any] = ...,
     callback: Optional[_Callback] = ...,
     nargs: Optional[int] = ...,
-    metavar: Optional[str] = ...,
+    metavar: Optional[Text] = ...,
     expose_value: bool = ...,
     is_eager: bool = ...,
-    envvar: Optional[Union[str, List[str]]] = ...
+    envvar: Optional[Union[Text, List[Text]]] = ...
 ) -> _Decorator:
     ...
 
 
 def version_option(
-    version: Optional[Union[str, Version]] = ...,
-    *param_decls: str,
+    version: Optional[Union[Text, Version]] = ...,
+    *param_decls: Text,
     cls: Type[Option] = ...,
     # Option
-    prog_name: Optional[str] = ...,
-    message: Optional[str] = ...,
+    prog_name: Optional[Text] = ...,
+    message: Optional[Text] = ...,
     show_default: bool = ...,
     prompt: Union[bool, Text] = ...,
     confirmation_prompt: bool = ...,
@@ -185,21 +185,21 @@ def version_option(
     count: bool = ...,
     allow_from_autoenv: bool = ...,
     type: Optional[Union[type, ParamType]] = ...,
-    help: str = ...,
+    help: Text = ...,
     # Parameter
     default: Optional[Any] = ...,
     callback: Optional[_Callback] = ...,
     nargs: Optional[int] = ...,
-    metavar: Optional[str] = ...,
+    metavar: Optional[Text] = ...,
     expose_value: bool = ...,
     is_eager: bool = ...,
-    envvar: Optional[Union[str, List[str]]] = ...
+    envvar: Optional[Union[Text, List[Text]]] = ...
 ) -> _Decorator:
     ...
 
 
 def help_option(
-    *param_decls: str,
+    *param_decls: Text,
     cls: Type[Option] = ...,
     # Option
     show_default: bool = ...,
@@ -212,14 +212,14 @@ def help_option(
     count: bool = ...,
     allow_from_autoenv: bool = ...,
     type: Optional[Union[type, ParamType]] = ...,
-    help: str = ...,
+    help: Text = ...,
     # Parameter
     default: Optional[Any] = ...,
     callback: Optional[_Callback] = ...,
     nargs: Optional[int] = ...,
-    metavar: Optional[str] = ...,
+    metavar: Optional[Text] = ...,
     expose_value: bool = ...,
     is_eager: bool = ...,
-    envvar: Optional[Union[str, List[str]]] = ...
+    envvar: Optional[Union[Text, List[Text]]] = ...
 ) -> _Decorator:
     ...

--- a/third_party/2and3/click/exceptions.pyi
+++ b/third_party/2and3/click/exceptions.pyi
@@ -1,4 +1,4 @@
-from typing import IO, List, Optional
+from typing import IO, List, Text, Optional
 
 from click.core import Context, Parameter
 
@@ -7,10 +7,10 @@ class ClickException(Exception):
     exit_code: int
     message: str
 
-    def __init__(self, message: str) -> None:
+    def __init__(self, message: Text) -> None:
         ...
 
-    def format_message(self) -> str:
+    def format_message(self) -> Text:
         ...
 
     def show(self, file=None) -> None:
@@ -20,7 +20,7 @@ class ClickException(Exception):
 class UsageError(ClickException):
     ctx: Optional[Context]
 
-    def __init__(self, message: str, ctx: Optional[Context] = ...) -> None:
+    def __init__(self, message: Text, ctx: Optional[Context] = ...) -> None:
         ...
 
     def show(self, file: Optional[IO] = ...) -> None:
@@ -29,61 +29,61 @@ class UsageError(ClickException):
 
 class BadParameter(UsageError):
     param: Optional[Parameter]
-    param_hint: Optional[str]
+    param_hint: Optional[Text]
 
     def __init__(
         self,
-        message: str,
+        message: Text,
         ctx: Optional[Context] = ...,
         param: Optional[Parameter] = ...,
-        param_hint: Optional[str] = ...
+        param_hint: Optional[Text] = ...
     ) -> None:
         ...
 
 
 class MissingParameter(BadParameter):
-    param_type: str  # valid values: 'parameter', 'option', 'argument'
+    param_type: Text  # valid values: 'parameter', 'option', 'argument'
 
     def __init__(
         self,
-        message: Optional[str] = ...,
+        message: Optional[Text] = ...,
         ctx: Optional[Context] = ...,
         param: Optional[Parameter] = ...,
-        param_hint: Optional[str] = ...,
-        param_type: Optional[str] = ...
+        param_hint: Optional[Text] = ...,
+        param_type: Optional[Text] = ...
     ) -> None:
         ...
 
 
 class NoSuchOption(UsageError):
-    option_name: str
-    possibilities: Optional[List[str]]
+    option_name: Text
+    possibilities: Optional[List[Text]]
 
     def __init__(
         self,
-        option_name: str,
-        message: Optional[str] = ...,
-        possibilities: Optional[List[str]] = ...,
+        option_name: Text,
+        message: Optional[Text] = ...,
+        possibilities: Optional[List[Text]] = ...,
         ctx: Optional[Context] = ...
     ) -> None:
         ...
 
 
 class BadOptionUsage(UsageError):
-    def __init__(self, message: str, ctx: Optional[Context] = ...) -> None:
+    def __init__(self, message: Text, ctx: Optional[Context] = ...) -> None:
         ...
 
 
 class BadArgumentUsage(UsageError):
-    def __init__(self, message: str, ctx: Optional[Context] = ...) -> None:
+    def __init__(self, message: Text, ctx: Optional[Context] = ...) -> None:
         ...
 
 
 class FileError(ClickException):
-    ui_filename: str
-    filename: str
+    ui_filename: Text
+    filename: Text
 
-    def __init__(self, filename: str, hint: Optional[str] = ...) -> None:
+    def __init__(self, filename: Text, hint: Optional[Text] = ...) -> None:
         ...
 
 

--- a/third_party/2and3/click/formatting.pyi
+++ b/third_party/2and3/click/formatting.pyi
@@ -1,27 +1,27 @@
 from contextlib import contextmanager
-from typing import Generator, Iterable, List, Optional, Tuple
+from typing import Generator, Iterable, List, Optional, Text, Tuple
 
 
 FORCED_WIDTH: Optional[int]
 
 
-def measure_table(rows: Iterable[Iterable[str]]) -> Tuple[int, ...]:
+def measure_table(rows: Iterable[Iterable[Text]]) -> Tuple[int, ...]:
     ...
 
 
 def iter_rows(
-    rows: Iterable[Iterable[str]], col_count: int
-) -> Generator[Tuple[str, ...], None, None]:
+    rows: Iterable[Iterable[Text]], col_count: int
+) -> Generator[Tuple[Text, ...], None, None]:
     ...
 
 
 def wrap_text(
-    text: str,
+    text: Text,
     width: int = ...,
-    initial_indent: str = ...,
-    subsequent_indent: str = ...,
+    initial_indent: Text = ...,
+    subsequent_indent: Text = ...,
     preserve_paragraphs: bool = ...
-) -> str:
+) -> Text:
     ...
 
 
@@ -29,7 +29,7 @@ class HelpFormatter:
     indent_increment: int
     width: Optional[int]
     current_indent: int
-    buffer: List[str]
+    buffer: List[Text]
 
     def __init__(
         self,
@@ -39,7 +39,7 @@ class HelpFormatter:
     ) -> None:
         ...
 
-    def write(self, string: str) -> None:
+    def write(self, string: Text) -> None:
         ...
 
     def indent(self) -> None:
@@ -50,24 +50,24 @@ class HelpFormatter:
 
     def write_usage(
         self,
-        prog: str,
-        args: str = ...,
-        prefix: str = ...,
+        prog: Text,
+        args: Text = ...,
+        prefix: Text = ...,
     ):
         ...
 
-    def write_heading(self, heading: str) -> None:
+    def write_heading(self, heading: Text) -> None:
         ...
 
     def write_paragraph(self) -> None:
         ...
 
-    def write_text(self, text: str) -> None:
+    def write_text(self, text: Text) -> None:
         ...
 
     def write_dl(
         self,
-        rows: Iterable[Iterable[str]],
+        rows: Iterable[Iterable[Text]],
         col_max: int = ...,
         col_spacing: int = ...,
     ) -> None:
@@ -81,9 +81,9 @@ class HelpFormatter:
     def indentation(self) -> Generator[None, None, None]:
         ...
 
-    def getvalue(self) -> str:
+    def getvalue(self) -> Text:
         ...
 
 
-def join_options(options: List[str]) -> Tuple[str, bool]:
+def join_options(options: List[Text]) -> Tuple[Text, bool]:
     ...

--- a/third_party/2and3/click/parser.pyi
+++ b/third_party/2and3/click/parser.pyi
@@ -1,43 +1,43 @@
-from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Set, Text, Tuple
 
 from click.core import Context
 
 
 def _unpack_args(
-    args: Iterable[str], nargs_spec: Iterable[int]
-) -> Tuple[Tuple[Optional[Tuple[str, ...]], ...], List[str]]:
+    args: Iterable[Text], nargs_spec: Iterable[int]
+) -> Tuple[Tuple[Optional[Tuple[Text, ...]], ...], List[Text]]:
     ...
 
 
-def split_opt(opt: str) -> Tuple[str, str]:
+def split_opt(opt: Text) -> Tuple[Text, Text]:
     ...
 
 
-def normalize_opt(opt: str, ctx: Context) -> str:
+def normalize_opt(opt: Text, ctx: Context) -> Text:
     ...
 
 
-def split_arg_string(string: str) -> List[str]:
+def split_arg_Texting(Texting: Text) -> List[Text]:
     ...
 
 
 class Option:
-    dest: str
-    action: str
+    dest: Text
+    action: Text
     nargs: int
     const: Any
     obj: Any
-    prefixes: Set[str]
-    _short_opts: List[str]
-    _long_opts: List[str]
+    prefixes: Set[Text]
+    _short_opts: List[Text]
+    _long_opts: List[Text]
     # properties
     takes_value: bool
 
     def __init__(
         self,
-        opts: Iterable[str],
-        dest: str,
-        action: Optional[str] = ...,
+        opts: Iterable[Text],
+        dest: Text,
+        action: Optional[Text] = ...,
         nargs: int = ...,
         const: Optional[Any] = ...,
         obj: Optional[Any] = ...
@@ -49,11 +49,11 @@ class Option:
 
 
 class Argument:
-    dest: str
+    dest: Text
     nargs: int
     obj: Any
 
-    def __init__(self, dest: str, nargs: int = ..., obj: Optional[Any] = ...) -> None:
+    def __init__(self, dest: Text, nargs: int = ..., obj: Optional[Any] = ...) -> None:
         ...
 
     def process(self, value: Any, state: 'ParsingState') -> None:
@@ -61,12 +61,12 @@ class Argument:
 
 
 class ParsingState:
-    opts: Dict[str, Any]
-    largs: List[str]
-    rargs: List[str]
+    opts: Dict[Text, Any]
+    largs: List[Text]
+    rargs: List[Text]
     order: List[Any]
 
-    def __init__(self, rargs: List[str]) -> None:
+    def __init__(self, rargs: List[Text]) -> None:
         ...
 
 
@@ -74,9 +74,9 @@ class OptionParser:
     ctx: Optional[Context]
     allow_interspersed_args: bool
     ignore_unknown_options: bool
-    _short_opt: Dict[str, Option]
-    _long_opt: Dict[str, Option]
-    _opt_prefixes: Set[str]
+    _short_opt: Dict[Text, Option]
+    _long_opt: Dict[Text, Option]
+    _opt_prefixes: Set[Text]
     _args: List[Argument]
 
     def __init__(self, ctx: Optional[Context] = ...) -> None:
@@ -84,19 +84,19 @@ class OptionParser:
 
     def add_option(
         self,
-        opts: Iterable[str],
-        dest: str,
-        action: Optional[str] = ...,
+        opts: Iterable[Text],
+        dest: Text,
+        action: Optional[Text] = ...,
         nargs: int = ...,
         const: Optional[Any] = ...,
         obj: Optional[Any] = ...
     ) -> None:
         ...
 
-    def add_argument(self, dest: str, nargs: int = ..., obj: Optional[Any] = ...) -> None:
+    def add_argument(self, dest: Text, nargs: int = ..., obj: Optional[Any] = ...) -> None:
         ...
 
     def parse_args(
-        self, args: List[str]
-    ) -> Tuple[Dict[str, Any], List[str], List[Any]]:
+        self, args: List[Text]
+    ) -> Tuple[Dict[Text, Any], List[Text], List[Any]]:
         ...

--- a/third_party/2and3/click/termui.pyi
+++ b/third_party/2and3/click/termui.pyi
@@ -7,32 +7,33 @@ from typing import (
     IO,
     List,
     Optional,
+    Text,
     Tuple,
     TypeVar,
 )
 
 
-def hidden_prompt_func(prompt: str) -> str:
+def hidden_prompt_func(prompt: Text) -> Text:
     ...
 
 
 def _build_prompt(
-    text: str,
-    suffix: str,
+    text: Text,
+    suffix: Text,
     show_default: bool = ...,
-    default: Optional[str] = ...,
-) -> str:
+    default: Optional[Text] = ...,
+) -> Text:
     ...
 
 
 def prompt(
-    text: str,
-    default: Optional[str] = ...,
+    text: Text,
+    default: Optional[Text] = ...,
     hide_input: bool = ...,
     confirmation_prompt: bool = ...,
     type: Optional[Any] = ...,
-    value_proc: Optional[Callable[[Optional[str]], Any]] = ...,
-    prompt_suffix: str = ...,
+    value_proc: Optional[Callable[[Optional[Text]], Any]] = ...,
+    prompt_suffix: Text = ...,
     show_default: bool = ...,
     err: bool = ...,
 ) -> Any:
@@ -40,10 +41,10 @@ def prompt(
 
 
 def confirm(
-    text: str,
+    text: Text,
     default: bool = ...,
     abort: bool = ...,
-    prompt_suffix: str = ...,
+    prompt_suffix: Text = ...,
     show_default: bool = ...,
     err: bool = ...,
 ) -> bool:
@@ -54,7 +55,7 @@ def get_terminal_size() -> Tuple[int, int]:
     ...
 
 
-def echo_via_pager(text: str, color: Optional[bool] = ...) -> None:
+def echo_via_pager(text: Text, color: Optional[bool] = ...) -> None:
     ...
 
 
@@ -65,15 +66,15 @@ _T = TypeVar('_T')
 def progressbar(
     iterable: Optional[Iterable[_T]] = ...,
     length: Optional[int] = ...,
-    label: Optional[str] = ...,
+    label: Optional[Text] = ...,
     show_eta: bool = ...,
     show_percent: Optional[bool] = ...,
     show_pos: bool = ...,
-    item_show_func: Optional[Callable[[_T], str]] = ...,
-    fill_char: str = ...,
-    empty_char: str = ...,
-    bar_template: str = ...,
-    info_sep: str = ...,
+    item_show_func: Optional[Callable[[_T], Text]] = ...,
+    fill_char: Text = ...,
+    empty_char: Text = ...,
+    bar_template: Text = ...,
+    info_sep: Text = ...,
     width: int = ...,
     file: Optional[IO] = ...,
     color: Optional[bool] = ...,
@@ -86,9 +87,9 @@ def clear() -> None:
 
 
 def style(
-    text: str,
-    fg: Optional[str] = ...,
-    bg: Optional[str] = ...,
+    text: Text,
+    fg: Optional[Text] = ...,
+    bg: Optional[Text] = ...,
     bold: Optional[bool] = ...,
     dim: Optional[bool] = ...,
     underline: Optional[bool] = ...,
@@ -99,19 +100,19 @@ def style(
     ...
 
 
-def unstyle(text: str) -> str:
+def unstyle(text: Text) -> Text:
     ...
 
 
 # Styling options copied from style() for nicer type checking.
 def secho(
-    text: str,
+    text: Text,
     file: Optional[IO] = ...,
     nl: bool = ...,
     err: bool = ...,
     color: Optional[bool] = ...,
-    fg: Optional[str] = ...,
-    bg: Optional[str] = ...,
+    fg: Optional[Text] = ...,
+    bg: Optional[Text] = ...,
     bold: Optional[bool] = ...,
     dim: Optional[bool] = ...,
     underline: Optional[bool] = ...,
@@ -123,25 +124,25 @@ def secho(
 
 
 def edit(
-    text: Optional[str] = ...,
-    editor: Optional[str] = ...,
-    env: Optional[str] = ...,
+    text: Optional[Text] = ...,
+    editor: Optional[Text] = ...,
+    env: Optional[Text] = ...,
     require_save: bool = ...,
-    extension: str = ...,
-    filename: Optional[str] = ...,
-) -> str:
+    extension: Text = ...,
+    filename: Optional[Text] = ...,
+) -> Text:
     ...
 
 
-def launch(url: str, wait: bool = ..., locate: bool = ...) -> int:
+def launch(url: Text, wait: bool = ..., locate: bool = ...) -> int:
     ...
 
 
-def getchar(echo: bool = ...) -> str:
+def getchar(echo: bool = ...) -> Text:
     ...
 
 
 def pause(
-    info: str = ..., err: bool = ...
+    info: Text = ..., err: bool = ...
 ) -> None:
     ...

--- a/third_party/2and3/click/types.pyi
+++ b/third_party/2and3/click/types.pyi
@@ -1,47 +1,47 @@
-from typing import Any, Callable, IO, Iterable, List, Optional, TypeVar, Union
+from typing import Any, Callable, IO, Iterable, List, Optional, Text, TypeVar, Union
 import uuid
 
 from click.core import Context, Parameter
 
 
 class ParamType:
-    name: str
+    name: Text
     is_composite: bool
-    envvar_list_splitter: Optional[str]
+    envvar_list_splitter: Optional[Text]
 
     def __call__(
         self,
-        value: Optional[str],
+        value: Optional[Text],
         param: Optional[Parameter] = ...,
         ctx: Optional[Context] = ...,
     ) -> Any:
         ...
 
-    def get_metavar(self, param: Parameter) -> str:
+    def get_metavar(self, param: Parameter) -> Text:
         ...
 
-    def get_missing_message(self, param: Parameter) -> str:
+    def get_missing_message(self, param: Parameter) -> Text:
         ...
 
     def convert(
         self,
-        value: str,
+        value: Text,
         param: Optional[Parameter],
         ctx: Optional[Context],
     ) -> Any:
         ...
 
-    def split_envvar_value(self, rv: str) -> List[str]:
+    def split_envvar_value(self, rv: Text) -> List[Text]:
         ...
 
-    def fail(self, message: str, param: Optional[Parameter] = ..., ctx: Optional[Context] = ...) -> None:
+    def fail(self, message: Text, param: Optional[Parameter] = ..., ctx: Optional[Context] = ...) -> None:
         ...
 
 
 class BoolParamType(ParamType):
     def __call__(
         self,
-        value: Optional[str],
+        value: Optional[Text],
         param: Optional[Parameter] = ...,
         ctx: Optional[Context] = ...,
     ) -> bool:
@@ -49,7 +49,7 @@ class BoolParamType(ParamType):
 
     def convert(
         self,
-        value: str,
+        value: Text,
         param: Optional[Parameter],
         ctx: Optional[Context],
     ) -> bool:
@@ -61,15 +61,15 @@ class CompositeParamType(ParamType):
 
 
 class Choice(ParamType):
-    choices: Iterable[str]
-    def __init__(self, choices: Iterable[str]) -> None:
+    choices: Iterable[Text]
+    def __init__(self, choices: Iterable[Text]) -> None:
         ...
 
 
 class FloatParamType(ParamType):
     def __call__(
         self,
-        value: Optional[str],
+        value: Optional[Text],
         param: Optional[Parameter] = ...,
         ctx: Optional[Context] = ...,
     ) -> float:
@@ -77,7 +77,7 @@ class FloatParamType(ParamType):
 
     def convert(
         self,
-        value: str,
+        value: Text,
         param: Optional[Parameter],
         ctx: Optional[Context],
     ) -> float:
@@ -91,9 +91,9 @@ class FloatRange(FloatParamType):
 class File(ParamType):
     def __init__(
         self,
-        mode: str = ...,
-        encoding: Optional[str] = ...,
-        errors: Optional[str] = ...,
+        mode: Text = ...,
+        encoding: Optional[Text] = ...,
+        errors: Optional[Text] = ...,
         lazy: Optional[bool] = ...,
         atomic: Optional[bool] = ...,
     ) -> None:
@@ -101,7 +101,7 @@ class File(ParamType):
 
     def __call__(
         self,
-        value: Optional[str],
+        value: Optional[Text],
         param: Optional[Parameter] = ...,
         ctx: Optional[Context] = ...,
     ) -> IO:
@@ -109,18 +109,18 @@ class File(ParamType):
 
     def convert(
         self,
-        value: str,
+        value: Text,
         param: Optional[Parameter],
         ctx: Optional[Context],
     ) -> IO:
         ...
 
-    def resolve_lazy_flag(self, value: str) -> bool:
+    def resolve_lazy_flag(self, value: Text) -> bool:
         ...
 
 
 _F = TypeVar('_F')  # result of the function
-_Func = Callable[[Optional[str]], _F]
+_Func = Callable[[Optional[Text]], _F]
 
 
 class FuncParamType(ParamType):
@@ -131,7 +131,7 @@ class FuncParamType(ParamType):
 
     def __call__(
         self,
-        value: Optional[str],
+        value: Optional[Text],
         param: Optional[Parameter] = ...,
         ctx: Optional[Context] = ...,
     ) -> _F:
@@ -139,7 +139,7 @@ class FuncParamType(ParamType):
 
     def convert(
         self,
-        value: str,
+        value: Text,
         param: Optional[Parameter],
         ctx: Optional[Context],
     ) -> _F:
@@ -149,7 +149,7 @@ class FuncParamType(ParamType):
 class IntParamType(ParamType):
     def __call__(
         self,
-        value: Optional[str],
+        value: Optional[Text],
         param: Optional[Parameter] = ...,
         ctx: Optional[Context] = ...,
     ) -> int:
@@ -157,7 +157,7 @@ class IntParamType(ParamType):
 
     def convert(
         self,
-        value: str,
+        value: Text,
         param: Optional[Parameter],
         ctx: Optional[Context],
     ) -> int:
@@ -171,7 +171,7 @@ class IntRange(IntParamType):
         ...
 
 
-_PathType = TypeVar('_PathType', str, bytes)
+_PathType = TypeVar('_PathType', Text, bytes)
 
 
 class Path(ParamType):
@@ -188,12 +188,12 @@ class Path(ParamType):
     ) -> None:
         ...
 
-    def coerce_path_result(self, rv: Union[str, bytes]) -> _PathType:
+    def coerce_path_result(self, rv: Union[Text, bytes]) -> _PathType:
         ...
 
     def __call__(
         self,
-        value: Optional[str],
+        value: Optional[Text],
         param: Optional[Parameter] = ...,
         ctx: Optional[Context] = ...,
     ) -> _PathType:
@@ -201,7 +201,7 @@ class Path(ParamType):
 
     def convert(
         self,
-        value: str,
+        value: Text,
         param: Optional[Parameter],
         ctx: Optional[Context],
     ) -> _PathType:
@@ -210,18 +210,18 @@ class Path(ParamType):
 class StringParamType(ParamType):
     def __call__(
         self,
-        value: Optional[str],
+        value: Optional[Text],
         param: Optional[Parameter] = ...,
         ctx: Optional[Context] = ...,
-    ) -> str:
+    ) -> Text:
         ...
 
     def convert(
         self,
-        value: str,
+        value: Text,
         param: Optional[Parameter],
         ctx: Optional[Context],
-    ) -> str:
+    ) -> Text:
         ...
 
 
@@ -233,7 +233,7 @@ class Tuple(CompositeParamType):
 
     def __call__(
         self,
-        value: Optional[str],
+        value: Optional[Text],
         param: Optional[Parameter] = ...,
         ctx: Optional[Context] = ...,
     ) -> Tuple:
@@ -241,7 +241,7 @@ class Tuple(CompositeParamType):
 
     def convert(
         self,
-        value: str,
+        value: Text,
         param: Optional[Parameter],
         ctx: Optional[Context],
     ) -> Tuple:
@@ -255,7 +255,7 @@ class UnprocessedParamType(ParamType):
 class UUIDParameterType(ParamType):
     def __call__(
         self,
-        value: Optional[str],
+        value: Optional[Text],
         param: Optional[Parameter] = ...,
         ctx: Optional[Context] = ...,
     ) -> uuid.UUID:
@@ -263,7 +263,7 @@ class UUIDParameterType(ParamType):
 
     def convert(
         self,
-        value: str,
+        value: Text,
         param: Optional[Parameter],
         ctx: Optional[Context],
     ) -> uuid.UUID:

--- a/third_party/2and3/click/utils.pyi
+++ b/third_party/2and3/click/utils.pyi
@@ -1,10 +1,10 @@
-from typing import Any, Callable, Iterator, IO, List, Optional, TypeVar, Union, Text
+from typing import Any, Callable, Iterator, IO, List, Optional, Text, TypeVar, Union
 
 _T = TypeVar('_T')
 _Decorator = Callable[[_T], _T]
 
 
-def _posixify(name: str) -> str:
+def _posixify(name: Text) -> Text:
     ...
 
 
@@ -12,27 +12,27 @@ def safecall(func: _T) -> _T:
     ...
 
 
-def make_str(value: Any) -> str:
+def make_str(value: Any) -> Text:
     ...
 
 
-def make_default_short_help(help: str, max_length: int = ...):
+def make_default_short_help(help: Text, max_length: int = ...):
     ...
 
 
 class LazyFile:
-    name: str
-    mode: str
-    encoding: Optional[str]
-    errors: str
+    name: Text
+    mode: Text
+    encoding: Optional[Text]
+    errors: Text
     atomic: bool
 
     def __init__(
         self,
-        filename: str,
-        mode: str = ...,
-        encoding: Optional[str] = ...,
-        errors: str = ...,
+        filename: Text,
+        mode: Text = ...,
+        encoding: Optional[Text] = ...,
+        errors: Text = ...,
         atomic: bool = ...
     ) -> None:
         ...
@@ -82,36 +82,36 @@ def echo(
     ...
 
 
-def get_binary_stream(name: str) -> IO[bytes]:
+def get_binary_stream(name: Text) -> IO[bytes]:
     ...
 
 
 def get_text_stream(
-    name: str, encoding: Optional[str] = ..., errors: str = ...
-) -> IO[str]:
+    name: Text, encoding: Optional[Text] = ..., errors: Text = ...
+) -> IO[Text]:
     ...
 
 
 def open_file(
-    filename: str,
-    mode: str = ...,
-    encoding: Optional[str] = ...,
-    errors: str = ...,
+    filename: Text,
+    mode: Text = ...,
+    encoding: Optional[Text] = ...,
+    errors: Text = ...,
     lazy: bool = ...,
     atomic: bool = ...
 ) -> Union[IO, LazyFile, KeepOpenFile]:
     ...
 
 
-def get_os_args() -> List[str]:
+def get_os_args() -> List[Text]:
     ...
 
 
-def format_filename(filename: str, shorten: bool = ...) -> str:
+def format_filename(filename: Text, shorten: bool = ...) -> Text:
     ...
 
 
 def get_app_dir(
-    app_name: str, roaming: bool = ..., force_posix: bool = ...
-) -> str:
+    app_name: Text, roaming: bool = ..., force_posix: bool = ...
+) -> Text:
     ...


### PR DESCRIPTION
The functions in the click module don't work when calling 'mypy --py2' and using `unicode_literals`, because they use type `str` but should use the python-2-compatible type `Text`. This PR fixes this.