### PR TITLE
Add six.moves.urllib_request and six.moves.urllib_response.

### DIFF
--- a/third_party/2/six/moves/urllib_request.pyi
+++ b/third_party/2/six/moves/urllib_request.pyi
@@ -1,0 +1,1 @@
+from .urllib.request import *

--- a/third_party/2/six/moves/urllib_response.pyi
+++ b/third_party/2/six/moves/urllib_response.pyi
@@ -1,0 +1,1 @@
+from .urllib.response import *

--- a/third_party/3/six/moves/urllib_request.pyi
+++ b/third_party/3/six/moves/urllib_request.pyi
@@ -1,0 +1,1 @@
+from .urllib.request import *

--- a/third_party/3/six/moves/urllib_response.pyi
+++ b/third_party/3/six/moves/urllib_response.pyi
@@ -1,0 +1,1 @@
+from .urllib.response import *


### PR DESCRIPTION
Like the other six.moves.urllib.{foo} modules, request and response can be imported as six.moves.urllib_{foo}.

There's a mypy_selftest failure that I'm also seeing in a couple other recent PRs (e.g., https://github.com/python/typeshed/pull/2433), so I don't think it's related to this change.