### PR TITLE
Always use fully qualified names to refer to nested classes.

### DIFF
--- a/third_party/2and3/google/protobuf/descriptor_pb2.pyi
+++ b/third_party/2and3/google/protobuf/descriptor_pb2.pyi
@@ -189,24 +189,24 @@ class FieldDescriptorProto(Message):
 
         @classmethod
         def items(cls) -> List[Tuple[bytes, FieldDescriptorProto.Type]]: ...
-    TYPE_DOUBLE: Type
-    TYPE_FLOAT: Type
-    TYPE_INT64: Type
-    TYPE_UINT64: Type
-    TYPE_INT32: Type
-    TYPE_FIXED64: Type
-    TYPE_FIXED32: Type
-    TYPE_BOOL: Type
-    TYPE_STRING: Type
-    TYPE_GROUP: Type
-    TYPE_MESSAGE: Type
-    TYPE_BYTES: Type
-    TYPE_UINT32: Type
-    TYPE_ENUM: Type
-    TYPE_SFIXED32: Type
-    TYPE_SFIXED64: Type
-    TYPE_SINT32: Type
-    TYPE_SINT64: Type
+    TYPE_DOUBLE: FieldDescriptorProto.Type
+    TYPE_FLOAT: FieldDescriptorProto.Type
+    TYPE_INT64: FieldDescriptorProto.Type
+    TYPE_UINT64: FieldDescriptorProto.Type
+    TYPE_INT32: FieldDescriptorProto.Type
+    TYPE_FIXED64: FieldDescriptorProto.Type
+    TYPE_FIXED32: FieldDescriptorProto.Type
+    TYPE_BOOL: FieldDescriptorProto.Type
+    TYPE_STRING: FieldDescriptorProto.Type
+    TYPE_GROUP: FieldDescriptorProto.Type
+    TYPE_MESSAGE: FieldDescriptorProto.Type
+    TYPE_BYTES: FieldDescriptorProto.Type
+    TYPE_UINT32: FieldDescriptorProto.Type
+    TYPE_ENUM: FieldDescriptorProto.Type
+    TYPE_SFIXED32: FieldDescriptorProto.Type
+    TYPE_SFIXED64: FieldDescriptorProto.Type
+    TYPE_SINT32: FieldDescriptorProto.Type
+    TYPE_SINT64: FieldDescriptorProto.Type
 
     class Label(int):
 
@@ -224,9 +224,9 @@ class FieldDescriptorProto(Message):
 
         @classmethod
         def items(cls) -> List[Tuple[bytes, FieldDescriptorProto.Label]]: ...
-    LABEL_OPTIONAL: Label
-    LABEL_REQUIRED: Label
-    LABEL_REPEATED: Label
+    LABEL_OPTIONAL: FieldDescriptorProto.Label
+    LABEL_REQUIRED: FieldDescriptorProto.Label
+    LABEL_REPEATED: FieldDescriptorProto.Label
     name: Text
     number: int
     label: FieldDescriptorProto.Label
@@ -390,9 +390,9 @@ class FileOptions(Message):
 
         @classmethod
         def items(cls) -> List[Tuple[bytes, FileOptions.OptimizeMode]]: ...
-    SPEED: OptimizeMode
-    CODE_SIZE: OptimizeMode
-    LITE_RUNTIME: OptimizeMode
+    SPEED: FileOptions.OptimizeMode
+    CODE_SIZE: FileOptions.OptimizeMode
+    LITE_RUNTIME: FileOptions.OptimizeMode
     java_package: Text
     java_outer_classname: Text
     java_multiple_files: bool
@@ -482,9 +482,9 @@ class FieldOptions(Message):
 
         @classmethod
         def items(cls) -> List[Tuple[bytes, FieldOptions.CType]]: ...
-    STRING: CType
-    CORD: CType
-    STRING_PIECE: CType
+    STRING: FieldOptions.CType
+    CORD: FieldOptions.CType
+    STRING_PIECE: FieldOptions.CType
 
     class JSType(int):
 
@@ -502,9 +502,9 @@ class FieldOptions(Message):
 
         @classmethod
         def items(cls) -> List[Tuple[bytes, FieldOptions.JSType]]: ...
