### PR TITLE
minor namedtuple fixes

### DIFF
--- a/stdlib/2/collections.pyi
+++ b/stdlib/2/collections.pyi
@@ -1,9 +1,4 @@
-# Stubs for collections
-
-# Based on http://docs.python.org/2.7/library/collections.html
-
 # These are not exported.
-import typing
 from typing import Dict, Generic, TypeVar, Tuple, overload, Type, Optional, List, Union, Reversible
 
 # These are exported.
@@ -31,7 +26,7 @@ _KT = TypeVar('_KT')
 _VT = TypeVar('_VT')
 
 # namedtuple is special-cased in the type checker; the initializer is ignored.
-def namedtuple(typename: Union[str, unicode], field_names: Union[str, unicode, Iterable[Union[str, unicode]]], *,
+def namedtuple(typename: Union[str, unicode], field_names: Union[str, unicode, Iterable[Union[str, unicode]]],
                verbose: bool = ..., rename: bool = ...) -> Type[tuple]: ...
 
 class deque(Sized, Iterable[_T], Reversible[_T], Generic[_T]):

--- a/stdlib/3/collections/__init__.pyi
+++ b/stdlib/3/collections/__init__.pyi
@@ -1,7 +1,3 @@
-# Stubs for collections
-
-# Based on http://docs.python.org/3.2/library/collections.html
-
 # These are not exported.
 import sys
 import typing
@@ -54,7 +50,7 @@ _VT = TypeVar('_VT')
 # namedtuple is special-cased in the type checker; the initializer is ignored.
 if sys.version_info >= (3, 7):
     def namedtuple(typename: str, field_names: Union[str, Iterable[str]], *,
-                   rename: bool = ..., module: Optional[str] = ...) -> Type[tuple]: ...
+                   rename: bool = ..., module: Optional[str] = ..., defaults: Optional[Iterable[Any]] = ...) -> Type[tuple]: ...
 elif sys.version_info >= (3, 6):
     def namedtuple(typename: str, field_names: Union[str, Iterable[str]], *,
                    verbose: bool = ..., rename: bool = ..., module: Optional[str] = ...) -> Type[tuple]: ...


### PR DESCRIPTION
- The extra arguments aren't keyword-only in 2.7.
- Added the `defaults` argument in 3.7 (https://docs.python.org/3.7/library/collections.html#collections.namedtuple).

I'm hoping I'll be able to convince mypy to use these stubs to check calls to `namedtuple()`; see python/mypy#2127 and python/mypy#4788. Regardless, we should fix the namedtuple stubs in case other type checkers may be using them.