### PR TITLE
Make `NamedTuple` accept `Text` names (#2761).

### DIFF
--- a/stdlib/2/typing.pyi
+++ b/stdlib/2/typing.pyi
@@ -457,8 +457,8 @@ def cast(tp: str, obj: Any) -> Any: ...
 class NamedTuple(tuple):
     _fields = ...  # type: Tuple[str, ...]
 
-    def __init__(self, typename: AnyStr,
-                 fields: Iterable[Tuple[AnyStr, Any]] = ..., *,
+    def __init__(self, typename: Union[str, unicode],
+                 fields: Iterable[Tuple[Union[str, unicode], Any]] = ..., *,
                  verbose: bool = ..., rename: bool = ..., **kwargs: Any) -> None: ...
 
     @classmethod

--- a/stdlib/2/typing.pyi
+++ b/stdlib/2/typing.pyi
@@ -457,8 +457,7 @@ def cast(tp: str, obj: Any) -> Any: ...
 class NamedTuple(tuple):
     _fields = ...  # type: Tuple[str, ...]
 
-    def __init__(self, typename: Text,
-                 fields: Iterable[Tuple[Text, Any]] = ..., *,
+    def __init__(self, typename: Text, fields: Iterable[Tuple[Text, Any]] = ..., *,
                  verbose: bool = ..., rename: bool = ..., **kwargs: Any) -> None: ...
 
     @classmethod

--- a/stdlib/2/typing.pyi
+++ b/stdlib/2/typing.pyi
@@ -457,8 +457,8 @@ def cast(tp: str, obj: Any) -> Any: ...
 class NamedTuple(tuple):
     _fields = ...  # type: Tuple[str, ...]
 
-    def __init__(self, typename: Union[str, Text],
-                 fields: Iterable[Tuple[Union[str, Text], Any]] = ..., *,
+    def __init__(self, typename: Text,
+                 fields: Iterable[Tuple[Text, Any]] = ..., *,
                  verbose: bool = ..., rename: bool = ..., **kwargs: Any) -> None: ...
 
     @classmethod

--- a/stdlib/2/typing.pyi
+++ b/stdlib/2/typing.pyi
@@ -457,7 +457,8 @@ def cast(tp: str, obj: Any) -> Any: ...
 class NamedTuple(tuple):
     _fields = ...  # type: Tuple[str, ...]
 
-    def __init__(self, typename: str, fields: Iterable[Tuple[str, Any]] = ..., *,
+    def __init__(self, typename: AnyStr,
+                 fields: Iterable[Tuple[AnyStr, Any]] = ..., *,
                  verbose: bool = ..., rename: bool = ..., **kwargs: Any) -> None: ...
 
     @classmethod

--- a/stdlib/2/typing.pyi
+++ b/stdlib/2/typing.pyi
@@ -457,8 +457,8 @@ def cast(tp: str, obj: Any) -> Any: ...
 class NamedTuple(tuple):
     _fields = ...  # type: Tuple[str, ...]
 
-    def __init__(self, typename: Union[str, unicode],
-                 fields: Iterable[Tuple[Union[str, unicode], Any]] = ..., *,
+    def __init__(self, typename: Union[str, Text],
+                 fields: Iterable[Tuple[Union[str, Text], Any]] = ..., *,
                  verbose: bool = ..., rename: bool = ..., **kwargs: Any) -> None: ...
 
     @classmethod


### PR DESCRIPTION
Both type and field names of `NamedTuple` can be specified with unicode strings now.

This fixes #2761.