### PR TITLE
Add stub file for click.testing

### DIFF
--- a/third_party/2and3/click/testing.pyi
+++ b/third_party/2and3/click/testing.pyi
@@ -1,0 +1,63 @@
+from typing import (IO, Any, BinaryIO, ContextManager, Dict, Iterable, List,
+                    Mapping, Optional, Text, Tuple, Union)
+
+from .core import BaseCommand
+
+clickpkg: Any
+
+class EchoingStdin:
+    def __init__(self, input: BinaryIO, output: BinaryIO) -> None: ...
+    def __getattr__(self, x: str) -> Any: ...
+    def read(self, n: int = ...) -> bytes: ...
+    def readline(self, n: int = ...) -> bytes: ...
+    def readlines(self) -> List[bytes]: ...
+    def __iter__(self) -> Iterable[bytes]: ...
+
+def make_input_stream(input: Optional[Union[bytes, Text, IO]], charset: Text) -> BinaryIO: ...
+
+class Result:
+    runner: CliRunner
+    exit_code: int
+    exception: Any
+    exc_info: Optional[Any]
+    def __init__(
+        self,
+        runner: CliRunner,
+        exit_code: int,
+        exception: Any,
+        exc_info: Optional[Any] = ...,
+    ) -> None: ...
+    @property
+    def output(self) -> Text: ...
+
+class CliRunner:
+    charset: str
+    env: Mapping[str, str]
+    echo_stdin: bool
+    def __init__(
+        self,
+        charset: Optional[Text] = ...,
+        env: Optional[Mapping[str, str]] = ...,
+        echo_stdin: bool = ...,
+    ) -> None:
+        ...
+    def get_default_prog_name(self, cli: BaseCommand) -> str: ...
+    def make_env(self, overrides: Optional[Mapping[str, str]] = ...) -> Dict[str, str]: ...
+    def isolation(
+        self,
+        input: Optional[IO] = ...,
+        env: Optional[Mapping[str, str]] = ...,
+        color: bool = ...,
+    ) -> ContextManager[BinaryIO]: ...
+    def invoke(
+        self,
+        cli: BaseCommand,
+        args: Optional[Union[str, Iterable[str]]] = ...,
+        input: Optional[IO] = ...,
+        env: Optional[Mapping[str, str]] = ...,
+        catch_exceptions: bool = ...,
+        color: bool = ...,
+        **extra: Any,
+    ) -> Result:
+        ...
+    def isolated_filesystem(self) -> ContextManager[str]: ...


### PR DESCRIPTION
Click already had stubs but not for the `testing` submodule.

I used stubgen and then narrowed the types when it was easy.  I left
`Any` where more work was necessary.