### PR TITLE
`Iterator` provides a concrete `__iter__` in 2.7

### DIFF
--- a/stdlib/2/typing.pyi
+++ b/stdlib/2/typing.pyi
@@ -118,6 +118,7 @@ class Iterable(Protocol[_T_co]):
 class Iterator(Iterable[_T_co], Protocol[_T_co]):
     @abstractmethod
     def next(self) -> _T_co: ...
+    def __iter__(self) -> Iterator[_T_co]: ...
 
 class Generator(Iterator[_T_co], Generic[_T_co, _T_contra, _V_co]):
     @abstractmethod


### PR DESCRIPTION
This is already how it works in the Python 3 stub.

`Iterator.__iter__` also exists at runtime: https://github.com/python/cpython/blob/2.7/Lib/_abcoll.py#L73.