### PR TITLE
zipfile.ZipInfo.__init__ is the same on py2/py3

### DIFF
--- a/stdlib/2and3/zipfile.pyi
+++ b/stdlib/2and3/zipfile.pyi
@@ -87,11 +87,10 @@ class ZipInfo:
     CRC = ...  # type: int
     compress_size = ...  # type: int
     file_size = ...  # type: int
+    def __init__(self, filename: Optional[Text] = ...,
+                 date_time: Optional[_DT] = ...) -> None: ...
     if sys.version_info >= (3, 6):
         def is_dir(self) -> bool: ...
-    if sys.version_info < (3,):
-        def __init__(self, filename: Optional[Text] = ...,
-                     date_time: Optional[_DT] = ...) -> None: ...
 
 
 def is_zipfile(filename: Union[_Path, IO[bytes]]) -> bool: ...


### PR DESCRIPTION
https://github.com/python/cpython/blob/2.7/Lib/zipfile.py#L310
https://github.com/python/cpython/blob/3.7/Lib/zipfile.py#L339