### PR TITLE
Refactor tests/pytype_test.py

### DIFF
--- a/tests/pytype_test.py
+++ b/tests/pytype_test.py
@@ -179,9 +179,8 @@ def pytype_test(args: argparse.Namespace) -> int:
             if args.print_stderr:
                 print(stderr)
             errors += 1
-            # We strip off the stack trace and just leave the last line with the
-            # actual error; to see the stack traces use --print_stderr.
-            bad.append((_get_relative(f), stderr.rstrip().rsplit("\n", 1)[-1]))
+            stacktrace_final_line = stderr.rstrip().rsplit("\n", 1)[-1]
+            bad.append((_get_relative(f), stacktrace_final_line))
 
         runs = i + 1
         if runs % 25 == 0:
@@ -190,6 +189,7 @@ def pytype_test(args: argparse.Namespace) -> int:
     print("Ran pytype with {:d} pyis, got {:d} errors.".format(total_tests, errors))
     for f, err in bad:
         print("{}: {}".format(f, err))
+    print("\nRun again with --print-stderr to get the full stacktrace.")
     return int(bool(errors))
 
 

--- a/tests/pytype_test.py
+++ b/tests/pytype_test.py
@@ -73,10 +73,8 @@ def load_blacklist(typeshed_location: str) -> List[str]:
     return skip
 
 
-def run_pytype(args: Sequence[str], dry_run: bool, typeshed_location: str) -> Optional[str]:
+def run_pytype(args: Sequence[str], typeshed_location: str) -> Optional[str]:
     """Runs pytype, returning the stderr if any."""
-    if dry_run:
-        return None
     old_typeshed_home = os.environ.get(TYPESHED_HOME, UNSET)
     os.environ[TYPESHED_HOME] = typeshed_location
     try:
@@ -141,6 +139,9 @@ def pytype_test(args: argparse.Namespace) -> int:
             print("Cannot run Python {version}. (point to a valid executable via {arg})".format(version=version, arg=arg))
             return 1
 
+    if args.dry_run:
+        return 0
+
     skipped = PathMatcher(load_blacklist(typeshed_location))
     files = []
     bad = []
@@ -153,7 +154,7 @@ def pytype_test(args: argparse.Namespace) -> int:
             version = "2.7"
             exe = args.python27_exe
         options = ["--module-name={}".format(_get_module_name(filename)), "--parse-pyi", "-V {}".format(version), "--python_exe={}".format(exe)]
-        return run_pytype(options + [filename], dry_run=args.dry_run, typeshed_location=typeshed_location)
+        return run_pytype(options + [filename], typeshed_location=typeshed_location)
 
     for root, _, filenames in itertools.chain.from_iterable(os.walk(p) for p in paths):
         for f in sorted(f for f in filenames if f.endswith(".pyi")):

--- a/tests/pytype_test.py
+++ b/tests/pytype_test.py
@@ -18,7 +18,7 @@ import subprocess
 import traceback
 from typing import List, Match, Optional, Sequence, Tuple
 
-import pytype
+from pytype import config as pytype_config, io as pytype_io
 
 TYPESHED_SUBDIRS = ["stdlib", "third_party"]
 
@@ -86,7 +86,7 @@ def load_blacklist(typeshed_location: str) -> List[str]:
 
 def run_pytype(*, filename: str, python_version: str, python_exe: str, typeshed_location: str) -> Optional[str]:
     """Runs pytype, returning the stderr if any."""
