### PR TITLE
Use type annotation syntax in traceback module

### DIFF
--- a/stdlib/2and3/traceback.pyi
+++ b/stdlib/2and3/traceback.pyi
@@ -72,8 +72,8 @@ if sys.version_info < (3,):
 
 if sys.version_info >= (3, 5):
     class TracebackException:
-        __cause__ = ...  # type:TracebackException
-        __context__ = ...  # type:TracebackException
+        __cause__: TracebackException
+        __context__: TracebackException
         __suppress_context__: bool
         stack: StackSummary
         exc_type: Type[BaseException]


### PR DESCRIPTION
This looks like a last example where type comment syntax is still used (apart from some commented-out code in `pydoc`).