### PR TITLE
Relate _curses.wrapper return type to its function arg

### DIFF
--- a/stdlib/3/curses/__init__.pyi
+++ b/stdlib/3/curses/__init__.pyi
@@ -1,10 +1,12 @@
 import _curses
 from _curses import *  # noqa: F403
-from typing import Callable, Any, Sequence, Mapping
+from typing import TypeVar, Callable, Any, Sequence, Mapping
+
+_T = TypeVar('_T')
 
 LINES: int
 COLS: int
 
 def initscr() -> _curses._CursesWindow: ...
 def start_color() -> None: ...
-def wrapper(func: Callable[..., Any], *arg: Any, **kwds: Any) -> None: ...
+def wrapper(func: Callable[..., _T], *arg: Any, **kwds: Any) -> _T: ...


### PR DESCRIPTION
`curses.wrapper` returns the return value of the function it is passed,
but its function argument is declared as `Callable[..., Any]` while its
return type is `None`. This changes the definition of `curses.wrapper`
to use a `TypeVar` that relates the return type of its function argument
to its own return type.