### PR TITLE
Make _NetlocResultMixinBytes derive from _NetlocResultMixinBase[bytes], not [str]

### DIFF
--- a/stdlib/3/urllib/parse.pyi
+++ b/stdlib/3/urllib/parse.pyi
@@ -33,8 +33,7 @@ class _NetlocResultMixinBase(Generic[AnyStr]):
 
 class _NetlocResultMixinStr(_NetlocResultMixinBase[str], _ResultMixinStr): ...
 
-
-class _NetlocResultMixinBytes(_NetlocResultMixinBase[str], _ResultMixinBytes): ...
+class _NetlocResultMixinBytes(_NetlocResultMixinBase[bytes], _ResultMixinBytes): ...
 
 class _DefragResultBase(tuple, Generic[AnyStr]):
     url = ...  # type: AnyStr


### PR DESCRIPTION
To fix issue #2501 