### PR TITLE
urllib2.build_open() accepts instances and classes

### DIFF
--- a/stdlib/2/urllib2.pyi
+++ b/stdlib/2/urllib2.pyi
@@ -1,6 +1,6 @@
 
 import ssl
-from typing import Any, AnyStr, Dict, List, Union, Optional, Mapping, Callable, Sequence, Tuple
+from typing import Any, AnyStr, Dict, List, Union, Optional, Mapping, Callable, Sequence, Tuple, Type
 from urllib import addinfourl
 from httplib import HTTPResponse
 
@@ -53,7 +53,7 @@ def urlopen(url: Union[Request, _string], data: Optional[_string] = ..., timeout
             cafile: Optional[_string] = ..., capath: Optional[_string] = ..., cadefault: bool = ...,
             context: Optional[ssl.SSLContext] = ...): ...
 def install_opener(opener: OpenerDirector) -> None: ...
-def build_opener(*handlers: BaseHandler) -> OpenerDirector: ...
+def build_opener(*handlers: Union[BaseHandler, Type[BaseHandler]]) -> OpenerDirector: ...
 
 class BaseHandler:
     handler_order = ...  # type: int


### PR DESCRIPTION
<https://docs.python.org/2/library/urllib2.html#urllib2.build_opener>
> handlers can be either instances of BaseHandler, or subclasses of
> BaseHandler (in which case it must be possible to call the constructor
> without any parameters).