### PR TITLE
Add 'file=...' to FieldDescriptor constructor.

### DIFF
--- a/third_party/2/google/protobuf/descriptor.pyi
+++ b/third_party/2/google/protobuf/descriptor.pyi
@@ -82,7 +82,7 @@ class FieldDescriptor(DescriptorBase):
     MAX_FIELD_NUMBER = ...  # type: Any
     FIRST_RESERVED_FIELD_NUMBER = ...  # type: Any
     LAST_RESERVED_FIELD_NUMBER = ...  # type: Any
-    def __new__(cls, name, full_name, index, number, type, cpp_type, label, default_value, message_type, enum_type, containing_type, is_extension, extension_scope, options=..., has_default_value=..., containing_oneof=...): ...
+    def __new__(cls, name, full_name, index, number, type, cpp_type, label, default_value, message_type, enum_type, containing_type, is_extension, extension_scope, options=..., file=..., has_default_value=..., containing_oneof=...): ...
     name = ...  # type: Any
     full_name = ...  # type: Any
     index = ...  # type: Any
@@ -98,7 +98,7 @@ class FieldDescriptor(DescriptorBase):
     is_extension = ...  # type: Any
     extension_scope = ...  # type: Any
     containing_oneof = ...  # type: Any
-    def __init__(self, name, full_name, index, number, type, cpp_type, label, default_value, message_type, enum_type, containing_type, is_extension, extension_scope, options=..., has_default_value=..., containing_oneof=...) -> None: ...
+    def __init__(self, name, full_name, index, number, type, cpp_type, label, default_value, message_type, enum_type, containing_type, is_extension, extension_scope, options=..., file=..., has_default_value=..., containing_oneof=...) -> None: ...
     @staticmethod
     def ProtoTypeToCppProtoType(proto_type): ...
 


### PR DESCRIPTION
Found this by running mypy over some internal code. Apparently the code generator can generate code like this:
```
    _descriptor.FieldDescriptor(
      name='cookie_info', full_name='user_auth.UserAuthInfo.cookie_info', index=0,
      number=1, type=11, cpp_type=10, label=1,
      has_default_value=False, default_value=None,
      message_type=None, enum_type=None, containing_type=None,
      is_extension=False, extension_scope=None,
      options=None, file=DESCRIPTOR),
  ],
```