### PR TITLE
Add missing class pdb.Pdb.

### DIFF
--- a/stdlib/2and3/pdb.pyi
+++ b/stdlib/2and3/pdb.pyi
@@ -51,6 +51,8 @@ class Pdb(Cmd):
             stdout: Optional[IO[str]] = ...,
             skip: Optional[Iterable[str]] = ...,
         ) -> None: ...
+    # TODO: The run* and set_trace() methods are actually defined on bdb.Bdb, from which Pdb inherits.
+    # Move these methods there once we have a bdb stub.
     def run(self, statement: str, globals: Optional[Dict[str, Any]] = ...,
             locals: Optional[Dict[str, Any]] = ...) -> None: ...
     def runeval(self, expression: str, globals: Optional[Dict[str, Any]] = ...,

--- a/stdlib/2and3/pdb.pyi
+++ b/stdlib/2and3/pdb.pyi
@@ -1,7 +1,8 @@
 # NOTE: This stub is incomplete - only contains some global functions
 
+from cmd import Cmd
 import sys
-from typing import Any, Dict, Optional
+from typing import Any, Dict, IO, Iterable, Optional
 
 class Restart(Exception): ...
 
@@ -19,3 +20,41 @@ else:
 
 def post_mortem(t: Optional[Any] = ...) -> None: ...
 def pm() -> None: ...
+
+class Pdb(Cmd):
+    if sys.version_info >= (3, 6):
+        def __init__(
+            self,
+            completekey: str = ...,
+            stdin: Optional[IO[str]] = ...,
+            stdout: Optional[IO[str]] = ...,
+            skip: Iterable[str] = ...,
+            nosigint: bool = ...,
+            readrc: bool = ...,
+        ) -> None: ...
+    elif sys.version_info >= (3, 2):
+        def __init__(
+            self,
+            completekey: str = ...,
+            stdin: Optional[IO[str]] = ...,
+            stdout: Optional[IO[str]] = ...,
+            skip: Iterable[str] = ...,
+            nosigint: bool = ...,
+        ) -> None: ...
+    else:
+        def __init__(
+            self,
+            completekey: str = ...,
+            stdin: Optional[IO[str]] = ...,
+            stdout: Optional[IO[str]] = ...,
+            skip: Iterable[str] = ...,
+        ) -> None: ...
+    def run(self, statement: str, globals: Optional[Dict[str, Any]] = ...,
+            locals: Optional[Dict[str, Any]] = ...) -> None: ...
+    def runeval(self, expression: str, globals: Optional[Dict[str, Any]] = ...,
+                locals: Optional[Dict[str, Any]] = ...) -> Any: ...
+    def runcall(self, *args: Any, **kwds: Any) -> Any: ...
+    if sys.version_info >= (3, 7):
+        def set_trace(self, *, header: Optional[str] = ...) -> None: ...
+    else:
+        def set_trace(self) -> None: ...

--- a/stdlib/2and3/pdb.pyi
+++ b/stdlib/2and3/pdb.pyi
@@ -28,7 +28,7 @@ class Pdb(Cmd):
             completekey: str = ...,
             stdin: Optional[IO[str]] = ...,
             stdout: Optional[IO[str]] = ...,
-            skip: Iterable[str] = ...,
+            skip: Optional[Iterable[str]] = ...,
             nosigint: bool = ...,
             readrc: bool = ...,
         ) -> None: ...
@@ -38,7 +38,7 @@ class Pdb(Cmd):
             completekey: str = ...,
             stdin: Optional[IO[str]] = ...,
             stdout: Optional[IO[str]] = ...,
-            skip: Iterable[str] = ...,
+            skip: Optional[Iterable[str]] = ...,
             nosigint: bool = ...,
         ) -> None: ...
     else:
@@ -47,7 +47,7 @@ class Pdb(Cmd):
             completekey: str = ...,
             stdin: Optional[IO[str]] = ...,
             stdout: Optional[IO[str]] = ...,
-            skip: Iterable[str] = ...,
+            skip: Optional[Iterable[str]] = ...,
         ) -> None: ...
     def run(self, statement: str, globals: Optional[Dict[str, Any]] = ...,
             locals: Optional[Dict[str, Any]] = ...) -> None: ...

--- a/stdlib/2and3/pdb.pyi
+++ b/stdlib/2and3/pdb.pyi
@@ -2,6 +2,7 @@
 
 from cmd import Cmd
 import sys
+from types import FrameType
 from typing import Any, Callable, Dict, IO, Iterable, Optional, TypeVar
 
 _T = TypeVar('_T')
@@ -58,7 +59,4 @@ class Pdb(Cmd):
     def runeval(self, expression: str, globals: Optional[Dict[str, Any]] = ...,
                 locals: Optional[Dict[str, Any]] = ...) -> Any: ...
     def runcall(self, func: Callable[..., _T], *args: Any, **kwds: Any) -> Optional[_T]: ...
-    if sys.version_info >= (3, 7):
-        def set_trace(self, *, header: Optional[str] = ...) -> None: ...
-    else:
-        def set_trace(self) -> None: ...
+    def set_trace(self, frame: Optional[FrameType] = ...) -> None: ...

--- a/stdlib/2and3/pdb.pyi
+++ b/stdlib/2and3/pdb.pyi
@@ -2,7 +2,9 @@
 
 from cmd import Cmd
 import sys
-from typing import Any, Dict, IO, Iterable, Optional
+from typing import Any, Callable, Dict, IO, Iterable, Optional, TypeVar
+
+_T = TypeVar('_T')
 
 class Restart(Exception): ...
 
@@ -53,7 +55,7 @@ class Pdb(Cmd):
             locals: Optional[Dict[str, Any]] = ...) -> None: ...
     def runeval(self, expression: str, globals: Optional[Dict[str, Any]] = ...,
                 locals: Optional[Dict[str, Any]] = ...) -> Any: ...
-    def runcall(self, *args: Any, **kwds: Any) -> Any: ...
+    def runcall(self, func: Callable[..., _T], *args: Any, **kwds: Any) -> Optional[_T]: ...
     if sys.version_info >= (3, 7):
         def set_trace(self, *, header: Optional[str] = ...) -> None: ...
     else:


### PR DESCRIPTION
Based on: https://docs.python.org/3/library/pdb.html#pdb.Pdb,
with the one difference that the `skip` argument to the
constructor is present in 2.7 despite being listed as new in 3.1.