### PR TITLE
Change return type for click.Context.fail and click.Context.abort to NoReturn

### DIFF
--- a/third_party/2and3/click/core.pyi
+++ b/third_party/2and3/click/core.pyi
@@ -115,10 +115,10 @@ class Context:
     def lookup_default(self, name: str) -> Any:
         ...
 
-    def fail(self, message: str) -> None:
+    def fail(self, message: str) -> NoReturn:
         ...
 
-    def abort(self) -> None:
+    def abort(self) -> NoReturn:
         ...
 
     def exit(self, code: Union[int, str] = ...) -> NoReturn:


### PR DESCRIPTION
Both of these methods always raise Exceptions.