### PR TITLE
Make overloads in Python 2 builtins with a 'None' fallback come first

### DIFF
--- a/stdlib/2/__builtin__.pyi
+++ b/stdlib/2/__builtin__.pyi
@@ -735,11 +735,11 @@ def divmod(a: int, b: int) -> Tuple[int, int]: ...
 def divmod(a: float, b: float) -> Tuple[float, float]: ...
 def exit(code: Any = ...) -> NoReturn: ...
 @overload
-def filter(function: Callable[[_T], Any],
-           iterable: Iterable[_T]) -> List[_T]: ...
-@overload
 def filter(function: None,
            iterable: Iterable[Optional[_T]]) -> List[_T]: ...
+@overload
+def filter(function: Callable[[_T], Any],
+           iterable: Iterable[_T]) -> List[_T]: ...
 def format(o: object, format_spec: str = ...) -> str: ...  # TODO unicode
 def getattr(o: Any, name: unicode, default: Optional[Any] = ...) -> Any: ...
 def hasattr(o: Any, name: unicode) -> bool: ...
@@ -755,39 +755,6 @@ def iter(function: Callable[[], _T], sentinel: _T) -> Iterator[_T]: ...
 def isinstance(o: object, t: Union[type, Tuple[Union[type, Tuple], ...]]) -> bool: ...
 def issubclass(cls: type, classinfo: Union[type, Tuple[Union[type, Tuple], ...]]) -> bool: ...
 def len(o: Sized) -> int: ...
-@overload
-def map(func: Callable[[_T1], _S], iter1: Iterable[_T1]) -> List[_S]: ...
-@overload
-def map(func: Callable[[_T1, _T2], _S],
-        iter1: Iterable[_T1],
-        iter2: Iterable[_T2]) -> List[_S]: ...
-@overload
-def map(func: Callable[[_T1, _T2, _T3], _S],
-        iter1: Iterable[_T1],
-        iter2: Iterable[_T2],
-        iter3: Iterable[_T3]) -> List[_S]: ...
-@overload
-def map(func: Callable[[_T1, _T2, _T3, _T4], _S],
-        iter1: Iterable[_T1],
-        iter2: Iterable[_T2],
-        iter3: Iterable[_T3],
-        iter4: Iterable[_T4]) -> List[_S]: ...
-@overload
-def map(func: Callable[[_T1, _T2, _T3, _T4, _T5], _S],
-        iter1: Iterable[_T1],
-        iter2: Iterable[_T2],
-        iter3: Iterable[_T3],
-        iter4: Iterable[_T4],
-        iter5: Iterable[_T5]) -> List[_S]: ...
-@overload
-def map(func: Callable[..., _S],
-        iter1: Iterable[Any],
-        iter2: Iterable[Any],
-        iter3: Iterable[Any],
-        iter4: Iterable[Any],
-        iter5: Iterable[Any],
-        iter6: Iterable[Any],
-        *iterables: Iterable[Any]) -> List[_S]: ...
 @overload
 def map(func: None, iter1: Iterable[_T1]) -> List[_T1]: ...
 @overload
@@ -821,6 +788,39 @@ def map(func: None,
         iter5: Iterable[Any],
         iter6: Iterable[Any],
         *iterables: Iterable[Any]) -> List[Tuple[Any, ...]]: ...
+@overload
+def map(func: Callable[[_T1], _S], iter1: Iterable[_T1]) -> List[_S]: ...
+@overload
+def map(func: Callable[[_T1, _T2], _S],
+        iter1: Iterable[_T1],
+        iter2: Iterable[_T2]) -> List[_S]: ...
+@overload
+def map(func: Callable[[_T1, _T2, _T3], _S],
+        iter1: Iterable[_T1],
+        iter2: Iterable[_T2],
+        iter3: Iterable[_T3]) -> List[_S]: ...
+@overload
+def map(func: Callable[[_T1, _T2, _T3, _T4], _S],
+        iter1: Iterable[_T1],
+        iter2: Iterable[_T2],
+        iter3: Iterable[_T3],
+        iter4: Iterable[_T4]) -> List[_S]: ...
+@overload
+def map(func: Callable[[_T1, _T2, _T3, _T4, _T5], _S],
+        iter1: Iterable[_T1],
+        iter2: Iterable[_T2],
+        iter3: Iterable[_T3],
+        iter4: Iterable[_T4],
+        iter5: Iterable[_T5]) -> List[_S]: ...
+@overload
+def map(func: Callable[..., _S],
+        iter1: Iterable[Any],
+        iter2: Iterable[Any],
+        iter3: Iterable[Any],
+        iter4: Iterable[Any],
+        iter5: Iterable[Any],
+        iter6: Iterable[Any],
+        *iterables: Iterable[Any]) -> List[_S]: ...
 @overload
 def max(arg1: _T, arg2: _T, *args: _T, key: Callable[[_T], Any] = ...) -> _T: ...
 @overload

