### PR TITLE
Add stubs for submodules of six.moves

### DIFF
--- a/third_party/2/six/moves/BaseHTTPServer.pyi
+++ b/third_party/2/six/moves/BaseHTTPServer.pyi
@@ -1,0 +1,1 @@
+from BaseHTTPServer import *

--- a/third_party/2/six/moves/SimpleHTTPServer.pyi
+++ b/third_party/2/six/moves/SimpleHTTPServer.pyi
@@ -1,0 +1,1 @@
+from SimpleHTTPServer import *

--- a/third_party/2/six/moves/__init__.pyi
+++ b/third_party/2/six/moves/__init__.pyi
@@ -22,27 +22,27 @@ from __builtin__ import xrange as xrange
 from itertools import izip as zip
 from itertools import izip_longest as zip_longest
 import __builtin__ as builtins
-import ConfigParser as configparser
+from . import configparser
 # import copy_reg as copyreg
 # import gdbm as dbm_gnu
-import dummy_thread as _dummy_thread
-import cookielib as http_cookiejar
-import Cookie as http_cookies
-import htmlentitydefs as html_entities
-import HTMLParser as html_parser
-import httplib as http_client
+from . import _dummy_thread
+from . import http_cookiejar
+from . import http_cookies
+from . import html_entities
+from . import html_parser
+from . import http_client
 # import email.MIMEMultipart as email_mime_multipart
 # import email.MIMENonMultipart as email_mime_nonmultipart
-import email.MIMEText as email_mime_text
+from . import email_mime_text
 # import email.MIMEBase as email_mime_base
-import BaseHTTPServer as BaseHTTPServer
+from . import BaseHTTPServer
 # import CGIHTTPServer as CGIHTTPServer
-# import SimpleHTTPServer as SimpleHTTPServer
-import cPickle as cPickle
-import Queue as queue
-import repr as reprlib
-import SocketServer as socketserver
-import thread as _thread
+from . import SimpleHTTPServer
+from . import cPickle
+from . import queue
+from . import reprlib
+from . import socketserver
+from . import _thread
 # import Tkinter as tkinter
 # import Dialog as tkinter_dialog
 # import FileDialog as tkinter_filedialog
@@ -58,9 +58,9 @@ import thread as _thread
 # import tkFont as tkinter_font
 # import tkMessageBox as tkinter_messagebox
 # import tkSimpleDialog as tkinter_tksimpledialog
-import six.moves.urllib.parse as urllib_parse
-import six.moves.urllib.error as urllib_error
-import six.moves.urllib as urllib
-import robotparser as urllib_robotparser
-import xmlrpclib as xmlrpc_client
+from . import urllib_parse
+from . import urllib_error
+from . import urllib
+from . import urllib_robotparser
+from . import xmlrpc_client
 # import SimpleXMLRPCServer as xmlrpc_server

--- a/third_party/2/six/moves/_dummy_thread.pyi
+++ b/third_party/2/six/moves/_dummy_thread.pyi
@@ -1,0 +1,1 @@
+from dummy_thread import *

--- a/third_party/2/six/moves/_thread.pyi
+++ b/third_party/2/six/moves/_thread.pyi
@@ -1,0 +1,1 @@
+from thread import *

--- a/third_party/2/six/moves/cPickle.pyi
+++ b/third_party/2/six/moves/cPickle.pyi
@@ -1,0 +1,1 @@
+from cPickle import *

--- a/third_party/2/six/moves/configparser.pyi
+++ b/third_party/2/six/moves/configparser.pyi
@@ -1,0 +1,1 @@
+from ConfigParser import *

--- a/third_party/2/six/moves/email_mime_text.pyi
+++ b/third_party/2/six/moves/email_mime_text.pyi
@@ -1,0 +1,1 @@
+from email.MIMEText import *

--- a/third_party/2/six/moves/html_entities.pyi
+++ b/third_party/2/six/moves/html_entities.pyi
@@ -1,0 +1,1 @@
+from htmlentitydefs import *

