### PR TITLE
Add hidden and deprecated click.Command options

### DIFF
--- a/third_party/2and3/click/core.pyi
+++ b/third_party/2and3/click/core.pyi
@@ -189,6 +189,8 @@ class Command(BaseCommand):
     short_help: Optional[str]
     options_metavar: str
     add_help_option: bool
+    hidden: bool
+    deprecated: bool
 
     def __init__(
         self,
@@ -200,7 +202,9 @@ class Command(BaseCommand):
         epilog: Optional[str] = ...,
         short_help: Optional[str] = ...,
         options_metavar: str = ...,
-        add_help_option: bool = ...
+        add_help_option: bool = ...,
+        hidden: bool = ...,
+        deprecated: bool = ...
     ) -> None:
         ...
 

--- a/third_party/2and3/click/core.pyi
+++ b/third_party/2and3/click/core.pyi
@@ -204,7 +204,7 @@ class Command(BaseCommand):
         options_metavar: str = ...,
         add_help_option: bool = ...,
         hidden: bool = ...,
-        deprecated: bool = ...
+        deprecated: bool = ...,
     ) -> None:
         ...
 

--- a/third_party/2and3/click/decorators.pyi
+++ b/third_party/2and3/click/decorators.pyi
@@ -41,6 +41,8 @@ def command(
     short_help: Optional[str] = ...,
     options_metavar: str = ...,
     add_help_option: bool = ...,
+    hidden: bool = ...,
+    deprecated: bool = ...,
 ) -> Callable[[Callable], Command]:
     ...
 
@@ -64,6 +66,8 @@ def group(
     short_help: Optional[str] = ...,
     options_metavar: str = ...,
     add_help_option: bool = ...,
+    hidden: bool = ...,
+    deprecated: bool = ...,
     # User-defined
     **kwargs: Any,
 ) -> Callable[[Callable], Group]:


### PR DESCRIPTION
`click.Group` class and `click.command` / `click.option` decorators are affected as well