### PR TITLE
Make ZipFile.NameToInfo use Text as the key type

### DIFF
--- a/stdlib/2and3/zipfile.pyi
+++ b/stdlib/2and3/zipfile.pyi
@@ -28,7 +28,7 @@ class ZipFile:
     comment = ...  # type: bytes
     filelist = ...  # type: List[ZipInfo]
     fp = ...  # type: IO[bytes]
-    NameToInfo = ...  # type: Dict[str, ZipInfo]
+    NameToInfo = ...  # type: Dict[Text, ZipInfo]
     def __init__(self, file: Union[_Path, IO[bytes]], mode: Text = ..., compression: int = ...,
                  allowZip64: bool = ...) -> None: ...
     def __enter__(self) -> ZipFile: ...


### PR DESCRIPTION
This makes it match ZipInfo.filename and also actual behavior.