### PR TITLE
Make metavar in argparse be Optional.

### DIFF
--- a/stdlib/2and3/argparse.pyi
+++ b/stdlib/2and3/argparse.pyi
@@ -62,7 +62,7 @@ class _ActionsContainer:
                      choices: Iterable[_T] = ...,
                      required: bool = ...,
                      help: Optional[_Text] = ...,
-                     metavar: Union[_Text, Tuple[_Text, ...]] = ...,
+                     metavar: Optional[Union[_Text, Tuple[_Text, ...]]] = ...,
                      dest: Optional[_Text] = ...,
                      version: _Text = ...,
                      **kwargs: Any) -> Action: ...
@@ -248,7 +248,7 @@ class Action(_AttributeHolder):
     choices: Optional[Iterable[Any]]
     required: bool
     help: Optional[_Text]
-    metavar: Union[_Text, Tuple[_Text, ...]]
+    metavar: Optional[Union[_Text, Tuple[_Text, ...]]]
 
     def __init__(self,
                  option_strings: Sequence[_Text],


### PR DESCRIPTION
The default value of metavar in  `argparse.Action` is `None`, therefore `argparse.Action.metavar` and the metavar argument of `argparse.ArgumentParser.add_argument` should be `Optional`.

https://github.com/python/cpython/blob/master/Lib/argparse.py#L809
https://github.com/python/cpython/blob/2.7/Lib/argparse.py#L779