### PR TITLE
Update types for requests.adapters

### DIFF
--- a/third_party/2and3/requests/adapters.pyi
+++ b/third_party/2and3/requests/adapters.pyi
@@ -44,12 +44,15 @@ DEFAULT_RETRIES = ...  # type: Any
 
 class BaseAdapter:
     def __init__(self) -> None: ...
-    def send(self, request: PreparedRequest, stream: bool = ...,
+    def send(self,
+             request: PreparedRequest,
+             stream: bool = ...,
              timeout: Union[None, float, Tuple[float, float]] = ...,
-             verify: bool = ...,
-             cert: Union[None, Union[bytes, Text], Container[Union[bytes, Text]]] = ...
-             ) -> Response: ...
+             verify: Union[bool, str] = ...,
+             cert: Union[None, Union[bytes, Text], Container[Union[bytes, Text]]] = ...,
+             proxies: Optional[Mapping[str, str]] = ...) -> Response: ...
     def close(self) -> None: ...
+
 class HTTPAdapter(BaseAdapter):
     __attrs__ = ...  # type: Any
     max_retries = ...  # type: Any
@@ -67,6 +70,10 @@ class HTTPAdapter(BaseAdapter):
     def request_url(self, request, proxies): ...
     def add_headers(self, request, **kwargs): ...
     def proxy_headers(self, proxy): ...
-    # TODO: "request" is not actually optional, modified to please mypy.
-    def send(self, request=..., stream=..., timeout=..., verify=..., cert=...,
-             proxies=...): ...
+    def send(self,
+             request: PreparedRequest,
+             stream: bool = ...,
+             timeout: Union[None, float, Tuple[float, float]] = ...,
+             verify: Union[bool, str] = ...,
+             cert: Union[None, Union[bytes, Text], Container[Union[bytes, Text]]] = ...,
+             proxies: Optional[Mapping[str, str]] = ...) -> Response: ...

--- a/third_party/2and3/requests/adapters.pyi
+++ b/third_party/2and3/requests/adapters.pyi
@@ -1,6 +1,6 @@
 # Stubs for requests.adapters (Python 3)
 
-from typing import Any, Container, Union, Text, Tuple
+from typing import Any, Container, Union, Text, Tuple, Optional, Mapping
 from . import models
 from .packages.urllib3 import poolmanager
 from .packages.urllib3 import response


### PR DESCRIPTION
There is a lot more that can be done here (a LOT of these types are implied `Any` which almost certainly too loose).  I do not have time at the moment to dig too deeply into the requests source to unravel all of the types, but `BaseAdapter.send` and `HTTPAdapter.send` should have the same signature anyway...

The docstrings are:

BaseAdapter:

```py
    def send(self, request, stream=False, timeout=None, verify=True,
             cert=None, proxies=None):
        """Sends PreparedRequest object. Returns Response object.
        :param request: The :class:`PreparedRequest <PreparedRequest>` being sent.
        :param stream: (optional) Whether to stream the request content.
        :param timeout: (optional) How long to wait for the server to send
            data before giving up, as a float, or a :ref:`(connect timeout,
            read timeout) <timeouts>` tuple.
        :type timeout: float or tuple
        :param verify: (optional) Either a boolean, in which case it controls whether we verify
            the server's TLS certificate, or a string, in which case it must be a path
            to a CA bundle to use
        :param cert: (optional) Any user-provided SSL certificate to be trusted.
        :param proxies: (optional) The proxies dictionary to apply to the request.
        """
        raise NotImplementedError
```

HTTPAdapter

```py
    def send(self, request, stream=False, timeout=None, verify=True, cert=None, proxies=None):
        """Sends PreparedRequest object. Returns Response object.
        :param request: The :class:`PreparedRequest <PreparedRequest>` being sent.
        :param stream: (optional) Whether to stream the request content.
        :param timeout: (optional) How long to wait for the server to send
            data before giving up, as a float, or a :ref:`(connect timeout,
            read timeout) <timeouts>` tuple.
        :type timeout: float or tuple or urllib3 Timeout object
        :param verify: (optional) Either a boolean, in which case it controls whether
            we verify the server's TLS certificate, or a string, in which case it
            must be a path to a CA bundle to use
        :param cert: (optional) Any user-provided SSL certificate to be trusted.
        :param proxies: (optional) The proxies dictionary to apply to the request.
        :rtype: requests.Response
        """
```