### PR TITLE
Added default setup.cfg for test/mypy_test.py to not use the .mypy.ini in home directory

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[mypy]
+
+[pytype]
+
+[flake8]


### PR DESCRIPTION
This is a partial fix for #2852 - it fixes `mypy_test.py` operation.