### PR TITLE
Allow json.dump to dump to BinaryIO again

### DIFF
--- a/stdlib/2/json.pyi
+++ b/stdlib/2/json.pyi
@@ -20,7 +20,7 @@ def dumps(obj: Any,
     **kwds: Any) -> str: ...
 
 def dump(obj: Any,
-    fp: IO[Text],
+    fp: Union[IO[str], IO[Text]],
     skipkeys: bool = ...,
     ensure_ascii: bool = ...,
     check_circular: bool = ...,


### PR DESCRIPTION
PR #2516 aimed to widen the accepted file argument to json.dump, but
since `IO` is invariant in its argument, it actually disallowed
passing binary files.