### PR TITLE
Accept bytes as 1st argument of `simplejson.loads`

### DIFF
--- a/third_party/2and3/simplejson/__init__.pyi
+++ b/third_party/2and3/simplejson/__init__.pyi
@@ -1,14 +1,10 @@
-import sys
 from typing import Any, IO, Text, Union
 
 from simplejson.scanner import JSONDecodeError as JSONDecodeError
 from simplejson.decoder import JSONDecoder as JSONDecoder
 from simplejson.encoder import JSONEncoder as JSONEncoder, JSONEncoderForHTML as JSONEncoderForHTML
 
-if sys.version_info >= (3, 6):
-    _LoadsString = Union[Text, bytes, bytearray]
-else:
-    _LoadsString = Text
+_LoadsString = Union[Text, bytes, bytearray]
 
 
 def dumps(obj: Any, *args: Any, **kwds: Any) -> str: ...

--- a/third_party/2and3/simplejson/__init__.pyi
+++ b/third_party/2and3/simplejson/__init__.pyi
@@ -1,10 +1,17 @@
-from typing import Any, IO, Text
+import sys
+from typing import Any, IO, Text, Union
 
 from simplejson.scanner import JSONDecodeError as JSONDecodeError
 from simplejson.decoder import JSONDecoder as JSONDecoder
 from simplejson.encoder import JSONEncoder as JSONEncoder, JSONEncoderForHTML as JSONEncoderForHTML
 
+if sys.version_info >= (3, 6):
+    _LoadsString = Union[Text, bytes, bytearray]
+else:
+    _LoadsString = Text
+
+
 def dumps(obj: Any, *args: Any, **kwds: Any) -> str: ...
 def dump(obj: Any, fp: IO[str], *args: Any, **kwds: Any) -> None: ...
-def loads(s: Text, **kwds: Any) -> Any: ...
+def loads(s: _LoadsString, **kwds: Any) -> Any: ...
 def load(fp: IO[str], **kwds: Any) -> Any: ...


### PR DESCRIPTION
This puts the expected signature of `simplejson.loads` with what is accepted by the library in the same way that the standard `json` is defined.