### PR TITLE
Replace StartResponse arguments with ...

### DIFF
--- a/stdlib/2and3/wsgiref/types.pyi
+++ b/stdlib/2and3/wsgiref/types.pyi
@@ -21,10 +21,8 @@ from types import TracebackType
 _exc_info = Tuple[Optional[Type[BaseException]],
                   Optional[BaseException],
                   Optional[TracebackType]]
-StartResponse = Union[
-    Callable[[Text, List[Tuple[Text, Text]]], Callable[[bytes], None]],
-    Callable[[Text, List[Tuple[Text, Text]], _exc_info], Callable[[bytes], None]]
-]
+# (status: str, headers: List[Tuple[str, str]], exc_info = None)
+StartResponse = Callable[..., Callable[[bytes], None]]
 WSGIEnvironment = Dict[Text, Any]
 WSGIApplication = Callable[[WSGIEnvironment, StartResponse], Iterable[bytes]]
 

--- a/stdlib/2and3/wsgiref/types.pyi
+++ b/stdlib/2and3/wsgiref/types.pyi
@@ -15,12 +15,8 @@
 # you need to use 'WSGIApplication' and not simply WSGIApplication when type
 # hinting your code.  Otherwise Python will raise NameErrors.
 
-from typing import Callable, Dict, Iterable, List, Optional, Tuple, Type, Any, Text, Protocol
-from types import TracebackType
+from typing import Callable, Dict, Iterable, List, Any, Text, Protocol
 
-_exc_info = Tuple[Optional[Type[BaseException]],
-                  Optional[BaseException],
-                  Optional[TracebackType]]
 # (status: str, headers: List[Tuple[str, str]], exc_info = None)
 StartResponse = Callable[..., Callable[[bytes], Any]]
 WSGIEnvironment = Dict[Text, Any]

--- a/stdlib/2and3/wsgiref/types.pyi
+++ b/stdlib/2and3/wsgiref/types.pyi
@@ -15,14 +15,14 @@
 # you need to use 'WSGIApplication' and not simply WSGIApplication when type
 # hinting your code.  Otherwise Python will raise NameErrors.
 
-from typing import Callable, Dict, Iterable, List, Optional, Tuple, Type, Union, Any, Text, Protocol
+from typing import Callable, Dict, Iterable, List, Optional, Tuple, Type, Any, Text, Protocol
 from types import TracebackType
 
 _exc_info = Tuple[Optional[Type[BaseException]],
                   Optional[BaseException],
                   Optional[TracebackType]]
 # (status: str, headers: List[Tuple[str, str]], exc_info = None)
-StartResponse = Callable[..., Callable[[bytes], None]]
+StartResponse = Callable[..., Callable[[bytes], Any]]
 WSGIEnvironment = Dict[Text, Any]
 WSGIApplication = Callable[[WSGIEnvironment, StartResponse], Iterable[bytes]]
 


### PR DESCRIPTION
StartResponse callbacks are required to accept and optional third argument.
Currently, there is no good way to describe this using type hints.
Previously, a Union was used, but that causes mypy to complain about any call
of start_response().