### PR TITLE
Add stub for pytz.VERSION

### DIFF
--- a/third_party/2and3/pytz/__init__.pyi
+++ b/third_party/2and3/pytz/__init__.pyi
@@ -38,3 +38,4 @@ country_timezones: Mapping[str, List[str]]
 country_names: Mapping[str, str]
 ZERO: datetime.timedelta
 HOUR: datetime.timedelta
+VERSION: str


### PR DESCRIPTION
The `VERSION` variable was missing from the pytz stubs, but it can be useful for applications that want to report which version of pytz they are using, for troubleshooting purposes.