### PR TITLE
Remove type cycle in click

### DIFF
--- a/third_party/2and3/click/core.pyi
+++ b/third_party/2and3/click/core.pyi
@@ -17,7 +17,7 @@ from typing import (
 
 from click.formatting import HelpFormatter
 from click.parser import OptionParser
-from click.types import ParamType, _ConvertibleType
+from click.types import ParamType
 
 
 def invoke_param_callback(
@@ -311,6 +311,10 @@ class CommandCollection(MultiCommand):
 
     def add_source(self, multi_cmd: MultiCommand) -> None:
         ...
+
+
+# This type is here to resolve https://github.com/python/mypy/issues/5275
+_ConvertibleType = Union[type, ParamType, Tuple[type, ...], Callable[[str], Any], Callable[[Optional[str]], Any]]
 
 
 class Parameter:

--- a/third_party/2and3/click/core.pyi
+++ b/third_party/2and3/click/core.pyi
@@ -17,8 +17,6 @@ from typing import (
 
 from click.formatting import HelpFormatter
 from click.parser import OptionParser
-from click.types import ParamType
-
 
 def invoke_param_callback(
     callback: Callable[['Context', 'Parameter', Optional[str]], Any],
@@ -313,8 +311,42 @@ class CommandCollection(MultiCommand):
         ...
 
 
+class _ParamType:
+    name: str
+    is_composite: bool
+    envvar_list_splitter: Optional[str]
+
+    def __call__(
+        self,
+        value: Optional[str],
+        param: Optional[Parameter] = ...,
+        ctx: Optional[Context] = ...,
+    ) -> Any:
+        ...
+
+    def get_metavar(self, param: Parameter) -> str:
+        ...
+
+    def get_missing_message(self, param: Parameter) -> str:
+        ...
+
+    def convert(
+        self,
+        value: str,
+        param: Optional[Parameter],
+        ctx: Optional[Context],
+    ) -> Any:
+        ...
+
+    def split_envvar_value(self, rv: str) -> List[str]:
+        ...
+
+    def fail(self, message: str, param: Optional[Parameter] = ..., ctx: Optional[Context] = ...) -> None:
+        ...
+
+
 # This type is here to resolve https://github.com/python/mypy/issues/5275
-_ConvertibleType = Union[type, ParamType, Tuple[type, ...], Callable[[str], Any], Callable[[Optional[str]], Any]]
+_ConvertibleType = Union[type, _ParamType, Tuple[type, ...], Callable[[str], Any], Callable[[Optional[str]], Any]]
 
 
 class Parameter:
@@ -322,7 +354,7 @@ class Parameter:
     name: str
     opts: List[str]
     secondary_opts: List[str]
-    type: ParamType
+    type: _ParamType
     required: bool
     callback: Optional[Callable[[Context, 'Parameter', str], Any]]
     nargs: int

--- a/third_party/2and3/click/decorators.pyi
+++ b/third_party/2and3/click/decorators.pyi
@@ -1,8 +1,7 @@
 from distutils.version import Version
 from typing import Any, Callable, Dict, List, Optional, Type, TypeVar, Union, Text
 
-from click.core import Command, Group, Argument, Option, Parameter, Context
-from click.types import _ConvertibleType
+from click.core import Command, Group, Argument, Option, Parameter, Context, _ConvertibleType
 
 _T = TypeVar('_T')
 _Decorator = Callable[[_T], _T]

--- a/third_party/2and3/click/termui.pyi
+++ b/third_party/2and3/click/termui.pyi
@@ -12,7 +12,7 @@ from typing import (
     TypeVar,
 )
 
-from click.types import _ConvertibleType
+from click.core import _ConvertibleType
 from click._termui_impl import ProgressBar as _ProgressBar
 
 

--- a/third_party/2and3/click/types.pyi
+++ b/third_party/2and3/click/types.pyi
@@ -1,7 +1,7 @@
 from typing import Any, Callable, IO, Iterable, List, Optional, TypeVar, Union, Tuple as _PyTuple, Type
 import uuid
 
-from click.core import Context, Parameter
+from click.core import Context, Parameter, _ConvertibleType
 
 
 class ParamType:
@@ -270,9 +270,7 @@ class UUIDParameterType(ParamType):
         ...
 
 
-_ConvertibleType = Union[type, ParamType, _PyTuple[type, ...], Callable[[str], Any], Callable[[Optional[str]], Any]]
-
-def convert_type(ty: Optional[_ConvertibleType], default: Optional[Any] = ...) -> ParamType:
+def convert_type(ty: Any, default: Optional[Any] = ...) -> ParamType:
     ...
 
 # parameter type shortcuts

--- a/third_party/2and3/click/types.pyi
+++ b/third_party/2and3/click/types.pyi
@@ -1,42 +1,7 @@
 from typing import Any, Callable, IO, Iterable, List, Optional, TypeVar, Union, Tuple as _PyTuple, Type
 import uuid
 
-from click.core import Context, Parameter, _ConvertibleType
-
-
-class ParamType:
-    name: str
-    is_composite: bool
-    envvar_list_splitter: Optional[str]
-
-    def __call__(
-        self,
-        value: Optional[str],
-        param: Optional[Parameter] = ...,
-        ctx: Optional[Context] = ...,
-    ) -> Any:
-        ...
-
-    def get_metavar(self, param: Parameter) -> str:
-        ...
-
-    def get_missing_message(self, param: Parameter) -> str:
-        ...
-
-    def convert(
-        self,
-        value: str,
-        param: Optional[Parameter],
-        ctx: Optional[Context],
-    ) -> Any:
-        ...
-
-    def split_envvar_value(self, rv: str) -> List[str]:
-        ...
-
-    def fail(self, message: str, param: Optional[Parameter] = ..., ctx: Optional[Context] = ...) -> None:
-        ...
-
+from click.core import Context, Parameter, _ParamType as ParamType, _ConvertibleType
 
 class BoolParamType(ParamType):
     def __call__(
@@ -270,7 +235,7 @@ class UUIDParameterType(ParamType):
         ...
 
 
-def convert_type(ty: Any, default: Optional[Any] = ...) -> ParamType:
+def convert_type(ty: Optional[_ConvertibleType], default: Optional[Any] = ...) -> ParamType:
     ...
 
 # parameter type shortcuts

--- a/third_party/2and3/click/utils.pyi
+++ b/third_party/2and3/click/utils.pyi
@@ -1,8 +1,8 @@
 from typing import Any, Callable, Iterator, IO, List, Optional, TypeVar, Union, Text
 
-
 _T = TypeVar('_T')
 _Decorator = Callable[[_T], _T]
+
 
 def _posixify(name: str) -> str:
     ...

--- a/third_party/2and3/click/utils.pyi
+++ b/third_party/2and3/click/utils.pyi
@@ -1,8 +1,8 @@
 from typing import Any, Callable, Iterator, IO, List, Optional, TypeVar, Union, Text
 
+
 _T = TypeVar('_T')
 _Decorator = Callable[[_T], _T]
-
 
 def _posixify(name: str) -> str:
     ...


### PR DESCRIPTION
This works around https://github.com/python/mypy/issues/5275

It sadly introduces an `Any`, but I felt that it is an acceptable compromise. Let me know if you have a different opinion on where the `Any` should be introduced.