### PR TITLE
[third_party/click] add Exit exception definition

### DIFF
--- a/third_party/2and3/click/exceptions.pyi
+++ b/third_party/2and3/click/exceptions.pyi
@@ -92,4 +92,5 @@ class Abort(RuntimeError):
 
 
 class Exit(RuntimeError):
-    ...
+    def __init__(self, code: Optional[int] = ...) -> None:
+        ...

--- a/third_party/2and3/click/exceptions.pyi
+++ b/third_party/2and3/click/exceptions.pyi
@@ -92,5 +92,5 @@ class Abort(RuntimeError):
 
 
 class Exit(RuntimeError):
-    def __init__(self, code: Optional[int] = ...) -> None:
+    def __init__(self, code: int = ...) -> None:
         ...

--- a/third_party/2and3/click/exceptions.pyi
+++ b/third_party/2and3/click/exceptions.pyi
@@ -89,3 +89,7 @@ class FileError(ClickException):
 
 class Abort(RuntimeError):
     ...
+
+
+class Exit(RuntimeError):
+    ...


### PR DESCRIPTION
This was added to the 7.0 release of click ([PR for reference](https://github.com/pallets/click/pull/1098)).  This may not make sense, as the `__init__` stub for click appears to be setting the version to `6.6`.