### PR TITLE
feat: sunder names in enum

### DIFF
--- a/stdlib/3/enum.pyi
+++ b/stdlib/3/enum.pyi
@@ -32,6 +32,22 @@ class Enum(metaclass=EnumMeta):
     name = ...  # type: str
     value = ...  # type: Any
 
+    _name_ = ...  # type: str
+    _value_ = ...  # type: Any
+
+    if sys.version_info >= (3, 7):
+        _ignore_ = ...  # type: List[str]
+
+    if sys.version_info >= (3, 6):
+        _order_ = ...  # type: str
+
+        @classmethod
+        def _missing_(cls: Type[_T], value: object) -> Any: ...
+
+        @staticmethod
+        def _generate_next_value_(name: str, start: int,
+                                  count: int, last_values: List[Any]) -> Any: ...
+
 class IntEnum(int, Enum):
     value = ...  # type: int
 

--- a/stdlib/3/enum.pyi
+++ b/stdlib/3/enum.pyi
@@ -21,6 +21,18 @@ class EnumMeta(ABCMeta):
     def __len__(self) -> int: ...
 
 class Enum(metaclass=EnumMeta):
+    name: str
+    value: Any
+    _name_: str
+    _value_: Any
+    if sys.version_info >= (3, 7):
+        _ignore_: Union[str, List[str]]
+    if sys.version_info >= (3, 6):
+        _order_: str
+        @classmethod
+        def _missing_(cls, value: object) -> Any: ...
+        @staticmethod
+        def _generate_next_value_(name: str, start: int, count: int, last_values: List[Any]) -> Any: ...
     def __new__(cls: Type[_T], value: object) -> _T: ...
     def __repr__(self) -> str: ...
     def __str__(self) -> str: ...
@@ -29,36 +41,17 @@ class Enum(metaclass=EnumMeta):
     def __hash__(self) -> Any: ...
     def __reduce_ex__(self, proto: object) -> Any: ...
 
-    name = ...  # type: str
-    value = ...  # type: Any
-
-    _name_ = ...  # type: str
-    _value_ = ...  # type: Any
-
-    if sys.version_info >= (3, 7):
-        _ignore_ = ...  # type: Union[str, List[str]]
-
-    if sys.version_info >= (3, 6):
-        _order_ = ...  # type: str
-
-        @classmethod
-        def _missing_(cls, value: object) -> Any: ...
-
-        @staticmethod
-        def _generate_next_value_(name: str, start: int,
-                                  count: int, last_values: List[Any]) -> Any: ...
-
 class IntEnum(int, Enum):
-    value = ...  # type: int
+    value: int
 
 def unique(enumeration: _S) -> _S: ...
 
 if sys.version_info >= (3, 6):
-    _auto_null = ...  # type: Any
+    _auto_null: Any
 
     # subclassing IntFlag so it picks up all implemented base functions, best modeling behavior of enum.auto()
     class auto(IntFlag):
-        value = ...  # type: Any
+        value: Any
 
     class Flag(Enum):
         def __contains__(self: _T, other: _T) -> bool: ...

--- a/stdlib/3/enum.pyi
+++ b/stdlib/3/enum.pyi
@@ -36,13 +36,13 @@ class Enum(metaclass=EnumMeta):
     _value_ = ...  # type: Any
 
     if sys.version_info >= (3, 7):
-        _ignore_ = ...  # type: List[str]
+        _ignore_ = ...  # type: Union[str, List[str]]
 
     if sys.version_info >= (3, 6):
         _order_ = ...  # type: str
 
         @classmethod
