### PR TITLE
fix third_party/2/enum.pyi

### DIFF
--- a/third_party/2/enum.pyi
+++ b/third_party/2/enum.pyi
@@ -1,7 +1,7 @@
 from typing import List, Any, TypeVar, Union, Iterable, Iterator, TypeVar, Generic, Type, Sized, Reversible, Container, Mapping
 from abc import ABCMeta
 
-_T = TypeVar('_T', bound=Enum)
+_T = TypeVar('_T')
 _S = TypeVar('_S', bound=Type[Enum])
 
 # Note: EnumMeta actually subclasses type directly, not ABCMeta.


### PR DESCRIPTION
This fixes an error in Travis that seems to have been caused by python/mypy#4319.

The fix was taken from the stdlib/3.4/enum.pyi stub. Mypy no longer assumes
that classes whose metaclass is EnumMeta are subclasses of Enum, so we can't
bound the typevar on Enum.