### PR TITLE
Add six.moves types for email_mime sources.

### DIFF
--- a/third_party/2/six/moves/email_mime_base.pyi
+++ b/third_party/2/six/moves/email_mime_base.pyi
@@ -1,0 +1,1 @@
+from email.MIMEBase import *

--- a/third_party/2/six/moves/email_mime_base.pyi
+++ b/third_party/2/six/moves/email_mime_base.pyi
@@ -1,1 +1,1 @@
-from email.MIMEBase import *
+from email.mime.base import *

--- a/third_party/2/six/moves/email_mime_multipart.pyi
+++ b/third_party/2/six/moves/email_mime_multipart.pyi
@@ -1,1 +1,1 @@
-from email.MIMEMultipart import *
+from email.mime.multipart import *

--- a/third_party/2/six/moves/email_mime_multipart.pyi
+++ b/third_party/2/six/moves/email_mime_multipart.pyi
@@ -1,0 +1,1 @@
+from email.MIMEMultipart import *

--- a/third_party/2/six/moves/email_mime_nonmultipart.pyi
+++ b/third_party/2/six/moves/email_mime_nonmultipart.pyi
@@ -1,0 +1,1 @@
+from email.MIMENonMultipart import *

--- a/third_party/2/six/moves/email_mime_nonmultipart.pyi
+++ b/third_party/2/six/moves/email_mime_nonmultipart.pyi
@@ -1,1 +1,1 @@
-from email.MIMENonMultipart import *
+from email.mime.nonmultipart import *


### PR DESCRIPTION
As a followup to the work done in #2767 and #2830, and to address a
piece of #66, most of the email_mime submodules aren't typed in six
under python2, only python3. Now they are.