### PR TITLE
fix type of msg argument to HTTPRedirectHandler.redirect_request

### DIFF
--- a/stdlib/3/urllib/request.pyi
+++ b/stdlib/3/urllib/request.pyi
@@ -85,7 +85,7 @@ class BaseHandler:
 class HTTPDefaultErrorHandler(BaseHandler): ...
 
 class HTTPRedirectHandler(BaseHandler):
-    def redirect_request(self, req: Request, fp: IO[str], code: int, msg: int,
+    def redirect_request(self, req: Request, fp: IO[str], code: int, msg: str,
                          hdrs: Mapping[str, str],
                          newurl: str) -> Optional[Request]: ...
     def http_error_301(self, req: Request, fp: IO[str], code: int, msg: int,


### PR DESCRIPTION
It's not really documented (https://docs.python.org/3/library/urllib.request.html#urllib.request.HTTPRedirectHandler.redirect_request), but logically a message is a str, and reading the code for the stdlib confirms that it's intended to be a str.