### PR TITLE
Add missing ENOTSUP alias to errno

### DIFF
--- a/stdlib/2and3/errno.pyi
+++ b/stdlib/2and3/errno.pyi
@@ -99,6 +99,7 @@ EPROTOTYPE = ...  # type: int
 ENOPROTOOPT = ...  # type: int
 EPROTONOSUPPORT = ...  # type: int
 ESOCKTNOSUPPORT = ...  # type: int
+ENOTSUP = ...  # type: int
 EOPNOTSUPP = ...  # type: int
 EPFNOSUPPORT = ...  # type: int
 EAFNOSUPPORT = ...  # type: int


### PR DESCRIPTION
`ENOTSUP` has the same value as `EOPNOTSUPP`, but is a fairly commonly-used alias and is present in both 2.7 and current 3.x.