### PR TITLE
Add some missing annotations in cyaml

### DIFF
--- a/third_party/2and3/yaml/cyaml.pyi
+++ b/third_party/2and3/yaml/cyaml.pyi
@@ -1,4 +1,4 @@
-from typing import Text, Union, IO, Optional, Sequence, Mapping, Any
+from typing import Any, IO, Mapping, Optional, Sequence, Text, Union
 from typing_extensions import Protocol
 
 from yaml.constructor import BaseConstructor, Constructor, SafeConstructor
@@ -23,19 +23,22 @@ class CSafeLoader(CParser, SafeConstructor, Resolver):
 
 class CDangerLoader(CParser, Constructor, Resolver): ...  # undocumented
 
-class CEmitter:
-    def __init__(self, stream: IO[Any], canonical: Any = ..., indent: Optional[int] = ...,
-                 width: Optional[int] = ..., allow_unicode: Any = ..., line_break: Optional[str] = ...,
-                 encoding: Optional[str] = ..., explicit_start: Any = ..., explicit_end: Any = ...,
-                 version: Optional[Sequence[int]] = ..., tags: Optional[Mapping[str, str]] = ...) -> None: ...
+class CEmitter(object):
+    def __init__(self, stream: IO[Any], canonical: Optional[Any] = ...,
+                 indent: Optional[int] = ..., width: Optional[int] = ...,
+                 allow_unicode: Optional[Any] = ..., line_break: Optional[str] = ...,
+                 encoding: Optional[Text] = ..., explicit_start: Optional[Any] = ...,
+                 explicit_end: Optional[Any] = ..., version: Optional[Sequence[int]] = ...,
+                 tags: Optional[Mapping[Text, Text]] = ...) -> None: ...
 
 class CBaseDumper(CEmitter, BaseRepresenter, BaseResolver):
     def __init__(self, stream: IO[Any], default_style: Optional[str] = ...,
-                 default_flow_style: Optional[bool] = ..., canonical: Any = ...,
+                 default_flow_style: Optional[bool] = ..., canonical: Optional[Any] = ...,
                  indent: Optional[int] = ..., width: Optional[int] = ...,
-                 allow_unicode: Any = ..., line_break: Optional[str] = ...,
-                 encoding: Optional[str] = ..., explicit_start: Any = ..., explicit_end: Any = ...,
-                 version: Optional[Sequence[int]] = ..., tags: Optional[Mapping[str, str]] = ...) -> None: ...
+                 allow_unicode: Optional[Any] = ..., line_break: Optional[str] = ...,
+                 encoding: Optional[Text] = ..., explicit_start: Optional[Any] = ...,
+                 explicit_end: Optional[Any] = ..., version: Optional[Sequence[int]] = ...,
+                 tags: Optional[Mapping[Text, Text]] = ...) -> None: ...
 
 class CDumper(CEmitter, SafeRepresenter, Resolver): ...
 

--- a/third_party/2and3/yaml/cyaml.pyi
+++ b/third_party/2and3/yaml/cyaml.pyi
@@ -1,8 +1,10 @@
-from typing import Text, Union
+from typing import Text, Union, IO, Optional, Sequence, Mapping, Any
 from typing_extensions import Protocol
 
-from yaml.constructor import BaseConstructor, SafeConstructor
+from yaml.constructor import BaseConstructor, Constructor, SafeConstructor
+from yaml.representer import BaseRepresenter, Representer, SafeRepresenter
 from yaml.resolver import BaseResolver, Resolver
+from yaml.serializer import Serializer
 
 class _Readable(Protocol):
     def read(self, size: int) -> Union[Text, bytes]: ...
@@ -18,3 +20,25 @@ class CLoader(CParser, SafeConstructor, Resolver):
 
 class CSafeLoader(CParser, SafeConstructor, Resolver):
     def __init__(self, stream: Union[str, bytes, _Readable]) -> None: ...
+
+class CDangerLoader(CParser, Constructor, Resolver): ...  # undocumented
+
+class CEmitter:
+    def __init__(self, stream: IO[Any], canonical: Any = ..., indent: Optional[int] = ...,
+                 width: Optional[int] = ..., allow_unicode: Any = ..., line_break: Optional[str] = ...,
+                 encoding: Optional[str] = ..., explicit_start: Any = ..., explicit_end: Any = ...,
+                 version: Optional[Sequence[int]] = ..., tags: Optional[Mapping[str, str]] = ...) -> None: ...
+
+class CBaseDumper(CEmitter, BaseRepresenter, BaseResolver):
+    def __init__(self, stream: IO[Any], default_style: Optional[str] = ...,
+                 default_flow_style: Optional[bool] = ..., canonical: Any = ...,
+                 indent: Optional[int] = ..., width: Optional[int] = ...,
+                 allow_unicode: Any = ..., line_break: Optional[str] = ...,
+                 encoding: Optional[str] = ..., explicit_start: Any = ..., explicit_end: Any = ...,
+                 version: Optional[Sequence[int]] = ..., tags: Optional[Mapping[str, str]] = ...) -> None: ...
+
+class CDumper(CEmitter, SafeRepresenter, Resolver): ...
+
+CSafeDumper = CDumper
+
+class CDangerDumper(CEmitter, Serializer, Representer, Resolver): ...  # undocumented


### PR DESCRIPTION
This pull request wants to resolve #2665. There are some details:

- `CDangerLoader` and `CDangerDumper` is not showed in [document](https://pyyaml.org/wiki/PyYAMLDocumentation). So I add `# undocumented` comment.

- `CEmitter` is defined in Cython extension file [_yaml.pyx#L935](https://github.com/yaml/pyyaml/blob/master/ext/_yaml.pyx#L935). Some variables like `canonical` is just used as a condition, I think it can be any type.

```Python
if canonical:
    yaml_emitter_set_canonical(&self.emitter, 1)
```
- Others are defined in [cyaml.py](https://github.com/yaml/pyyaml/blob/master/lib3/yaml/cyaml.py#L36).