### PR TITLE
Fix type of indent in JSONEncoder

### DIFF
--- a/stdlib/2/json.pyi
+++ b/stdlib/2/json.pyi
@@ -73,7 +73,7 @@ class JSONEncoder(object):
     check_circular = ...  # type: bool
     allow_nan = ...  # type: bool
     sort_keys = ...  # type: bool
-    indent = ...  # type: int
+    indent = ...  # type: Optional[int]
 
     def __init__(self,
                  skipkeys: bool = ...,
@@ -81,7 +81,7 @@ class JSONEncoder(object):
                  check_circular: bool = ...,
                  allow_nan: bool = ...,
                  sort_keys: bool = ...,
-                 indent: int = ...,
+                 indent: Optional[int] = ...,
                  separators: Tuple[Union[Text, bytes], Union[Text, bytes]] = ...,
                  encoding: Union[Text, bytes] = ...,
                  default: Callable[..., Any] = ...) -> None: ...


### PR DESCRIPTION
A None value for indent means the most compact representation (no newlines), it is also the default value.