### PR TITLE
Use dunder parameter name in `Container.__contains__`

### DIFF
--- a/stdlib/3/typing.pyi
+++ b/stdlib/3/typing.pyi
@@ -235,7 +235,7 @@ if sys.version_info >= (3, 6):
 @runtime
 class Container(Protocol[_T_co]):
     @abstractmethod
-    def __contains__(self, x: object) -> bool: ...
+    def __contains__(self, __x: object) -> bool: ...
 
 
 if sys.version_info >= (3, 6):


### PR DESCRIPTION
According to Ivan, PEP 544 intentionally did not specify whether method conformance check in protocol inference should look at parameter names. For example, it's up to the type checker to decide whether a class with method defined as `def foo(self, x: int)` would implement a protocol with method `def foo(self, y: int)`.
Mypy decided to ignore parameter names altogether, but we Pyre team decided to be more strict and refuse to match different parameter names (as it is unsound to do so when those methods are invoked with named parameters). Since Pyre also rely on the typeshed stubs, we want to make sure at least the important stubs on typeshed conform to our standard. 
This PR changes `Container.__contains__` to use dunder (i.e. positional-only) parameter name specified in PEP484. This change should not affect mypy since it ignores parameter names, but will make Pyre happy as it eliminate the naming requirement for all existing and future class stubs that want to conform to the `Container` protocol.
Note there are likely to be other cases where we might want this. We'll submit subsequent PRs in a demand-driven fashion. 