--- a/third_party/2/six/moves/html_parser.pyi
+++ b/third_party/2/six/moves/html_parser.pyi
@@ -1,0 +1,1 @@
+from HTMLParser import *

--- a/third_party/2/six/moves/http_client.pyi
+++ b/third_party/2/six/moves/http_client.pyi
@@ -1,0 +1,1 @@
+from httplib import *

--- a/third_party/2/six/moves/http_cookiejar.pyi
+++ b/third_party/2/six/moves/http_cookiejar.pyi
@@ -1,0 +1,1 @@
+from cookielib import *

--- a/third_party/2/six/moves/http_cookies.pyi
+++ b/third_party/2/six/moves/http_cookies.pyi
@@ -1,0 +1,1 @@
+from Cookie import *

--- a/third_party/2/six/moves/queue.pyi
+++ b/third_party/2/six/moves/queue.pyi
@@ -1,0 +1,1 @@
+from Queue import *

--- a/third_party/2/six/moves/reprlib.pyi
+++ b/third_party/2/six/moves/reprlib.pyi
@@ -1,0 +1,1 @@
+from repr import *

--- a/third_party/2/six/moves/socketserver.pyi
+++ b/third_party/2/six/moves/socketserver.pyi
@@ -1,0 +1,1 @@
+from SocketServer import *

--- a/third_party/2/six/moves/urllib_error.pyi
+++ b/third_party/2/six/moves/urllib_error.pyi
@@ -1,0 +1,1 @@
+from .urllib.error import *

--- a/third_party/2/six/moves/urllib_parse.pyi
+++ b/third_party/2/six/moves/urllib_parse.pyi
@@ -1,0 +1,1 @@
+from .urllib.parse import *

--- a/third_party/2/six/moves/urllib_robotparser.pyi
+++ b/third_party/2/six/moves/urllib_robotparser.pyi
@@ -1,0 +1,1 @@
+from robotparser import *

--- a/third_party/2/six/moves/xmlrpc_client.pyi
+++ b/third_party/2/six/moves/xmlrpc_client.pyi
@@ -1,0 +1,1 @@
+from xmlrpclib import *

--- a/third_party/3/six/moves/BaseHTTPServer.pyi
+++ b/third_party/3/six/moves/BaseHTTPServer.pyi
@@ -1,0 +1,1 @@
+from http.server import *

--- a/third_party/3/six/moves/CGIHTTPServer.pyi
+++ b/third_party/3/six/moves/CGIHTTPServer.pyi
@@ -1,0 +1,1 @@
+from http.server import *

--- a/third_party/3/six/moves/SimpleHTTPServer.pyi
+++ b/third_party/3/six/moves/SimpleHTTPServer.pyi
@@ -1,0 +1,1 @@
+from http.server import *

--- a/third_party/3/six/moves/__init__.pyi
+++ b/third_party/3/six/moves/__init__.pyi
@@ -22,47 +22,47 @@ from collections import UserString as UserString
 from builtins import range as xrange
 from builtins import zip as zip
 from itertools import zip_longest as zip_longest
-import builtins as builtins
-import configparser as configparser
+from . import builtins
+from . import configparser
 # import copyreg as copyreg
 # import dbm.gnu as dbm_gnu
