### PR TITLE
Make dataclasses availible as a backported third_party library.

### DIFF
--- a/tests/check_consistent.py
+++ b/tests/check_consistent.py
@@ -22,6 +22,7 @@ consistent_files = [
     {'stdlib/3/concurrent/futures/_base.pyi', 'third_party/2/concurrent/futures/_base.pyi'},
     {'stdlib/3/concurrent/futures/thread.pyi', 'third_party/2/concurrent/futures/thread.pyi'},
     {'stdlib/3/concurrent/futures/process.pyi', 'third_party/2/concurrent/futures/process.pyi'},
+    {'stdlib/3.7/dataclasses.pyi', 'third_party/3/dataclasses.pyi'},
 ]
 
 def main():

--- a/third_party/3/dataclasses.pyi
+++ b/third_party/3/dataclasses.pyi
@@ -1,0 +1,64 @@
+from typing import overload, Any, Callable, Dict, Generic, Iterable, List, Mapping, Optional, Tuple, Type, TypeVar, Union
+
+
+_T = TypeVar('_T')
+
+class _MISSING_TYPE: ...
+MISSING: _MISSING_TYPE
+
+def asdict(obj: Any, *, dict_factory: Callable[[List[Tuple[str, Any]]], _T] = ...) -> _T: ...
+
+def astuple(obj: Any, *, tuple_factory: Callable[[List[Any]], _T] = ...) -> _T: ...
+
+
+@overload
+def dataclass(_cls: Type[_T]) -> Type[_T]: ...
+
+@overload
+def dataclass(*, init: bool = ..., repr: bool = ..., eq: bool = ..., order: bool = ...,
+    unsafe_hash: bool = ..., frozen: bool = ...) -> Callable[[Type[_T]], Type[_T]]: ...
+
+
+class Field(Generic[_T]):
+    name: str
+    type: Type[_T]
+    default: _T
+    default_factory: Callable[[], _T]
+    repr: bool
+    hash: Optional[bool]
+    init: bool
+    compare: bool
+    metadata: Optional[Mapping[str, Any]]
+
+
+# NOTE: Actual return type is 'Field[_T]', but we want to help type checkers
+# to understand the magic that happens at runtime.
+@overload  # `default` and `default_factory` are optional and mutually exclusive.
+def field(*, default: _T,
+    init: bool = ..., repr: bool = ..., hash: Optional[bool] = ..., compare: bool = ...,
+    metadata: Optional[Mapping[str, Any]] = ...) -> _T: ...
+
+@overload
+def field(*, default_factory: Callable[[], _T],
+    init: bool = ..., repr: bool = ..., hash: Optional[bool] = ..., compare: bool = ...,
+    metadata: Optional[Mapping[str, Any]] = ...) -> _T: ...
+
+@overload
+def field(*,
+    init: bool = ..., repr: bool = ..., hash: Optional[bool] = ..., compare: bool = ...,
+    metadata: Optional[Mapping[str, Any]] = ...) -> Any: ...
+
+
+def fields(class_or_instance: Any) -> Tuple[Field[Any], ...]: ...
+
+def is_dataclass(obj: Any) -> bool: ...
+
+class FrozenInstanceError(AttributeError): ...
+
+class InitVar(Generic[_T]): ...
+
+def make_dataclass(cls_name: str, fields: Iterable[Union[str, Tuple[str, type], Tuple[str, type, Field[Any]]]], *,
+    bases: Tuple[type, ...] = ..., namespace: Optional[Dict[str, Any]] = ...,
+    init: bool = ..., repr: bool = ..., eq: bool = ..., order: bool = ..., hash: bool = ..., frozen: bool = ...): ...
+
+def replace(obj: _T, **changes: Any) -> _T: ...


### PR DESCRIPTION
This fixes python/mypy#5389, and implements the fix suggested by @gvanrossum 

I have manually tested the change, and it fixes the issue for me. 

I'm not sure if there is a way to write a automated test for the change?

I have not requested permission from the library owner, as I am assuming that this is not necessary for stdlib backports.