### PR TITLE
fix type of loop.sock_connect

### DIFF
--- a/stdlib/3/asyncio/base_events.pyi
+++ b/stdlib/3/asyncio/base_events.pyi
@@ -1,5 +1,5 @@
 import selectors
-from socket import socket
+from socket import socket, _Address
 import ssl
 import sys
 from typing import Any, Awaitable, Callable, Dict, Generator, List, Optional, Sequence, Tuple, TypeVar, Union, overload
@@ -122,6 +122,8 @@ class BaseEventLoop(AbstractEventLoop):
     def sock_recv(self, sock: socket, nbytes: int) -> Generator[Any, None, bytes]: ...
     @coroutine
     def sock_sendall(self, sock: socket, data: bytes) -> Generator[Any, None, None]: ...
+    @coroutine
+    def sock_connect(self, sock: socket, address: _Address) -> Generator[Any, None, None]: ...
     @coroutine
     def sock_accept(self, sock: socket) -> Generator[Any, None, Tuple[socket, Any]]: ...
     # Signal handling.

--- a/stdlib/3/asyncio/base_events.pyi
+++ b/stdlib/3/asyncio/base_events.pyi
@@ -1,5 +1,5 @@
 import selectors
-from socket import socket, _Address
+from socket import socket
 import ssl
 import sys
 from typing import Any, Awaitable, Callable, Dict, Generator, List, Optional, Sequence, Tuple, TypeVar, Union, overload
@@ -122,8 +122,6 @@ class BaseEventLoop(AbstractEventLoop):
     def sock_recv(self, sock: socket, nbytes: int) -> Generator[Any, None, bytes]: ...
     @coroutine
     def sock_sendall(self, sock: socket, data: bytes) -> Generator[Any, None, None]: ...
-    @coroutine
-    def sock_connect(self, sock: socket, address: _Address) -> Generator[Any, None, None]: ...
     @coroutine
     def sock_accept(self, sock: socket) -> Generator[Any, None, Tuple[socket, Any]]: ...
     # Signal handling.

--- a/stdlib/3/asyncio/base_events.pyi
+++ b/stdlib/3/asyncio/base_events.pyi
@@ -1,5 +1,5 @@
 import selectors
-from socket import socket
+from socket import socket, _Address
 import ssl
 import sys
 from typing import Any, Awaitable, Callable, Dict, Generator, List, Optional, Sequence, Tuple, TypeVar, Union, overload
@@ -123,7 +123,7 @@ class BaseEventLoop(AbstractEventLoop):
     @coroutine
     def sock_sendall(self, sock: socket, data: bytes) -> Generator[Any, None, None]: ...
     @coroutine
-    def sock_connect(self, sock: socket, address: str) -> Generator[Any, None, None]: ...
+    def sock_connect(self, sock: socket, address: _Address) -> Generator[Any, None, None]: ...
     @coroutine
     def sock_accept(self, sock: socket) -> Generator[Any, None, Tuple[socket, Any]]: ...
     # Signal handling.

--- a/stdlib/3/asyncio/events.pyi
+++ b/stdlib/3/asyncio/events.pyi
@@ -1,5 +1,5 @@
 import selectors
-from socket import socket
+from socket import socket, _Address
 import ssl
 import sys
 from typing import Any, Awaitable, Callable, Dict, Generator, List, Optional, Sequence, Tuple, TypeVar, Union, overload
@@ -185,7 +185,7 @@ class AbstractEventLoop(metaclass=ABCMeta):
     def sock_sendall(self, sock: socket, data: bytes) -> Generator[Any, None, None]: ...
     @abstractmethod
     @coroutine
-    def sock_connect(self, sock: socket, address: str) -> Generator[Any, None, None]: ...
+    def sock_connect(self, sock: socket, address: _Address) -> Generator[Any, None, None]: ...
     @abstractmethod
     @coroutine
     def sock_accept(self, sock: socket) -> Generator[Any, None, Tuple[socket, Any]]: ...


### PR DESCRIPTION
I ran into a place in our code where we pass a (host, port) tuple to sock_connect. According to https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.loop.sock_connect, the address argument is the same as that to socket.connect (https://docs.python.org/3/library/socket.html#socket.socket.connect), so I use the same type alias used for socket.

socket.connect also takes bytes according to our annotations, but from my experiments it seems that asyncio's version does not.