### PR TITLE
Fix py2 unicode handling for ArgumentParser.add_argument's text arg

### DIFF
--- a/stdlib/2and3/argparse.pyi
+++ b/stdlib/2and3/argparse.pyi
@@ -57,7 +57,7 @@ class _ActionsContainer:
                      nargs: Union[int, _Text] = ...,
                      const: Any = ...,
                      default: Any = ...,
-                     type: Union[Callable[[_Text], _T], FileType] = ...,
+                     type: Union[Callable[[str], _T], FileType] = ...,
                      choices: Iterable[_T] = ...,
                      required: bool = ...,
                      help: Optional[_Text] = ...,


### PR DESCRIPTION
add_argument's type argument was recently changed to be (approximately)
`Callable[[_Text], _T]`. Because of contravariant subtyping for functions,
this had the effect of requiring that add_argument *always*
be unicode, which is wrong.

Change it to be `Callable[[str], _T]`.