-import _dummy_thread as _dummy_thread
-import http.cookiejar as http_cookiejar
-import http.cookies as http_cookies
-import html.entities as html_entities
-import html.parser as html_parser
-import http.client as http_client
-import email.mime.multipart as email_mime_multipart
-import email.mime.nonmultipart as email_mime_nonmultipart
-import email.mime.text as email_mime_text
-import email.mime.base as email_mime_base
-import http.server as BaseHTTPServer
-import http.server as CGIHTTPServer
-import http.server as SimpleHTTPServer
-import pickle as cPickle
-import queue as queue
-import reprlib as reprlib
-import socketserver as socketserver
-import _thread as _thread
-import tkinter as tkinter
-# import tkinter.dialog as tkinter_dialog
-# import tkinter.filedialog as tkinter_filedialog
+from . import _dummy_thread
+from . import http_cookiejar
+from . import http_cookies
+from . import html_entities
+from . import html_parser
+from . import http_client
+from . import email_mime_multipart
+from . import email_mime_nonmultipart
+from . import email_mime_text
+from . import email_mime_base
+from . import BaseHTTPServer
+from . import CGIHTTPServer
+from . import SimpleHTTPServer
+from . import cPickle
+from . import queue
+from . import reprlib
+from . import socketserver
+from . import _thread
+from . import tkinter
+from . import tkinter_dialog
+from . import tkinter_filedialog
 # import tkinter.scrolledtext as tkinter_scrolledtext
 # import tkinter.simpledialog as tkinter_simpledialog
 # import tkinter.tix as tkinter_tix
-import tkinter.ttk as tkinter_ttk
-import tkinter.constants as tkinter_constants
+from . import tkinter_ttk
+from . import tkinter_constants
 # import tkinter.dnd as tkinter_dnd
 # import tkinter.colorchooser as tkinter_colorchooser
-# import tkinter.commondialog as tkinter_commondialog
-# import tkinter.filedialog as tkinter_tkfiledialog
+from . import tkinter_commondialog
+from . import tkinter_tkfiledialog
 # import tkinter.font as tkinter_font
 # import tkinter.messagebox as tkinter_messagebox
 # import tkinter.simpledialog as tkinter_tksimpledialog
-import urllib.parse as urllib_parse
-import urllib.error as urllib_error
-import six.moves.urllib as urllib
-import urllib.robotparser as urllib_robotparser
+from . import urllib_parse
+from . import urllib_error
+from . import urllib
+from . import urllib_robotparser
 # import xmlrpc.client as xmlrpc_client
 # import xmlrpc.server as xmlrpc_server
 

--- a/third_party/3/six/moves/_dummy_thread.pyi
+++ b/third_party/3/six/moves/_dummy_thread.pyi
@@ -1,0 +1,1 @@
+from _dummy_thread import *

--- a/third_party/3/six/moves/_thread.pyi
+++ b/third_party/3/six/moves/_thread.pyi
@@ -1,0 +1,1 @@
+from _thread import *

--- a/third_party/3/six/moves/builtins.pyi
+++ b/third_party/3/six/moves/builtins.pyi
@@ -1,0 +1,1 @@
+from builtins import *

--- a/third_party/3/six/moves/cPickle.pyi
+++ b/third_party/3/six/moves/cPickle.pyi
@@ -1,0 +1,1 @@
+from pickle import *

--- a/third_party/3/six/moves/configparser.pyi
+++ b/third_party/3/six/moves/configparser.pyi
@@ -1,0 +1,1 @@
+from configparser import *

--- a/third_party/3/six/moves/email_mime_base.pyi
+++ b/third_party/3/six/moves/email_mime_base.pyi
@@ -1,0 +1,1 @@
+from email.mime.base import *

--- a/third_party/3/six/moves/email_mime_multipart.pyi
+++ b/third_party/3/six/moves/email_mime_multipart.pyi
@@ -1,0 +1,1 @@
+from email.mime.multipart import *

--- a/third_party/3/six/moves/email_mime_nonmultipart.pyi
+++ b/third_party/3/six/moves/email_mime_nonmultipart.pyi
@@ -1,0 +1,1 @@
+from email.mime.nonmultipart import *

--- a/third_party/3/six/moves/email_mime_text.pyi
+++ b/third_party/3/six/moves/email_mime_text.pyi
@@ -1,0 +1,1 @@
+from email.mime.text import *

--- a/third_party/3/six/moves/html_entities.pyi
+++ b/third_party/3/six/moves/html_entities.pyi
@@ -1,0 +1,1 @@
+from html.entities import *

--- a/third_party/3/six/moves/html_parser.pyi
+++ b/third_party/3/six/moves/html_parser.pyi
@@ -1,0 +1,1 @@
+from html.parser import *

