### PR TITLE
Fixup the boto stubs to allow `mypy --strict`.

### DIFF
--- a/third_party/2and3/boto/compat.pyi
+++ b/third_party/2and3/boto/compat.pyi
@@ -1,10 +1,17 @@
+import sys
+
 from typing import Any
 from base64 import encodestring as encodebytes
 
 from six.moves import http_client
 
 expanduser = ...  # type: Any
-StandardError = ...  # type: Any
+
+if sys.version_info >= (3, 0):
+    StandardError = Exception
+else:
+    StandardError = __builtins__.StandardError
+
 long_type = ...  # type: Any
 unquote_str = ...  # type: Any
 parse_qs_safe = ...  # type: Any


### PR DESCRIPTION
This passes the standard complement of tests (`mypy_selftest.py`, `mypy_test.py` and `pytype_test.py`) and fixes #1955 
