### PR TITLE
Add undocumented `trait` decorator to mypy_extensions

### DIFF
--- a/third_party/2and3/mypy_extensions.pyi
+++ b/third_party/2and3/mypy_extensions.pyi
@@ -1,4 +1,4 @@
-from typing import Dict, Type, TypeVar, Optional, Union
+from typing import Dict, Type, TypeVar, Optional, Union, Any
 
 _T = TypeVar('_T')
 
@@ -15,3 +15,7 @@ def KwArg(type: _T = ...) -> _T: ...
 # This type is equivalent to the None type, but the no-op Union is necessary to
 # distinguish the None type from the None value.
 NoReturn = Union[None]  # Deprecated: Use typing.NoReturn instead.
+
+# This is intended as a class decorator, but mypy rejects abstract classes
+# when a Type[_T] is expected, so we can't give it the type we want
+def trait(cls: Any) -> Any: ...


### PR DESCRIPTION
`@trait` has special meaning to the experimental mypyc compiler,
slightly restricting the behavior of the class in exchange for
allowing it to be multiply inherited from.