### PR TITLE
Add subprocess.list2cmdline for python 2

### DIFF
--- a/stdlib/2/subprocess.pyi
+++ b/stdlib/2/subprocess.pyi
@@ -103,6 +103,8 @@ class Popen:
     def __enter__(self) -> Popen: ...
     def __exit__(self, type, value, traceback) -> bool: ...
 
+def list2cmdline(seq: Sequence[str]) -> str: ...  # undocumented
+
 # Windows-only: STARTUPINFO etc.
 
 STD_INPUT_HANDLE: Any


### PR DESCRIPTION
This was already added for python 3 but not for python 2.  
