### PR TITLE
Fix requests.post signature

### DIFF
--- a/third_party/2and3/requests/api.pyi
+++ b/third_party/2and3/requests/api.pyi
@@ -15,10 +15,8 @@ _Data = Union[
     None,
     _Text,
     bytes,
-    MutableMapping[str, Optional[str]],
-    MutableMapping[str, Optional[Text]],
-    MutableMapping[Text, Optional[str]],
-    MutableMapping[Text, Optional[Text]],
+    MutableMapping[str, Any],
+    MutableMapping[Text, Any],
     Iterable[Tuple[_Text, Optional[_Text]]],
     IO
 ]


### PR DESCRIPTION
The change introduced in 395ab5abd1102d7db1f57cad4febe8fe977fd960
broke the signature of `requests.post`, among others, since
`MutableSequence` is invariant, and plain `Dict[str, str]` values
were no longer valid for the `data` argument.

This changes the signature to have `Any` components as a
compromise. Adding more items to the union seems a bit too much, since
the mypy error messages for invalid argument types are already pretty hard to
read.

Another option might be to use `Mapping` instead of `MutableMapping`
due to covariance, but I assume there's a reason why `MutableMapping`
is used here.