### PR TITLE
Move Sized earlier in the bases of Sequence

### DIFF
--- a/stdlib/2/typing.pyi
+++ b/stdlib/2/typing.pyi
@@ -144,7 +144,7 @@ class Container(Protocol[_T_co]):
     @abstractmethod
     def __contains__(self, x: object) -> bool: ...
 
-class Sequence(Iterable[_T_co], Container[_T_co], Sized, Reversible[_T_co], Generic[_T_co]):
+class Sequence(Sized, Iterable[_T_co], Container[_T_co], Reversible[_T_co], Generic[_T_co]):
     @overload
     @abstractmethod
     def __getitem__(self, i: int) -> _T_co: ...


### PR DESCRIPTION
See https://github.com/rominf/ordered-set-stubs/issues/1:
```
class OrderedSet(MutableSet[T], Sequence[T]): ...
```
works in Python 3, but not in Python 2 -- this fixes that.

(I haven't run the tests yet -- if they show problems with this I may just withdraw this.)