### PR TITLE
add deprecation comment to mypy_extensions

### DIFF
--- a/third_party/2and3/mypy_extensions.pyi
+++ b/third_party/2and3/mypy_extensions.pyi
@@ -14,4 +14,4 @@ def KwArg(type: _T = ...) -> _T: ...
 # Return type that indicates a function does not return.
 # This type is equivalent to the None type, but the no-op Union is necessary to
 # distinguish the None type from the None value.
-NoReturn = Union[None]
+NoReturn = Union[None]  # Deprecated: Use typing.NoReturn instead.


### PR DESCRIPTION
In typeshed itself, we don't use mypy_extensions anymore. But there might be Python code that does. So we need to keep the file around.