### PR TITLE
Add mmap as a valid buffer type.

### DIFF
--- a/stdlib/2and3/struct.pyi
+++ b/stdlib/2and3/struct.pyi
@@ -6,16 +6,17 @@
 import sys
 from typing import Any, Tuple, Text, Union, Iterator
 from array import array
+from mmap import mmap
 
 class error(Exception): ...
 
 _FmtType = Union[bytes, Text]
 if sys.version_info >= (3,):
-    _BufferType = Union[array[int], bytes, bytearray, memoryview]
-    _WriteBufferType = Union[array, bytearray, memoryview]
+    _BufferType = Union[array[int], bytes, bytearray, memoryview, mmap]
+    _WriteBufferType = Union[array, bytearray, memoryview, mmap]
 else:
-    _BufferType = Union[array[int], bytes, bytearray, buffer, memoryview]
-    _WriteBufferType = Union[array[Any], bytearray, buffer, memoryview]
+    _BufferType = Union[array[int], bytes, bytearray, buffer, memoryview, mmap]
+    _WriteBufferType = Union[array[Any], bytearray, buffer, memoryview, mmap]
 
 def pack(fmt: _FmtType, *v: Any) -> bytes: ...
 def pack_into(fmt: _FmtType, buffer: _WriteBufferType, offset: int, *v: Any) -> None: ...


### PR DESCRIPTION
Currently seeing the following error from `mypy`, which I think this should solve:

    foo.py:47: error: Argument 1 to "pack_into" of "Struct" has incompatible type "mmap"; expected "Union[array[Any], bytearray, memoryview]"