### PR TITLE
make http.client.HTTPResponse concrete in 3.4

### DIFF
--- a/stdlib/3/http/client.pyi
+++ b/stdlib/3/http/client.pyi
@@ -105,7 +105,7 @@ if sys.version_info >= (3, 5):
                      exc_val: Optional[BaseException],
                      exc_tb: Optional[types.TracebackType]) -> bool: ...
 else:
-    class HTTPResponse(BinaryIO):
+    class HTTPResponse(io.RawIOBase, BinaryIO):  # type: ignore
         msg = ...  # type: HTTPMessage
         headers = ...  # type: HTTPMessage
         version = ...  # type: int


### PR DESCRIPTION
Matches the implementation in https://github.com/python/cpython/blob/3.4/Lib/http/client.py#L308

The ignore works around python/mypy#5027 (commented further up in the 3.5 branch).

Part of #1476.