### PR TITLE
Update locale.pyi

### DIFF
--- a/stdlib/2and3/locale.pyi
+++ b/stdlib/2and3/locale.pyi
@@ -110,3 +110,4 @@ def str(float: float) -> _str: ...
 
 locale_alias: Dict[_str, _str]  # undocumented
 locale_encoding_alias: Dict[_str, _str]  # undocumented
+windows_locale: Dict[int, _str]


### PR DESCRIPTION
to add type annotation for windows_locale after noticing it was missing while checking my own project with mypy.

Simply importing windows_locale in the name space of any module foo.py with the single statement

`
from locale import windows_locale
`

 produces the following error when type checking the module with mypy:

`
foo.py:1: error: Module 'locale' has no attribute 'windows_locale'
`

After checking the [typeshed repo for locale](https://github.com/python/typeshed/blob/master/stdlib/2and3/locale.pyi), it appears that the type annotation for windows_locale is missing.

After making sure of the type by checking the code for [local.py](https://github.com/python/cpython/blob/master/Lib/locale.py), 
I added the following line in locale.pyi:

`
windows_locale: Dict[int, _str]
`

I ran the tests on my local branch and they all passed successfully.

Thanks.

SekouD.