### PR TITLE
Add `bytes` as legal type for `RawConfigParser.read`.

### DIFF
--- a/stdlib/3/configparser.pyi
+++ b/stdlib/3/configparser.pyi
@@ -18,7 +18,7 @@ _converter = Callable[[str], Any]
 _converters = Dict[str, _converter]
 _T = TypeVar('_T')
 
-if sys.version info >= (3, 7):
+if sys.version_info >= (3, 7):
     _Path = Union[str, bytes, PathLike[str]]
 elif sys.version_info >= (3, 6):
     _Path = Union[str, PathLike[str]]

--- a/stdlib/3/configparser.pyi
+++ b/stdlib/3/configparser.pyi
@@ -19,7 +19,7 @@ _converters = Dict[str, _converter]
 _T = TypeVar('_T')
 
 if sys.version_info >= (3, 6):
-    _Path = Union[str, PathLike[str]]
+    _Path = Union[str, bytes, PathLike[str]]
 else:
     _Path = str
 

--- a/stdlib/3/configparser.pyi
+++ b/stdlib/3/configparser.pyi
@@ -18,8 +18,10 @@ _converter = Callable[[str], Any]
 _converters = Dict[str, _converter]
 _T = TypeVar('_T')
 
-if sys.version_info >= (3, 6):
+if sys.version info >= (3, 7):
     _Path = Union[str, bytes, PathLike[str]]
+elif sys.version_info >= (3, 6):
+    _Path = Union[str, PathLike[str]]
 else:
     _Path = str
 


### PR DESCRIPTION
Closes #2476.