### PR TITLE
Add missing attributes to the dateutil/relativedelta stub

### DIFF
--- a/third_party/2and3/dateutil/relativedelta.pyi
+++ b/third_party/2and3/dateutil/relativedelta.pyi
@@ -6,17 +6,35 @@ from ._common import weekday
 
 _SelfT = TypeVar('_SelfT', bound=relativedelta)
 _DateT = TypeVar('_DateT', date, datetime)
+# Work around attribute and type having the same name.
+_weekday = weekday
 
-MO = ...  # type: weekday
-TU = ...  # type: weekday
-WE = ...  # type: weekday
-TH = ...  # type: weekday
-FR = ...  # type: weekday
-SA = ...  # type: weekday
-SU = ...  # type: weekday
+MO: weekday
+TU: weekday
+WE: weekday
+TH: weekday
+FR: weekday
+SA: weekday
+SU: weekday
 
 
 class relativedelta(object):
+    years: int
+    months: int
+    days: int
+    leapdays: int
+    hours: int
+    minutes: int
+    seconds: int
+    microseconds: int
+    year: Optional[int]
+    month: Optional[int]
+    weekday: Optional[_weekday]
+    day: Optional[int]
+    hour: Optional[int]
+    minute: Optional[int]
+    second: Optional[int]
+    microsecond: Optional[int]
     def __init__(self,
                  dt1: Optional[date]=...,
                  dt2: Optional[date]=...,
@@ -27,7 +45,7 @@ class relativedelta(object):
                  seconds: Optional[int]=..., microseconds: Optional[int]=...,
                  year: Optional[int]=..., month: Optional[int]=...,
                  day: Optional[int]=...,
-                 weekday: Optional[Union[int, weekday]]=...,
+                 weekday: Optional[Union[int, _weekday]]=...,
                  yearday: Optional[int]=...,
                  nlyearday: Optional[int]=...,
                  hour: Optional[int]=..., minute: Optional[int]=...,


### PR DESCRIPTION
I have deduced the types from docstring & source code of the
relativedelta class.

Fixes #2269.