### PR TITLE
Fix type of loop parameter to asyncio.start_unix_server

### DIFF
--- a/stdlib/3.4/asyncio/streams.pyi
+++ b/stdlib/3.4/asyncio/streams.pyi
@@ -56,7 +56,7 @@ if sys.platform != 'win32':
         client_connected_cb: _ClientConnectedCallback,
         path: str = ...,
         *,
-        loop: int = ...,
+        loop: Optional[events.AbstractEventLoop] = ...,
         limit: int = ...,
         **kwds: Any) -> Generator[Any, None, events.AbstractServer]: ...
 


### PR DESCRIPTION
Not sure why it was `int` previously (maybe a copy-paste error from `limit` below?), but this makes it match the loop parameter to start_server.

I've run `python3 tests/mypy_test.py` over this and it passes.