### PR TITLE
Install Black and isort autoformatters

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [tool.black]
 line_length = 130
+target_version = ["py37"]
 
 [tool.isort]
 multi_line_output = 3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[tool.black]
+line_length = 130
+
+[tool.isort]
+multi_line_output = 3
+include_trailing_comma = true
+force_grid_wrap = 0
+use_parentheses = true
+combine_as_imports = true
+line_length = 130

--- a/requirements-tests-py3.txt
+++ b/requirements-tests-py3.txt
@@ -1,6 +1,8 @@
 git+https://github.com/python/mypy.git@master
 typed-ast>=1.0.4
+black==19.3b0
 flake8==3.6.0
 flake8-bugbear==18.8.0
 flake8-pyi==18.3.1
+isort==4.3.20
 pytype>=2019.5.15


### PR DESCRIPTION
The first stage of adding auto-formatters (https://github.com/python/typeshed/issues/3058), as described by https://github.com/python/typeshed/pull/3062#issuecomment-502809479. This allows users to use Black and isort, but we do not yet document how to do so nor do we enforce it.

We configure isort to work with Black and instruct both tools to use a line length of 130, per the consensus described in https://github.com/python/typeshed/issues/3058#issuecomment-502433305.