### PR TITLE
Represent the use of AddressFamily in socket.getaddrinfo

### DIFF
--- a/stdlib/2and3/socket.pyi
+++ b/stdlib/2and3/socket.pyi
@@ -590,7 +590,7 @@ def create_connection(address: Tuple[Optional[str], int],
 def getaddrinfo(
         host: Optional[Union[bytearray, bytes, Text]], port: Union[str, int, None], family: int = ...,
         socktype: int = ..., proto: int = ...,
-        flags: int = ...) -> List[Tuple[int, int, int, str, Tuple[Any, ...]]]:
+        flags: int = ...) -> List[Tuple[AddressFamily, SocketKind, int, str, Tuple[Any, ...]]]:
     ...
 
 def getfqdn(name: str = ...) -> str: ...


### PR DESCRIPTION
The Pull Request #1121 added the `AddressFamily` type to `socket.pyi` for Python 3.4+, so constants such as `AF_INET` are correctly represented as being an enum member rather than an int.

Various functions in the socket module can accept either an int or an `AF_*` enum member as arguments, which is allowed by the int argument type. However the `getaddrinfo` function returns an `AddressFamily` member rather than an int in the first position of its list members, so code that access enum specific members such as the `name` attribute causes a typing error to be found.

This change corrects the return type of `getaddrinfo` but leaves the family parameters as int, given that `AddressFamily` members are `IntEnum` and only ever treated as `int`s internally.