### PR TITLE
add E741 to ignored flake8 codes

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -14,7 +14,7 @@
 #    34 E127 continuation line over-indented for visual indent
 
 [flake8]
-ignore = F401, F403, F405, F811, E127, E128, E301, E302, E305, E501, E701, E704, B303
+ignore = F401, F403, F405, F811, E127, E128, E301, E302, E305, E501, E701, E704, E741, B303
 # We are checking with Python 3 but many of the stubs are Python 2 stubs.
 # A nice future improvement would be to provide separate .flake8
 # configurations for Python 2 and Python 3 files.


### PR DESCRIPTION
This was introduced in a recent version (so it doesn't affect us right now but will if we upgrade the flake8 version used in tests). It gives errors like:
```
/home/travis/build/ambv/flake8-pyi/.tox/typeshed/tmp/typeshed/stdlib/3/re.pyi:21:9: E741 ambiguous variable name 'I'
/home/travis/build/ambv/flake8-pyi/.tox/typeshed/tmp/typeshed/stdlib/3/re.pyi:39:5: E741 ambiguous variable name 'I'
/home/travis/build/ambv/flake8-pyi/.tox/typeshed/tmp/typeshed/stdlib/3/re.pyi:58:5: E741 ambiguous variable name 'I'
/home/travis/build/ambv/flake8-pyi/.tox/typeshed/tmp/typeshed/third_party/2/OpenSSL/crypto.pyi:43:5: E741 ambiguous variable name 'O'
```
These aren't useful for typeshed, because regardless of whether it's good style, these libraries really do contain variables named `I` and `O`.