### PR TITLE
Remove some files from pytype's third_party blacklist.

### DIFF
--- a/requirements-tests-py3.txt
+++ b/requirements-tests-py3.txt
@@ -3,4 +3,4 @@ typed-ast>=1.0.4
 flake8==3.6.0
 flake8-bugbear==18.8.0
 flake8-pyi==18.3.1
-pytype>=2019.4.2.1
+pytype>=2019.5.6

--- a/tests/pytype_blacklist.txt
+++ b/tests/pytype_blacklist.txt
@@ -106,13 +106,3 @@ third_party/2and3/pymysql/converters.pyi
 third_party/2and3/pymysql/cursors.pyi
 third_party/2and3/pymysql/err.pyi
 third_party/2and3/pynamodb/models.pyi
-third_party/2and3/requests/__init__.pyi
-third_party/2and3/requests/adapters.pyi
-third_party/2and3/requests/api.pyi
-third_party/2and3/requests/auth.pyi
-third_party/2and3/requests/models.pyi
-third_party/2and3/requests/packages/urllib3/__init__.pyi
-third_party/2and3/requests/packages/urllib3/connectionpool.pyi
-third_party/2and3/requests/sessions.pyi
-third_party/2and3/werkzeug/__init__.pyi
-third_party/2and3/werkzeug/urls.pyi


### PR DESCRIPTION
Removes files that are parseable with the most recent release.