### PR TITLE
Support PathLike arguments in the logging module

### DIFF
--- a/stdlib/2and3/logging/__init__.pyi
+++ b/stdlib/2and3/logging/__init__.pyi
@@ -19,6 +19,11 @@ else:
 _ArgsType = Union[Tuple[Any, ...], Dict[str, Any]]
 _FilterType = Union[Filter, Callable[[LogRecord], int]]
 _Level = Union[int, Text]
+if sys.version_info >= (3, 6):
+    from os import PathLike
+    _Path = Union[str, PathLike[str]]
+else:
+    _Path = str
 
 raiseExceptions: bool
 
@@ -344,7 +349,7 @@ def getLevelName(lvl: int) -> str: ...
 def makeLogRecord(attrdict: Mapping[str, Any]) -> LogRecord: ...
 
 if sys.version_info >= (3,):
-    def basicConfig(*, filename: str = ..., filemode: str = ...,
+    def basicConfig(*, filename: _Path = ..., filemode: str = ...,
                     format: str = ..., datefmt: str = ..., style: str = ...,
                     level: _Level = ..., stream: IO[str] = ...,
                     handlers: Iterable[Handler] = ...) -> None: ...
@@ -381,7 +386,7 @@ class FileHandler(Handler):
     mode = ...  # type: str
     encoding = ...  # type: Optional[str]
     delay = ...  # type: bool
-    def __init__(self, filename: str, mode: str = ...,
+    def __init__(self, filename: _Path, mode: str = ...,
                  encoding: Optional[str] = ..., delay: bool = ...) -> None: ...
 
 

--- a/stdlib/2and3/logging/config.pyi
+++ b/stdlib/2and3/logging/config.pyi
@@ -6,11 +6,20 @@ if sys.version_info >= (3,):
     from configparser import RawConfigParser
 else:
     from ConfigParser import RawConfigParser
+if sys.version_info >= (3, 6):
+    from os import PathLike
+
+if sys.version_info >= (3, 7):
+    _Path = Union[str, bytes, PathLike[str]]
+elif sys.version_info >= (3, 6):
+    _Path = Union[str, PathLike[str]]
+else:
+    _Path = str
 
 
 def dictConfig(config: Dict[str, Any]) -> None: ...
 if sys.version_info >= (3, 4):
-    def fileConfig(fname: Union[str, IO[str], RawConfigParser],
+    def fileConfig(fname: Union[_Path, IO[str], RawConfigParser],
                    defaults: Optional[Dict[str, str]] = ...,
                    disable_existing_loggers: bool = ...) -> None: ...
     def listen(port: int = ...,

--- a/stdlib/2and3/logging/handlers.pyi
+++ b/stdlib/2and3/logging/handlers.pyi
@@ -10,20 +10,26 @@ if sys.version_info >= (3,):
     from queue import Queue
 else:
     from Queue import Queue
+
 # TODO update socket stubs to add SocketKind
 _SocketKind = int
+if sys.version_info >= (3, 6):
+    from os import PathLike
+    _Path = Union[str, PathLike[str]]
+else:
+    _Path = str
 
 
 class WatchedFileHandler(Handler):
     @overload
-    def __init__(self, filename: str) -> None: ...
+    def __init__(self, filename: _Path) -> None: ...
     @overload
-    def __init__(self, filename: str, mode: str) -> None: ...
+    def __init__(self, filename: _Path, mode: str) -> None: ...
     @overload
-    def __init__(self, filename: str, mode: str,
+    def __init__(self, filename: _Path, mode: str,
                  encoding: Optional[str]) -> None: ...
     @overload
-    def __init__(self, filename: str, mode: str, encoding: Optional[str],
+    def __init__(self, filename: _Path, mode: str, encoding: Optional[str],
                  delay: bool) -> None: ...
 
 
@@ -32,7 +38,7 @@ if sys.version_info >= (3,):
         terminator = ...  # type: str
         namer = ...  # type: Optional[Callable[[str], str]]
         rotator = ...  # type: Optional[Callable[[str, str], None]]
-        def __init__(self, filename: str, mode: str,
+        def __init__(self, filename: _Path, mode: str,
                      encoding: Optional[str] = ...,
                      delay: bool = ...) -> None: ...
         def rotation_filename(self, default_name: str) -> None: ...
@@ -41,7 +47,7 @@ if sys.version_info >= (3,):
 
 if sys.version_info >= (3,):
     class RotatingFileHandler(BaseRotatingHandler):
-        def __init__(self, filename: str, mode: str = ..., maxBytes: int = ...,
+        def __init__(self, filename: _Path, mode: str = ..., maxBytes: int = ...,
                      backupCount: int = ..., encoding: Optional[str] = ...,
                      delay: bool = ...) -> None: ...
         def doRollover(self) -> None: ...
@@ -56,7 +62,7 @@ else:
 if sys.version_info >= (3,):
     class TimedRotatingFileHandler(BaseRotatingHandler):
         if sys.version_info >= (3, 4):
-            def __init__(self, filename: str, when: str = ...,
+            def __init__(self, filename: _Path, when: str = ...,
                          interval: int = ...,
                          backupCount: int = ..., encoding: Optional[str] = ...,
                          delay: bool = ..., utc: bool = ...,


### PR DESCRIPTION
Since Python 3.6 `logging.FileHandler`'s `filename` argument can be a `PathLike` object. Same for `FileHandler`'s subclasses.
`logging.basicConfig` passes its `filename` argument to a `FileHandler`, so this can be a `PathLike` object too.
Finally, `logging.config.fileConfig` passes its `fname` argument to `ConfigParser.read`, which also takes a `PathLike` since version 3.6.1.

Prior to this change, the following code did not pass mypy checks under Python 3.6:
```python
import logging
from pathlib import Path

p = Path("/foo/bar")
handler = logging.FileHandler(p)
# error: Argument 1 to "FileHandler" has incompatible type "Path"; expected "str"
```