### PR TITLE
Change WatchedFileHandler to inherit from FileHandler

### DIFF
--- a/stdlib/2and3/logging/handlers.pyi
+++ b/stdlib/2and3/logging/handlers.pyi
@@ -26,7 +26,7 @@ DEFAULT_SOAP_LOGGING_PORT: int
 SYSLOG_UDP_PORT: int
 SYSLOG_TCP_PORT: int
 
-class WatchedFileHandler(Handler):
+class WatchedFileHandler(FileHandler):
     @overload
     def __init__(self, filename: _Path) -> None: ...
     @overload


### PR DESCRIPTION
`WatchedFileHandler` extends `FileHandler` in the cpython implementation and in the [language docs](https://docs.python.org/2/library/logging.handlers.html#watchedfilehandler).

Updating the type stub to reflect this