### PR TITLE
Support new ast features and node types introduced in Python 3.8

### DIFF
--- a/stdlib/3/_ast.pyi
+++ b/stdlib/3/_ast.pyi
@@ -10,12 +10,13 @@ class AST:
     _attributes: ClassVar[typing.Tuple[str, ...]]
     _fields: ClassVar[typing.Tuple[str, ...]]
     def __init__(self, *args: Any, **kwargs: Any) -> None: ...
+    # TODO: Not all nodes have all of the following attributes
     lineno: int
-    col_offset: int  # TODO: Not all nodes have this
+    col_offset: int
     if sys.version_info >= (3, 8):
-        end_lineno: int
-        end_col_offset: int  # TODO: Not all nodes have this
-        type_comment: Optional[str]  # TODO: Only put this where it exists
+        end_lineno: Optional[int]
+        end_col_offset: Optional[int]
+        type_comment: Optional[str]
 
 class mod(AST):
     ...
@@ -26,8 +27,8 @@ if sys.version_info >= (3, 8):
     class TypeIgnore(type_ignore): ...
 
     class FunctionType(mod):
-        argtypes = ...  # type: typing.List[expr]
-        returns = ...  # type: expr
+        argtypes: typing.List[expr]
+        returns: expr
 
 class Module(mod):
     body = ...  # type: typing.List[stmt]
@@ -247,13 +248,11 @@ class Call(expr):
     args = ...  # type: typing.List[expr]
     keywords = ...  # type: typing.List[keyword]
 
-class Num(expr):
-    n = ...  # type: float
+class Num(expr):  # Deprecated in 3.8; use Constant
+    n = ...  # type: complex
 
-class Str(expr):
+class Str(expr):  # Deprecated in 3.8; use Constant
     s = ...  # type: str
-    if sys.version_info >= (3, 7):
-        kind = ...  # type: str
 
 if sys.version_info >= (3, 6):
     class FormattedValue(expr):
@@ -264,7 +263,7 @@ if sys.version_info >= (3, 6):
     class JoinedStr(expr):
         values = ...  # type: typing.List[expr]
 
-class Bytes(expr):
+class Bytes(expr):  # Deprecated in 3.8; use Constant
     s = ...  # type: bytes
 
 class NameConstant(expr):
@@ -272,11 +271,15 @@ class NameConstant(expr):
 
 if sys.version_info >= (3, 8):
     class Constant(expr):
-        value = ...  # type: expr
+        value: Any  # None, str, bytes, bool, int, float, complex, Ellipsis
+        kind: Optional[str]
+        # Aliases for value, for backwards compatibility
+        s: Any
+        n: complex
 
     class NamedExpr(expr):
-        target = ...  # type: expr
-        value = ...  # type: expr
+        target: expr
+        value: expr
 
 class Ellipsis(expr): ...
 

--- a/stdlib/3/_ast.pyi
+++ b/stdlib/3/_ast.pyi
@@ -11,15 +11,30 @@ class AST:
     _fields: ClassVar[typing.Tuple[str, ...]]
     def __init__(self, *args: Any, **kwargs: Any) -> None: ...
     lineno: int
-    col_offset: int
+    col_offset: int  # TODO: Not all nodes have this
+    if sys.version_info >= (3, 8):
+        end_lineno: int
+        end_col_offset: int  # TODO: Not all nodes have this
+        type_comment: Optional[str]  # TODO: Only put this where it exists
 
 class mod(AST):
     ...
+
+if sys.version_info >= (3, 8):
+    class type_ignore(AST): ...
+
+    class TypeIgnore(type_ignore): ...
+
+    class FunctionType(mod):
+        argtypes = ...  # type: typing.List[expr]
+        returns = ...  # type: expr
 
 class Module(mod):
     body = ...  # type: typing.List[stmt]
     if sys.version_info >= (3, 7):
         docstring: Optional[str]
+    if sys.version_info >= (3, 8):
+        type_ignores: typing.List[TypeIgnore]
 
 class Interactive(mod):
     body = ...  # type: typing.List[stmt]
@@ -237,6 +252,8 @@ class Num(expr):
 
 class Str(expr):
     s = ...  # type: str
+    if sys.version_info >= (3, 7):
+        kind = ...  # type: str
 
 if sys.version_info >= (3, 6):
     class FormattedValue(expr):
@@ -252,6 +269,14 @@ class Bytes(expr):
 
 class NameConstant(expr):
     value = ...  # type: Any
+
+if sys.version_info >= (3, 8):
+    class Constant(expr):
+        value = ...  # type: expr
+
+    class NamedExpr(expr):
+        target = ...  # type: expr
+        value = ...  # type: expr
 
 class Ellipsis(expr): ...
 

--- a/stdlib/3/ast.pyi
+++ b/stdlib/3/ast.pyi
@@ -1,5 +1,6 @@
 # Python 3.5 ast
 
+import sys
 # Rename typing to _typing, as not to conflict with typing imported
 # from _ast below when loaded in an unorthodox way by the Dropbox
 # internal Bazel integration.
@@ -17,7 +18,12 @@ class NodeTransformer(NodeVisitor):
 
 _T = TypeVar('_T', bound=AST)
 
-def parse(source: Union[str, bytes], filename: Union[str, bytes] = ..., mode: str = ...) -> Module: ...
+if sys.version_info >= (3, 8):
+    def parse(source: Union[str, bytes], filename: Union[str, bytes] = ..., mode: str = ...,
+              type_comments: bool = ..., feature_version: int = ...) -> AST: ...
+else:
+    def parse(source: Union[str, bytes], filename: Union[str, bytes] = ..., mode: str = ...) -> AST: ...
+
 def copy_location(new_node: _T, old_node: AST) -> _T: ...
 def dump(node: AST, annotate_fields: bool = ..., include_attributes: bool = ...) -> str: ...
 def fix_missing_locations(node: _T) -> _T: ...


### PR DESCRIPTION
Specifically:

- New classes `TypeIgnore`, `FunctionType`, `Constant` and `NamedExpr`
- New `AST` attributes `end_lineno`, `end_col_offset`, and `type_comment`
- New attribute `Module.type_ignores`
- New attribute `Str.kind` (that's new in 3.7 actually)
- New keyword args for `ast.parse()`: `type_comments=<bool>` and `feature_version=<int>`

I had to adjust the return type of `ast.parse()` from Module to `AST`, which is more truthful anyways.