### PR TITLE
Set correct type for _SubParsersAction.choices

### DIFF
--- a/stdlib/2and3/argparse.pyi
+++ b/stdlib/2and3/argparse.pyi
@@ -383,6 +383,7 @@ class _SubParsersAction(Action):
     _prog_prefix: _Text
     _parser_class: Type[ArgumentParser]
     _name_parser_map: Dict[_Text, ArgumentParser]
+    choices: Dict[_Text, ArgumentParser]
     _choices_actions: List[Action]
     def __init__(self,
                  option_strings: Sequence[_Text],


### PR DESCRIPTION
`_SubParsersAction` sets `choices` as an alias for `_name_parser_map`, see https://github.com/python/cpython/blob/a11d44056e4f9b64d28efec295e1c1c45d4cb9e1/Lib/argparse.py#L1097