### PR TITLE
Add Restart to pdb.pyi

### DIFF
--- a/stdlib/2and3/pdb.pyi
+++ b/stdlib/2and3/pdb.pyi
@@ -3,6 +3,8 @@
 import sys
 from typing import Any, Dict, Optional
 
+class Restart(Exception): ...
+
 def run(statement: str, globals: Optional[Dict[str, Any]] = ...,
         locals: Optional[Dict[str, Any]] = ...) -> None: ...
 def runeval(expression: str, globals: Optional[Dict[str, Any]] = ...,


### PR DESCRIPTION
Add `Restart` class to `pdb.pyi`, which has no internal implementation.

|head|location|
|---|---|
|master|https://github.com/python/cpython/blob/master/Lib/pdb.py#L85
|3.7|https://github.com/python/cpython/blob/3.7/Lib/pdb.py#L85|
|2.7|https://github.com/python/cpython/blob/2.7/Lib/pdb.py#L18|