### PR TITLE
Improve asyncio APIs which take TCP port

### DIFF
--- a/stdlib/3.4/asyncio/streams.pyi
+++ b/stdlib/3.4/asyncio/streams.pyi
@@ -1,5 +1,5 @@
 import sys
-from typing import Any, Awaitable, Callable, Generator, Iterable, List, Optional, Tuple
+from typing import Any, Awaitable, Callable, Generator, Iterable, List, Optional, Tuple, Union
 
 from . import coroutines
 from . import events
@@ -23,7 +23,7 @@ class LimitOverrunError(Exception):
 @coroutines.coroutine
 def open_connection(
     host: str = ...,
-    port: int = ...,
+    port: Union[int, str] = ...,
     *,
     loop: Optional[events.AbstractEventLoop] = ...,
     limit: int = ...,
@@ -33,8 +33,8 @@ def open_connection(
 @coroutines.coroutine
 def start_server(
     client_connected_cb: _ClientConnectedCallback,
-    host: str = ...,
-    port: int = ...,
+    host: Optional[str] = ...,
+    port: Optional[Union[int, str]] = ...,
     *,
     loop: Optional[events.AbstractEventLoop] = ...,
     limit: int = ...,


### PR DESCRIPTION
They have `getaddrinfo(3)` as their backend, and accept `port='http'` etc. You can even omit (pass `None` to) either of `host` or `port` for `start_server()` to effectively select `'localhost'` and an arbitrary ephemeral port, respectively.