### PR TITLE
Added excepthandler to ast stubfiles

### DIFF
--- a/stdlib/2/_ast.pyi
+++ b/stdlib/2/_ast.pyi
@@ -305,7 +305,11 @@ class comprehension(AST):
     ifs = ...  # type: typing.List[expr]
 
 
-class ExceptHandler(AST):
+class excepthandler(AST):
+    ...
+
+
+class ExceptHandler(excepthandler):
     type = ...  # type: Optional[expr]
     name = ...  # type: Optional[expr]
     body = ...  # type: typing.List[stmt]

--- a/stdlib/3/_ast.pyi
+++ b/stdlib/3/_ast.pyi
@@ -375,7 +375,10 @@ class comprehension(AST):
         is_async = ...  # type: int
 
 
-class ExceptHandler(AST):
+class excepthandler(AST):
+    ...
+
+class ExceptHandler(excepthandler):
     type = ...  # type: Optional[expr]
     name = ...  # type: Optional[_identifier]
     body = ...  # type: typing.List[stmt]


### PR DESCRIPTION
I've been working on adding type annotations to the pandas library and was running into:

```sh
error: Module has no attribute "excepthandler"
```

With mypy type checking. I think this was a simple oversight in the stub file and have added as such. 

Tests pass locally before and after. Let me know if there's anything else I need to do!