### PR TITLE
Remove pytype workaround in os/__init__.pyi.

### DIFF
--- a/requirements-tests-py3.txt
+++ b/requirements-tests-py3.txt
@@ -3,4 +3,4 @@ typed-ast>=1.0.4
 flake8==3.6.0
 flake8-bugbear==18.8.0
 flake8-pyi==18.3.1
-pytype>=2018.9.19
+pytype>=2019.2.13

--- a/stdlib/2/os/__init__.pyi
+++ b/stdlib/2/os/__init__.pyi
@@ -11,9 +11,6 @@ from typing import (
 )
 from . import path as path
 
-# Workaround a pytype crash (see #2683)
-from builtins import bytes
-
 _T = TypeVar('_T')
 
 # ----- os variables -----

--- a/stdlib/3/os/__init__.pyi
+++ b/stdlib/3/os/__init__.pyi
@@ -12,9 +12,6 @@ from typing import (
 from builtins import OSError as error
 from . import path as path
 
-# Workaround a pytype crash (see #2683)
-from builtins import bytes
-
 _T = TypeVar('_T')
 
 # ----- os variables -----


### PR DESCRIPTION
Pytype release 2019.02.13 fixed the bug that
necessitated this workaround.