### PR TITLE
ssl.pyi: fix types of cadata argument

### DIFF
--- a/stdlib/2and3/ssl.pyi
+++ b/stdlib/2and3/ssl.pyi
@@ -51,7 +51,7 @@ if sys.version_info < (3,) or sys.version_info >= (3, 4):
     def create_default_context(purpose: Any = ..., *,
                                cafile: Optional[str] = ...,
                                capath: Optional[str] = ...,
-                               cadata: Optional[str] = ...) -> SSLContext: ...
+                               cadata: Union[str, bytes, None] = ...) -> SSLContext: ...
 
 if sys.version_info >= (3, 4):
     def _create_unverified_context(protocol: int = ..., *,
@@ -62,7 +62,7 @@ if sys.version_info >= (3, 4):
                                    keyfile: Optional[str] = ...,
                                    cafile: Optional[str] = ...,
                                    capath: Optional[str] = ...,
-                                   cadata: Optional[str] = ...) -> SSLContext: ...
+                                   cadata: Union[str, bytes, None] = ...) -> SSLContext: ...
     _create_default_https_context: Callable[..., SSLContext]
 
 if sys.version_info >= (3, 3):


### PR DESCRIPTION
The `cadata` argument can be a bytes-like object to load DER-encoded certificates.

https://docs.python.org/3.7/library/ssl.html#ssl.create_default_context