### PR TITLE
Add name attribute to logging.Handler

### DIFF
--- a/stdlib/2and3/logging/__init__.pyi
+++ b/stdlib/2and3/logging/__init__.pyi
@@ -125,20 +125,21 @@ class Logger(Filterer):
         def hasHandlers(self) -> bool: ...
 
 
-CRITICAL = ...  # type: int
-FATAL = ...  # type: int
-ERROR = ...  # type: int
-WARNING = ...  # type: int
-WARN = ...  # type: int
-INFO = ...  # type: int
-DEBUG = ...  # type: int
-NOTSET = ...  # type: int
+CRITICAL: int
+FATAL: int
+ERROR: int
+WARNING: int
+WARN: int
+INFO: int
+DEBUG: int
+NOTSET: int
 
 
 class Handler(Filterer):
-    level = ...  # type: int
-    formatter = ...  # type: Optional[Formatter]
-    lock = ...  # type: Optional[threading.Lock]
+    level: int
+    formatter: Optional[Formatter]
+    lock: Optional[threading.Lock]
+    name: str
     def __init__(self, level: _Level = ...) -> None: ...
     def createLock(self) -> None: ...
     def acquire(self) -> None: ...

--- a/stdlib/2and3/logging/__init__.pyi
+++ b/stdlib/2and3/logging/__init__.pyi
@@ -136,10 +136,10 @@ NOTSET: int
 
 
 class Handler(Filterer):
-    level: int
-    formatter: Optional[Formatter]
-    lock: Optional[threading.Lock]
-    name: str
+    level: int  # undocumented
+    formatter: Optional[Formatter]  # undocumented
+    lock: Optional[threading.Lock]  # undocumented
+    name: Optional[str]  # undocumented
     def __init__(self, level: _Level = ...) -> None: ...
     def createLock(self) -> None: ...
     def acquire(self) -> None: ...


### PR DESCRIPTION
This attribute has been a part of the `logging.Handler` for quite some time. Exists in [2.7](https://github.com/python/cpython/blob/2.7/Lib/logging/__init__.py#L699) and [onward](https://github.com/python/cpython/blob/3.6/Lib/logging/__init__.py#L798).

```python
file_handler = FileHandler(log_file_path)
file_handler.set_name("file")  # flake8 T484 - "FileHandler" has no attribute "set_name" (ignoring to encourage property syntax)
file_handler.name = "file"  # flake8 T484 - "FileHandler" has no attribute "name"
print(file_handler.name)  # flake8 T484 - "FileHandler" has no attribute "name"

console_handler = logging.StreamHandler()
console_handler.set_name("console")  # flake8 T484 - "StreamHandler" has no attribute "set_name" (ignoring to encourage property syntax)
console_handler.name = "console"  # flake8 T484 - "StreamHandler" has no attribute "name"
print(console_handler.name)  # flake8 T484 - "StreamHandler" has no attribute "name"
```

The chosen type of `str` may be incorrect in some scenarios (that can work with the implementation) because the provided object just needs to be a [key in a dictionary](https://github.com/python/cpython/blob/3.6/Lib/logging/__init__.py#L794). `str` seems to make the most sense given the name of the attribute.

Replace some older type comments with variable annotations around the addition line.