### PR TITLE
fix module argument to unittest.main

### DIFF
--- a/stdlib/2/unittest.pyi
+++ b/stdlib/2/unittest.pyi
@@ -226,7 +226,7 @@ def skip(reason: Union[str, unicode]) -> Any: ...
 class TestProgram:
     result = ...  # type: TestResult
 
-def main(module: str = ..., defaultTest: Optional[str] = ...,
+def main(module: Union[None, Text, types.ModuleType] = ..., defaultTest: Optional[str] = ...,
          argv: Optional[Sequence[str]] = ...,
          testRunner: Union[Type[TextTestRunner], TextTestRunner, None] = ...,
          testLoader: TestLoader = ..., exit: bool = ..., verbosity: int = ...,

--- a/stdlib/3/unittest/__init__.pyi
+++ b/stdlib/3/unittest/__init__.pyi
@@ -307,7 +307,7 @@ class TextTestRunner(TestRunner):
 class TestProgram:
     result = ...  # type: TestResult
 
-def main(module: str = ...,
+def main(module: Union[None, str, ModuleType] = ...,
          defaultTest: Union[str, Iterable[str], None] = ...,
          argv: Optional[List[str]] = ...,
          testRunner: Union[Type[TestRunner], TestRunner, None] = ...,


### PR DESCRIPTION
Fixes #2388.

Inspection of the code shows that the argument can also be None or module (https://github.com/python/cpython/blob/master/Lib/unittest/main.py#L69), although the docs (https://docs.python.org/3/library/unittest.html#unittest.main) don't say anything much about the type of `module`.