### PR TITLE
Add missing constructor to types.CodeType.

### DIFF
--- a/stdlib/2/types.pyi
+++ b/stdlib/2/types.pyi
@@ -64,6 +64,23 @@ class CodeType:
     co_nlocals: int
     co_stacksize: int
     co_varnames: Tuple[str, ...]
+    def __init__(
+        self,
+        argcount: int,
+        nlocals: int,
+        stacksize: int,
+        flags: int,
+        codestring: str,
+        constants: Tuple[Any, ...],
+        names: Tuple[str, ...],
+        varnames: Tuple[str, ...],
+        filename: str,
+        name: str,
+        firstlineno: int,
+        lnotab: str,
+        freevars: Tuple[str, ...] = ...,
+        cellvars: Tuple[str, ...] = ...,
+    ) -> None: ...
 
 class GeneratorType:
     gi_code: CodeType


### PR DESCRIPTION
The py3 stub already has this constructor, but it was missing from the py2 stub.

I got the argument order from
https://github.com/python/cpython/blob/2bfc2dc214445550521074f428245b502d215eac/Objects/codeobject.c#L263
and the types from the attributes already in the stub.