### PR TITLE
Bleach stubs: fix typos, use protocol classes

### DIFF
--- a/third_party/2and3/bleach/__init__.pyi
+++ b/third_party/2and3/bleach/__init__.pyi
@@ -6,7 +6,7 @@ from bleach.sanitizer import (
     ALLOWED_PROTOCOLS as ALLOWED_PROTOCOLS,
     ALLOWED_STYLES as ALLOWED_STYLES,
     ALLOWED_TAGS as ALLOWED_TAGS,
-    Cleaner as Clear,
+    Cleaner as Cleaner,
 )
 
 from .linkifier import _Callback

--- a/third_party/2and3/bleach/__init__.pyi
+++ b/third_party/2and3/bleach/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import List, Any, Optional, Text
+from typing import Any, Container, Iterable, Optional, Text
 
 from bleach.linkifier import DEFAULT_CALLBACKS as DEFAULT_CALLBACKS, Linker as Linker
 from bleach.sanitizer import (
@@ -17,13 +17,16 @@ VERSION: Any  # packaging.version.Version
 
 def clean(
     text: Text,
-    tags: List[Text] = ...,
+    tags: Container[Text] = ...,
     attributes: Any = ...,
-    styles: List[Text] = ...,
-    protocols: List[Text] = ...,
+    styles: Container[Text] = ...,
+    protocols: Container[Text] = ...,
     strip: bool = ...,
     strip_comments: bool = ...,
 ) -> Text: ...
 def linkify(
-    text: Text, callbacks: List[_Callback] = ..., skip_tags: Optional[List[Text]] = ..., parse_email: bool = ...
+    text: Text,
+    callbacks: Iterable[_Callback] = ...,
+    skip_tags: Optional[Container[Text]] = ...,
+    parse_email: bool = ...,
 ) -> Text: ...

--- a/third_party/2and3/bleach/linkifier.pyi
+++ b/third_party/2and3/bleach/linkifier.pyi
@@ -12,7 +12,7 @@ TLDS: List[Text]
 def build_url_re(tlds: Iterable[Text] = ..., protocols: Iterable[Text] = ...) -> Pattern[Text]: ...
 
 URL_RE: Pattern[Text]
-PHOTO_RE: Pattern[Text]
+PROTO_RE: Pattern[Text]
 EMAIL_RE: Pattern[Text]
 
 class Linker(object):

--- a/third_party/2and3/bleach/linkifier.pyi
+++ b/third_party/2and3/bleach/linkifier.pyi
@@ -1,4 +1,4 @@
-from typing import Any, List, MutableMapping, Protocol, Pattern, Iterable, Optional, Text
+from typing import Any, Container, Iterable, List, MutableMapping, Optional, Pattern, Protocol, Text
 
 _Attrs = MutableMapping[Any, Text]
 
@@ -18,11 +18,12 @@ EMAIL_RE: Pattern[Text]
 class Linker(object):
     def __init__(
         self,
-        callbacks: List[_Callback] = ...,
-        skip_tags: Optional[List[Text]] = ...,
+        callbacks: Iterable[_Callback] = ...,
+        skip_tags: Optional[Container[Text]] = ...,
         parse_email: bool = ...,
         url_re: Pattern[Text] = ...,
         email_re: Pattern[Text] = ...,
+        recognized_tags: Optional[Container[Text]] = ...,
     ) -> None: ...
     def linkify(self, text: Text) -> Text: ...
 

--- a/third_party/2and3/bleach/sanitizer.pyi
+++ b/third_party/2and3/bleach/sanitizer.pyi
@@ -1,7 +1,7 @@
 from typing import Any, Callable, Container, Dict, Iterable, List, Optional, Pattern, Text, Type, Union
 
 ALLOWED_TAGS: List[Text]
-ALLOWED_ATTRIBUTES: Dict[Text, Container[Text]]
+ALLOWED_ATTRIBUTES: Dict[Text, List[Text]]
 ALLOWED_STYLES: List[Text]
 ALLOWED_PROTOCOLS: List[Text]
 

--- a/third_party/2and3/bleach/sanitizer.pyi
+++ b/third_party/2and3/bleach/sanitizer.pyi
@@ -1,7 +1,7 @@
-from typing import List, Dict, Any, Optional, Type, Pattern, Union, Callable, Container, Text
+from typing import Any, Callable, Container, Dict, Iterable, List, Optional, Pattern, Text, Type, Union
 
 ALLOWED_TAGS: List[Text]
-ALLOWED_ATTRIBUTES: Dict[Text, List[Text]]
+ALLOWED_ATTRIBUTES: Dict[Text, Container[Text]]
 ALLOWED_STYLES: List[Text]
 ALLOWED_PROTOCOLS: List[Text]
 
@@ -15,21 +15,20 @@ _Filter = Any
 class Cleaner(object):
     def __init__(
         self,
-        tags: List[Text] = ...,
+        tags: Container[Text] = ...,
         attributes: Any = ...,
-        styles: List[Text] = ...,
-        protocols: List[Text] = ...,
+        styles: Container[Text] = ...,
+        protocols: Container[Text] = ...,
         strip: bool = ...,
         strip_comments: bool = ...,
-        filters: Optional[List[Type[_Filter]]] = ...,
+        filters: Optional[Iterable[_Filter]] = ...,
     ) -> None: ...
     def clean(self, text: Text) -> Text: ...
 
 _AttributeFilter = Callable[[Text, Text, Text], bool]
 _AttributeDict = Dict[Text, Union[Container[Text], _AttributeFilter]]
 
-def attribute_filter_factory(attributes: Union[_AttributeFilter, _AttributeDict, List[Text]]) -> _AttributeFilter: ...
+def attribute_filter_factory(attributes: Union[_AttributeFilter, _AttributeDict, Container[Text]]) -> _AttributeFilter: ...
 
 class BleachSanitizerFilter(object):  # TODO: derives from html5lib.sanitizer.Filter
-
     def __getattr__(self, item: str) -> Any: ...  # incomplete


### PR DESCRIPTION
I mentioned [in a comment a few weeks ago](https://github.com/python/typeshed/pull/2709#issuecomment-483120729) that I was hitting some errors on my codebase from the new Bleach stubs. This was mostly due to the stubs being very specific and using `List[]` for various arguments. These arguments are generally used for `x in y` checks, so I switched all of them to use the `Container[]` protocol class instead.

There were also a couple of other minor, similar changes, and I fixed a couple of typos (in a separate commit to make it easier to see for review, but they could be squashed together if you like).

(I'll ping @srittau since he wrote the original stubs)