### PR TITLE
TracebackType is optional

### DIFF
--- a/stdlib/2and3/logging/__init__.pyi
+++ b/stdlib/2and3/logging/__init__.pyi
@@ -10,7 +10,7 @@ from types import TracebackType
 import sys
 import threading
 
-_SysExcInfoType = Union[Tuple[type, BaseException, TracebackType],
+_SysExcInfoType = Union[Tuple[type, BaseException, Optional[TracebackType]],
                         Tuple[None, None, None]]
 if sys.version_info >= (3, 5):
     _ExcInfoType = Union[None, bool, _SysExcInfoType, BaseException]


### PR DESCRIPTION
Consider the following piece of code:

```python
import logging
logging.basicConfig()
logger = logging.getLogger()

try:
    1/0
except Exception as e:
    exc = e

exc_info = (type(exc), exc, exc.__traceback__)
logger.error('error', exc_info=exc_info)
```

When executed I get what I expect:
```
$ python test.py
ERROR:root:error
Traceback (most recent call last):
  File "test.py", line 6, in <module>
    1/0
ZeroDivisionError: division by zero
```

However, `mypy` complains:
```
$ mypy test.py
test.py:11: error: Argument "exc_info" to "error" of "Logger" has incompatible type "Tuple[Type[Exception], Exception, Optional[TracebackType]]"; expected "Union[None, bool, Tuple[type, BaseException, TracebackType], Tuple[None, None, None], BaseException]"
```

The problem is that `exc.__traceback__` is `Optional[TracebackType]` whereas the `typeshed` definition of `_SysExcInfoType` only allows a strict `TracebackType` (not optional).

For further evidence that it should be `Optional`, it should be noted that the third item in the `exc_info` tuple can be `None` and the logging still works as seen below:

```python
exc_info = (type(exc), exc, None)
logger.error('error', exc_info=exc_info)
```
```
$ python test.py
ERROR:root:error
ZeroDivisionError: division by zero
```