### PR TITLE
Remove asyncio.tasks.async

### DIFF
--- a/stdlib/3.4/asyncio/__init__.pyi
+++ b/stdlib/3.4/asyncio/__init__.pyi
@@ -46,7 +46,6 @@ from asyncio.tasks import (
     ALL_COMPLETED as ALL_COMPLETED,
     as_completed as as_completed,
     ensure_future as ensure_future,
-    async as async,
     gather as gather,
     run_coroutine_threadsafe as run_coroutine_threadsafe,
     shield as shield,

--- a/stdlib/3.4/asyncio/tasks.pyi
+++ b/stdlib/3.4/asyncio/tasks.pyi
@@ -24,9 +24,8 @@ def as_completed(fs: Sequence[_FutureT[_T]], *, loop: AbstractEventLoop = ...,
                  timeout: Optional[float] = ...) -> Iterator[Generator[Any, None, _T]]: ...
 def ensure_future(coro_or_future: _FutureT[_T],
                   *, loop: AbstractEventLoop = ...) -> Future[_T]: ...
-# The following alias causes a syntax error since Python 3.7:
-# if sys.version_info < (3, 7):
-#     async = ensure_future
+# Prior to Python 3.7 'async' was an alias for 'ensure_future'.
+# It became a keyword in 3.7.
 @overload
 def gather(coro_or_future1: _FutureT[_T1],
            *, loop: AbstractEventLoop = ..., return_exceptions: bool = ...) -> Future[Tuple[_T1]]: ...

--- a/stdlib/3.4/asyncio/tasks.pyi
+++ b/stdlib/3.4/asyncio/tasks.pyi
@@ -24,7 +24,9 @@ def as_completed(fs: Sequence[_FutureT[_T]], *, loop: AbstractEventLoop = ...,
                  timeout: Optional[float] = ...) -> Iterator[Generator[Any, None, _T]]: ...
 def ensure_future(coro_or_future: _FutureT[_T],
                   *, loop: AbstractEventLoop = ...) -> Future[_T]: ...
-async = ensure_future
+# The following alias causes a syntax error since Python 3.7:
+# if sys.version_info < (3, 7):
+#     async = ensure_future
 @overload
 def gather(coro_or_future1: _FutureT[_T1],
            *, loop: AbstractEventLoop = ..., return_exceptions: bool = ...) -> Future[Tuple[_T1]]: ...


### PR DESCRIPTION
While this alias for `ensure_future` existed prior to Python 3.7, it causes a syntax error when parsing it with Python 3.7 or above. `ensure_future` was introduced in Python 3.4.4 and `asyncio` was deprecated at the same time. While this change makes valid code emit warnings, I see no other fix.