### PR TITLE
remove Optional from type of __slots__

### DIFF
--- a/stdlib/2/__builtin__.pyi
+++ b/stdlib/2/__builtin__.pyi
@@ -28,7 +28,7 @@ class object:
     __doc__ = ...  # type: Optional[str]
     __class__ = ...  # type: type
     __dict__ = ...  # type: Dict[str, Any]
-    __slots__ = ...  # type: Optional[Union[str, unicode, Iterable[Union[str, unicode]]]]
+    __slots__ = ...  # type: Union[str, unicode, Iterable[Union[str, unicode]]]
     __module__ = ...  # type: str
 
     def __init__(self) -> None: ...

--- a/stdlib/3/builtins.pyi
+++ b/stdlib/3/builtins.pyi
@@ -30,7 +30,7 @@ class object:
     __doc__ = ...  # type: Optional[str]
     __class__ = ...  # type: type
     __dict__ = ...  # type: Dict[str, Any]
-    __slots__ = ...  # type: Optional[Union[str, Iterable[str]]]
+    __slots__ = ...  # type: Union[str, Iterable[str]]
     __module__ = ...  # type: str
     if sys.version_info >= (3, 6):
         __annotations__ = ...  # type: Dict[str, Any]


### PR DESCRIPTION
Fixes #1853 

This is going to fail mypy_selftest in Travis because it needs a concurrent change to mypy. I'll send out a mypy PR for doing that.