### PR TITLE
Import _PathLike from os/path.pyi

### DIFF
--- a/stdlib/3.4/pathlib.pyi
+++ b/stdlib/3.4/pathlib.pyi
@@ -8,7 +8,7 @@ import sys
 _P = TypeVar('_P', bound='PurePath')
 
 if sys.version_info >= (3, 6):
-    _PurePathBase = os.PathLike[str]
+    _PurePathBase = os._PathLike[str]
 else:
     _PurePathBase = object
 


### PR DESCRIPTION
See https://github.com/python/typeshed/blob/master/stdlib/2/os/path.pyi

It looks like this import is missing an underscore, as os/path.pyi only defines _PathLike.