### PR TITLE
Switch usages of mypy_extensions.NoReturn over to typing.NoReturn.

### DIFF
--- a/stdlib/2/__builtin__.pyi
+++ b/stdlib/2/__builtin__.pyi
@@ -4,14 +4,13 @@
 # Python 3, and stub files conform to Python 3 syntax.
 
 from typing import (
-    TypeVar, Iterator, Iterable, overload,
+    TypeVar, Iterator, Iterable, NoReturn, overload,
     Sequence, Mapping, Tuple, List, Any, Dict, Callable, Generic, Set,
     AbstractSet, FrozenSet, Sized, Reversible, SupportsInt, SupportsFloat, SupportsAbs,
     SupportsRound, IO, BinaryIO, Union, AnyStr, MutableSequence, MutableMapping,
     MutableSet, ItemsView, KeysView, ValuesView, Optional, Container, Type
 )
 from abc import abstractmethod, ABCMeta
-from mypy_extensions import NoReturn
 
 _T = TypeVar('_T')
 _T_co = TypeVar('_T_co', covariant=True)

--- a/stdlib/2/dummy_thread.pyi
+++ b/stdlib/2/dummy_thread.pyi
@@ -1,5 +1,4 @@
-from mypy_extensions import NoReturn
-from typing import Any, Callable, Dict, Optional, Tuple
+from typing import Any, Callable, Dict, NoReturn, Optional, Tuple
 
 class error(Exception):
     def __init__(self, *args: Any) -> None: ...

--- a/stdlib/2/os/__init__.pyi
+++ b/stdlib/2/os/__init__.pyi
@@ -7,10 +7,9 @@ from posix import stat_result as stat_result  # TODO: use this, see https://gith
 import sys
 from typing import (
     Mapping, MutableMapping, Dict, List, Any, Tuple, Iterator, overload, Union, AnyStr,
-    Optional, Generic, Set, Callable, Text, Sequence, IO, NamedTuple, TypeVar
+    Optional, Generic, Set, Callable, Text, Sequence, IO, NamedTuple, NoReturn, TypeVar
 )
 from . import path as path
-from mypy_extensions import NoReturn
 
 _T = TypeVar('_T')
 

--- a/stdlib/2/pydoc.pyi
+++ b/stdlib/2/pydoc.pyi
@@ -1,5 +1,4 @@
-from typing import Any, AnyStr, Callable, Container, Dict, IO, List, Mapping, MutableMapping, Optional, Tuple, Type, Union
-from mypy_extensions import NoReturn
+from typing import Any, AnyStr, Callable, Container, Dict, IO, List, Mapping, MutableMapping, NoReturn, Optional, Tuple, Type, Union
 from repr import Repr
 
 from types import FunctionType, MethodType, ModuleType, TracebackType

--- a/stdlib/2/sys.pyi
+++ b/stdlib/2/sys.pyi
@@ -1,11 +1,10 @@
 """Stubs for the 'sys' module."""
 
 from typing import (
-    IO, Union, List, Sequence, Any, Dict, Tuple, BinaryIO, Optional, Callable,
-    overload, Text, Type,
+    IO, NoReturn, Union, List, Sequence, Any, Dict, Tuple, BinaryIO, Optional,
+    Callable, overload, Text, Type,
 )
 from types import FrameType, ModuleType, TracebackType, ClassType
-from mypy_extensions import NoReturn
 
 class _flags:
     bytes_warning = ...  # type: int

--- a/stdlib/2/unittest.pyi
+++ b/stdlib/2/unittest.pyi
@@ -2,10 +2,9 @@
 
 # Based on http://docs.python.org/2.7/library/unittest.html
 
-from mypy_extensions import NoReturn
 from typing import (Any, Callable, Dict, FrozenSet, Iterable, Iterator,
-                    List, Optional, overload, Pattern, Sequence, Set, Text,
-                    TextIO, Tuple, Type, TypeVar, Union)
+                    List, NoReturn, Optional, overload, Pattern, Sequence, Set,
+                    Text, TextIO, Tuple, Type, TypeVar, Union)
 from abc import abstractmethod, ABCMeta
 import types
 

--- a/stdlib/2and3/lib2to3/pgen2/pgen.pyi
+++ b/stdlib/2and3/lib2to3/pgen2/pgen.pyi
@@ -1,7 +1,8 @@
 # Stubs for lib2to3.pgen2.pgen (Python 3.6)
 
-from typing import Any, Dict, IO, Iterable, Iterator, List, Optional, Text, Tuple
-from mypy_extensions import NoReturn
+from typing import (
+    Any, Dict, IO, Iterable, Iterator, List, NoReturn, Optional, Text, Tuple
+)
 
 from lib2to3.pgen2 import _Path, grammar
 from lib2to3.pgen2.tokenize import _TokenInfo

--- a/stdlib/2and3/poplib.pyi
+++ b/stdlib/2and3/poplib.pyi
@@ -1,10 +1,12 @@
 # Stubs for poplib (Python 2 and 3)
 
-from mypy_extensions import NoReturn
 import socket
 import ssl
 import sys
-from typing import Any, BinaryIO, Dict, List, Optional, overload, Pattern, Text, Tuple
+from typing import (
+    Any, BinaryIO, Dict, List, NoReturn, Optional, overload, Pattern, Text,
+    Tuple,
+)
 
 _LongResp = Tuple[bytes, List[bytes], int]
 

--- a/stdlib/2and3/sunau.pyi
+++ b/stdlib/2and3/sunau.pyi
@@ -1,8 +1,7 @@
 # Stubs for sunau (Python 2 and 3)
 
 import sys
-from mypy_extensions import NoReturn
-from typing import Any, NamedTuple, Optional, Text, IO, Union, Tuple
+from typing import Any, NamedTuple, NoReturn, Optional, Text, IO, Union, Tuple
 
 _File = Union[Text, IO[bytes]]
 