-    JS_NORMAL: JSType
-    JS_STRING: JSType
-    JS_NUMBER: JSType
+    JS_NORMAL: FieldOptions.JSType
+    JS_STRING: FieldOptions.JSType
+    JS_NUMBER: FieldOptions.JSType
     ctype: FieldOptions.CType
     packed: bool
     jstype: FieldOptions.JSType
@@ -612,9 +612,9 @@ class MethodOptions(Message):
 
         @classmethod
         def items(cls) -> List[Tuple[bytes, MethodOptions.IdempotencyLevel]]: ...
-    IDEMPOTENCY_UNKNOWN: IdempotencyLevel
-    NO_SIDE_EFFECTS: IdempotencyLevel
-    IDEMPOTENT: IdempotencyLevel
+    IDEMPOTENCY_UNKNOWN: MethodOptions.IdempotencyLevel
+    NO_SIDE_EFFECTS: MethodOptions.IdempotencyLevel
+    IDEMPOTENT: MethodOptions.IdempotencyLevel
     deprecated: bool
     idempotency_level: MethodOptions.IdempotencyLevel
 

--- a/third_party/2and3/google/protobuf/map_unittest_pb2.pyi
+++ b/third_party/2and3/google/protobuf/map_unittest_pb2.pyi
@@ -800,7 +800,7 @@ class MessageContainingEnumCalledType(Message):
         @classmethod
         def items(cls) -> List[Tuple[bytes,
                                      MessageContainingEnumCalledType.Type]]: ...
-    TYPE_FOO: Type
+    TYPE_FOO: MessageContainingEnumCalledType.Type
 
     class TypeEntry(Message):
         key: Text

--- a/third_party/2and3/google/protobuf/test_messages_proto2_pb2.pyi
+++ b/third_party/2and3/google/protobuf/test_messages_proto2_pb2.pyi
@@ -59,10 +59,10 @@ class TestAllTypesProto2(Message):
 
         @classmethod
         def items(cls) -> List[Tuple[bytes, TestAllTypesProto2.NestedEnum]]: ...
-    FOO: NestedEnum
-    BAR: NestedEnum
-    BAZ: NestedEnum
-    NEG: NestedEnum
+    FOO: TestAllTypesProto2.NestedEnum
+    BAR: TestAllTypesProto2.NestedEnum
+    BAZ: TestAllTypesProto2.NestedEnum
+    NEG: TestAllTypesProto2.NestedEnum
 
     class NestedMessage(Message):
         a: int

--- a/third_party/2and3/google/protobuf/test_messages_proto3_pb2.pyi
+++ b/third_party/2and3/google/protobuf/test_messages_proto3_pb2.pyi
@@ -83,10 +83,10 @@ class TestAllTypesProto3(Message):
 
         @classmethod
         def items(cls) -> List[Tuple[bytes, TestAllTypesProto3.NestedEnum]]: ...
-    FOO: NestedEnum
-    BAR: NestedEnum
-    BAZ: NestedEnum
-    NEG: NestedEnum
+    FOO: TestAllTypesProto3.NestedEnum
+    BAR: TestAllTypesProto3.NestedEnum
+    BAZ: TestAllTypesProto3.NestedEnum
+    NEG: TestAllTypesProto3.NestedEnum
 
     class NestedMessage(Message):
         a: int

--- a/third_party/2and3/google/protobuf/type_pb2.pyi
+++ b/third_party/2and3/google/protobuf/type_pb2.pyi
@@ -88,25 +88,25 @@ class Field(Message):
 
         @classmethod
         def items(cls) -> List[Tuple[bytes, Field.Kind]]: ...
