### PR TITLE
Fix werkzeug.wrappers.BaseResponse.__init__

### DIFF
--- a/third_party/2and3/werkzeug/wrappers.pyi
+++ b/third_party/2and3/werkzeug/wrappers.pyi
@@ -84,7 +84,7 @@ class BaseResponse:
     status = ...  # type: str
     direct_passthrough = ...  # type: bool
     response = ...  # type: Iterable[bytes]
-    def __init__(self, response: Optional[Union[Iterable[bytes], bytes]] = ...,
+    def __init__(self, response: Optional[Union[str, bytes, bytearray, Iterable[str], Iterable[bytes]]] = ...,
                  status: Optional[Union[Text, int]] = ...,
                  headers: Optional[Union[Headers,
                                          Mapping[Text, Text],


### PR DESCRIPTION
This additionally allows strings, bytearrays and string iterables to be
passed as the `response` argument of `BaseResponse` (and thus also
`Response`).

Strings and bytearrays are explicitly handled in `__init__` [1].
Strings are also featured on the Werkzeug front-page snippet (`'Hello
World!'`) [2].

[1]: https://github.com/pallets/werkzeug/blob/d129d17066768238139b8f8a5d667d9a4f4d68db/werkzeug/wrappers.py#L861
[2]: http://werkzeug.pocoo.org/