### PR TITLE
Fix py3 types of inspect.FullArgSpec.var(args|kw)

### DIFF
--- a/stdlib/3/inspect.pyi
+++ b/stdlib/3/inspect.pyi
@@ -192,8 +192,8 @@ def getargs(co: CodeType) -> Arguments: ...
 def getargspec(func: object) -> ArgSpec: ...
 
 FullArgSpec = NamedTuple('FullArgSpec', [('args', List[str]),
-                                         ('varargs', str),
-                                         ('varkw', str),
+                                         ('varargs', Optional[str]),
+                                         ('varkw', Optional[str]),
                                          ('defaults', tuple),
                                          ('kwonlyargs', List[str]),
                                          ('kwonlydefaults', Dict[str, Any]),


### PR DESCRIPTION
The documentation (https://docs.python.org/3/library/inspect.html#inspect.getfullargspec) says, "varargs is the name of the * parameter or None if arbitrary positional arguments are not accepted. varkw is the name of the ** parameter or None if arbitrary keyword arguments are not accepted."