### PR TITLE
Improve the stubs in charset.pyi under python3.

### DIFF
--- a/stdlib/3/email/charset.pyi
+++ b/stdlib/3/email/charset.pyi
@@ -1,6 +1,10 @@
 # Stubs for email.charset (Python 3.4)
 
-from typing import List, Optional, Iterator, Any
+from typing import List, Optional, Iterator, Any, Union
+
+QP: int
+BASE64: int
+SHORTEST: int
 
 class Charset:
     input_charset = ...  # type: str
@@ -20,7 +24,7 @@ class Charset:
     def __eq__(self, other: Any) -> bool: ...
     def __ne__(self, other: Any) -> bool: ...
 
-def add_charset(charset: Charset, header_enc: Optional[int] = ...,
+def add_charset(charset: Union[str, Charset], header_enc: Optional[int] = ...,
                 body_enc: Optional[int] = ...,
                 output_charset: Optional[str] = ...) -> None: ...
 def add_alias(alias: str, canonical: str) -> None: ...

--- a/stdlib/3/email/charset.pyi
+++ b/stdlib/3/email/charset.pyi
@@ -1,6 +1,6 @@
 # Stubs for email.charset (Python 3.4)
 
-from typing import List, Optional, Iterator, Any, Union
+from typing import List, Optional, Iterator, Any
 
 QP: int
 BASE64: int
@@ -24,7 +24,7 @@ class Charset:
     def __eq__(self, other: Any) -> bool: ...
     def __ne__(self, other: Any) -> bool: ...
 
-def add_charset(charset: Union[str, Charset], header_enc: Optional[int] = ...,
+def add_charset(charset: str, header_enc: Optional[int] = ...,
                 body_enc: Optional[int] = ...,
                 output_charset: Optional[str] = ...) -> None: ...
 def add_alias(alias: str, canonical: str) -> None: ...


### PR DESCRIPTION
The python3 charset stubs didn't include certain necessary module level
constansts (like `QP`) and too-tightly defined the arguments to some of
the functions in the module. This is no longer the case.

Fixes #2767.