### PR TITLE
use pytype-single rather than pytype

### DIFF
--- a/tests/pytype_test.py
+++ b/tests/pytype_test.py
@@ -144,7 +144,7 @@ def can_run(path, exe, *args):
 
 def pytype_test(args):
     dirs = get_project_dirs(args)
-    pytype_exe = os.path.join(dirs.pytype, 'pytype')
+    pytype_exe = os.path.join(dirs.pytype, 'pytype-single')
     stdlib_path = os.path.join(dirs.typeshed, 'stdlib')
 
     if not os.path.isdir(stdlib_path):


### PR DESCRIPTION
Looks like this happened in https://github.com/google/pytype/commit/3de774361b2481b55ef493391429e88571f7b9f2.