### PR TITLE
Update click.option to allow for user defined kwargs.

### DIFF
--- a/third_party/2and3/click/decorators.pyi
+++ b/third_party/2and3/click/decorators.pyi
@@ -109,7 +109,9 @@ def option(
     metavar: Optional[str] = ...,
     expose_value: bool = ...,
     is_eager: bool = ...,
-    envvar: Optional[Union[str, List[str]]] = ...
+    envvar: Optional[Union[str, List[str]]] = ...,
+    # User-defined
+    **kwargs: Any,
 ) -> _Decorator:
     ...
 


### PR DESCRIPTION
Click's option decorator can take a cls= argument, which allows that class to parse arbitrary arguments from the decorator.