### PR TITLE
Fix named tuple name in posix.pyi

### DIFF
--- a/stdlib/3/posix.pyi
+++ b/stdlib/3/posix.pyi
@@ -31,7 +31,7 @@ waitid_result = NamedTuple('waitid_result', [
     ('si_code', int),
 ])
 
-sched_param = NamedTuple('sched_priority', [
+sched_param = NamedTuple('sched_param', [
     ('sched_priority', int),
 ])
 


### PR DESCRIPTION
This caused problems with new semantic analyzer in mypy (and didn't match runtime)