### PR TITLE
Make SyntaxError.offset be optional (again)

### DIFF
--- a/stdlib/2/__builtin__.pyi
+++ b/stdlib/2/__builtin__.pyi
@@ -1494,7 +1494,7 @@ if sys.version_info >= (3, 5):
 class SyntaxError(_StandardError):
     msg: str
     lineno: int
-    offset: int
+    offset: Optional[int]
     text: str
     filename: str
 class SystemError(_StandardError): ...

--- a/stdlib/2and3/builtins.pyi
+++ b/stdlib/2and3/builtins.pyi
@@ -1494,7 +1494,7 @@ if sys.version_info >= (3, 5):
 class SyntaxError(_StandardError):
     msg: str
     lineno: int
-    offset: int
+    offset: Optional[int]
     text: str
     filename: str
 class SystemError(_StandardError): ...


### PR DESCRIPTION
This was originally done in #2557, but got lost in #2533.