### PR TITLE
fix: list_commands returns strings

### DIFF
--- a/third_party/2and3/click/core.pyi
+++ b/third_party/2and3/click/core.pyi
@@ -278,7 +278,7 @@ class MultiCommand(Command):
     def get_command(self, ctx: Context, cmd_name: str) -> Optional[Command]:
         ...
 
-    def list_commands(self, ctx: Context) -> Iterable[Command]:
+    def list_commands(self, ctx: Context) -> Iterable[str]:
         ...
 
 


### PR DESCRIPTION
list_commands previously returned `Iterable[click.Command]` and now returns `Iterable[str]` to comply with the method's return value.

The method can be found [here](https://github.com/pallets/click/blob/7463db5c2ce1cf7697f6aeded5798da35fcb4968/click/core.py#L1169) for validation.

Issue here: https://github.com/pallets/click/issues/693