### PR TITLE
Fixing type for asyncio.StreamWriter reader init parameter (#2718)

### DIFF
--- a/stdlib/3/asyncio/streams.pyi
+++ b/stdlib/3/asyncio/streams.pyi
@@ -76,7 +76,7 @@ class StreamWriter:
     def __init__(self,
                  transport: transports.BaseTransport,
                  protocol: protocols.BaseProtocol,
-                 reader: StreamReader,
+                 reader: Optional[StreamReader],
                  loop: events.AbstractEventLoop) -> None: ...
     @property
     def transport(self) -> transports.BaseTransport: ...


### PR DESCRIPTION
closes #2718 