### PR TITLE
Move posix.stat_result to os.stat_result on python 3

### DIFF
--- a/stdlib/2/os/__init__.pyi
+++ b/stdlib/2/os/__init__.pyi
@@ -11,6 +11,9 @@ from typing import (
 )
 from . import path as path
 
+# Workaround a pytype crash (see #2683)
+from builtins import bytes
+
 _T = TypeVar('_T')
 
 # ----- os variables -----

--- a/stdlib/2/os/path.pyi
+++ b/stdlib/2/os/path.pyi
@@ -2,7 +2,7 @@
 # Stubs for os.path
 # Ron Murawski <ron@horizonchess.com>
 
-from posix import stat_result
+import os
 import sys
 from typing import (
     overload, List, Any, AnyStr, Sequence, Tuple, BinaryIO, TextIO,
@@ -150,7 +150,7 @@ def relpath(path: _StrPath, start: Optional[_StrPath] = ...) -> Text: ...
 
 def samefile(path1: _PathType, path2: _PathType) -> bool: ...
 def sameopenfile(fp1: int, fp2: int) -> bool: ...
-def samestat(stat1: stat_result, stat2: stat_result) -> bool: ...
+def samestat(stat1: os.stat_result, stat2: os.stat_result) -> bool: ...
 
 if sys.version_info >= (3, 6):
     @overload

--- a/stdlib/3/os/__init__.pyi
+++ b/stdlib/3/os/__init__.pyi
@@ -12,6 +12,9 @@ from typing import (
 from builtins import OSError as error
 from . import path as path
 
+# Workaround a pytype crash (see #2683)
+from builtins import bytes
+
 _T = TypeVar('_T')
 
 # ----- os variables -----

--- a/stdlib/3/os/__init__.pyi
+++ b/stdlib/3/os/__init__.pyi
@@ -10,7 +10,6 @@ from typing import (
 
 # Re-exported names from other modules.
 from builtins import OSError as error
-from posix import stat_result as stat_result
 from . import path as path
 
 _T = TypeVar('_T')
@@ -193,6 +192,47 @@ if sys.platform != 'win32':
 TMP_MAX: int  # Undocumented, but used by tempfile
 
 # ----- os classes (structures) -----
+class stat_result:
+    # For backward compatibility, the return value of stat() is also
+    # accessible as a tuple of at least 10 integers giving the most important
+    # (and portable) members of the stat structure, in the order st_mode,
+    # st_ino, st_dev, st_nlink, st_uid, st_gid, st_size, st_atime, st_mtime,
+    # st_ctime. More items may be added at the end by some implementations.
+
+    st_mode: int  # protection bits,
+    st_ino: int  # inode number,
+    st_dev: int  # device,
+    st_nlink: int  # number of hard links,
+    st_uid: int  # user id of owner,
+    st_gid: int  # group id of owner,
+    st_size: int  # size of file, in bytes,
+    st_atime: float  # time of most recent access,
+    st_mtime: float  # time of most recent content modification,
+    st_ctime: float  # platform dependent (time of most recent metadata change on Unix, or the time of creation on Windows)
+    st_atime_ns: int  # time of most recent access, in nanoseconds
+    st_mtime_ns: int  # time of most recent content modification in nanoseconds
+    st_ctime_ns: int  # platform dependent (time of most recent metadata change on Unix, or the time of creation on Windows) in nanoseconds
+
+    # not documented
+    def __init__(self, tuple: Tuple[int, ...]) -> None: ...
+
+    # On some Unix systems (such as Linux), the following attributes may also
+    # be available:
+    st_blocks: int  # number of blocks allocated for file
+    st_blksize: int  # filesystem blocksize
+    st_rdev: int  # type of device if an inode device
+    st_flags: int  # user defined flags for file
+
+    # On other Unix systems (such as FreeBSD), the following attributes may be
+    # available (but may be only filled out if root tries to use them):
+    st_gen: int  # file generation number
+    st_birthtime: int  # time of file creation
+
+    # On Mac OS systems, the following attributes may also be available:
+    st_rsize: int
+    st_creator: int
+    st_type: int
+
 if sys.version_info >= (3, 6):
     from builtins import _PathLike as PathLike  # See comment in builtins
 

--- a/stdlib/3/os/path.pyi
+++ b/stdlib/3/os/path.pyi
@@ -2,7 +2,7 @@
 # Stubs for os.path
 # Ron Murawski <ron@horizonchess.com>
 
-from posix import stat_result
+import os
 import sys
 from typing import (
     overload, List, Any, AnyStr, Sequence, Tuple, BinaryIO, TextIO,
@@ -150,7 +150,7 @@ def relpath(path: _StrPath, start: Optional[_StrPath] = ...) -> Text: ...
 
 def samefile(path1: _PathType, path2: _PathType) -> bool: ...
 def sameopenfile(fp1: int, fp2: int) -> bool: ...
-def samestat(stat1: stat_result, stat2: stat_result) -> bool: ...
+def samestat(stat1: os.stat_result, stat2: os.stat_result) -> bool: ...
 
 if sys.version_info >= (3, 6):
     @overload

--- a/stdlib/3/posix.pyi
+++ b/stdlib/3/posix.pyi
@@ -5,46 +5,7 @@
 import sys
 from typing import NamedTuple, Tuple
 
-class stat_result:
-    # For backward compatibility, the return value of stat() is also
-    # accessible as a tuple of at least 10 integers giving the most important
-    # (and portable) members of the stat structure, in the order st_mode,
-    # st_ino, st_dev, st_nlink, st_uid, st_gid, st_size, st_atime, st_mtime,
-    # st_ctime. More items may be added at the end by some implementations.
-
-    st_mode: int  # protection bits,
-    st_ino: int  # inode number,
-    st_dev: int  # device,
-    st_nlink: int  # number of hard links,
-    st_uid: int  # user id of owner,
-    st_gid: int  # group id of owner,
-    st_size: int  # size of file, in bytes,
-    st_atime: float  # time of most recent access,
-    st_mtime: float  # time of most recent content modification,
-    st_ctime: float  # platform dependent (time of most recent metadata change on Unix, or the time of creation on Windows)
-    st_atime_ns: int  # time of most recent access, in nanoseconds
-    st_mtime_ns: int  # time of most recent content modification in nanoseconds
-    st_ctime_ns: int  # platform dependent (time of most recent metadata change on Unix, or the time of creation on Windows) in nanoseconds
-
-    # not documented
-    def __init__(self, tuple: Tuple[int, ...]) -> None: ...
-
-    # On some Unix systems (such as Linux), the following attributes may also
-    # be available:
-    st_blocks: int  # number of blocks allocated for file
-    st_blksize: int  # filesystem blocksize
-    st_rdev: int  # type of device if an inode device
-    st_flags: int  # user defined flags for file
-
-    # On other Unix systems (such as FreeBSD), the following attributes may be
-    # available (but may be only filled out if root tries to use them):
-    st_gen: int  # file generation number
-    st_birthtime: int  # time of file creation
-
-    # On Mac OS systems, the following attributes may also be available:
-    st_rsize: int
-    st_creator: int
-    st_type: int
+from os import stat_result as stat_result
 
 uname_result = NamedTuple('uname_result', [
     ('sysname', str),


### PR DESCRIPTION
In python 3, posix.stat_result is a re-export of os.stat_result, while
in python 2 it was the reverse. Update typeshed to reflect this.

In some sense this arguably should not matter? It impacts mypyc, though
which perhaps takes typeshed a little too seriously.