### PR TITLE
Allow DictReader values to be None (#2346)

### DIFF
--- a/stdlib/2and3/csv.pyi
+++ b/stdlib/2and3/csv.pyi
@@ -52,9 +52,9 @@ if sys.version_info >= (3,):
         quoting = ...  # type: int
 
 if sys.version_info >= (3, 6):
-    _DRMapping = OrderedDict[str, str]
+    _DRMapping = OrderedDict[str, Optional[str]]
 else:
-    _DRMapping = Dict[str, str]
+    _DRMapping = Dict[str, Optional[str]]
 
 
 class DictReader(Iterator[_DRMapping]):


### PR DESCRIPTION
Fixes #2346.

I only opened #2346 a couple of hours ago so I'm still anticipating feedback on whether or not this is a correct way to go about fixing that problem, but since the diff was so simple I figured I might as well make the PR for it.

Tests pass locally ✔️