--- a/stdlib/2/builtins.pyi
+++ b/stdlib/2/builtins.pyi
@@ -735,11 +735,11 @@ def divmod(a: int, b: int) -> Tuple[int, int]: ...
 def divmod(a: float, b: float) -> Tuple[float, float]: ...
 def exit(code: Any = ...) -> NoReturn: ...
 @overload
-def filter(function: Callable[[_T], Any],
-           iterable: Iterable[_T]) -> List[_T]: ...
-@overload
 def filter(function: None,
            iterable: Iterable[Optional[_T]]) -> List[_T]: ...
+@overload
+def filter(function: Callable[[_T], Any],
+           iterable: Iterable[_T]) -> List[_T]: ...
 def format(o: object, format_spec: str = ...) -> str: ...  # TODO unicode
 def getattr(o: Any, name: unicode, default: Optional[Any] = ...) -> Any: ...
 def hasattr(o: Any, name: unicode) -> bool: ...
@@ -755,39 +755,6 @@ def iter(function: Callable[[], _T], sentinel: _T) -> Iterator[_T]: ...
 def isinstance(o: object, t: Union[type, Tuple[Union[type, Tuple], ...]]) -> bool: ...
 def issubclass(cls: type, classinfo: Union[type, Tuple[Union[type, Tuple], ...]]) -> bool: ...
 def len(o: Sized) -> int: ...
-@overload
-def map(func: Callable[[_T1], _S], iter1: Iterable[_T1]) -> List[_S]: ...
-@overload
-def map(func: Callable[[_T1, _T2], _S],
-        iter1: Iterable[_T1],
-        iter2: Iterable[_T2]) -> List[_S]: ...
-@overload
-def map(func: Callable[[_T1, _T2, _T3], _S],
-        iter1: Iterable[_T1],
-        iter2: Iterable[_T2],
-        iter3: Iterable[_T3]) -> List[_S]: ...
-@overload
-def map(func: Callable[[_T1, _T2, _T3, _T4], _S],
-        iter1: Iterable[_T1],
-        iter2: Iterable[_T2],
-        iter3: Iterable[_T3],
-        iter4: Iterable[_T4]) -> List[_S]: ...
-@overload
-def map(func: Callable[[_T1, _T2, _T3, _T4, _T5], _S],
-        iter1: Iterable[_T1],
-        iter2: Iterable[_T2],
-        iter3: Iterable[_T3],
-        iter4: Iterable[_T4],
-        iter5: Iterable[_T5]) -> List[_S]: ...
-@overload
-def map(func: Callable[..., _S],
-        iter1: Iterable[Any],
-        iter2: Iterable[Any],
-        iter3: Iterable[Any],
-        iter4: Iterable[Any],
-        iter5: Iterable[Any],
-        iter6: Iterable[Any],
-        *iterables: Iterable[Any]) -> List[_S]: ...
 @overload
 def map(func: None, iter1: Iterable[_T1]) -> List[_T1]: ...
 @overload
@@ -821,6 +788,39 @@ def map(func: None,
         iter5: Iterable[Any],
         iter6: Iterable[Any],
         *iterables: Iterable[Any]) -> List[Tuple[Any, ...]]: ...
+@overload
+def map(func: Callable[[_T1], _S], iter1: Iterable[_T1]) -> List[_S]: ...
+@overload
+def map(func: Callable[[_T1, _T2], _S],
+        iter1: Iterable[_T1],
+        iter2: Iterable[_T2]) -> List[_S]: ...
+@overload
+def map(func: Callable[[_T1, _T2, _T3], _S],
+        iter1: Iterable[_T1],
+        iter2: Iterable[_T2],
+        iter3: Iterable[_T3]) -> List[_S]: ...
+@overload
+def map(func: Callable[[_T1, _T2, _T3, _T4], _S],
+        iter1: Iterable[_T1],
+        iter2: Iterable[_T2],
+        iter3: Iterable[_T3],
+        iter4: Iterable[_T4]) -> List[_S]: ...
+@overload
+def map(func: Callable[[_T1, _T2, _T3, _T4, _T5], _S],
+        iter1: Iterable[_T1],
+        iter2: Iterable[_T2],
+        iter3: Iterable[_T3],
+        iter4: Iterable[_T4],
+        iter5: Iterable[_T5]) -> List[_S]: ...
+@overload
+def map(func: Callable[..., _S],
+        iter1: Iterable[Any],
+        iter2: Iterable[Any],
+        iter3: Iterable[Any],
+        iter4: Iterable[Any],
+        iter5: Iterable[Any],
+        iter6: Iterable[Any],
+        *iterables: Iterable[Any]) -> List[_S]: ...
 @overload
 def max(arg1: _T, arg2: _T, *args: _T, key: Callable[[_T], Any] = ...) -> _T: ...
 @overload


### PR DESCRIPTION
In short, this change makes sure calls like `map(None, a, b)` behave as
expected when using `--no-strict-optional` is enabled.

For additional context, see https://github.com/python/mypy/issues/5246