### PR TITLE
Fix type of click.Path path_type arg

### DIFF
--- a/third_party/2and3/click/types.pyi
+++ b/third_party/2and3/click/types.pyi
@@ -1,4 +1,4 @@
-from typing import Any, Callable, IO, Iterable, List, Optional, TypeVar, Union, Tuple as _PyTuple
+from typing import Any, Callable, IO, Iterable, List, Optional, TypeVar, Union, Tuple as _PyTuple, Type
 import uuid
 
 from click.core import Context, Parameter
@@ -184,7 +184,7 @@ class Path(ParamType):
         readable: bool = ...,
         resolve_path: bool = ...,
         allow_dash: bool = ...,
-        path_type: Optional[_PathType] = ...,
+        path_type: Optional[Type[_PathType]] = ...,
     ) -> None:
         ...
 


### PR DESCRIPTION
path_type takes a type, not an instance of the type

Tested with a simple click app using click.Path:

```python
#!/usr/bin/env python3
import click


@click.command()
@click.argument(
    'path',
    required=True,
    type=click.Path(
        exists=True,
        path_type=str
    )
)
def testapp(path):
    print(f'Hi: {path}')


if __name__ == '__main__':
    testapp()
```

Passes typecheck with this change, before was failing with

```
clicktest.py:9: error: Value of type variable "_PathType" of "Path" cannot be "Type[str]"
```