### PR TITLE
Make os.altsep Optional on non-win32 platforms

### DIFF
--- a/stdlib/2/os/__init__.pyi
+++ b/stdlib/2/os/__init__.pyi
@@ -63,7 +63,10 @@ O_LARGEFILE: int  # Gnu extension if in C library
 curdir: str
 pardir: str
 sep: str
-altsep: str
+if sys.platform == 'win32':
+    altsep: str
+else:
+    altsep: Optional[str]
 extsep: str
 pathsep: str
 defpath: str

--- a/stdlib/2/os/path.pyi
+++ b/stdlib/2/os/path.pyi
@@ -27,7 +27,10 @@ supports_unicode_filenames: bool
 curdir: str
 pardir: str
 sep: str
-altsep: str
+if sys.platform == 'win32':
+    altsep: str
+else:
+    altsep: Optional[str]
 extsep: str
 pathsep: str
 defpath: str

--- a/stdlib/2/os2emxpath.pyi
+++ b/stdlib/2/os2emxpath.pyi
@@ -27,7 +27,10 @@ supports_unicode_filenames: bool
 curdir: str
 pardir: str
 sep: str
-altsep: str
+if sys.platform == 'win32':
+    altsep: str
+else:
+    altsep: Optional[str]
 extsep: str
 pathsep: str
 defpath: str

--- a/stdlib/2and3/macpath.pyi
+++ b/stdlib/2and3/macpath.pyi
@@ -27,7 +27,10 @@ supports_unicode_filenames: bool
 curdir: str
 pardir: str
 sep: str
-altsep: str
+if sys.platform == 'win32':
+    altsep: str
+else:
+    altsep: Optional[str]
 extsep: str
 pathsep: str
 defpath: str

--- a/stdlib/2and3/ntpath.pyi
+++ b/stdlib/2and3/ntpath.pyi
@@ -27,7 +27,10 @@ supports_unicode_filenames: bool
 curdir: str
 pardir: str
 sep: str
-altsep: str
+if sys.platform == 'win32':
+    altsep: str
+else:
+    altsep: Optional[str]
 extsep: str
 pathsep: str
 defpath: str

--- a/stdlib/2and3/posixpath.pyi
+++ b/stdlib/2and3/posixpath.pyi
@@ -27,7 +27,10 @@ supports_unicode_filenames: bool
 curdir: str
 pardir: str
 sep: str
-altsep: str
+if sys.platform == 'win32':
+    altsep: str
+else:
+    altsep: Optional[str]
 extsep: str
 pathsep: str
 defpath: str

--- a/stdlib/3/os/__init__.pyi
+++ b/stdlib/3/os/__init__.pyi
@@ -128,7 +128,10 @@ O_LARGEFILE: int  # Gnu extension if in C library
 curdir: str
 pardir: str
 sep: str
-altsep: str
+if sys.platform == 'win32':
+    altsep: str
+else:
+    altsep: Optional[str]
 extsep: str
 pathsep: str
 defpath: str

--- a/stdlib/3/os/path.pyi
+++ b/stdlib/3/os/path.pyi
@@ -27,7 +27,10 @@ supports_unicode_filenames: bool
 curdir: str
 pardir: str
 sep: str
-altsep: str
+if sys.platform == 'win32':
+    altsep: str
+else:
+    altsep: Optional[str]
 extsep: str
 pathsep: str
 defpath: str


### PR DESCRIPTION
Keep it str on win32 to avoid breaking win32-specific code that relies
on it.