### PR TITLE
tty.set*() accepts fd or file object

### DIFF
--- a/stdlib/2and3/tty.pyi
+++ b/stdlib/2and3/tty.pyi
@@ -1,5 +1,9 @@
 # Stubs for tty (Python 3.6)
 
+from typing import IO, Union
+
+_FD = Union[int, IO[str]]
+
 # XXX: Undocumented integer constants
 IFLAG = ...  # type: int
 OFLAG = ...  # type: int
@@ -9,5 +13,5 @@ ISPEED = ...  # type: int
 OSPEED = ...  # type: int
 CC = ...  # type: int
 
-def setraw(fd: int, when: int = ...) -> None: ...
-def setcbreak(fd: int, when: int = ...) -> None: ...
+def setraw(fd: _FD, when: int = ...) -> None: ...
+def setcbreak(fd: _FD, when: int = ...) -> None: ...


### PR DESCRIPTION
<https://docs.python.org/2/library/tty.html>
> ... requires the termios module ...

<https://docs.python.org/2/library/termios.html#module-termios>
> All functions in this module take a file descriptor fd as their first
> argument. This can be an integer file descriptor ... or a file object,