### PR TITLE
Overload ast.parse to recognize that mode=exec means Module return.

### DIFF
--- a/stdlib/3/ast.pyi
+++ b/stdlib/3/ast.pyi
@@ -25,7 +25,7 @@ _T = TypeVar('_T', bound=AST)
 
 if sys.version_info >= (3, 8):
     @overload
-    def parse(source: Union[str, bytes], filename: Union[str, bytes] = ..., mode: Literal["exec"] = "exec",
+    def parse(source: Union[str, bytes], filename: Union[str, bytes] = ..., mode: Literal["exec"] = ...,
               type_comments: bool = ..., feature_version: int = ...) -> Module: ...
 
     @overload
@@ -33,7 +33,7 @@ if sys.version_info >= (3, 8):
               type_comments: bool = ..., feature_version: int = ...) -> AST: ...
 else:
     @overload
-    def parse(source: Union[str, bytes], filename: Union[str, bytes] = ..., mode: Literal["exec"] = "exec") -> Module: ...
+    def parse(source: Union[str, bytes], filename: Union[str, bytes] = ..., mode: Literal["exec"] = ...) -> Module: ...
 
     @overload
     def parse(source: Union[str, bytes], filename: Union[str, bytes] = ..., mode: str = ...) -> AST: ...

--- a/stdlib/3/ast.pyi
+++ b/stdlib/3/ast.pyi
@@ -5,7 +5,8 @@ import sys
 # from _ast below when loaded in an unorthodox way by the Dropbox
 # internal Bazel integration.
 import typing as _typing
-from typing import Any, Iterator, Optional, Union, TypeVar
+from typing import overload, Any, Iterator, Optional, Union, TypeVar
+from typing_extensions import Literal
 
 # The same unorthodox Bazel integration causes issues with sys, which
 # is imported in both modules. unfortunately we can't just rename sys,
@@ -23,9 +24,18 @@ class NodeTransformer(NodeVisitor):
 _T = TypeVar('_T', bound=AST)
 
 if sys.version_info >= (3, 8):
+    @overload
+    def parse(source: Union[str, bytes], filename: Union[str, bytes] = ..., mode: Literal["exec"] = "exec",
+              type_comments: bool = ..., feature_version: int = ...) -> Module: ...
+
+    @overload
     def parse(source: Union[str, bytes], filename: Union[str, bytes] = ..., mode: str = ...,
               type_comments: bool = ..., feature_version: int = ...) -> AST: ...
 else:
+    @overload
+    def parse(source: Union[str, bytes], filename: Union[str, bytes] = ..., mode: Literal["exec"] = "exec") -> Module: ...
+
+    @overload
     def parse(source: Union[str, bytes], filename: Union[str, bytes] = ..., mode: str = ...) -> AST: ...
 
 def copy_location(new_node: _T, old_node: AST) -> _T: ...


### PR DESCRIPTION
With `mode="exec"` (which is the default mode), `ast.parse` always returns an `ast.Module`. It's irritating to always have to `cast` this.

Verified this change with a small file:

```
import ast

def foo() -> ast.Module:
    return ast.parse("a = 1")
```

This raises an error (expected Module, got AST) on typeshed master, passes with this PR.
Also added explicit `mode="exec"`, same results.
With `mode="eval"`, error on both master and this PR.