### PR TITLE
Fix attr.Factory signature

### DIFF
--- a/third_party/2and3/attr/__init__.pyi
+++ b/third_party/2and3/attr/__init__.pyi
@@ -21,11 +21,11 @@ _ValidatorArgType = Union[_ValidatorType[_T], Sequence[_ValidatorType[_T]]]
 NOTHING: object
 
 # NOTE: Factory lies about its return type to make this possible: `x: List[int] = Factory(list)`
-# Work around mypy issue #4554 by using an overload vs a Union.
+# Work around mypy issue #4554 in the common case by using an overload.
 @overload
-def Factory(factory: Callable[[], _T], takes_self: bool = ...) -> _T: ...
+def Factory(factory: Callable[[], _T]) -> _T: ...
 @overload
-def Factory(factory: Callable[[Any], _T], takes_self: bool = ...) -> _T: ...
+def Factory(factory: Union[Callable[[Any], _T], Callable[[], _T]], takes_self: bool = ...) -> _T: ...
 
 class Attribute(Generic[_T]):
     name: str


### PR DESCRIPTION
The first overload was catching all calls including take_self=True.
Fix it by modifying the overloads.

Fixes https://github.com/python-attrs/attrs/issues/366