### PR TITLE
logging.BASIC_FORMAT also for python2.7

### DIFF
--- a/stdlib/2and3/logging/__init__.pyi
+++ b/stdlib/2and3/logging/__init__.pyi
@@ -413,5 +413,7 @@ if sys.version_info >= (3,):
     class StringTemplateStyle(PercentStyle):
         _tpl = ...  # type: Template
 
-    BASIC_FORMAT = ...  # type: str
     _STYLES = ...  # type: Dict[str, Tuple[PercentStyle, str]]
+
+
+BASIC_FORMAT = ...  # type: str


### PR DESCRIPTION
    python2.7 -c 'from logging import BASIC_FORMAT;print(type(BASIC_FORMAT))'
    # <type 'str'>