-    TYPE_UNKNOWN: Kind
-    TYPE_DOUBLE: Kind
-    TYPE_FLOAT: Kind
-    TYPE_INT64: Kind
-    TYPE_UINT64: Kind
-    TYPE_INT32: Kind
-    TYPE_FIXED64: Kind
-    TYPE_FIXED32: Kind
-    TYPE_BOOL: Kind
-    TYPE_STRING: Kind
-    TYPE_GROUP: Kind
-    TYPE_MESSAGE: Kind
-    TYPE_BYTES: Kind
-    TYPE_UINT32: Kind
-    TYPE_ENUM: Kind
-    TYPE_SFIXED32: Kind
-    TYPE_SFIXED64: Kind
-    TYPE_SINT32: Kind
-    TYPE_SINT64: Kind
+    TYPE_UNKNOWN: Field.Kind
+    TYPE_DOUBLE: Field.Kind
+    TYPE_FLOAT: Field.Kind
+    TYPE_INT64: Field.Kind
+    TYPE_UINT64: Field.Kind
+    TYPE_INT32: Field.Kind
+    TYPE_FIXED64: Field.Kind
+    TYPE_FIXED32: Field.Kind
+    TYPE_BOOL: Field.Kind
+    TYPE_STRING: Field.Kind
+    TYPE_GROUP: Field.Kind
+    TYPE_MESSAGE: Field.Kind
+    TYPE_BYTES: Field.Kind
+    TYPE_UINT32: Field.Kind
+    TYPE_ENUM: Field.Kind
+    TYPE_SFIXED32: Field.Kind
+    TYPE_SFIXED64: Field.Kind
+    TYPE_SINT32: Field.Kind
+    TYPE_SINT64: Field.Kind
 
     class Cardinality(int):
 
@@ -124,10 +124,10 @@ class Field(Message):
 
         @classmethod
         def items(cls) -> List[Tuple[bytes, Field.Cardinality]]: ...
-    CARDINALITY_UNKNOWN: Cardinality
-    CARDINALITY_OPTIONAL: Cardinality
-    CARDINALITY_REQUIRED: Cardinality
-    CARDINALITY_REPEATED: Cardinality
+    CARDINALITY_UNKNOWN: Field.Cardinality
+    CARDINALITY_OPTIONAL: Field.Cardinality
+    CARDINALITY_REQUIRED: Field.Cardinality
+    CARDINALITY_REPEATED: Field.Cardinality
     kind: Field.Kind
     cardinality: Field.Cardinality
     number: int

--- a/third_party/2and3/google/protobuf/unittest_custom_options_pb2.pyi
+++ b/third_party/2and3/google/protobuf/unittest_custom_options_pb2.pyi
@@ -80,8 +80,8 @@ class TestMessageWithCustomOptions(Message):
         @classmethod
         def items(cls) -> List[Tuple[bytes,
                                      TestMessageWithCustomOptions.AnEnum]]: ...
-    ANENUM_VAL1: AnEnum
-    ANENUM_VAL2: AnEnum
+    ANENUM_VAL1: TestMessageWithCustomOptions.AnEnum
+    ANENUM_VAL2: TestMessageWithCustomOptions.AnEnum
     field1: Text
     oneof_field: int
 
@@ -149,8 +149,8 @@ class DummyMessageContainingEnum(Message):
         @classmethod
         def items(cls) -> List[Tuple[bytes,
                                      DummyMessageContainingEnum.TestEnumType]]: ...
-    TEST_OPTION_ENUM_TYPE1: TestEnumType
-    TEST_OPTION_ENUM_TYPE2: TestEnumType
+    TEST_OPTION_ENUM_TYPE1: DummyMessageContainingEnum.TestEnumType
+    TEST_OPTION_ENUM_TYPE2: DummyMessageContainingEnum.TestEnumType
 
     def __init__(self,
                  ) -> None: ...
@@ -385,7 +385,7 @@ class NestedOptionType(Message):
 
         @classmethod
         def items(cls) -> List[Tuple[bytes, NestedOptionType.NestedEnum]]: ...
-    NESTED_ENUM_VALUE: NestedEnum
+    NESTED_ENUM_VALUE: NestedOptionType.NestedEnum
 
     class NestedMessage(Message):
         nested_field: int
@@ -422,7 +422,7 @@ class OldOptionType(Message):
 
         @classmethod
         def items(cls) -> List[Tuple[bytes, OldOptionType.TestEnum]]: ...
