### PR TITLE
Add undocumented but used method LWPCookieJar.as_lwp_str.

### DIFF
--- a/stdlib/2/cookielib.pyi
+++ b/stdlib/2/cookielib.pyi
@@ -105,6 +105,8 @@ class FileCookieJar(CookieJar):
     def load(self, filename: Optional[Any] = ..., ignore_discard: bool = ..., ignore_expires: bool = ...): ...
     def revert(self, filename: Optional[Any] = ..., ignore_discard: bool = ..., ignore_expires: bool = ...): ...
 
+class LWPCookieJar(FileCookieJar):
+    def as_lwp_str(self, ignore_discard: bool = ..., ignore_expires: bool = ...) -> str: ...  # undocumented
+
 MozillaCookieJar = FileCookieJar
-LWPCookieJar = FileCookieJar
 def lwp_cookie_str(cookie: Cookie) -> str: ...

--- a/stdlib/3/http/cookiejar.pyi
+++ b/stdlib/3/http/cookiejar.pyi
@@ -37,8 +37,9 @@ class FileCookieJar(CookieJar):
                ignore_expires: bool = ...) -> None: ...
 
 class MozillaCookieJar(FileCookieJar): ...
-class LWPCookieJar(FileCookieJar): ...
 
+class LWPCookieJar(FileCookieJar):
+    def as_lwp_str(self, ignore_discard: bool = ..., ignore_expires: bool = ...) -> str: ...  # undocumented
 
 class CookiePolicy:
     netscape: bool


### PR DESCRIPTION
The method is defined here:
https://github.com/python/cpython/blob/e36ed475ea429f7cc80a4d65f80b44686a74b246/Lib/http/cookiejar.py#L1864