### PR TITLE
Add new show_choices argument to click options

### DIFF
--- a/third_party/2and3/click/core.pyi
+++ b/third_party/2and3/click/core.pyi
@@ -439,6 +439,7 @@ class Option(Parameter):
     allow_from_autoenv: bool
     help: Optional[str]
     show_default: bool
+    show_choices: bool
 
     def __init__(
         self,
@@ -454,6 +455,7 @@ class Option(Parameter):
         allow_from_autoenv: bool = ...,
         type: Optional[_ConvertibleType] = ...,
         help: Optional[str] = ...,
+        show_choices: bool = ...,
         **attrs
     ) -> None:
         ...

--- a/third_party/2and3/click/decorators.pyi
+++ b/third_party/2and3/click/decorators.pyi
@@ -109,6 +109,7 @@ def option(
     allow_from_autoenv: bool = ...,
     type: Optional[_ConvertibleType] = ...,
     help: Optional[str] = ...,
+    show_choices: bool = ...,
     # Parameter
     default: Optional[Any] = ...,
     required: bool = ...,
@@ -140,6 +141,7 @@ def option(
     allow_from_autoenv: bool = ...,
     type: _T = ...,
     help: Optional[str] = ...,
+    show_choices: bool = ...,
     # Parameter
     default: Optional[Any] = ...,
     required: bool = ...,
@@ -171,6 +173,7 @@ def option(
     allow_from_autoenv: bool = ...,
     type: Type[str] = ...,
     help: Optional[str] = ...,
+    show_choices: bool = ...,
     # Parameter
     default: Optional[Any] = ...,
     required: bool = ...,
@@ -202,6 +205,7 @@ def option(
     allow_from_autoenv: bool = ...,
     type: Type[int] = ...,
     help: Optional[str] = ...,
+    show_choices: bool = ...,
     # Parameter
     default: Optional[Any] = ...,
     required: bool = ...,
@@ -232,6 +236,7 @@ def confirmation_option(
     allow_from_autoenv: bool = ...,
     type: Optional[_ConvertibleType] = ...,
     help: str = ...,
+    show_choices: bool = ...,
     # Parameter
     default: Optional[Any] = ...,
     callback: Optional[_Callback] = ...,
@@ -259,6 +264,7 @@ def password_option(
     allow_from_autoenv: bool = ...,
     type: Optional[_ConvertibleType] = ...,
     help: Optional[str] = ...,
+    show_choices: bool = ...,
     # Parameter
     default: Optional[Any] = ...,
     callback: Optional[_Callback] = ...,
@@ -289,6 +295,7 @@ def version_option(
     allow_from_autoenv: bool = ...,
     type: Optional[_ConvertibleType] = ...,
     help: str = ...,
+    show_choices: bool = ...,
     # Parameter
     default: Optional[Any] = ...,
     callback: Optional[_Callback] = ...,
@@ -316,6 +323,7 @@ def help_option(
     allow_from_autoenv: bool = ...,
     type: Optional[_ConvertibleType] = ...,
     help: str = ...,
+    show_choices: bool = ...,
     # Parameter
     default: Optional[Any] = ...,
     callback: Optional[_Callback] = ...,

--- a/third_party/2and3/click/termui.pyi
+++ b/third_party/2and3/click/termui.pyi
@@ -39,6 +39,7 @@ def prompt(
     prompt_suffix: str = ...,
     show_default: bool = ...,
     err: bool = ...,
+    show_choices: bool = ...,
 ) -> Any:
     ...
 


### PR DESCRIPTION
This adds a new argument `show_choices` added to command options by click 7.0 :

- add the argument `show_choices` and the corresponding attribute to class `Option` annotation.
It is present in the class signature even if it is not yet in the list of described arguments: https://click.palletsprojects.com/en/7.x/api/#click.Option
- add same argument to overloaded annotations of decorator `option`  that has the same arguments as `Option`: https://click.palletsprojects.com/en/7.x/api/#click.option