### PR TITLE
unittest.TestCase.assertRaises(): BaseException

### DIFF
--- a/stdlib/3/unittest/__init__.pyi
+++ b/stdlib/3/unittest/__init__.pyi
@@ -12,7 +12,7 @@ from types import ModuleType, TracebackType
 
 _T = TypeVar('_T')
 _FT = TypeVar('_FT', bound=Callable[..., Any])
-_E = TypeVar('_E', bound=Exception)
+_E = TypeVar('_E', bound=BaseException)
 
 
 def expectedFailure(func: _FT) -> _FT: ...


### PR DESCRIPTION
In Python 3, just as in Python 2, the expected exception argument to
assertRaises() and assertRaisesRegex() must be a subtype of
BaseException, not just of Exception.

Closes #2593