### PR TITLE
concurrent.futures: Sync with Python 3.7

### DIFF
--- a/stdlib/3/concurrent/futures/process.pyi
+++ b/stdlib/3/concurrent/futures/process.pyi
@@ -10,8 +10,8 @@ if sys.version_info >= (3,):
 if sys.version_info >= (3, 7):
     class ProcessPoolExecutor(Executor):
         def __init__(self, max_workers: Optional[int] = ...,
-                     initializer: Callable[..., None] = ...,
-                     initargs: Tuple[Any] = ...) -> None: ...
+                     initializer: Optional[Callable[..., None]] = ...,
+                     initargs: Tuple[Any, ...] = ...) -> None: ...
 else:
     class ProcessPoolExecutor(Executor):
         def __init__(self, max_workers: Optional[int] = ...) -> None: ...

--- a/stdlib/3/concurrent/futures/process.pyi
+++ b/stdlib/3/concurrent/futures/process.pyi
@@ -1,4 +1,4 @@
-from typing import Optional, Any
+from typing import Any, Callable, Optional, Tuple
 from ._base import Future, Executor
 import sys
 
@@ -7,5 +7,11 @@ EXTRA_QUEUED_CALLS = ...  # type: Any
 if sys.version_info >= (3,):
     class BrokenProcessPool(RuntimeError): ...
 
-class ProcessPoolExecutor(Executor):
-    def __init__(self, max_workers: Optional[int] = ...) -> None: ...
+if sys.version_info >= (3, 7):
+    class ProcessPoolExecutor(Executor):
+        def __init__(self, max_workers: Optional[int] = ...,
+                     initializer: Callable[..., None] = ...,
+                     initargs: Tuple[Any] = ...) -> None: ...
+else:
+    class ProcessPoolExecutor(Executor):
+        def __init__(self, max_workers: Optional[int] = ...) -> None: ...

--- a/stdlib/3/concurrent/futures/thread.pyi
+++ b/stdlib/3/concurrent/futures/thread.pyi
@@ -1,9 +1,14 @@
-from typing import Optional
+from typing import Any, Callable, Optional, Tuple
 from ._base import Executor, Future
 import sys
 
 class ThreadPoolExecutor(Executor):
-    if sys.version_info >= (3, 6) or sys.version_info < (3,):
+    if sys.version_info >= (3, 7):
+        def __init__(self, max_workers: Optional[int] = ...,
+                     thread_name_prefix: str = ...,
+                     initializer: Callable[..., None] = ...,
+                     initargs: Tuple[Any] = ...) -> None: ...
+    elif sys.version_info >= (3, 6) or sys.version_info < (3,):
         def __init__(self, max_workers: Optional[int] = ...,
                      thread_name_prefix: str = ...) -> None: ...
     else:

--- a/stdlib/3/concurrent/futures/thread.pyi
+++ b/stdlib/3/concurrent/futures/thread.pyi
@@ -6,8 +6,8 @@ class ThreadPoolExecutor(Executor):
     if sys.version_info >= (3, 7):
         def __init__(self, max_workers: Optional[int] = ...,
                      thread_name_prefix: str = ...,
-                     initializer: Callable[..., None] = ...,
-                     initargs: Tuple[Any] = ...) -> None: ...
+                     initializer: Optional[Callable[..., None]] = ...,
+                     initargs: Tuple[Any, ...] = ...) -> None: ...
     elif sys.version_info >= (3, 6) or sys.version_info < (3,):
         def __init__(self, max_workers: Optional[int] = ...,
                      thread_name_prefix: str = ...) -> None: ...

--- a/third_party/2/concurrent/futures/process.pyi
+++ b/third_party/2/concurrent/futures/process.pyi
@@ -10,8 +10,8 @@ if sys.version_info >= (3,):
 if sys.version_info >= (3, 7):
     class ProcessPoolExecutor(Executor):
         def __init__(self, max_workers: Optional[int] = ...,
-                     initializer: Callable[..., None] = ...,
-                     initargs: Tuple[Any] = ...) -> None: ...
+                     initializer: Optional[Callable[..., None]] = ...,
+                     initargs: Tuple[Any, ...] = ...) -> None: ...
 else:
     class ProcessPoolExecutor(Executor):
         def __init__(self, max_workers: Optional[int] = ...) -> None: ...

--- a/third_party/2/concurrent/futures/process.pyi
+++ b/third_party/2/concurrent/futures/process.pyi
@@ -1,4 +1,4 @@
-from typing import Optional, Any
+from typing import Any, Callable, Optional, Tuple
 from ._base import Future, Executor
 import sys
 
@@ -7,5 +7,11 @@ EXTRA_QUEUED_CALLS = ...  # type: Any
 if sys.version_info >= (3,):
     class BrokenProcessPool(RuntimeError): ...
 
-class ProcessPoolExecutor(Executor):
-    def __init__(self, max_workers: Optional[int] = ...) -> None: ...
+if sys.version_info >= (3, 7):
+    class ProcessPoolExecutor(Executor):
+        def __init__(self, max_workers: Optional[int] = ...,
+                     initializer: Callable[..., None] = ...,
+                     initargs: Tuple[Any] = ...) -> None: ...
+else:
+    class ProcessPoolExecutor(Executor):
+        def __init__(self, max_workers: Optional[int] = ...) -> None: ...

--- a/third_party/2/concurrent/futures/thread.pyi
+++ b/third_party/2/concurrent/futures/thread.pyi
@@ -1,9 +1,14 @@
-from typing import Optional
+from typing import Any, Callable, Optional, Tuple
 from ._base import Executor, Future
 import sys
 
 class ThreadPoolExecutor(Executor):
-    if sys.version_info >= (3, 6) or sys.version_info < (3,):
+    if sys.version_info >= (3, 7):
+        def __init__(self, max_workers: Optional[int] = ...,
+                     thread_name_prefix: str = ...,
+                     initializer: Callable[..., None] = ...,
+                     initargs: Tuple[Any] = ...) -> None: ...
+    elif sys.version_info >= (3, 6) or sys.version_info < (3,):
         def __init__(self, max_workers: Optional[int] = ...,
                      thread_name_prefix: str = ...) -> None: ...
     else:

--- a/third_party/2/concurrent/futures/thread.pyi
+++ b/third_party/2/concurrent/futures/thread.pyi
@@ -6,8 +6,8 @@ class ThreadPoolExecutor(Executor):
     if sys.version_info >= (3, 7):
         def __init__(self, max_workers: Optional[int] = ...,
                      thread_name_prefix: str = ...,
-                     initializer: Callable[..., None] = ...,
-                     initargs: Tuple[Any] = ...) -> None: ...
+                     initializer: Optional[Callable[..., None]] = ...,
+                     initargs: Tuple[Any, ...] = ...) -> None: ...
     elif sys.version_info >= (3, 6) or sys.version_info < (3,):
         def __init__(self, max_workers: Optional[int] = ...,
                      thread_name_prefix: str = ...) -> None: ...


### PR DESCRIPTION
Tests fail requiring files to be copied to third_party/2, but the third party concurrent.futures has not been updated with these changes yet even in git, so I don't think that would be appropriate.