-        def _missing_(cls: Type[_T], value: object) -> Any: ...
+        def _missing_(cls, value: object) -> Any: ...
 
         @staticmethod
         def _generate_next_value_(name: str, start: int,

--- a/third_party/2/enum.pyi
+++ b/third_party/2/enum.pyi
@@ -32,6 +32,22 @@ class Enum(metaclass=EnumMeta):
     name = ...  # type: str
     value = ...  # type: Any
 
+    _name_ = ...  # type: str
+    _value_ = ...  # type: Any
+
+    if sys.version_info >= (3, 7):
+        _ignore_ = ...  # type: List[str]
+
+    if sys.version_info >= (3, 6):
+        _order_ = ...  # type: str
+
+        @classmethod
+        def _missing_(cls: Type[_T], value: object) -> Any: ...
+
+        @staticmethod
+        def _generate_next_value_(name: str, start: int,
+                                  count: int, last_values: List[Any]) -> Any: ...
+
 class IntEnum(int, Enum):
     value = ...  # type: int
 

--- a/third_party/2/enum.pyi
+++ b/third_party/2/enum.pyi
@@ -21,6 +21,18 @@ class EnumMeta(ABCMeta):
     def __len__(self) -> int: ...
 
 class Enum(metaclass=EnumMeta):
+    name: str
+    value: Any
+    _name_: str
+    _value_: Any
+    if sys.version_info >= (3, 7):
+        _ignore_: Union[str, List[str]]
+    if sys.version_info >= (3, 6):
+        _order_: str
+        @classmethod
+        def _missing_(cls, value: object) -> Any: ...
+        @staticmethod
+        def _generate_next_value_(name: str, start: int, count: int, last_values: List[Any]) -> Any: ...
     def __new__(cls: Type[_T], value: object) -> _T: ...
     def __repr__(self) -> str: ...
     def __str__(self) -> str: ...
@@ -29,36 +41,17 @@ class Enum(metaclass=EnumMeta):
     def __hash__(self) -> Any: ...
     def __reduce_ex__(self, proto: object) -> Any: ...
 
-    name = ...  # type: str
-    value = ...  # type: Any
-
-    _name_ = ...  # type: str
-    _value_ = ...  # type: Any
-
-    if sys.version_info >= (3, 7):
-        _ignore_ = ...  # type: Union[str, List[str]]
-
-    if sys.version_info >= (3, 6):
-        _order_ = ...  # type: str
-
-        @classmethod
-        def _missing_(cls, value: object) -> Any: ...
-
-        @staticmethod
-        def _generate_next_value_(name: str, start: int,
-                                  count: int, last_values: List[Any]) -> Any: ...
-
 class IntEnum(int, Enum):
-    value = ...  # type: int
+    value: int
 
 def unique(enumeration: _S) -> _S: ...
 
 if sys.version_info >= (3, 6):
-    _auto_null = ...  # type: Any
+    _auto_null: Any
 
     # subclassing IntFlag so it picks up all implemented base functions, best modeling behavior of enum.auto()
     class auto(IntFlag):
-        value = ...  # type: Any
+        value: Any
 
     class Flag(Enum):
         def __contains__(self: _T, other: _T) -> bool: ...

--- a/third_party/2/enum.pyi
+++ b/third_party/2/enum.pyi
@@ -36,13 +36,13 @@ class Enum(metaclass=EnumMeta):
     _value_ = ...  # type: Any
 
     if sys.version_info >= (3, 7):
-        _ignore_ = ...  # type: List[str]
+        _ignore_ = ...  # type: Union[str, List[str]]
 
     if sys.version_info >= (3, 6):
         _order_ = ...  # type: str
 
         @classmethod
-        def _missing_(cls: Type[_T], value: object) -> Any: ...
+        def _missing_(cls, value: object) -> Any: ...
 
         @staticmethod
         def _generate_next_value_(name: str, start: int,


### PR DESCRIPTION
This pull request wants to resolve #2766. Some details list here:

Python [enum doc](https://docs.python.org/3/library/enum.html#supported-sunder-names)

> Supported `_sunder_` names
> 
>  - `_name_` – name of the member
>  - `_value_` – value of the member; can be set / modified in `__new__`
>  - `_missing_` – a lookup function used when a value is not found; may be overridden
>  - `_ignore_` – a list of names, either as a `list(`) or a `str()`, that will not be transformed into members, and will be removed from the final class
>  - ` _order_` – used in Python 2/3 code to ensure member order is consistent (class attribute, removed during class creation)
>  - `_generate_next_value_` – used by the Functional API and by auto to get an appropriate value for an enum member; may be overridden
> 
> New in version 3.6: `_missing_`, `_order_`, `_generate_next_value_`
> 
> New in version 3.7: `_ignore_`

From https://github.com/python/cpython/blob/848037c1476ddf86dd2798fca35527a63c764a8a/Lib/enum.py#L653-L661

```Python
    @DynamicClassAttribute
    def name(self):
        """The name of the Enum member."""
        return self._name_

    @DynamicClassAttribute
    def value(self):
        """The value of the Enum member."""
        return self._value_
```

`name` and `value` both are wrapper of `_name_` and `_value`.

From https://github.com/python/cpython/blob/848037c1476ddf86dd2798fca35527a63c764a8a/Lib/enum.py#L575-L581

```Python
        # still not found -- try _missing_ hook
        try:
            exc = None
            result = cls._missing_(value)
        except Exception as e:
            exc = e
            result = None
```
The type of `value` should to be consistent with `__new__` parameter which is `object`. But the return type is not determinate. It seems like it can be `Any`.

From the doc example,  `_order_` should be `str`.

I'm not sure about `_generate_next_value_`. From https://github.com/python/cpython/blob/848037c1476ddf86dd2798fca35527a63c764a8a/Lib/enum.py#L380-L406

```Python
        if isinstance(names, (tuple, list)) and names and isinstance(names[0], str):
            original_names, names = names, []
            last_values = []
            for count, name in enumerate(original_names):
                value = first_enum._generate_next_value_(name, start, count, last_values[:])
                last_values.append(value)
                names.append((name, value))
```

It can infer that `name` is `str`, `start` is `int`, `count` is `int` and `last_values` could be `List[Any]`.  But in the docstring of `Flag`(subclass of `Enum`).

```
        name: the name of the member
        start: the initital start value or None
        count: the number of existing members
        last_value: the last value assigned or None
```

`start` could be `None`. But I don't see anywhere passing `None`.

Another problem is `_generate_next_value_` is not decorated by `staticmethod`, mypy will report `Self argument missing for a non-static method (or an invalid type for self)`. 