### PR TITLE
Removed extraneous import statement

### DIFF
--- a/third_party/2and3/markupsafe/__init__.pyi
+++ b/third_party/2and3/markupsafe/__init__.pyi
@@ -4,7 +4,6 @@ from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Text
 from collections import Mapping
 from markupsafe._compat import text_type
 import string
-from markupsafe._speedups import escape as escape, escape_silent as escape_silent, soft_unicode as soft_unicode
 from markupsafe._native import escape as escape, escape_silent as escape_silent, soft_unicode as soft_unicode
 
 class Markup(text_type):


### PR DESCRIPTION
Removed extraneous import statement that was redefining three symbols in markupsafe/__init__.py. This redefinition triggered type checking/linting errors.