### PR TITLE
make __class__ refer to the current object's class

### DIFF
--- a/stdlib/2/__builtin__.pyi
+++ b/stdlib/2/__builtin__.pyi
@@ -11,7 +11,7 @@ from typing import (
     SupportsComplex, SupportsRound, IO, BinaryIO, Union, AnyStr, MutableSequence, MutableMapping,
     MutableSet, ItemsView, KeysView, ValuesView, Optional, Container, Type
 )
-from abc import abstractmethod, ABCMeta
+from abc import ABCMeta
 
 _T = TypeVar('_T')
 _T_co = TypeVar('_T_co', covariant=True)
@@ -27,11 +27,14 @@ _TT = TypeVar('_TT', bound='type')
 
 class object:
     __doc__ = ...  # type: Optional[str]
-    __class__ = ...  # type: type
     __dict__ = ...  # type: Dict[str, Any]
     __slots__ = ...  # type: Union[str, unicode, Iterable[Union[str, unicode]]]
     __module__ = ...  # type: str
 
+    @property
+    def __class__(self: _T) -> Type[_T]: ...
+    @__class__.setter
+    def __class__(self, __type: Type[object]) -> None: ...
     def __init__(self) -> None: ...
     def __new__(cls) -> Any: ...
     def __setattr__(self, name: str, value: Any) -> None: ...

--- a/stdlib/2/builtins.pyi
+++ b/stdlib/2/builtins.pyi
@@ -11,7 +11,7 @@ from typing import (
     SupportsComplex, SupportsRound, IO, BinaryIO, Union, AnyStr, MutableSequence, MutableMapping,
     MutableSet, ItemsView, KeysView, ValuesView, Optional, Container, Type
 )
-from abc import abstractmethod, ABCMeta
+from abc import ABCMeta
 
 _T = TypeVar('_T')
 _T_co = TypeVar('_T_co', covariant=True)
@@ -27,11 +27,14 @@ _TT = TypeVar('_TT', bound='type')
 
 class object:
     __doc__ = ...  # type: Optional[str]
-    __class__ = ...  # type: type
     __dict__ = ...  # type: Dict[str, Any]
     __slots__ = ...  # type: Union[str, unicode, Iterable[Union[str, unicode]]]
     __module__ = ...  # type: str
 
+    @property
+    def __class__(self: _T) -> Type[_T]: ...
+    @__class__.setter
+    def __class__(self, __type: Type[object]) -> None: ...
     def __init__(self) -> None: ...
     def __new__(cls) -> Any: ...
     def __setattr__(self, name: str, value: Any) -> None: ...

--- a/stdlib/2/types.pyi
+++ b/stdlib/2/types.pyi
@@ -90,7 +90,6 @@ class UnboundMethodType:
 
 class InstanceType:
     __doc__ = ...  # type: Optional[str]
-    __class__ = ...  # type: type
     __module__ = ...  # type: Any
 
 MethodType = UnboundMethodType

--- a/stdlib/3/builtins.pyi
+++ b/stdlib/3/builtins.pyi
@@ -28,13 +28,16 @@ _TT = TypeVar('_TT', bound='type')
 
 class object:
     __doc__ = ...  # type: Optional[str]
-    __class__ = ...  # type: type
     __dict__ = ...  # type: Dict[str, Any]
     __slots__ = ...  # type: Union[str, Iterable[str]]
     __module__ = ...  # type: str
     if sys.version_info >= (3, 6):
         __annotations__ = ...  # type: Dict[str, Any]
 
+    @property
+    def __class__(self: _T) -> Type[_T]: ...
+    @__class__.setter
+    def __class__(self, __type: Type[object]) -> None: ...
     def __init__(self) -> None: ...
     def __new__(cls) -> Any: ...
     def __setattr__(self, name: str, value: Any) -> None: ...


### PR DESCRIPTION
This is just a direct rehash of #1549.

I checked this against our internal codebases and it caused two errors, both resolvable by deleting the type annotations that were conflicting.