### PR TITLE
Loosen parameters of traceback.format_list and traceback.StackSummary.from_list

### DIFF
--- a/stdlib/2and3/traceback.pyi
+++ b/stdlib/2and3/traceback.pyi
@@ -1,6 +1,6 @@
 # Stubs for traceback
 
-from typing import Any, Dict, Generator, IO, Iterator, List, Mapping, Optional, Tuple, Type, Iterable
+from typing import Any, Dict, Generator, IO, Iterable, Iterator, List, Mapping, Optional, Tuple, Type
 from types import FrameType, TracebackType
 import sys
 
@@ -35,7 +35,10 @@ if sys.version_info >= (3, 5):
     def extract_tb(tb: Optional[TracebackType], limit: Optional[int] = ...) -> StackSummary: ...
     def extract_stack(f: Optional[FrameType] = ...,
                       limit: Optional[int] = ...) -> StackSummary: ...
-    def format_list(extracted_list: List[FrameSummary]) -> List[str]: ...
+    # NOTE(https://bugs.python.org/issue34648): Authors who are diligent
+    # enough to type-check their code are authors who are diligent enough to
+    # upgrade their Tuple[str, int, str, Optional[str]]s to FrameSummarys.
+    def format_list(extracted_list: Iterable[FrameSummary]) -> List[str]: ...
 else:
     def extract_tb(tb: Optional[TracebackType], limit: Optional[int] = ...) -> List[_PT]: ...
     def extract_stack(f: Optional[FrameType] = ...,
@@ -111,6 +114,10 @@ if sys.version_info >= (3, 5):
                     frame_gen: Generator[Tuple[FrameType, int], None, None],
                     *, limit: Optional[int] = ..., lookup_lines: bool = ...,
                     capture_locals: bool = ...) -> StackSummary: ...
+        # NOTE(https://bugs.python.org/issue34648): Authors who are diligent
+        # enough to type-check their code are authors who are diligent enough
+        # to upgrade their Tuple[str, int, str, Optional[str]]s to
+        # FrameSummarys.
         @classmethod
-        def from_list(cls, a_list: List[_PT]) -> StackSummary: ...
+        def from_list(cls, a_list: Iterable[FrameSummary]) -> StackSummary: ...
         def format(self) -> List[str]: ...


### PR DESCRIPTION
`traceback.FrameSummary`'s `line` parameter is a string that is the text
of a line of code, not an int that is the line number of a line of
code.

Also relax type of `traceback.format_list`'s `extracted_list` parameter
in 3.5-and-later from `List[FrameSummary]` to `Iterable[FrameSummary]`.
Never ask for a `List` when asking for a `Sequence` will do, and never ask
for a `Sequence` when asking for a `Collection` will do, and never ask for
a `Collection` when asking for an `Iterable` will do (and so on in other
cases, but this case stops at `Iterable`).

Also add a note about deliberately not supporting for type-checking
purposes the 3.4-and-earlier `List[Tuple[str, int, str, Optional[str]]]`
semantics for `traceback.format_list`'s `extracted_list` parameter.
`traceback` currently supports the old type of parameter, but if
authors are typechecking their 3.5-and-later code, it's reasonable to
expect that they'll want to modernize their code to use `FrameSummary`
objects rather than four-tuples.