### PR TITLE
Add parse_{http,keqv}_list to six.moves.urllib.request

### DIFF
--- a/third_party/2/six/moves/urllib/request.pyi
+++ b/third_party/2/six/moves/urllib/request.pyi
@@ -32,3 +32,5 @@ from urllib import urlcleanup as urlcleanup
 from urllib import URLopener as URLopener
 from urllib import FancyURLopener as FancyURLopener
 from urllib import proxy_bypass as proxy_bypass
+from urllib2 import parse_http_list as parse_http_list
+from urllib2 import parse_keqv_list as parse_keqv_list

--- a/third_party/3/six/moves/urllib/request.pyi
+++ b/third_party/3/six/moves/urllib/request.pyi
@@ -35,3 +35,5 @@ from urllib.request import urlcleanup as urlcleanup
 from urllib.request import URLopener as URLopener
 from urllib.request import FancyURLopener as FancyURLopener
 # from urllib.request import proxy_bypass as proxy_bypass
+from urllib.request import parse_http_list as parse_http_list
+from urllib.request import parse_keqv_list as parse_keqv_list


### PR DESCRIPTION
`parse_http_list` and `parse_keqv_list` were added to `six.moves.urllib.request`
in version 1.11 (see corresponding [pull request](https://github.com/benjaminp/six/pull/203)).

These functions should be added to the stubs for `six.moves.urllib.request`.