-    options = pytype.config.Options(
+    options = pytype_config.Options(
         [
             "--module-name={}".format(_get_module_name(filename)),
             "--parse-pyi",
@@ -98,7 +98,7 @@ def run_pytype(*, filename: str, python_version: str, python_exe: str, typeshed_
     old_typeshed_home = os.environ.get(TYPESHED_HOME, UNSET)
     os.environ[TYPESHED_HOME] = typeshed_location
     try:
-        pytype.io.parse_pyi(options)
+        pytype_io.parse_pyi(options)
     except Exception:
         stderr = traceback.format_exc()
     else:

--- a/tests/pytype_test.py
+++ b/tests/pytype_test.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python
-r"""Test runner for typeshed.
+#!/usr/bin/env python3
+"""Test runner for typeshed.
 
 Depends on pytype being installed.
 
@@ -44,7 +44,7 @@ def main():
     sys.exit(code)
 
 
-class PathMatcher(object):
+class PathMatcher:
     def __init__(self, patterns):
         if patterns:
             self.matcher = re.compile("(%s)$" % "|".join(patterns))

--- a/tests/pytype_test.py
+++ b/tests/pytype_test.py
@@ -147,7 +147,7 @@ def check_subdirs_discoverable(subdir_paths: List[str]) -> None:
 
 
 def check_python_exes_runnable(*, python27_exe_arg: str, python36_exe_arg: str) -> None:
-    for exe, version_str in zip([python27_exe_arg, python36_exe_arg], ["27", "3.6"]):
+    for exe, version_str in zip([python27_exe_arg, python36_exe_arg], ["27", "36"]):
         if can_run(exe, args=["--version"]):
             continue
         formatted_version = ".".join(list(version_str))

--- a/tests/pytype_test.py
+++ b/tests/pytype_test.py
@@ -11,15 +11,14 @@ will also discover incorrect usage of imported modules.
 """
 
 import argparse
-import collections
 import itertools
 import os
-from pytype import config
-from pytype import io
 import re
 import subprocess
 import sys
 import traceback
+
+import pytype
 
 parser = argparse.ArgumentParser(description='Pytype/typeshed tests.')
 parser.add_argument('-n', '--dry-run', action='store_true', default=False,
@@ -84,7 +83,7 @@ def run_pytype(args, dry_run, typeshed_location):
     old_typeshed_home = os.environ.get(TYPESHED_HOME, UNSET)
     os.environ[TYPESHED_HOME] = typeshed_location
     try:
-        io.parse_pyi(config.Options(args))
+        pytype.io.parse_pyi(pytype.config.Options(args))
     except Exception:
         stderr = traceback.format_exc()
     else:

--- a/tests/pytype_test.py
+++ b/tests/pytype_test.py
@@ -51,7 +51,7 @@ def create_parser() -> argparse.ArgumentParser:
 class PathMatcher:
     def __init__(self, patterns):
         if patterns:
-            self.matcher = re.compile("(%s)$" % "|".join(patterns))
+            self.matcher = re.compile(r"({})$".format("|".join(patterns)))
         else:
             self.matcher = None
 
@@ -121,7 +121,7 @@ def can_run(path, exe, *args):
 
 
 def _is_version(path, version):
-    return any("%s/%s" % (d, version) in path for d in TYPESHED_SUBDIRS)
+    return any("{}/{}".format(d, version) in path for d in TYPESHED_SUBDIRS)
 
 
 def pytype_test(args):
@@ -131,15 +131,15 @@ def pytype_test(args):
 
     for p in paths:
         if not os.path.isdir(p):
-            print("Cannot find typeshed subdir at %s " "(specify parent dir via --typeshed-location)" % p)
+            print("Cannot find typeshed subdir at {} (specify parent dir via --typeshed-location)".format(p))
             return 1
 
     for python_version_str in ("27", "36"):
-        dest = "python%s_exe" % python_version_str
+        dest = "python{}_exe".format(python_version_str)
         version = ".".join(list(python_version_str))
-        arg = "--python%s-exe" % python_version_str
+        arg = "--python{}-exe".format(python_version_str)
         if not can_run("", getattr(args, dest), "--version"):
-            print("Cannot run Python {version}. (point to a valid executable " "via {arg})".format(version=version, arg=arg))
+            print("Cannot run Python {version}. (point to a valid executable via {arg})".format(version=version, arg=arg))
             return 1
 
     skipped = PathMatcher(load_blacklist(typeshed_location))
@@ -153,7 +153,7 @@ def pytype_test(args):
         else:
             version = "2.7"
             exe = args.python27_exe
-        options = ["--module-name=%s" % _get_module_name(filename), "--parse-pyi", "-V %s" % version, "--python_exe=%s" % exe]
+        options = ["--module-name={}".format(_get_module_name(filename)), "--parse-pyi", "-V {}".format(version), "--python_exe={}".format(exe)]
         return run_pytype(options + [filename], dry_run=args.dry_run, typeshed_location=typeshed_location)
 
     for root, _, filenames in itertools.chain.from_iterable(os.walk(p) for p in paths):
@@ -169,7 +169,7 @@ def pytype_test(args):
                 elif _is_version(f, "3"):
                     files.append((f, 3))
                 else:
-                    print("Unrecognized path: %s" % f)
+                    print("Unrecognized path: {}".format(f))
 
     errors = 0
     total_tests = len(files)
@@ -186,11 +186,11 @@ def pytype_test(args):
 
         runs = i + 1
         if runs % 25 == 0:
-            print("  %3d/%d with %3d errors" % (runs, total_tests, errors))
+            print("  {:3d}/{:d} with {:3d} errors".format(runs, total_tests, errors))
 
-    print("Ran pytype with %d pyis, got %d errors." % (total_tests, errors))
+    print("Ran pytype with {:d} pyis, got {:d} errors.".format(total_tests, errors))
     for f, err in bad:
-        print("%s: %s" % (f, err))
+        print("{}: {}".format(f, err))
     return int(bool(errors))
 
 

--- a/tests/pytype_test.py
+++ b/tests/pytype_test.py
@@ -20,17 +20,6 @@ import traceback
 
 import pytype
 
-parser = argparse.ArgumentParser(description="Pytype/typeshed tests.")
-parser.add_argument("-n", "--dry-run", action="store_true", default=False, help="Don't actually run tests")
-# Default to '' so that symlinking typeshed subdirs in cwd will work.
-parser.add_argument("--typeshed-location", type=str, default="", help="Path to typeshed installation.")
-# Set to true to print a stack trace every time an exception is thrown.
-parser.add_argument("--print-stderr", action="store_true", default=False, help="Print stderr every time an error is encountered.")
-# We need to invoke python2.7 and 3.6.
-parser.add_argument("--python27-exe", type=str, default="python2.7", help="Path to a python 2.7 interpreter.")
-parser.add_argument("--python36-exe", type=str, default="python3.6", help="Path to a python 3.6 interpreter.")
-
-
 TYPESHED_SUBDIRS = ["stdlib", "third_party"]
 
 
@@ -39,9 +28,24 @@ UNSET = object()  # marker for tracking the TYPESHED_HOME environment variable
 
 
 def main():
-    args = parser.parse_args()
+    args = create_parser().parse_args()
     code = pytype_test(args)
     sys.exit(code)
+
+
+def create_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Pytype/typeshed tests.")
+    parser.add_argument("-n", "--dry-run", action="store_true", default=False, help="Don't actually run tests")
+    # Default to '' so that symlinking typeshed subdirs in cwd will work.
+    parser.add_argument("--typeshed-location", type=str, default="", help="Path to typeshed installation.")
+    # Set to true to print a stack trace every time an exception is thrown.
+    parser.add_argument(
+        "--print-stderr", action="store_true", default=False, help="Print stderr every time an error is encountered."
+    )
+    # We need to invoke python2.7 and 3.6.
+    parser.add_argument("--python27-exe", type=str, default="python2.7", help="Path to a python 2.7 interpreter.")
+    parser.add_argument("--python36-exe", type=str, default="python3.6", help="Path to a python 3.6 interpreter.")
+    return parser
 
 
 class PathMatcher:

--- a/tests/pytype_test.py
+++ b/tests/pytype_test.py
@@ -114,10 +114,11 @@ def _get_module_name(filename):
 def can_run(path, exe, *args):
     exe = os.path.join(path, exe)
     try:
-        subprocess.Popen([exe] + list(args), stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()
-        return True
+        subprocess.run([exe] + list(args), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     except OSError:
         return False
+    else:
+        return True
 
 
 def _is_version(path, version):

--- a/tests/pytype_test.py
+++ b/tests/pytype_test.py
@@ -20,26 +20,21 @@ import traceback
 
 import pytype
 
-parser = argparse.ArgumentParser(description='Pytype/typeshed tests.')
-parser.add_argument('-n', '--dry-run', action='store_true', default=False,
-                    help='Don\'t actually run tests')
+parser = argparse.ArgumentParser(description="Pytype/typeshed tests.")
+parser.add_argument("-n", "--dry-run", action="store_true", default=False, help="Don't actually run tests")
 # Default to '' so that symlinking typeshed subdirs in cwd will work.
-parser.add_argument('--typeshed-location', type=str, default='',
-                    help='Path to typeshed installation.')
+parser.add_argument("--typeshed-location", type=str, default="", help="Path to typeshed installation.")
 # Set to true to print a stack trace every time an exception is thrown.
-parser.add_argument('--print-stderr', action='store_true', default=False,
-                    help='Print stderr every time an error is encountered.')
+parser.add_argument("--print-stderr", action="store_true", default=False, help="Print stderr every time an error is encountered.")
 # We need to invoke python2.7 and 3.6.
-parser.add_argument('--python27-exe', type=str, default='python2.7',
-                    help='Path to a python 2.7 interpreter.')
-parser.add_argument('--python36-exe', type=str, default='python3.6',
-                    help='Path to a python 3.6 interpreter.')
+parser.add_argument("--python27-exe", type=str, default="python2.7", help="Path to a python 2.7 interpreter.")
+parser.add_argument("--python36-exe", type=str, default="python3.6", help="Path to a python 3.6 interpreter.")
 
 
-TYPESHED_SUBDIRS = ['stdlib', 'third_party']
+TYPESHED_SUBDIRS = ["stdlib", "third_party"]
 
 
-TYPESHED_HOME = 'TYPESHED_HOME'
+TYPESHED_HOME = "TYPESHED_HOME"
 UNSET = object()  # marker for tracking the TYPESHED_HOME environment variable
 
 
@@ -52,7 +47,7 @@ def main():
 class PathMatcher(object):
     def __init__(self, patterns):
         if patterns:
-            self.matcher = re.compile('(%s)$' % '|'.join(patterns))
+            self.matcher = re.compile("(%s)$" % "|".join(patterns))
         else:
             self.matcher = None
 
@@ -63,8 +58,8 @@ class PathMatcher(object):
 
 
 def load_blacklist(typeshed_location):
-    filename = os.path.join(typeshed_location, 'tests', 'pytype_blacklist.txt')
-    skip_re = re.compile(r'^\s*([^\s#]+)\s*(?:#.*)?$')
+    filename = os.path.join(typeshed_location, "tests", "pytype_blacklist.txt")
+    skip_re = re.compile(r"^\s*([^\s#]+)\s*(?:#.*)?$")
     skip = []
 
     with open(filename) as f:
@@ -109,23 +104,20 @@ def _get_relative(filename):
 
 def _get_module_name(filename):
     """Converts a filename {subdir}/m.n/module/foo to module.foo."""
-    return '.'.join(_get_relative(filename).split(os.path.sep)[2:]).replace(
-        '.pyi', '').replace('.__init__', '')
+    return ".".join(_get_relative(filename).split(os.path.sep)[2:]).replace(".pyi", "").replace(".__init__", "")
 
 
 def can_run(path, exe, *args):
     exe = os.path.join(path, exe)
     try:
-        subprocess.Popen(
-            [exe] + list(args), stdout=subprocess.PIPE, stderr=subprocess.PIPE
-        ).communicate()
+        subprocess.Popen([exe] + list(args), stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()
         return True
     except OSError:
         return False
 
 
 def _is_version(path, version):
-    return any('%s/%s' % (d, version) in path for d in TYPESHED_SUBDIRS)
+    return any("%s/%s" % (d, version) in path for d in TYPESHED_SUBDIRS)
 
 
 def pytype_test(args):
@@ -135,17 +127,15 @@ def pytype_test(args):
 
     for p in paths:
         if not os.path.isdir(p):
-            print('Cannot find typeshed subdir at %s '
-                  '(specify parent dir via --typeshed-location)' % p)
+            print("Cannot find typeshed subdir at %s " "(specify parent dir via --typeshed-location)" % p)
             return 1
 
-    for python_version_str in ('27', '36'):
-        dest = 'python%s_exe' % python_version_str
-        version = '.'.join(list(python_version_str))
-        arg = '--python%s-exe' % python_version_str
-        if not can_run('', getattr(args, dest), '--version'):
-            print('Cannot run Python {version}. (point to a valid executable '
-                  'via {arg})'.format(version=version, arg=arg))
+    for python_version_str in ("27", "36"):
+        dest = "python%s_exe" % python_version_str
+        version = ".".join(list(python_version_str))
+        arg = "--python%s-exe" % python_version_str
+        if not can_run("", getattr(args, dest), "--version"):
+            print("Cannot run Python {version}. (point to a valid executable " "via {arg})".format(version=version, arg=arg))
             return 1
 
     skipped = PathMatcher(load_blacklist(typeshed_location))
@@ -154,40 +144,32 @@ def pytype_test(args):
 
     def _parse(filename, major_version):
         if major_version == 3:
-            version = '3.6'
+            version = "3.6"
             exe = args.python36_exe
         else:
-            version = '2.7'
+            version = "2.7"
             exe = args.python27_exe
-        options = [
-            '--module-name=%s' % _get_module_name(filename),
-            '--parse-pyi',
-            '-V %s' % version,
-            '--python_exe=%s' % exe,
-        ]
-        return run_pytype(options + [filename],
-                          dry_run=args.dry_run,
-                          typeshed_location=typeshed_location)
+        options = ["--module-name=%s" % _get_module_name(filename), "--parse-pyi", "-V %s" % version, "--python_exe=%s" % exe]
+        return run_pytype(options + [filename], dry_run=args.dry_run, typeshed_location=typeshed_location)
 
-    for root, _, filenames in itertools.chain.from_iterable(
-            os.walk(p) for p in paths):
-        for f in sorted(f for f in filenames if f.endswith('.pyi')):
+    for root, _, filenames in itertools.chain.from_iterable(os.walk(p) for p in paths):
+        for f in sorted(f for f in filenames if f.endswith(".pyi")):
             f = os.path.join(root, f)
             rel = _get_relative(f)
             if not skipped.search(rel):
-                if _is_version(f, '2and3'):
+                if _is_version(f, "2and3"):
                     files.append((f, 2))
                     files.append((f, 3))
-                elif _is_version(f, '2'):
+                elif _is_version(f, "2"):
                     files.append((f, 2))
-                elif _is_version(f, '3'):
+                elif _is_version(f, "3"):
                     files.append((f, 3))
                 else:
-                    print('Unrecognized path: %s' % f)
+                    print("Unrecognized path: %s" % f)
 
     errors = 0
     total_tests = len(files)
-    print('Testing files with pytype...')
+    print("Testing files with pytype...")
     for i, (f, version) in enumerate(files):
         stderr = _parse(f, version)
         if stderr:
@@ -196,17 +178,17 @@ def pytype_test(args):
             errors += 1
             # We strip off the stack trace and just leave the last line with the
             # actual error; to see the stack traces use --print_stderr.
-            bad.append((_get_relative(f), stderr.rstrip().rsplit('\n', 1)[-1]))
+            bad.append((_get_relative(f), stderr.rstrip().rsplit("\n", 1)[-1]))
 
         runs = i + 1
         if runs % 25 == 0:
-            print('  %3d/%d with %3d errors' % (runs, total_tests, errors))
+            print("  %3d/%d with %3d errors" % (runs, total_tests, errors))
 
-    print('Ran pytype with %d pyis, got %d errors.' % (total_tests, errors))
+    print("Ran pytype with %d pyis, got %d errors." % (total_tests, errors))
     for f, err in bad:
-        print('%s: %s' % (f, err))
+        print("%s: %s" % (f, err))
     return int(bool(errors))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/tests/pytype_test.py
+++ b/tests/pytype_test.py
@@ -33,8 +33,6 @@ def main() -> None:
     subdir_paths = [os.path.join(typeshed_location, d) for d in TYPESHED_SUBDIRS]
     check_subdirs_discoverable(subdir_paths)
     check_python_exes_runnable(python27_exe_arg=args.python27_exe, python36_exe_arg=args.python36_exe)
-    if args.dry_run:
-        return
     files_to_test = determine_files_to_test(typeshed_location=typeshed_location, subdir_paths=subdir_paths)
     run_all_tests(
         files_to_test=files_to_test,
@@ -42,6 +40,7 @@ def main() -> None:
         python27_exe=args.python27_exe,
         python36_exe=args.python36_exe,
         print_stderr=args.print_stderr,
+        dry_run=args.dry_run,
     )
 
 
@@ -184,18 +183,28 @@ def determine_files_to_test(*, typeshed_location: str, subdir_paths: Sequence[st
 
 
 def run_all_tests(
-    *, files_to_test: Sequence[Tuple[str, int]], typeshed_location: str, python27_exe: str, python36_exe: str, print_stderr: bool
+    *,
+    files_to_test: Sequence[Tuple[str, int]],
+    typeshed_location: str,
+    python27_exe: str,
+    python36_exe: str,
+    print_stderr: bool,
+    dry_run: bool
 ) -> None:
     bad = []
     errors = 0
     total_tests = len(files_to_test)
     print("Testing files with pytype...")
     for i, (f, version) in enumerate(files_to_test):
-        stderr = run_pytype(
-            filename=f,
-            python_version="2.7" if version == 2 else "3.6",
-            python_exe=python27_exe if version == 2 else python36_exe,
-            typeshed_location=typeshed_location,
+        stderr = (
+            run_pytype(
+                filename=f,
+                python_version="2.7" if version == 2 else "3.6",
+                python_exe=python27_exe if version == 2 else python36_exe,
+                typeshed_location=typeshed_location,
+            )
+            if not dry_run
+            else None
         )
         if stderr:
             if print_stderr:


### PR DESCRIPTION
While working on https://github.com/python/typeshed/pull/3062, the `tests/pytype_test.py` file has been failing and it was realized that the file could be refactored (https://github.com/python/typeshed/pull/3062#issuecomment-502501728).

This does the following to try to improve the readability while preserving all original behavior:
* Mark as Python 3.
* Use `.format()` instead of `%` for string interpolation.
* Apply Black and isort.
* Add type hints.
* Use `raise SystemExit()` rather than manually managing return codes and calling `sys.exit()`.
* Move the high level logic into `main()` instead of `pytype_test()`.
   * Make `run_pytype()` less generic. It no longer accepts generic `args`, because it does not need that much flexibility. This allowed removing `_parse()`.
   * Extract out `check_subdirs_discoverable()` and `check_python_exes_runnable`.
   * Extract out `determine_files_to_test()`.
* Invert conditionals for early returns in loops to reduce indentation.
* Add a `print()` statement to run with `--print-stderr` upon failures for more useful output.