--- a/stdlib/2and3/wave.pyi
+++ b/stdlib/2and3/wave.pyi
@@ -1,8 +1,9 @@
 # Stubs for wave (Python 2 and 3)
 
 import sys
-from mypy_extensions import NoReturn
-from typing import Any, NamedTuple, Optional, Text, BinaryIO, Union, Tuple
+from typing import (
+    Any, NamedTuple, NoReturn, Optional, Text, BinaryIO, Union, Tuple
+)
 
 _File = Union[Text, BinaryIO]
 

--- a/stdlib/2and3/xml/sax/__init__.pyi
+++ b/stdlib/2and3/xml/sax/__init__.pyi
@@ -1,5 +1,4 @@
-from typing import Any, List, Optional, Text, Union, IO
-from mypy_extensions import NoReturn
+from typing import Any, List, NoReturn, Optional, Text, Union, IO
 
 import xml.sax
 from xml.sax.xmlreader import InputSource, Locator

--- a/stdlib/3/_dummy_thread.pyi
+++ b/stdlib/3/_dummy_thread.pyi
@@ -1,5 +1,4 @@
-from mypy_extensions import NoReturn
-from typing import Any, Callable, Dict, Optional, Tuple
+from typing import Any, Callable, Dict, NoReturn, Optional, Tuple
 
 TIMEOUT_MAX: int
 error = RuntimeError

--- a/stdlib/3/builtins.pyi
+++ b/stdlib/3/builtins.pyi
@@ -2,7 +2,7 @@
 
 from typing import (
     TypeVar, Iterator, Iterable, overload, Container,
-    Sequence, MutableSequence, Mapping, MutableMapping, Tuple, List, Any, Dict, Callable, Generic,
+    Sequence, MutableSequence, Mapping, MutableMapping, NoReturn, Tuple, List, Any, Dict, Callable, Generic,
     Set, AbstractSet, FrozenSet, MutableSet, Sized, Reversible, SupportsInt, SupportsFloat,
     SupportsBytes, SupportsAbs, SupportsRound, IO, Union, ItemsView, KeysView, ValuesView,
     ByteString, Optional, AnyStr, Type,
@@ -10,7 +10,6 @@ from typing import (
 from abc import abstractmethod, ABCMeta
 from types import TracebackType, CodeType
 import sys
-from mypy_extensions import NoReturn
 
 # Note that names imported above are not automatically made visible via the
 # implicit builtins import.

--- a/stdlib/3/os/__init__.pyi
+++ b/stdlib/3/os/__init__.pyi
@@ -4,10 +4,9 @@
 from io import TextIOWrapper as _TextIOWrapper
 import sys
 from typing import (
-    Mapping, MutableMapping, Dict, List, Any, Tuple, IO, Iterable, Iterator, overload, Union, AnyStr,
+    Mapping, MutableMapping, Dict, List, Any, Tuple, IO, Iterable, Iterator, NoReturn, overload, Union, AnyStr,
     Optional, Generic, Set, Callable, Text, Sequence, NamedTuple, TypeVar, ContextManager
 )
-from mypy_extensions import NoReturn
 
 # Re-exported names from other modules.
 from builtins import OSError as error

--- a/stdlib/3/sys.pyi
+++ b/stdlib/3/sys.pyi
@@ -4,12 +4,11 @@
 # based on http://docs.python.org/3.2/library/sys.html
 
 from typing import (
-    List, Sequence, Any, Dict, Tuple, TextIO, overload, Optional, Union,
-    TypeVar, Callable, Type,
+    List, NoReturn, Sequence, Any, Dict, Tuple, TextIO, overload, Optional,
+    Union, TypeVar, Callable, Type,
 )
 import sys
 from types import FrameType, TracebackType
-from mypy_extensions import NoReturn
 
 _T = TypeVar('_T')
 

--- a/stdlib/3/unittest/__init__.pyi
+++ b/stdlib/3/unittest/__init__.pyi
@@ -1,10 +1,9 @@
 # Stubs for unittest
 
-from mypy_extensions import NoReturn
 from typing import (
     Any, Callable, ContextManager, Dict, FrozenSet, Generic, Iterable, Iterator,
-    List, Optional, overload, Pattern, Sequence, Set, TextIO, Tuple, Type,
-    TypeVar, Union
+    List, NoReturn, Optional, overload, Pattern, Sequence, Set, TextIO, Tuple,
+    Type, TypeVar, Union
 )
 import logging
 import sys

--- a/third_party/2/six/__init__.pyi
+++ b/third_party/2/six/__init__.pyi
@@ -4,12 +4,11 @@ from __future__ import print_function
 
 import types
 from typing import (
-    Any, AnyStr, Callable, Dict, Iterable, Mapping, Optional,
+    Any, AnyStr, Callable, Dict, Iterable, Mapping, NoReturn, Optional,
     Pattern, Tuple, Type, TypeVar, Union, overload, ValuesView, KeysView, ItemsView
 )
 import typing
 import unittest
-from mypy_extensions import NoReturn
 
 # Exports
 from __builtin__ import unichr as unichr

--- a/third_party/3/six/__init__.pyi
+++ b/third_party/3/six/__init__.pyi
@@ -11,6 +11,7 @@ from typing import (
     Iterable,
     KeysView,
     Mapping,
+    NoReturn,
     Optional,
     Pattern,
     Tuple,
@@ -23,7 +24,6 @@ from typing import (
 import types
 import typing
 import unittest
-from mypy_extensions import NoReturn
 
 # Exports
 from io import StringIO as StringIO, BytesIO as BytesIO


### PR DESCRIPTION
Pytype now supports NoReturn.