### PR TITLE
Use class with __call__ method instead of callable.

### DIFF
--- a/stdlib/2and3/codecs.pyi
+++ b/stdlib/2and3/codecs.pyi
@@ -1,5 +1,5 @@
 import sys
-from typing import Any, BinaryIO, Callable, Generator, IO, Iterable, List, Optional, Text, TextIO, Tuple, Type, TypeVar, Union
+from typing import Any, BinaryIO, Callable, Generator, IO, Iterable, List, Optional, Protocol, Text, TextIO, Tuple, Type, TypeVar, Union
 
 from abc import abstractmethod
 import types
@@ -13,9 +13,9 @@ import types
 _Decoded = Text
 _Encoded = bytes
 
-class _Encoder:
+class _Encoder(Protocol):
     def __call__(self, input: _Decoded, errors: str = ...) -> Tuple[_Encoded, int]: ...  # signature of Codec().encode
-class _Decoder:
+class _Decoder(Protocol):
     def __call__(self, input: _Encoded, errors: str = ...) -> Tuple[_Decoded, int]: ...  # signature of Codec().decode
 
 _StreamReader = Callable[[IO[_Encoded]], StreamReader]  # signature of StreamReader __init__

--- a/stdlib/2and3/codecs.pyi
+++ b/stdlib/2and3/codecs.pyi
@@ -18,10 +18,12 @@ class _Encoder(Protocol):
 class _Decoder(Protocol):
     def __call__(self, input: _Encoded, errors: str = ...) -> Tuple[_Decoded, int]: ...  # signature of Codec().decode
 
+# TODO: Replace the following Callable definitions with protocol classes as above.
 _StreamReader = Callable[[IO[_Encoded]], StreamReader]  # signature of StreamReader __init__
 _StreamWriter = Callable[[IO[_Encoded]], StreamWriter]  # signature of StreamWriter __init__
 _IncrementalEncoder = Callable[[], IncrementalEncoder]  # signature of IncrementalEncoder __init__
 _IncrementalDecoder = Callable[[], IncrementalDecoder]  # signature of IncrementalDecoder __init__
+
 def encode(obj: _Decoded, encoding: str = ..., errors: str = ...) -> _Encoded: ...
 def decode(obj: _Encoded, encoding: str = ..., errors: str = ...) -> _Decoded: ...
 def lookup(encoding: str) -> CodecInfo: ...

--- a/stdlib/2and3/codecs.pyi
+++ b/stdlib/2and3/codecs.pyi
@@ -13,10 +13,11 @@ import types
 _Decoded = Text
 _Encoded = bytes
 
-# TODO: It is not possible to specify these signatures correctly, because
-# they have an optional positional or keyword argument for errors=.
-_Encoder = Callable[[_Decoded], Tuple[_Encoded, int]]  # signature of Codec().encode
-_Decoder = Callable[[_Encoded], Tuple[_Decoded, int]]  # signature of Codec().decode
+class _Encoder:
+    def __call__(self, input: _Decoded, errors: str = ...) -> Tuple[_Encoded, int]: ...  # signature of Codec().encode
+class _Decoder:
+    def __call__(self, input: _Encoded, errors: str = ...) -> Tuple[_Decoded, int]: ...  # signature of Codec().decode
+
 _StreamReader = Callable[[IO[_Encoded]], StreamReader]  # signature of StreamReader __init__
 _StreamWriter = Callable[[IO[_Encoded]], StreamWriter]  # signature of StreamWriter __init__
 _IncrementalEncoder = Callable[[], IncrementalEncoder]  # signature of IncrementalEncoder __init__


### PR DESCRIPTION
This will enable checking positional and keyword parameters.