### PR TITLE
Adding stubs for pyre_extensions

### DIFF
--- a/third_party/2and3/pyre_extensions.pyi
+++ b/third_party/2and3/pyre_extensions.pyi
@@ -1,0 +1,6 @@
+from typing import List, Optional, Type, TypeVar
+
+_T = TypeVar("_T")
+
+def none_throws(optional: Optional[_T]) -> _T: ...
+def ParameterSpecification(__name: str) -> List[Type]: ...


### PR DESCRIPTION
Because it was decided (in https://github.com/python/typing/pull/636) that CallableParametersVariable (now renamed ParameterSpecification) wasn't quite ready for inclusion in `typing_extensions` we went ahead and published our implementation under a new PyPI package, `pyre_extensions` (https://pypi.org/project/pyre-extensions/).  
This is the corresponding typeshed stub.