### PR TITLE
Properly type `requests.Session.cookies`

### DIFF
--- a/third_party/2and3/requests/sessions.pyi
+++ b/third_party/2and3/requests/sessions.pyi
@@ -72,7 +72,7 @@ class Session(SessionRedirectMixin):
     cert: Union[None, Text, Tuple[Text, Text]]
     max_redirects: int
     trust_env: bool
-    cookies: Union[RequestsCookieJar, MutableMapping[Text, Text]]
+    cookies: RequestsCookieJar
     adapters: MutableMapping
     redirect_cache: RecentlyUsedContainer
     def __init__(self) -> None: ...


### PR DESCRIPTION
Not sure why it is annotated as a union. Union would lead to type errors when accessing any field that's presented in `RequestsCookieJar` but not `MutableMapping`.