### PR TITLE
Fix handling of logging args

### DIFF
--- a/stdlib/2and3/logging/__init__.pyi
+++ b/stdlib/2and3/logging/__init__.pyi
@@ -114,7 +114,7 @@ class Logger(Filterer):
     def handle(self, record: LogRecord) -> None: ...
     if sys.version_info >= (3,):
         def makeRecord(self, name: str, lvl: int, fn: str, lno: int, msg: Any,
-                       args: Mapping[str, Any],
+                       args: _ArgsType,
                        exc_info: Optional[_SysExcInfoType],
                        func: Optional[str] = ...,
                        extra: Optional[Mapping[str, Any]] = ...,
@@ -122,7 +122,7 @@ class Logger(Filterer):
     else:
         def makeRecord(self,
                        name: str, lvl: int, fn: str, lno: int, msg: Any,
-                       args: Mapping[str, Any],
+                       args: _ArgsType,
                        exc_info: Optional[_SysExcInfoType],
                        func: Optional[str] = ...,
                        extra: Optional[Mapping[str, Any]] = ...) -> LogRecord: ...

--- a/stdlib/2and3/logging/__init__.pyi
+++ b/stdlib/2and3/logging/__init__.pyi
@@ -16,7 +16,7 @@ if sys.version_info >= (3, 5):
     _ExcInfoType = Union[None, bool, _SysExcInfoType, BaseException]
 else:
     _ExcInfoType = Union[None, bool, _SysExcInfoType]
-_ArgsType = Union[Tuple[Any, ...], Dict[str, Any]]
+_ArgsType = Union[Tuple[Any, ...], Mapping[str, Any]]
 _FilterType = Union[Filter, Callable[[LogRecord], int]]
 _Level = Union[int, Text]
 if sys.version_info >= (3, 6):


### PR DESCRIPTION
- The `args` argument of `makeRecord` is passed to `LogMessage`, so passing a `Tuple` in is fine as well.
- `LogRecord.args` can be any mapping, see https://bugs.python.org/issue21172