### PR TITLE
Set urllib.parse.urljoin url argument to optional

### DIFF
--- a/stdlib/3/urllib/parse.pyi
+++ b/stdlib/3/urllib/parse.pyi
@@ -1,5 +1,5 @@
 # Stubs for urllib.parse
-from typing import Any, List, Dict, Tuple, AnyStr, Generic, overload, Sequence, Mapping, Union, NamedTuple, Callable
+from typing import Any, List, Dict, Tuple, AnyStr, Generic, overload, Sequence, Mapping, Union, NamedTuple, Callable, Optional
 import sys
 
 _Str = Union[bytes, str]
@@ -123,7 +123,7 @@ else:
                                Sequence[Tuple[Any, Sequence[Any]]]],
                   doseq: bool = ..., safe: AnyStr = ..., encoding: str = ..., errors: str = ...) -> str: ...
 
-def urljoin(base: AnyStr, url: AnyStr, allow_fragments: bool = ...) -> AnyStr: ...
+def urljoin(base: AnyStr, url: Optional[AnyStr], allow_fragments: bool = ...) -> AnyStr: ...
 
 @overload
 def urlparse(url: str, scheme: str = ..., allow_fragments: bool = ...) -> ParseResult: ...


### PR DESCRIPTION
The `url` argument to `urllib.parse.urljoin` can be `None`.