### PR TITLE
Allow lines up to 200 characters

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -185,7 +185,7 @@ you should know about.
 
 Style conventions for stub files are different from PEP 8. The general
 rule is that they should be as concise as possible.  Specifically:
-* there is no line length limit;
+* lines can be up to 200 characters long;
 * prefer long lines over elaborate indentation;
 * all function bodies should be empty;
 * prefer ``...`` over ``pass``;


### PR DESCRIPTION
Fixes #2124.

As mentioned in the issue, the current guidelines lead to extremely long lines of many hundreds of characters, which make code hard to read and review. I think there should be some limit to line length, but it's OK for stubs to have somewhat longer lines than normal code. I picked 200 but am happy to go with something else too; 200 is still a lot.

For reference, there are currently 115 lines in typeshed over 200 characters; 523 over 120 characters; and 2980 over 79 characters.