### PR TITLE
Remove asyncio.tasks from the pytype blacklist.

### DIFF
--- a/requirements-tests-py3.txt
+++ b/requirements-tests-py3.txt
@@ -3,4 +3,4 @@ typed-ast>=1.0.4
 flake8==3.6.0
 flake8-bugbear==18.8.0
 flake8-pyi==18.3.1
-pytype>=2019.2.13
+pytype>=2019.3.15

--- a/tests/pytype_blacklist.txt
+++ b/tests/pytype_blacklist.txt
@@ -7,7 +7,3 @@ stdlib/2/typing.pyi
 stdlib/2and3/builtins.pyi
 stdlib/3/typing.pyi
 stdlib/3/collections/__init__.pyi # parse only
-
-# pytype doesn't yet support aliases with implicit type parameters
-# (e.g., here, FutureT = Future[T])
-stdlib/3/asyncio/tasks.pyi


### PR DESCRIPTION
With version 2019.03.15, pytype is able to parse this file.