### PR TITLE
Correct the type signature of assertRaisesRegexp

### DIFF
--- a/stdlib/3/unittest/__init__.pyi
+++ b/stdlib/3/unittest/__init__.pyi
@@ -184,12 +184,14 @@ class TestCase:
                             msg: Any = ...) -> None: ...
     @overload
     def assertRaisesRegexp(self,  # type: ignore
-                           exception: Union[Type[BaseException], Tuple[Type[BaseException], ...]],
-                           callable: Callable[..., Any] = ...,
+                           expected_exception: Union[Type[BaseException], Tuple[Type[BaseException], ...]],
+                           expected_regex: Union[str, bytes, Pattern[str], Pattern[bytes]],
+                           callable: Callable[..., Any],
                            *args: Any, **kwargs: Any) -> None: ...
     @overload
     def assertRaisesRegexp(self,
-                           exception: Union[Type[_E], Tuple[Type[_E], ...]],
+                           expected_exception: Union[Type[_E], Tuple[Type[_E], ...]],
+                           expected_regex: Union[str, bytes, Pattern[str], Pattern[bytes]],
                            msg: Any = ...) -> _AssertRaisesContext[_E]: ...
 
 class FunctionTestCase(TestCase):


### PR DESCRIPTION
assertRaisesRegexp is the old name of assertRaisesRegex, they are the
same, just that the old one is deprecated.

Closes #2925 