### PR TITLE
Add exc_text to LogRecord

### DIFF
--- a/stdlib/2and3/logging/__init__.pyi
+++ b/stdlib/2and3/logging/__init__.pyi
@@ -191,6 +191,7 @@ class LogRecord:
     asctime = ...  # type: str
     created = ...  # type: int
     exc_info = ...  # type: Optional[_SysExcInfoType]
+    exc_text = ...  # type: Optional[str]
     filename = ...  # type: str
     funcName = ...  # type: str
     levelname = ...  # type: str


### PR DESCRIPTION
Looks like this was missed. It seems to have been there since at least 2.7.