### PR TITLE
json.load can also take IO[bytes] in py36+

### DIFF
--- a/stdlib/3/json/__init__.pyi
+++ b/stdlib/3/json/__init__.pyi
@@ -41,7 +41,11 @@ def loads(s: Union[str, bytes, bytearray],
     object_pairs_hook: Optional[Callable[[List[Tuple[Any, Any]]], Any]] = ...,
     **kwds: Any) -> Any: ...
 
-def load(fp: IO[str],
+if sys.version_info >= (3, 6):
+    _LoadIO = IO[Any]
+else:
+    _LoadIO = IO[str]
+def load(fp: _LoadIO,
     cls: Any = ...,
     object_hook: Optional[Callable[[Dict], Any]] = ...,
     parse_float: Optional[Callable[[str], Any]] = ...,


### PR DESCRIPTION
### testcase

```python
import io
import json
json.load(io.BytesIO(b'{}'))
```

### before
```console
$ mypy test.py
test.py:3: error: Argument 1 to "load" has incompatible type "BytesIO"; expected "IO[str]"
```
### after
```
$ mypy --custom-typeshed-dir . test.py
$
```