### PR TITLE
Add headers attribute to HTTPResponse

### DIFF
--- a/stdlib/3/http/client.pyi
+++ b/stdlib/3/http/client.pyi
@@ -81,6 +81,7 @@ class HTTPMessage(email.message.Message): ...
 if sys.version_info >= (3, 5):
     class HTTPResponse(io.BufferedIOBase):
         msg = ...  # type: HTTPMessage
+        headers = ...  # type: HTTPMessage
         version = ...  # type: int
         debuglevel = ...  # type: int
         closed = ...  # type: bool
@@ -104,6 +105,7 @@ if sys.version_info >= (3, 5):
 else:
     class HTTPResponse:
         msg = ...  # type: HTTPMessage
+        headers = ...  # type: HTTPMessage
         version = ...  # type: int
         debuglevel = ...  # type: int
         closed = ...  # type: bool


### PR DESCRIPTION
Though not documented, there's precedent from https://github.com/python/typeshed/pull/968

### sample script

```python
import urllib.request

print(urllib.request.urlopen('https://example.com').headers['content-type'])
```

### before

```console
$ mypy test.py
test.py:3: error: Item "HTTPResponse" of "Union[HTTPResponse, addinfourl]" has no attribute "headers"
```

### after

```console
$ mypy test.py --custom-typeshed-dir .
$
```