### PR TITLE
Remove __all__ = ... from stubs

### DIFF
--- a/stdlib/2/ConfigParser.pyi
+++ b/stdlib/2/ConfigParser.pyi
@@ -1,6 +1,5 @@
 from typing import Any, IO, Sequence, Tuple, Union, List, Dict
 
-__all__ = ...  # type: List[str]
 DEFAULTSECT = ...  # type: str
 MAX_INTERPOLATION_DEPTH = ...  # type: int
 

--- a/stdlib/2/multiprocessing/dummy/__init__.pyi
+++ b/stdlib/2/multiprocessing/dummy/__init__.pyi
@@ -13,7 +13,6 @@ from threading import Event
 from Queue import Queue
 
 
-
 class DummyProcess(threading.Thread):
     _children = ...  # type: weakref.WeakKeyDictionary
     _parent = ...  # type: threading.Thread

--- a/stdlib/2/multiprocessing/dummy/__init__.pyi
+++ b/stdlib/2/multiprocessing/dummy/__init__.pyi
@@ -12,7 +12,6 @@ from threading import Lock, RLock, Semaphore, BoundedSemaphore
 from threading import Event
 from Queue import Queue
 
-__all__ = ...  # type: List[str]
 
 
 class DummyProcess(threading.Thread):

--- a/stdlib/2/multiprocessing/dummy/connection.pyi
+++ b/stdlib/2/multiprocessing/dummy/connection.pyi
@@ -1,7 +1,6 @@
 from Queue import Queue
 from typing import Any, List, Optional, Tuple, Type
 
-__all__ = ...  # type: List[str]
 families = ...  # type: List[None]
 
 class Connection(object):

--- a/stdlib/2/popen2.pyi
+++ b/stdlib/2/popen2.pyi
@@ -2,7 +2,6 @@ from typing import Any, Iterable, List, Optional, Union, TextIO, Tuple, TypeVar
 
 _T = TypeVar('_T')
 
-__all__ = ...  # type: List[str]
 
 class Popen3:
     sts = ...  # type: int

--- a/stdlib/2/tokenize.pyi
+++ b/stdlib/2/tokenize.pyi
@@ -2,7 +2,6 @@
 
 from typing import Any, Callable, Dict, Generator, Iterator, List, Tuple, Union, Iterable
 
-__all__ = ...  # type: List[str]
 __author__ = ...  # type: str
 __credits__ = ...  # type: str
 

--- a/stdlib/3/multiprocessing/dummy/__init__.pyi
+++ b/stdlib/3/multiprocessing/dummy/__init__.pyi
@@ -13,7 +13,6 @@ from queue import Queue
 JoinableQueue = Queue
 
 
-
 class DummyProcess(threading.Thread):
     _children = ...  # type: weakref.WeakKeyDictionary
     _parent = ...  # type: threading.Thread

--- a/stdlib/3/multiprocessing/dummy/__init__.pyi
+++ b/stdlib/3/multiprocessing/dummy/__init__.pyi
@@ -12,7 +12,6 @@ from queue import Queue
 
 JoinableQueue = Queue
 
-__all__ = ...  # type: List[str]
 
 
 class DummyProcess(threading.Thread):

--- a/stdlib/3/multiprocessing/dummy/connection.pyi
+++ b/stdlib/3/multiprocessing/dummy/connection.pyi
@@ -2,7 +2,6 @@ from typing import Any, List, Optional, Tuple, Type, TypeVar
 
 from queue import Queue
 
-__all__ = ...  # type: List[str]
 families = ...  # type: List[None]
 
 _TConnection = TypeVar('_TConnection', bound=Connection)

--- a/stdlib/3/urllib/parse.pyi
+++ b/stdlib/3/urllib/parse.pyi
@@ -4,7 +4,6 @@ import sys
 
 _Str = Union[bytes, str]
 
-__all__ = ...  # type: Tuple[str]
 
 uses_relative = ...  # type: List[str]
 uses_netloc = ...  # type: List[str]

--- a/third_party/2and3/dateutil/parser.pyi
+++ b/third_party/2and3/dateutil/parser.pyi
@@ -3,7 +3,6 @@ from datetime import datetime, tzinfo
 
 _FileOrStr = Union[bytes, Text, IO[str], IO[Any]]
 
-__all__ = ...  # type: List[str]
 
 class parserinfo(object):
     JUMP = ...  # type: List[str]

--- a/third_party/2and3/dateutil/relativedelta.pyi
+++ b/third_party/2and3/dateutil/relativedelta.pyi
@@ -3,7 +3,6 @@ from datetime import date, datetime, timedelta
 
 from ._common import weekday
 
-__all__ = ...  # type: List[str]
 
 _SelfT = TypeVar('_SelfT', bound=relativedelta)
 _DateT = TypeVar('_DateT', date, datetime)


### PR DESCRIPTION
The presence of a __all__ causes everything to not get picked up by
import *, which among other things breaks the new six.moves stubs.