### PR TITLE
Allow array[int] as a valid input to struct.unpack().

### DIFF
--- a/stdlib/2and3/struct.pyi
+++ b/stdlib/2and3/struct.pyi
@@ -11,10 +11,10 @@ class error(Exception): ...
 
 _FmtType = Union[bytes, Text]
 if sys.version_info >= (3,):
-    _BufferType = Union[bytes, bytearray, memoryview]
+    _BufferType = Union[array[int], bytes, bytearray, memoryview]
     _WriteBufferType = Union[array, bytearray, memoryview]
 else:
-    _BufferType = Union[bytes, bytearray, buffer, memoryview]
+    _BufferType = Union[array[int], bytes, bytearray, buffer, memoryview]
     _WriteBufferType = Union[array[Any], bytearray, buffer, memoryview]
 
 def pack(fmt: _FmtType, *v: Any) -> bytes: ...


### PR DESCRIPTION
There does not seem to be an easy way to express that the array needs to be of a 1-byte type ('b', 'B', or 'c' in Python 2 only), so it is a bit more permissive than it should be.