### PR TITLE
Remove an unused import from stdlib/3/importlib/__init__.pyi.

### DIFF
--- a/stdlib/3/importlib/__init__.pyi
+++ b/stdlib/3/importlib/__init__.pyi
@@ -1,4 +1,3 @@
-from importlib import util
 from importlib.abc import Loader
 import sys
 import types


### PR DESCRIPTION
pytype has trouble resolving unused imports, since it looks at usage
to distinguish submodules from other imports.