### PR TITLE
Update pytype_test to remove now-unnecessary parse-only functionality.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
     - name: "pytype"
       python: 3.6
       env:
-        - TEST_CMD="./tests/pytype_test.py --num-parallel=4"
+        - TEST_CMD="./tests/pytype_test.py"
         - INSTALL="test"
     - name: "mypy"
       env:

--- a/requirements-tests-py3.txt
+++ b/requirements-tests-py3.txt
@@ -3,4 +3,4 @@ typed-ast>=1.0.4
 flake8==3.6.0
 flake8-bugbear==18.8.0
 flake8-pyi==18.3.1
-pytype>=2019.3.15
+pytype>=2019.4.2.1

--- a/tests/pytype_blacklist.txt
+++ b/tests/pytype_blacklist.txt
@@ -6,4 +6,3 @@ stdlib/2/__builtin__.pyi
 stdlib/2/typing.pyi
 stdlib/2and3/builtins.pyi
 stdlib/3/typing.pyi
-stdlib/3/collections/__init__.pyi # parse only


### PR DESCRIPTION
With today's release, pytype is able to fully load
`stdlib/3/collections/__init__.pyi`, so the test no longer needs the
ability to partially parse stubs using the pytd tool. Removing this
functionality allows the test code to be simplified considerably.