### PR TITLE
add click.types.DateTime to click stubs

### DIFF
--- a/third_party/2and3/click/types.pyi
+++ b/third_party/2and3/click/types.pyi
@@ -1,4 +1,5 @@
 from typing import Any, Callable, IO, Iterable, List, Optional, TypeVar, Union, Tuple as _PyTuple, Type
+import datetime
 import uuid
 
 from click.core import Context, Parameter, _ParamType as ParamType, _ConvertibleType
@@ -32,6 +33,22 @@ class Choice(ParamType):
         choices: Iterable[str],
         case_sensitive: bool = ...,
     ) -> None:
+        ...
+
+
+class DateTime(ParamType):
+    def __init__(
+        self,
+        formats: Optional[List[str]] = ...,
+    ) -> None:
+        ...
+
+    def convert(
+        self,
+        value: str,
+        param: Optional[Parameter],
+        ctx: Optional[Context],
+    ) -> datetime.datetime:
         ...
 
 


### PR DESCRIPTION
`click.types.DateTime` appears to have been added in 7.0, and as near as I can tell (from https://github.com/pallets/click/issues/693) the existing stubs are based on click 6.6. This is probably far from completely what has changed between 6 and 7, but I don't have time at the moment to do a more thorough check for what might have changed.