### PR TITLE
Change a use of frozenset[int] to FrozenSet[int]

### DIFF
--- a/third_party/2and3/pymysql/__init__.pyi
+++ b/third_party/2and3/pymysql/__init__.pyi
@@ -1,5 +1,5 @@
 import sys
-from typing import Union, Tuple, Callable
+from typing import Union, Tuple, Callable, FrozenSet
 
 from .connections import Connection as _Connection
 from .constants import FIELD_TYPE as FIELD_TYPE
@@ -30,7 +30,7 @@ threadsafety: int
 apilevel: str
 paramstyle: str
 
-class DBAPISet(frozenset[int]):
+class DBAPISet(FrozenSet[int]):
     def __ne__(self, other) -> bool: ...
     def __eq__(self, other) -> bool: ...
     def __hash__(self) -> int: ...


### PR DESCRIPTION
Using FrozenSet is I think preferred (because it works in general) and
I am about to propose a mypy PR that breaks this particular use.