### PR TITLE
Add Str.kind field to typed_ast stubs

### DIFF
--- a/third_party/3/typed_ast/ast27.pyi
+++ b/third_party/3/typed_ast/ast27.pyi
@@ -246,6 +246,7 @@ class Num(expr):
 
 class Str(expr):
     s = ...  # type: bytes
+    kind = ...  # type: str
 
 class Attribute(expr):
     value = ...  # type: expr

--- a/third_party/3/typed_ast/ast3.pyi
+++ b/third_party/3/typed_ast/ast3.pyi
@@ -264,6 +264,7 @@ class Num(expr):
 
 class Str(expr):
     s = ...  # type: str
+    kind = ...  # type: str
 
 class FormattedValue(expr):
     value = ...  # type: expr


### PR DESCRIPTION
We recently cut a new-ish release of typed-ast that [adds a new field][0] named `kind` to the `ast27.Str` and `ast3.Str` classes. This field stores whatever string modifiers (like `b` or `u`) were present on the original string.

As a note, I've confirmed that this field is indeed a str (and not bytes) for ast27's Str class.

  [0]: https://github.com/python/typed_ast/pull/49