### PR TITLE
types.CodeType.co_filename isn't Optional.

### DIFF
--- a/stdlib/2/types.pyi
+++ b/stdlib/2/types.pyi
@@ -53,7 +53,7 @@ class CodeType:
     co_cellvars = ...  # type: Tuple[str, ...]
     co_code = ...  # type: str
     co_consts = ...  # type: Tuple[Any, ...]
-    co_filename = ...  # type: Optional[str]
+    co_filename = ...  # type: str
     co_firstlineno = ...  # type: int
     co_flags = ...  # type: int
     co_freevars = ...  # type: Tuple[str, ...]

--- a/stdlib/3/types.pyi
+++ b/stdlib/3/types.pyi
@@ -47,7 +47,7 @@ class CodeType:
     co_consts = ...  # type: Tuple[Any, ...]
     co_names = ...  # type: Tuple[str, ...]
     co_varnames = ...  # type: Tuple[str, ...]
-    co_filename = ...  # type: Optional[str]
+    co_filename = ...  # type: str
     co_name = ...  # type: str
     co_firstlineno = ...  # type: int
     co_lnotab = ...  # type: bytes


### PR DESCRIPTION
`types.CodeType.co_filename` cannot be `None`.