--- a/third_party/3/six/moves/http_client.pyi
+++ b/third_party/3/six/moves/http_client.pyi
@@ -1,0 +1,1 @@
+from http.client import *

--- a/third_party/3/six/moves/http_cookiejar.pyi
+++ b/third_party/3/six/moves/http_cookiejar.pyi
@@ -1,0 +1,1 @@
+from http.cookiejar import *

--- a/third_party/3/six/moves/http_cookies.pyi
+++ b/third_party/3/six/moves/http_cookies.pyi
@@ -1,0 +1,1 @@
+from http.cookies import *

--- a/third_party/3/six/moves/queue.pyi
+++ b/third_party/3/six/moves/queue.pyi
@@ -1,0 +1,1 @@
+from queue import *

--- a/third_party/3/six/moves/reprlib.pyi
+++ b/third_party/3/six/moves/reprlib.pyi
@@ -1,0 +1,1 @@
+from reprlib import *

--- a/third_party/3/six/moves/socketserver.pyi
+++ b/third_party/3/six/moves/socketserver.pyi
@@ -1,0 +1,1 @@
+from socketserver import *

--- a/third_party/3/six/moves/tkinter.pyi
+++ b/third_party/3/six/moves/tkinter.pyi
@@ -1,0 +1,1 @@
+from tkinter import *

--- a/third_party/3/six/moves/tkinter_commondialog.pyi
+++ b/third_party/3/six/moves/tkinter_commondialog.pyi
@@ -1,0 +1,1 @@
+from tkinter.commondialog import *

--- a/third_party/3/six/moves/tkinter_constants.pyi
+++ b/third_party/3/six/moves/tkinter_constants.pyi
@@ -1,0 +1,1 @@
+from tkinter.constants import *

--- a/third_party/3/six/moves/tkinter_dialog.pyi
+++ b/third_party/3/six/moves/tkinter_dialog.pyi
@@ -1,0 +1,1 @@
+from tkinter.dialog import *

--- a/third_party/3/six/moves/tkinter_filedialog.pyi
+++ b/third_party/3/six/moves/tkinter_filedialog.pyi
@@ -1,0 +1,1 @@
+from tkinter.filedialog import *

--- a/third_party/3/six/moves/tkinter_tkfiledialog.pyi
+++ b/third_party/3/six/moves/tkinter_tkfiledialog.pyi
@@ -1,0 +1,1 @@
+from tkinter.filedialog import *

--- a/third_party/3/six/moves/tkinter_ttk.pyi
+++ b/third_party/3/six/moves/tkinter_ttk.pyi
@@ -1,0 +1,1 @@
+from tkinter.ttk import *

--- a/third_party/3/six/moves/urllib_error.pyi
+++ b/third_party/3/six/moves/urllib_error.pyi
@@ -1,0 +1,1 @@
+from urllib.error import *

--- a/third_party/3/six/moves/urllib_parse.pyi
+++ b/third_party/3/six/moves/urllib_parse.pyi
@@ -1,0 +1,1 @@
+from urllib.parse import *

--- a/third_party/3/six/moves/urllib_robotparser.pyi
+++ b/third_party/3/six/moves/urllib_robotparser.pyi
@@ -1,0 +1,1 @@
+from urllib.robotparser import *


### PR DESCRIPTION
To support "from six.moves.cPickle import loads", we must add a stub for
six.moves.cPickle as if it were a real submodule, even though it isn't
implemented as such. This fixes python/mypy#1550.

We also add stubs for aliases in six.moves whose underlying modules have
been added to typeshed.

For Python 2:
    - six.moves.SimpleHTTPServer (alias for SimpleHTTPServer)

For Python 3:
    - six.moves.tkinter_dialog (alias for tkinter.dialog)
    - six.moves.tkinter_filedialog (alias for tkinter.filedialog)
    - six.moves.tkinter_commondialog (alias for tkinter.commondialog)
    - six.moves.tkinter_tkfiledialog (alias for tkinter.filedialog)