### PR TITLE
Make contribution guidelines state when to use (and not use) 'Any'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -210,7 +210,6 @@ checker, and leave out unnecessary detail:
 Some further tips for good type hints:
 * avoid invariant collection types (`List`, `Dict`) in argument
   positions, in favor of covariant types like `Mapping` or `Sequence`;
-* prefer using `object` over `Any`, especially in argument positions;
 * avoid Union return types: https://github.com/python/mypy/issues/1693;
 * in Python 2, whenever possible, use `unicode` if that's the only
   possible type, and `Text` if it can be either `unicode` or `bytes`;
@@ -223,6 +222,17 @@ unless:
   explicit ``as`` even if the name stays the same); or
 * they use the form ``from library import *`` which means all names
   from that library are exported.
+
+When adding type hints, avoid using the `Any` type when possible. Reserve
+the use of `Any` for when:
+* it is simply not possible to construct the correct type;
+* you are contributing a preliminary set of stubs and are not sure
+  in some cases what the correct types are; and
+* to avoid Union returns (see above).
+
+Note that `Any` is not the correct type to use if you want to indicate
+that some function can accept literally anything: in those cases use
+`object` instead.
 
 For arguments with type and a default value of `None`, PEP 484
 prescribes that the type automatically becomes `Optional`.  However we

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -225,7 +225,7 @@ unless:
 
 When adding type hints, avoid using the `Any` type when possible. Reserve
 the use of `Any` for when:
-* it is simply not possible to construct the correct type;
+* the correct type cannot be expressed in the current type system;
 * you are contributing a preliminary set of stubs and are not sure
   in some cases what the correct types are; and
 * to avoid Union returns (see above).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -210,6 +210,7 @@ checker, and leave out unnecessary detail:
 Some further tips for good type hints:
 * avoid invariant collection types (`List`, `Dict`) in argument
   positions, in favor of covariant types like `Mapping` or `Sequence`;
+* prefer using `object` over `Any`, especially in argument positions;
 * avoid Union return types: https://github.com/python/mypy/issues/1693;
 * in Python 2, whenever possible, use `unicode` if that's the only
   possible type, and `Text` if it can be either `unicode` or `bytes`;


### PR DESCRIPTION
This pull request modifies the contribution guidelines to state that pull requests should prefer using `object` over `Any` whenever possible.

In particular, I think there's never really a case where you'd want to use `Any` as a function argument type in stubs -- whenever you do, `object` should suffice instead.

Typing stubs this way probably won't impact most people, but does make life a bit easier for people (like me) who want to restrict/forbid the use of Any as much as possible.

I'm hoping that this is an uncontroversial change -- iiuc avoiding the use of `Any` is already a sort of informal guideline anyways. But if people think this needs more discussion first, I'd be happy to shelve this PR and open an issue for discussion instead.