### PR TITLE
Improve typing of dialect parameter in csv module

### DIFF
--- a/stdlib/2and3/csv.pyi
+++ b/stdlib/2and3/csv.pyi
@@ -1,6 +1,6 @@
 from collections import OrderedDict
 import sys
-from typing import Any, Dict, Iterable, Iterator, List, Mapping, Optional, Sequence, Union
+from typing import Any, Dict, Iterable, Iterator, List, Mapping, Optional, Sequence, Type, Union
 
 from _csv import (_reader,
                   _writer,
@@ -18,7 +18,7 @@ from _csv import (_reader,
                   Error as Error,
                   )
 
-_Dialect = Union[str, Dialect]
+_Dialect = Union[str, Dialect, Type[Dialect]]
 _DictRow = Mapping[str, Any]
 
 class Dialect(object):
@@ -89,5 +89,5 @@ class DictWriter(object):
 class Sniffer(object):
     preferred: List[str]
     def __init__(self) -> None: ...
-    def sniff(self, sample: str, delimiters: Optional[str] = ...) -> Dialect: ...
+    def sniff(self, sample: str, delimiters: Optional[str] = ...) -> Type[Dialect]: ...
     def has_header(self, sample: str) -> bool: ...


### PR DESCRIPTION
resolves #2987 

- make `csv.DictReader` accepting a subclass of `csv.Dialect` as dialect argument.
- fix the return type of `Sniffer.sniff`, change from `Dialect` to`Type[Dialect]`.

From the example code and the doc of `Sniffer.sniff`, https://docs.python.org/3/library/csv.html#csv.Sniffer.sniff

>  sniff(sample, delimiters=None)
> 
>  Analyze the given sample and return a `Dialect` subclass reflecting the parameters found. If the optional delimiters parameter is given, it is interpreted as a string containing possible valid delimiter characters.

```Python
with open('example.csv', newline='') as csvfile:
    dialect = csv.Sniffer().sniff(csvfile.read(1024))
    csvfile.seek(0)
    reader = csv.reader(csvfile, dialect)
```

The return type of Sniffer.sniff should be `Type[Dialect]` instead of `Dialect`.

And the `DictReader` or `reader` can both accept instance or subclass of `csv.Dialect` as dialect argument.

Test code here
```Python
import csv


class CustomDialect(csv.Dialect):
    delimiter = ";"
    escapechar = '\\'
    doublequote = False
    skipinitialspace = True
    lineterminator = '\r\n'
    quoting = csv.QUOTE_NONE


with open("eggs.csv", newline="") as csvfile:
    reader = csv.DictReader(csvfile, dialect=CustomDialect)
    for row in reader:
        print(row)

with open("eggs.csv", newline="") as csvfile:
    reader = csv.DictReader(csvfile, dialect=CustomDialect())
    for row in reader:
        print(row)
```
eggs.csv

```CSV
a;b;c;d
1;2;3;4
0;1;2;3
```

However, In the doc of `csv.reader` https://docs.python.org/3/library/csv.html#csv.reader

> An optional dialect parameter can be given which is used to define a set of parameters specific to a particular CSV dialect. It may be an instance of a subclass of the Dialect class or one of the strings returned by the `list_dialects()` function. 

Accepting a subclass of `csv.Dialect` is undocumented.