### PR TITLE
Click: Make group and command decorators return the correct types

### DIFF
--- a/third_party/2and3/click/core.pyi
+++ b/third_party/2and3/click/core.pyi
@@ -293,10 +293,10 @@ class Group(MultiCommand):
     def add_command(self, cmd: Command, name: Optional[str] = ...):
         ...
 
-    def command(self, *args, **kwargs) -> Callable[[_F], _F]:
+    def command(self, *args, **kwargs) -> Callable[[_F], Command]:
         ...
 
-    def group(self, *args, **kwargs) -> Callable[[_F], _F]:
+    def group(self, *args, **kwargs) -> Callable[[_F], Group]:
         ...
 
 

--- a/third_party/2and3/click/decorators.pyi
+++ b/third_party/2and3/click/decorators.pyi
@@ -41,7 +41,7 @@ def command(
     short_help: Optional[str] = ...,
     options_metavar: str = ...,
     add_help_option: bool = ...,
-) -> Callable[[_F], _F]:
+) -> Callable[[_F], Command]:
     ...
 
 
@@ -66,7 +66,7 @@ def group(
     add_help_option: bool = ...,
     # User-defined
     **kwargs: Any,
-) -> Callable[[_F], _F]:
+) -> Callable[[_F], Group]:
     ...
 
 


### PR DESCRIPTION
These decorators actually replace the function with an object.  I checked the others and they are correct.