### PR TITLE
Improve typing of pwd.struct_passwd.

### DIFF
--- a/stdlib/2and3/pwd.pyi
+++ b/stdlib/2and3/pwd.pyi
@@ -1,12 +1,13 @@
-from typing import List, NamedTuple
+from typing import List, Tuple
 
-struct_passwd = NamedTuple("struct_passwd", [("pw_name", str),
-                                             ("pw_passwd", str),
-                                             ("pw_uid", int),
-                                             ("pw_gid", int),
-                                             ("pw_gecos", str),
-                                             ("pw_dir", str),
-                                             ("pw_shell", str)])
+class struct_passwd(Tuple[str, str, int, int, str, str, str]):
+    pw_name: str
+    pw_passwd: str
+    pw_uid: int
+    pw_gid: int
+    pw_gecos: str
+    pw_dir: str
+    pw_shell: str
 
 def getpwall() -> List[struct_passwd]: ...
 def getpwuid(uid: int) -> struct_passwd: ...


### PR DESCRIPTION
I believe the CPython structseq type is slightly better represented by a custom tuple subclass.