### PR TITLE
Relax type for click.echo.

### DIFF
--- a/third_party/2and3/click/utils.pyi
+++ b/third_party/2and3/click/utils.pyi
@@ -72,7 +72,7 @@ class KeepOpenFile:
 
 
 def echo(
-    message: Optional[Union[bytes, Text]] = ...,
+    message: Optional[object] = ...,
     file: Optional[IO] = ...,
     nl: bool = ...,
     err: bool = ...,


### PR DESCRIPTION
See #2604 -- the tl;dr; is that `click.echo` checks the type of the input object and will call `str` on it for python3.x or `unicode` on it for python2.x.  Since that should work for virtually any type, we shouldn't require the input to be some kind of string/bytes.