### PR TITLE
[re] Add attribute '_pattern_type' to re.

### DIFF
--- a/stdlib/3/re.pyi
+++ b/stdlib/3/re.pyi
@@ -71,7 +71,7 @@ else:
     TEMPLATE = 0
     _FlagsType = int
 
-if sys.version_info <= (3, 6):
+if sys.version_info < (3, 7):
     # undocumented
     _pattern_type = ...  # type: type
 

--- a/stdlib/3/re.pyi
+++ b/stdlib/3/re.pyi
@@ -71,6 +71,10 @@ else:
     TEMPLATE = 0
     _FlagsType = int
 
+if sys.version_info <= (3, 6):
+    # undocumented
+    _pattern_type = ...  # type: type
+
 class error(Exception): ...
 
 @overload


### PR DESCRIPTION
This is only available before python 3.7 based on:
https://github.com/python/cpython/blob/3.6/Lib/re.py#L283
https://github.com/python/cpython/blob/3.7/Lib/re.py