### PR TITLE
decorators.pyi: Add Any to Callable[]

### DIFF
--- a/third_party/2and3/click/decorators.pyi
+++ b/third_party/2and3/click/decorators.pyi
@@ -10,7 +10,7 @@ _F = TypeVar('_F', bound=Callable[..., Any])
 # _Decorator = Callable[[_F], _F]
 
 _Callback = Callable[
-    [Context, Union[Option, Parameter], Union[bool, int, str]],
+    [Context, Union[Option, Parameter], Any],
     Any
 ]
 


### PR DESCRIPTION
This adds `Optional` around `Callable[...]`.

Fixes https://github.com/python/typeshed/issues/2615