### PR TITLE
click: Use property decorator for read-only properties

### DIFF
--- a/third_party/2and3/click/core.pyi
+++ b/third_party/2and3/click/core.pyi
@@ -65,10 +65,6 @@ class Context:
     _close_callbacks: List
     _depth: int
 
-    # properties
-    meta: Dict[str, Any]
-    command_path: str
-
     def __init__(
         self,
         command: Command,
@@ -87,6 +83,14 @@ class Context:
         token_normalize_func: Optional[Callable[[str], str]] = ...,
         color: Optional[bool] = ...
     ) -> None:
+        ...
+
+    @property
+    def meta(self) -> Dict[str, Any]:
+        ...
+
+    @property
+    def command_path(self) -> str:
         ...
 
     def scope(self, cleanup: bool = ...) -> ContextManager[Context]:
@@ -367,8 +371,6 @@ class Parameter:
     is_eager: bool
     metavar: Optional[str]
     envvar: Union[str, List[str], None]
-    # properties
-    human_readable_name: str
 
     def __init__(
         self,
@@ -383,6 +385,10 @@ class Parameter:
         is_eager: bool = ...,
         envvar: Optional[Union[str, List[str]]] = ...
     ) -> None:
+        ...
+
+    @property
+    def human_readable_name(self) -> str:
         ...
 
     def make_metavar(self) -> str:

--- a/third_party/2and3/click/parser.pyi
+++ b/third_party/2and3/click/parser.pyi
@@ -30,8 +30,6 @@ class Option:
     prefixes: Set[str]
     _short_opts: List[str]
     _long_opts: List[str]
-    # properties
-    takes_value: bool
 
     def __init__(
         self,
@@ -42,6 +40,10 @@ class Option:
         const: Optional[Any] = ...,
         obj: Optional[Any] = ...
     ) -> None:
+        ...
+
+    @property
+    def takes_value(self) -> bool:
         ...
 
     def process(self, value: Any, state: ParsingState) -> None:


### PR DESCRIPTION
Since these properties do not have a setter, be explicit with the
`@property` decorator. This will allow type checkers to see that
assignment of these attributes is an error.

See https://github.com/python/typeshed/pull/3027#discussion_r289623016
for some related context.