### PR TITLE
logging: inherit TimedRotatingFileHandler from Handler

### DIFF
--- a/stdlib/2and3/logging/handlers.pyi
+++ b/stdlib/2and3/logging/handlers.pyi
@@ -80,7 +80,7 @@ if sys.version_info >= (3,):
                          delay: bool = ..., utc: bool = ...) -> None: ...
         def doRollover(self) -> None: ...
 else:
-    class TimedRotatingFileHandler:
+    class TimedRotatingFileHandler(Handler):
         def __init__(self,
                      filename: str, when: str = ..., interval: int = ...,
                      backupCount: int = ..., encoding: Optional[str] = ...,


### PR DESCRIPTION
I've noticed that the stub for `TimedRotatingFileHandler` from `logging.handlers` module does not inherit from the base `Handler` class in python 2 case, which causes mypy to report errors when, for example, you try to add an instance of this handler to a logger.