### PR TITLE
Fix typo in FrameType 3.7 attributes

### DIFF
--- a/stdlib/3/types.pyi
+++ b/stdlib/3/types.pyi
@@ -179,7 +179,7 @@ class FrameType:
     f_locals = ...  # type: Dict[str, Any]
     f_trace = ...  # type: Callable[[], None]
     if sys.version_info >= (3, 7):
-        f_frace_lines: bool
+        f_trace_lines: bool
         f_trace_opcodes: bool
 
     def clear(self) -> None: ...


### PR DESCRIPTION
Fixes #2898 with `f_frace_lines -> f_trace_lines`