### PR TITLE
pkg_resources Add PKG_INFO str attribute for Distribution class

### DIFF
--- a/third_party/3/pkg_resources/__init__.pyi
+++ b/third_party/3/pkg_resources/__init__.pyi
@@ -120,6 +120,7 @@ def find_distributions(path_item: str, only: bool = ...) -> Generator[Distributi
 def get_distribution(dist: Union[Requirement, str, Distribution]) -> Distribution: ...
 
 class Distribution(IResourceProvider, IMetadataProvider):
+    PKG_INFO: str
     location: str
     project_name: str
     key: str


### PR DESCRIPTION
To avoid
```
error: "Distribution" has no attribute "PKG_INFO"
```
This is the corresponding implementation:
https://github.com/pypa/setuptools/blob/8f82e5077e2d3aab14aa3da636f79d37ff6d7ed7/pkg_resources/__init__.py#L2531