### PR TITLE
switch order of base classes on awaitable classes

### DIFF
--- a/stdlib/3.4/asyncio/futures.pyi
+++ b/stdlib/3.4/asyncio/futures.pyi
@@ -26,7 +26,7 @@ class _TracebackLogger:
 if sys.version_info >= (3, 5):
     def isfuture(obj: object) -> bool: ...
 
-class Future(Iterable[_T], Awaitable[_T], Generic[_T]):
+class Future(Awaitable[_T], Iterable[_T]):
     _state = ...  # type: str
     _exception = ...  # type: BaseException
     _blocking = False

--- a/stdlib/3/typing.pyi
+++ b/stdlib/3/typing.pyi
@@ -173,7 +173,7 @@ class Coroutine(Awaitable[_V_co], Generic[_T_co, _T_contra, _V_co]):
 
 # NOTE: This type does not exist in typing.py or PEP 484.
 # The parameters corrrespond to Generator, but the 4th is the original type.
-class AwaitableGenerator(Generator[_T_co, _T_contra, _V_co], Awaitable[_V_co],
+class AwaitableGenerator(Awaitable[_V_co], Generator[_T_co, _T_contra, _V_co],
                          Generic[_T_co, _T_contra, _V_co, _S]):
     pass
 


### PR DESCRIPTION
Fixes #1940.

This makes it so that mypy will infer the common base class of these
classes to be Awaitable instead of Iterable. I verified that this
fixes the errors in the script posted by @neilconway.