### PR TITLE
ImportFrom level cannot be optional

### DIFF
--- a/stdlib/3/_ast.pyi
+++ b/stdlib/3/_ast.pyi
@@ -132,7 +132,7 @@ class Import(stmt):
 class ImportFrom(stmt):
     module = ...  # type: Optional[_identifier]
     names = ...  # type: typing.List[alias]
-    level = ...  # type: Optional[int]
+    level = ...  # type: int
 
 class Global(stmt):
     names = ...  # type: typing.List[_identifier]


### PR DESCRIPTION
I've just found that the `level` attribute of `ImportFrom` is typed as an optional, so I have to test if it is None to gain static type safety. 

That's kind of confusing for the conflicts against my observations from `ast.parse` in Python2.7/3.5+.

Although in [Python-asdl](https://github.com/python/cpython/blob/master/Parser/Python.asdl) the  ASDL is defined as `ImportFrom(identifier? module, alias* names, int? level)`, this 
https://github.com/python/cpython/blob/97cf0828727ac2a269c89c5aa09570a69a22c83c/Python/ast.c#L3311
 tells that `level` cannot be `None`(even if you assign it with a NULL).

`ImportFrom(identifier? module, alias* names, int level)` should be okay.

I wonder if there should be a change in Python-asdl? 
