### PR TITLE
Posix Attributes

### DIFF
--- a/stdlib/3/posix.pyi
+++ b/stdlib/3/posix.pyi
@@ -2,6 +2,7 @@
 
 # NOTE: These are incomplete!
 
+import sys
 from typing import NamedTuple, Tuple
 
 class stat_result:
@@ -72,3 +73,79 @@ waitid_result = NamedTuple('waitid_result', [
 sched_param = NamedTuple('sched_priority', [
     ('sched_priority', int),
 ])
+
+
+EX_CANTCREAT: int
+EX_CONFIG: int
+EX_DATAERR: int
+EX_IOERR: int
+EX_NOHOST: int
+EX_NOINPUT: int
+EX_NOPERM: int
+EX_NOTFOUND: int
+EX_NOUSER: int
+EX_OK: int
+EX_OSERR: int
+EX_OSFILE: int
+EX_PROTOCOL: int
+EX_SOFTWARE: int
+EX_TEMPFAIL: int
+EX_UNAVAILABLE: int
+EX_USAGE: int
+
+F_OK: int
+R_OK: int
+W_OK: int
+X_OK: int
+
+if sys.version_info >= (3, 6):
+    GRND_NONBLOCK: int
+    GRND_RANDOM: int
+NGROUPS_MAX: int
+
+O_APPEND: int
+if sys.version_info >= (3, 4):
+    O_ACCMODE: int
+O_ASYNC: int
+O_CREAT: int
+O_DIRECT: int
+O_DIRECTORY: int
+O_DSYNC: int
+O_EXCL: int
+O_LARGEFILE: int
+O_NDELAY: int
+O_NOATIME: int
+O_NOCTTY: int
+O_NOFOLLOW: int
+O_NONBLOCK: int
+O_RDONLY: int
+O_RDWR: int
+O_RSYNC: int
+O_SYNC: int
+O_TRUNC: int
+O_WRONLY: int
+
+ST_APPEND: int
+ST_MANDLOCK: int
+ST_NOATIME: int
+ST_NODEV: int
+ST_NODIRATIME: int
+ST_NOEXEC: int
+ST_NOSUID: int
+ST_RDONLY: int
+ST_RELATIME: int
+ST_SYNCHRONOUS: int
+ST_WRITE: int
+
+TMP_MAX: int
+WCONTINUED: int
+WCOREDUMP: int
+WEXITSTATUS: int
+WIFCONTINUED: int
+WIFEXITED: int
+WIFSIGNALED: int
+WIFSTOPPED: int
+WNOHANG: int
+WSTOPSIG: int
+WTERMSIG: int
+WUNTRACED: int


### PR DESCRIPTION
The posix module in Python 3 lacks some attributes that are present in both os/__init__.pyi and Python 2's posix.pyi.

We should probably consider in the future to just import all of posix with `from posix import *` in `os/__init__.pyi`.