### PR TITLE
Revert "Move Sized earlier in the bases of Sequence (#2602)"

### DIFF
--- a/stdlib/2/typing.pyi
+++ b/stdlib/2/typing.pyi
@@ -144,7 +144,7 @@ class Container(Protocol[_T_co]):
     @abstractmethod
     def __contains__(self, x: object) -> bool: ...
 
-class Sequence(Sized, Iterable[_T_co], Container[_T_co], Reversible[_T_co], Generic[_T_co]):
+class Sequence(Iterable[_T_co], Container[_T_co], Sized, Reversible[_T_co], Generic[_T_co]):
     @overload
     @abstractmethod
     def __getitem__(self, i: int) -> _T_co: ...


### PR DESCRIPTION
This reverts commit 4dc21f04dd8c797c20325088837ccab182d5679c.

Fixes #2655.