### PR TITLE
Remove duplicate `adapters` import.

### DIFF
--- a/third_party/2and3/requests/sessions.pyi
+++ b/third_party/2and3/requests/sessions.pyi
@@ -12,7 +12,6 @@ from . import utils
 from . import exceptions
 from .packages.urllib3 import _collections
 from . import structures
-from . import adapters
 from . import status_codes
 
 BaseAdapter = adapters.BaseAdapter


### PR DESCRIPTION
This causes an error in pytype.