### PR TITLE
Make the help argument of argparse.add_argument Optional.

### DIFF
--- a/stdlib/2and3/argparse.pyi
+++ b/stdlib/2and3/argparse.pyi
@@ -60,7 +60,7 @@ class _ActionsContainer:
                      type: Union[Callable[[_Text], _T], FileType] = ...,
                      choices: Iterable[_T] = ...,
                      required: bool = ...,
-                     help: _Text = ...,
+                     help: Optional[_Text] = ...,
                      metavar: Union[_Text, Tuple[_Text, ...]] = ...,
                      dest: Optional[_Text] = ...,
                      version: _Text = ...) -> Action: ...


### PR DESCRIPTION
This argument has a default value of `None`, therefore must be optional.

Closes #1969.