### PR TITLE
Support *contiguous attributes of memoryview.

### DIFF
--- a/stdlib/2/__builtin__.pyi
+++ b/stdlib/2/__builtin__.pyi
@@ -771,6 +771,9 @@ class memoryview(Sized, Container[_mv_container_type]):
     ndim: int
 
     if sys.version_info >= (3,):
+        c_contiguous: bool
+        f_contiguous: bool
+        contiguous: bool
         def __init__(self, obj: Union[bytes, bytearray, memoryview]) -> None: ...
         def __enter__(self) -> memoryview: ...
         def __exit__(self, exc_type: Optional[Type[BaseException]], exc_val: Optional[BaseException], exc_tb: Optional[TracebackType]) -> bool: ...

--- a/stdlib/2and3/builtins.pyi
+++ b/stdlib/2and3/builtins.pyi
@@ -771,6 +771,9 @@ class memoryview(Sized, Container[_mv_container_type]):
     ndim: int
 
     if sys.version_info >= (3,):
+        c_contiguous: bool
+        f_contiguous: bool
+        contiguous: bool
         def __init__(self, obj: Union[bytes, bytearray, memoryview]) -> None: ...
         def __enter__(self) -> memoryview: ...
         def __exit__(self, exc_type: Optional[Type[BaseException]], exc_val: Optional[BaseException], exc_tb: Optional[TracebackType]) -> bool: ...


### PR DESCRIPTION
Without this change, here's the problem I encountered:

```
$ cat testmypy.py
def is_c_contiguous(m: memoryview):
    return m.c_contiguous

print(is_c_contiguous(memoryview(b'abc')))
```

```
$ python testmypy.py
True
```

```
$ mypy testmypy.py
testmypy.py:2: error: "memoryview" has no attribute "c_contiguous"
```

With this change, the problem is fixed.

I'm not sure why memoryview is defined in two modules. In doubt, I stuck with the existing style.