### PR TITLE
traceback.print_exception(): Arguments optional in Python 3

### DIFF
--- a/stdlib/2and3/traceback.pyi
+++ b/stdlib/2and3/traceback.pyi
@@ -10,7 +10,8 @@ _PT = Tuple[str, int, str, Optional[str]]
 def print_tb(tb: Optional[TracebackType], limit: Optional[int] = ...,
              file: Optional[IO[str]] = ...) -> None: ...
 if sys.version_info >= (3,):
-    def print_exception(etype: Type[BaseException], value: BaseException,
+    def print_exception(etype: Optional[Type[BaseException]],
+                        value: Optional[BaseException],
                         tb: Optional[TracebackType], limit: Optional[int] = ...,
                         file: Optional[IO[str]] = ...,
                         chain: bool = ...) -> None: ...


### PR DESCRIPTION
The first two arguments were already optional for Python 2, but they are also optional in Python 3:

```python
>>> import traceback
>>> traceback.print_exception(None, None, None)
NoneType: None
```

This should fix mypy warnings in the following line: `print_exception(*sys.exc_info())` (untested).