### PR TITLE
socket: timeout may be None

### DIFF
--- a/stdlib/2and3/socket.pyi
+++ b/stdlib/2and3/socket.pyi
@@ -537,7 +537,7 @@ class socket:
     @overload
     def getsockopt(self, level: int, optname: int, buflen: int) -> bytes: ...
 
-    def gettimeout(self) -> float: ...
+    def gettimeout(self) -> Optional[float]: ...
     def ioctl(self, control: object,
               option: Tuple[int, int, int]) -> None: ...
     if sys.version_info < (3, 5):
@@ -579,7 +579,7 @@ class socket:
 
 # ----- functions -----
 def create_connection(address: Tuple[Optional[str], int],
-                      timeout: float = ...,
+                      timeout: Optional[float] = ...,
                       source_address: Tuple[Union[bytearray, bytes, Text], int] = ...) -> socket: ...
 
 # the 5th tuple item is an address


### PR DESCRIPTION
timeout=None puts the socket into blocking mode.

```
import socket

s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
assert s.gettimeout() is None
s.settimeout(None)
assert s.gettimeout() is None

assert socket.getdefaulttimeout() is None
socket.setdefaulttimeout(None)
assert socket.getdefaulttimeout() is None

socket.setdefaulttimeout(0.01)
try:
    s = socket.create_connection(('github.com', 443))
    # this defaults to timeout=socket._GLOBAL_DEFAULT_TIMEOUT, which
    # triggers code in socket.py to use socket.getdefaulttimeout()
except socket.timeout:
    pass
s = socket.create_connection(('github.com', 443), timeout=None)
 # this will wait infinitely
```

Read <https://bugs.python.org/issue18417> and the referenced other
issues for more gory details.

This is split from <https://github.com/python/typeshed/pull/2688/commits/46d856847e5bcced97b974fa9060212e9cb71674>