### PR TITLE
always run mypy with --no-implicit-optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
     - python: "3.6"
       env: TEST_CMD="./tests/mypy_selftest.py"
     - python: "3.5"
-      env: TEST_CMD="./tests/mypy_test.py --no-implicit-optional"
+      env: TEST_CMD="./tests/mypy_test.py"
     - python: "3.4"
       env: TEST_CMD="./tests/check_consistent.py"
     - python: "2.7"

--- a/tests/mypy_test.py
+++ b/tests/mypy_test.py
@@ -24,11 +24,9 @@ parser.add_argument('-n', '--dry-run', action='store_true', help="Don't actually
 parser.add_argument('-x', '--exclude', type=str, nargs='*', help="Exclude pattern")
 parser.add_argument('-p', '--python-version', type=str, nargs='*',
                     help="These versions only (major[.minor])")
-parser.add_argument('--no-implicit-optional', action='store_true',
-                    help="Run mypy with --no-implicit-optional (causes lots of errors)")
 parser.add_argument('--warn-unused-ignores', action='store_true',
                     help="Run mypy with --warn-unused-ignores "
-                    "(hint: only git rid of warnings that are "
+                    "(hint: only get rid of warnings that are "
                     "unused for all platforms and Python versions)")
 
 parser.add_argument('filter', type=str, nargs='*', help="Include pattern (default all)")
@@ -133,8 +131,7 @@ def main():
             flags.append('--strict-optional')
             flags.append('--no-site-packages')
             flags.append('--show-traceback')
-            if args.no_implicit_optional:
-                flags.append('--no-implicit-optional')
+            flags.append('--no-implicit-optional')
             if args.warn_unused_ignores:
                 flags.append('--warn-unused-ignores')
             sys.argv = ['mypy'] + flags + files


### PR DESCRIPTION
This was already the configuration in Travis and it's been working fine. It's
confusing that Travis was using a different configuration than the default
when you run tests/mypy_test.py yourself.