### PR TITLE
Add missing BaseException.__suppress_context__ attribute

### DIFF
--- a/stdlib/2/__builtin__.pyi
+++ b/stdlib/2/__builtin__.pyi
@@ -1451,6 +1451,7 @@ class BaseException(object):
     if sys.version_info >= (3,):
         __cause__: Optional[BaseException]
         __context__: Optional[BaseException]
+        __suppress_context__: bool
         __traceback__: Optional[TracebackType]
     def __init__(self, *args: object) -> None: ...
     if sys.version_info < (3,):

--- a/stdlib/2and3/builtins.pyi
+++ b/stdlib/2and3/builtins.pyi
@@ -1451,6 +1451,7 @@ class BaseException(object):
     if sys.version_info >= (3,):
         __cause__: Optional[BaseException]
         __context__: Optional[BaseException]
+        __suppress_context__: bool
         __traceback__: Optional[TracebackType]
     def __init__(self, *args: object) -> None: ...
     if sys.version_info < (3,):


### PR DESCRIPTION
See also PEP 415: https://www.python.org/dev/peps/pep-0415/

Fixes #2875.