### PR TITLE
Update Black URL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -237,7 +237,7 @@ rule is that they should be as concise as possible.  Specifically:
 * use variable annotations instead of type comments, even for stubs
   that target older versions of Python;
 * for arguments with a type and a default, use spaces around the `=`.
-The code formatter [black](https://github.com/ambv/black) will format
+The code formatter [black](https://github.com/python/black) will format
 stubs according to this standard.
 
 Stub files should only contain information necessary for the type


### PR DESCRIPTION
> Black, your uncompromising #Python code formatter, was a project
> created with the community in mind from Day 1. Today we moved it under
> the PSF umbrella. It's now available on GitHub under
> https://github.com/python/black/ . You install and use it just like
> before.

https://twitter.com/llanga/status/1123980466292445190