### PR TITLE
add constructor arguments for TimeoutExpired

### DIFF
--- a/stdlib/3/subprocess.pyi
+++ b/stdlib/3/subprocess.pyi
@@ -209,6 +209,7 @@ STDOUT = ...  # type: int
 DEVNULL = ...  # type: int
 class SubprocessError(Exception): ...
 class TimeoutExpired(SubprocessError):
+    def __init__(self, cmd: _CMD, timeout: float, output: Optional[_TXT] = ..., stderr: Optional[_TXT] = ...) -> None: ...
     # morally: _CMD
     cmd = ...  # type: Any
     timeout = ...  # type: float


### PR DESCRIPTION
Previously, constructing a TimeoutExpired directly worked because Exception allowed arbitrary kwargs. We fixed that recently, but now mypy gives an error on creating a TimeoutExpired with legal arguments.