### PR TITLE
Make defaultdict.default_factory Optional.

### DIFF
--- a/stdlib/3/collections/__init__.pyi
+++ b/stdlib/3/collections/__init__.pyi
@@ -305,7 +305,7 @@ class OrderedDict(Dict[_KT, _VT], Reversible[_KT], Generic[_KT, _VT]):
 _DefaultDictT = TypeVar('_DefaultDictT', bound=defaultdict)
 
 class defaultdict(Dict[_KT, _VT], Generic[_KT, _VT]):
-    default_factory = ...  # type: Callable[[], _VT]
+    default_factory = ...  # type: Optional[Callable[[], _VT]]
 
     @overload
     def __init__(self, **kwargs: _VT) -> None: ...


### PR DESCRIPTION
The API allows for setting this to `None`.  It makes the defaultdict behave more like a regular dict.

This should fix or partially fix #2375