### PR TITLE
Have Python 2 IntEnum values be ints

### DIFF
--- a/third_party/2/enum.pyi
+++ b/third_party/2/enum.pyi
@@ -28,6 +28,7 @@ class Enum(metaclass=EnumMeta):
     name = ...  # type: str
     value = ...  # type: Any
 
-class IntEnum(int, Enum): ...
+class IntEnum(int, Enum):
+    value = ...  # type: int
 
 def unique(enumeration: _S) -> _S: ...


### PR DESCRIPTION
Currently the Python 2 stub for `IntEnum` just inherits from `Enum` without changing anything, meaning that its `value` has type `Any`. This changes it such that, if you know you have an `IntEnum` you get the more specific `int` type for the `value`. Note that this has already been done for Python 3 `IntEnum` (both in `third_party/3/enum.pyi` and `stdlib/3.4/enum.pyi`).