### PR TITLE
Remove redundant variable definitions in ast module

### DIFF
--- a/stdlib/2/_ast.pyi
+++ b/stdlib/2/_ast.pyi
@@ -2,9 +2,7 @@ import typing
 from typing import Optional
 
 __version__: str
-
 PyCF_ONLY_AST: int
-
 _identifier = str
 
 class AST:

--- a/stdlib/2/ast.pyi
+++ b/stdlib/2/ast.pyi
@@ -9,10 +9,6 @@ from typing import Any, Iterator, Optional, Union
 from _ast import *
 from _ast import AST, Module
 
-__version__: str
-PyCF_ONLY_AST: int
-
-
 def parse(source: Union[str, unicode], filename: Union[str, unicode] = ..., mode: Union[str, unicode] = ...) -> Module: ...
 def copy_location(new_node: AST, old_node: AST) -> AST: ...
 def dump(node: AST, annotate_fields: bool = ..., include_attributes: bool = ...) -> str: ...


### PR DESCRIPTION
These variables are already imported from `_ast.pyi`.