-    OLD_VALUE: TestEnum
+    OLD_VALUE: OldOptionType.TestEnum
     value: OldOptionType.TestEnum
 
     def __init__(self,
@@ -451,8 +451,8 @@ class NewOptionType(Message):
 
         @classmethod
         def items(cls) -> List[Tuple[bytes, NewOptionType.TestEnum]]: ...
-    OLD_VALUE: TestEnum
-    NEW_VALUE: TestEnum
+    OLD_VALUE: NewOptionType.TestEnum
+    NEW_VALUE: NewOptionType.TestEnum
     value: NewOptionType.TestEnum
 
     def __init__(self,

--- a/third_party/2and3/google/protobuf/unittest_no_arena_pb2.pyi
+++ b/third_party/2and3/google/protobuf/unittest_no_arena_pb2.pyi
@@ -66,10 +66,10 @@ class TestAllTypes(Message):
 
         @classmethod
         def items(cls) -> List[Tuple[bytes, TestAllTypes.NestedEnum]]: ...
-    FOO: NestedEnum
-    BAR: NestedEnum
-    BAZ: NestedEnum
-    NEG: NestedEnum
+    FOO: TestAllTypes.NestedEnum
+    BAR: TestAllTypes.NestedEnum
+    BAZ: TestAllTypes.NestedEnum
+    NEG: TestAllTypes.NestedEnum
 
     class NestedMessage(Message):
         bb: int

--- a/third_party/2and3/google/protobuf/unittest_pb2.pyi
+++ b/third_party/2and3/google/protobuf/unittest_pb2.pyi
@@ -112,10 +112,10 @@ class TestAllTypes(Message):
 
         @classmethod
         def items(cls) -> List[Tuple[bytes, TestAllTypes.NestedEnum]]: ...
-    FOO: NestedEnum
-    BAR: NestedEnum
-    BAZ: NestedEnum
-    NEG: NestedEnum
+    FOO: TestAllTypes.NestedEnum
+    BAR: TestAllTypes.NestedEnum
+    BAZ: TestAllTypes.NestedEnum
+    NEG: TestAllTypes.NestedEnum
 
     class NestedMessage(Message):
         bb: int
@@ -1207,9 +1207,9 @@ class TestOneof2(Message):
 
         @classmethod
         def items(cls) -> List[Tuple[bytes, TestOneof2.NestedEnum]]: ...
-    FOO: NestedEnum
-    BAR: NestedEnum
-    BAZ: NestedEnum
+    FOO: TestOneof2.NestedEnum
+    BAR: TestOneof2.NestedEnum
+    BAZ: TestOneof2.NestedEnum
 
     class FooGroup(Message):
         a: int
@@ -1417,9 +1417,9 @@ class TestDynamicExtensions(Message):
         @classmethod
         def items(cls) -> List[Tuple[bytes,
                                      TestDynamicExtensions.DynamicEnumType]]: ...
-    DYNAMIC_FOO: DynamicEnumType
-    DYNAMIC_BAR: DynamicEnumType
-    DYNAMIC_BAZ: DynamicEnumType
+    DYNAMIC_FOO: TestDynamicExtensions.DynamicEnumType
+    DYNAMIC_BAR: TestDynamicExtensions.DynamicEnumType
+    DYNAMIC_BAZ: TestDynamicExtensions.DynamicEnumType
 
     class DynamicMessageType(Message):
         dynamic_field: int

--- a/third_party/2and3/google/protobuf/unittest_proto3_arena_pb2.pyi
+++ b/third_party/2and3/google/protobuf/unittest_proto3_arena_pb2.pyi
@@ -63,11 +63,11 @@ class TestAllTypes(Message):
 
         @classmethod
         def items(cls) -> List[Tuple[bytes, TestAllTypes.NestedEnum]]: ...
-    ZERO: NestedEnum
-    FOO: NestedEnum
-    BAR: NestedEnum
-    BAZ: NestedEnum
-    NEG: NestedEnum
+    ZERO: TestAllTypes.NestedEnum
+    FOO: TestAllTypes.NestedEnum
+    BAR: TestAllTypes.NestedEnum
+    BAZ: TestAllTypes.NestedEnum
+    NEG: TestAllTypes.NestedEnum
 
     class NestedMessage(Message):
         bb: int


### PR DESCRIPTION
The main purpose of this change is to get the stubs into a
form that pytype will support with its next release. Since
these stubs already mostly use fully qualified names, this
will also increase consistency.