### PR TITLE
README.md suggests running tests with PYTHONPATH instead of MYPYPATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,10 +135,10 @@ For mypy, if you are in the typeshed repo that is submodule of the
 mypy repo (so `..` refers to the mypy repo), there's a shortcut to run
 the mypy tests that avoids installing mypy:
 ```bash
-$ MYPYPATH=.. python3 tests/mypy_test.py
+$ PYTHONPATH=../.. python3 tests/mypy_test.py
 ```
 You can mypy tests to a single version by passing `-p2` or `-p3.5` e.g.
 ```bash
-$ MYPYPATH=.. python3 tests/mypy_test.py -p3.5
+$ PYTHONPATH=../.. python3 tests/mypy_test.py -p3.5
 running mypy --python-version 3.5 --strict-optional # with 342 files
 ```

--- a/README.md
+++ b/README.md
@@ -135,10 +135,10 @@ For mypy, if you are in the typeshed repo that is submodule of the
 mypy repo (so `..` refers to the mypy repo), there's a shortcut to run
 the mypy tests that avoids installing mypy:
 ```bash
-$ PYTHONPATH=.. python3 tests/mypy_test.py
+$ MYPYPATH=.. python3 tests/mypy_test.py
 ```
 You can mypy tests to a single version by passing `-p2` or `-p3.5` e.g.
 ```bash
-$ PYTHONPATH=.. python3 tests/mypy_test.py -p3.5
+$ MYPYPATH=.. python3 tests/mypy_test.py -p3.5
 running mypy --python-version 3.5 --strict-optional # with 342 files
 ```


### PR DESCRIPTION
The README suggests that when you've checked out `typeshed` as a submodule of `mypy` you can set `PYTHONPATH=..` before running tests ... but this causes slightly odd errors (like `ImportError: cannot import name 'WrapperDescriptorType' from 'types'`). It turns out that this is because we should instead be using the `MYPYPATH` variable.