### PR TITLE
Add TestCase._outcome, safe_repr, _feedErrorsToResult type defs

### DIFF
--- a/stdlib/3/unittest/__init__.pyi
+++ b/stdlib/3/unittest/__init__.pyi
@@ -8,6 +8,7 @@ from typing import (
 import logging
 import sys
 from types import ModuleType, TracebackType
+from unittest.case import _Outcome, _SysExcInfoType
 
 
 _T = TypeVar('_T')
@@ -30,6 +31,7 @@ class TestCase:
     maxDiff = ...  # type: Optional[int]
     # undocumented
     _testMethodName = ...  # type: str
+    _outcome = ...  # type: Optional[_Outcome]
     def __init__(self, methodName: str = ...) -> None: ...
     def setUp(self) -> None: ...
     def tearDown(self) -> None: ...
@@ -146,6 +148,10 @@ class TestCase:
     def addCleanup(self, function: Callable[..., Any], *args: Any,
                    **kwargs: Any) -> None: ...
     def doCleanups(self) -> None: ...
+    def _feedErrorsToResult(
+        self, result: TestResult,
+        errors: Iterable[Tuple[TestCase, Optional[_SysExcInfoType]]]
+    ) -> None: ...  # undocumented
     def _formatMessage(self, msg: Optional[str], standardMsg: str) -> str: ...  # undocumented
     def _getAssertEqualityFunc(self, first: Any, second: Any) -> Callable[..., None]: ...  # undocumented
     # below is deprecated
@@ -250,10 +256,6 @@ class TestLoader:
                          testCaseClass: Type[TestCase]) -> Sequence[str]: ...
     def discover(self, start_dir: str, pattern: str = ...,
                  top_level_dir: Optional[str] = ...) -> TestSuite: ...
-
-_SysExcInfoType = Tuple[Optional[Type[BaseException]],
-                        Optional[BaseException],
-                        Optional[TracebackType]]
 
 class TestResult:
     errors = ...  # type: List[Tuple[TestCase, str]]

--- a/stdlib/3/unittest/case.pyi
+++ b/stdlib/3/unittest/case.pyi
@@ -1,0 +1,16 @@
+from typing import Iterable, Tuple, Optional, Any, Type
+from types import TracebackType
+
+def __getattr__(name: str) -> Any: ...  # incomplete
+
+_SysExcInfoType = Tuple[
+    Optional[Type[BaseException]], Optional[BaseException], Optional[TracebackType]
+]
+
+# undocumented
+class _Outcome:
+    def __getattr__(name: str) -> Any: ...  # incomplete
+    # Any below should actually be TestCase, but that results in circular
+    # references, and moving TestCase in here means moving a lot of other
+    # pieces around. So, for now, just use Any.
+    errors = ...  # type: Iterable[Tuple[Any, Optional[_SysExcInfoType]]]

--- a/stdlib/3/unittest/util.pyi
+++ b/stdlib/3/unittest/util.pyi
@@ -1,0 +1,3 @@
+from typing import Any
+def __getattr__(name: str) -> Any: ...  # incomplete
+def safe_repr(obj: object, short: bool = ...) -> str: ...


### PR DESCRIPTION
Adds the following undocumented unittest type defs/stubs, which are
used by the absl testing library:

 * TestCase._outcome, _feedErrorsToResult
 * unittest.util.safe_repr
 * unittest.case._Outcome. This class uses Any because of circular
   references with the unitest.TestCase definition; it is an incomplete
   definition.
 * unittest.util and unittest.case are incomplete.

Also moves the _SysExcInfoType def into unittest.case to avoid a
circular reference between unittest.__init__ and unittest.case.

Newly added files are formatted with black to aid auto-formatting them
for future edits.