### PR TITLE
Fix signature of ConfigParser's dict_type argument

### DIFF
--- a/stdlib/3/configparser.pyi
+++ b/stdlib/3/configparser.pyi
@@ -136,7 +136,7 @@ class RawConfigParser(_parser):
 class ConfigParser(RawConfigParser):
     def __init__(self,
                  defaults: Optional[_section] = ...,
-                 dict_type: Mapping[str, str] = ...,
+                 dict_type: Type[Mapping[str, str]] = ...,
                  allow_no_value: bool = ...,
                  delimiters: Sequence[str] = ...,
                  comment_prefixes: Sequence[str] = ...,


### PR DESCRIPTION
#1572 has fixed `RawConfigParser`'s incorrect `dict_type` signature, but `ConfigParser`'s signature was still incorrect.