### PR TITLE
Fix type for click.Context.exit

### DIFF
--- a/third_party/2and3/click/core.pyi
+++ b/third_party/2and3/click/core.pyi
@@ -7,6 +7,7 @@ from typing import (
     Iterable,
     List,
     Mapping,
+    NoReturn,
     Optional,
     Sequence,
     Set,
@@ -120,7 +121,7 @@ class Context:
     def abort(self) -> None:
         ...
 
-    def exit(self, code: Union[int, str] = ...) -> None:
+    def exit(self, code: Union[int, str] = ...) -> NoReturn:
         ...
 
     def get_usage(self) -> str:


### PR DESCRIPTION
click.Context.exit() calls sys.exit() and hence should be a NoReturn return type.