### PR TITLE
Fix traceback.FrameSummary's "line" parameter

### DIFF
--- a/stdlib/2and3/traceback.pyi
+++ b/stdlib/2and3/traceback.pyi
@@ -90,8 +90,6 @@ if sys.version_info >= (3, 5):
         def format(self, *, chain: bool = ...) -> Generator[str, None, None]: ...
         def format_exception_only(self) -> Generator[str, None, None]: ...
 
-
-if sys.version_info >= (3, 5):
     class FrameSummary(Iterable):
         filename: str
         lineno: int
@@ -101,7 +99,7 @@ if sys.version_info >= (3, 5):
         def __init__(self, filename: str, lineno: int, name: str,
                      lookup_line: bool = ...,
                      locals: Optional[Mapping[str, str]] = ...,
-                     line: Optional[int] = ...) -> None: ...
+                     line: Optional[str] = ...) -> None: ...
         # TODO: more precise typing for __getitem__ and __iter__,
         # for a namedtuple-like view on (filename, lineno, name, str).
         def __getitem__(self, i: int) -> Any: ...


### PR DESCRIPTION
This is the non-controversial, non-have-to-think-about-it-for-a-bit portion of [pull request 2436](https://github.com/python/typeshed/pull/2436).