### PR TITLE
Have click.style return a str

### DIFF
--- a/third_party/2and3/click/termui.pyi
+++ b/third_party/2and3/click/termui.pyi
@@ -117,7 +117,7 @@ def style(
     blink: Optional[bool] = ...,
     reverse: Optional[bool] = ...,
     reset: bool = ...,
-):
+) -> str:
     ...
 
 


### PR DESCRIPTION
This previously was missing a return type and therefore defaulting to `Any`, but it actually returns a `str`.