### PR TITLE
Update select and selectors to use _HasFileno protocol

### DIFF
--- a/stdlib/2and3/select.pyi
+++ b/stdlib/2and3/select.pyi
@@ -1,9 +1,10 @@
 import sys
-from typing import Any, Optional, Sequence, Tuple, Iterable, List, Union
+from typing import Any, Iterable, List, Optional, Protocol, Sequence, Tuple, Union
 
-# When we have protocols, this should change to a protocol with a fileno method
-# See https://docs.python.org/3/c-api/file.html#c.PyObject_AsFileDescriptor
-_FileDescriptor = Union[int, Any]
+class _HasFileno(Protocol):
+    def fileno(self) -> int: ...
+
+_FileDescriptor = Union[int, _HasFileno]
 
 EPOLLERR: int
 EPOLLET: int

--- a/stdlib/3/selectors.pyi
+++ b/stdlib/3/selectors.pyi
@@ -1,16 +1,14 @@
 # Stubs for selector
 # See https://docs.python.org/3/library/selectors.html
 
-from typing import Any, List, NamedTuple, Mapping, Tuple, Optional, Union
 from abc import ABCMeta, abstractmethod
-import socket
+from typing import Any, List, Mapping, NamedTuple, Optional, Protocol, Tuple, Union
 
+class _HasFileno(Protocol):
+    def fileno(self) -> int: ...
 
 # Type aliases added mainly to preserve some context
-#
-# See https://github.com/python/typeshed/issues/482
-# for details regarding how _FileObject is typed.
-_FileObject = Union[int, socket.socket]
+_FileObject = Union[int, _HasFileno]
 _FileDescriptor = int
 _EventMask = int
 


### PR DESCRIPTION
At the time of creating type stubs for the stdlib `select.pyi` and `selectors.pyi`, there was no support for structural subtyping via protocols. So, the stubs had to use `Any` (no type safety) and `socket.socket` (only a subset of supported types).

Now that protocols are widely supported (https://www.python.org/dev/peps/pep-0544/ and https://mypy-lang.blogspot.com/2017/10/mypy-0530-released.html), the exact types can be expressed properly.

Here, we use the naming convention established in `faulthandler.pyi`:

https://github.com/python/typeshed/blob/1f740a7926049cbddc8d1b795c66381104a96aa6/stdlib/3/faulthandler.pyi#L5-L6

This properly fixes https://github.com/python/typeshed/issues/482. 