### PR TITLE
Add thread_name_prefix to ThreadPoolExecutor stub

### DIFF
--- a/stdlib/3/concurrent/futures/thread.pyi
+++ b/stdlib/3/concurrent/futures/thread.pyi
@@ -3,7 +3,7 @@ from ._base import Executor, Future
 import sys
 
 class ThreadPoolExecutor(Executor):
-    if sys.version_info >= (3, 6):
+    if sys.version_info >= (3, 6) or sys.version_info < (3,):
         def __init__(self, max_workers: Optional[int] = ...,
                      thread_name_prefix: str = ...) -> None: ...
     else:

--- a/third_party/2/concurrent/futures/thread.pyi
+++ b/third_party/2/concurrent/futures/thread.pyi
@@ -3,7 +3,7 @@ from ._base import Executor, Future
 import sys
 
 class ThreadPoolExecutor(Executor):
-    if sys.version_info >= (3, 6):
+    if sys.version_info >= (3, 6) or sys.version_info < (3,):
         def __init__(self, max_workers: Optional[int] = ...,
                      thread_name_prefix: str = ...) -> None: ...
     else:


### PR DESCRIPTION
The thread_name_prefix argument of ThreadPoolExecutor.__init__ was added
to the Python 2 backport in agronholm/pythonfutures#64.