### PR TITLE
Revert "Define functools.partial as overloaded function instead of its own class"

### DIFF
--- a/stdlib/2/_functools.pyi
+++ b/stdlib/2/_functools.pyi
@@ -3,10 +3,6 @@
 from typing import Any, Callable, Dict, Iterable, Optional, TypeVar, Tuple, overload
 
 _T = TypeVar("_T")
-_T2 = TypeVar("_T2")
-_T3 = TypeVar("_T3")
-_T4 = TypeVar("_T4")
-_T5 = TypeVar("_T5")
 _S = TypeVar("_S")
 
 @overload
@@ -16,72 +12,9 @@ def reduce(function: Callable[[_T, _T], _T],
 def reduce(function: Callable[[_T, _S], _T],
            sequence: Iterable[_S], initial: _T) -> _T: ...
 
-@overload
-def partial(__func: Callable[[_T], _S], __arg: _T) -> Callable[[], _S]: ...
-@overload
-def partial(__func: Callable[[_T, _T2], _S], __arg: _T) -> Callable[[_T2], _S]: ...
-@overload
-def partial(__func: Callable[[_T, _T2, _T3], _S], __arg: _T) -> Callable[[_T2, _T3], _S]: ...
-@overload
-def partial(__func: Callable[[_T, _T2, _T3, _T4], _S], __arg: _T) -> Callable[[_T2, _T3, _T4], _S]: ...
-@overload
-def partial(__func: Callable[[_T, _T2, _T3, _T4, _T5], _S], __arg: _T) -> Callable[[_T2, _T3, _T4, _T5], _S]: ...
-
-@overload
-def partial(__func: Callable[[_T, _T2], _S],
-            __arg1: _T,
-            __arg2: _T2) -> Callable[[], _S]: ...
-@overload
-def partial(__func: Callable[[_T, _T2, _T3], _S],
-            __arg1: _T,
-            __arg2: _T2) -> Callable[[_T3], _S]: ...
-@overload
-def partial(__func: Callable[[_T, _T2, _T3, _T4], _S],
-            __arg1: _T,
-            __arg2: _T2) -> Callable[[_T3, _T4], _S]: ...
-@overload
-def partial(__func: Callable[[_T, _T2, _T3, _T4, _T5], _S],
-            __arg1: _T,
-            __arg2: _T2) -> Callable[[_T3, _T4, _T5], _S]: ...
-
-@overload
-def partial(__func: Callable[[_T, _T2, _T3], _S],
-            __arg1: _T,
-            __arg2: _T2,
-            __arg3: _T3) -> Callable[[], _S]: ...
-@overload
-def partial(__func: Callable[[_T, _T2, _T3, _T4], _S],
-            __arg1: _T,
-            __arg2: _T2,
-            __arg3: _T3) -> Callable[[_T4], _S]: ...
-@overload
-def partial(__func: Callable[[_T, _T2, _T3, _T4, _T5], _S],
-            __arg1: _T,
-            __arg2: _T2,
-            __arg3: _T3) -> Callable[[_T4, _T5], _S]: ...
-
-@overload
-def partial(__func: Callable[[_T, _T2, _T3, _T4], _S],
-            __arg1: _T,
-            __arg2: _T2,
-            __arg3: _T3,
-            __arg4: _T4) -> Callable[[], _S]: ...
-@overload
-def partial(__func: Callable[[_T, _T2, _T3, _T4, _T5], _S],
-            __arg1: _T,
-            __arg2: _T2,
-            __arg3: _T3,
-            __arg4: _T4) -> Callable[[_T5], _S]: ...
-
-@overload
-def partial(__func: Callable[[_T, _T2, _T3, _T4, _T5], _S],
-            __arg1: _T,
-            __arg2: _T2,
-            __arg3: _T3,
-            __arg4: _T4,
-            __arg5: _T5) -> Callable[[], _S]: ...
-
-@overload
-def partial(__func: Callable[..., _S],
-            *args: Any,
-            **kwargs: Any) -> Callable[..., _S]: ...
+class partial(object):
+    func: Callable[..., Any]
+    args: Tuple[Any, ...]
+    keywords: Dict[str, Any]
+    def __init__(self, func: Callable[..., Any], *args: Any, **kwargs: Any) -> None: ...
+    def __call__(self, *args: Any, **kwargs: Any) -> Any: ...

--- a/stdlib/2/functools.pyi
+++ b/stdlib/2/functools.pyi
@@ -9,10 +9,6 @@ from collections import namedtuple
 _AnyCallable = Callable[..., Any]
 
 _T = TypeVar("_T")
-_T2 = TypeVar("_T2")
-_T3 = TypeVar("_T3")
-_T4 = TypeVar("_T4")
-_T5 = TypeVar("_T5")
 _S = TypeVar("_S")
 @overload
 def reduce(function: Callable[[_T, _T], _T],
@@ -30,72 +26,9 @@ def wraps(wrapped: _AnyCallable, assigned: Sequence[str] = ..., updated: Sequenc
 def total_ordering(cls: type) -> type: ...
 def cmp_to_key(mycmp: Callable[[_T, _T], int]) -> Callable[[_T], Any]: ...
 
-@overload
-def partial(__func: Callable[[_T], _S], __arg: _T) -> Callable[[], _S]: ...
-@overload
-def partial(__func: Callable[[_T, _T2], _S], __arg: _T) -> Callable[[_T2], _S]: ...
-@overload
-def partial(__func: Callable[[_T, _T2, _T3], _S], __arg: _T) -> Callable[[_T2, _T3], _S]: ...
-@overload
-def partial(__func: Callable[[_T, _T2, _T3, _T4], _S], __arg: _T) -> Callable[[_T2, _T3, _T4], _S]: ...
-@overload
-def partial(__func: Callable[[_T, _T2, _T3, _T4, _T5], _S], __arg: _T) -> Callable[[_T2, _T3, _T4, _T5], _S]: ...
-
-@overload
-def partial(__func: Callable[[_T, _T2], _S],
-            __arg1: _T,
-            __arg2: _T2) -> Callable[[], _S]: ...
-@overload
-def partial(__func: Callable[[_T, _T2, _T3], _S],
-            __arg1: _T,
-            __arg2: _T2) -> Callable[[_T3], _S]: ...
-@overload
-def partial(__func: Callable[[_T, _T2, _T3, _T4], _S],
-            __arg1: _T,
-            __arg2: _T2) -> Callable[[_T3, _T4], _S]: ...
-@overload
-def partial(__func: Callable[[_T, _T2, _T3, _T4, _T5], _S],
-            __arg1: _T,
-            __arg2: _T2) -> Callable[[_T3, _T4, _T5], _S]: ...
-
-@overload
-def partial(__func: Callable[[_T, _T2, _T3], _S],
-            __arg1: _T,
-            __arg2: _T2,
-            __arg3: _T3) -> Callable[[], _S]: ...
-@overload
-def partial(__func: Callable[[_T, _T2, _T3, _T4], _S],
-            __arg1: _T,
-            __arg2: _T2,
-            __arg3: _T3) -> Callable[[_T4], _S]: ...
-@overload
-def partial(__func: Callable[[_T, _T2, _T3, _T4, _T5], _S],
-            __arg1: _T,
-            __arg2: _T2,
-            __arg3: _T3) -> Callable[[_T4, _T5], _S]: ...
-
-@overload
-def partial(__func: Callable[[_T, _T2, _T3, _T4], _S],
-            __arg1: _T,
-            __arg2: _T2,
-            __arg3: _T3,
-            __arg4: _T4) -> Callable[[], _S]: ...
-@overload
-def partial(__func: Callable[[_T, _T2, _T3, _T4, _T5], _S],
-            __arg1: _T,
-            __arg2: _T2,
-            __arg3: _T3,
-            __arg4: _T4) -> Callable[[_T5], _S]: ...
-
-@overload
-def partial(__func: Callable[[_T, _T2, _T3, _T4, _T5], _S],
-            __arg1: _T,
-            __arg2: _T2,
-            __arg3: _T3,
-            __arg4: _T4,
-            __arg5: _T5) -> Callable[[], _S]: ...
-
-@overload
-def partial(__func: Callable[..., _S],
-            *args: Any,
-            **kwargs: Any) -> Callable[..., _S]: ...
+class partial(Generic[_T]):
+    func = ...  # Callable[..., _T]
+    args: Tuple[Any, ...]
+    keywords: Dict[str, Any]
+    def __init__(self, func: Callable[..., _T], *args: Any, **kwargs: Any) -> None: ...
+    def __call__(self, *args: Any, **kwargs: Any) -> _T: ...

--- a/stdlib/3/functools.pyi
+++ b/stdlib/3/functools.pyi
@@ -4,10 +4,6 @@ from typing import Any, Callable, Generic, Dict, Iterable, Mapping, Optional, Se
 _AnyCallable = Callable[..., Any]
 
 _T = TypeVar("_T")
-_T2 = TypeVar("_T2")
-_T3 = TypeVar("_T3")
-_T4 = TypeVar("_T4")
-_T5 = TypeVar("_T5")
 _S = TypeVar("_S")
 @overload
 def reduce(function: Callable[[_T, _S], _T],
@@ -44,75 +40,12 @@ def wraps(wrapped: _AnyCallable, assigned: Sequence[str] = ..., updated: Sequenc
 def total_ordering(cls: type) -> type: ...
 def cmp_to_key(mycmp: Callable[[_T, _T], int]) -> Callable[[_T], Any]: ...
 
-@overload
-def partial(__func: Callable[[_T], _S], __arg: _T) -> Callable[[], _S]: ...
-@overload
-def partial(__func: Callable[[_T, _T2], _S], __arg: _T) -> Callable[[_T2], _S]: ...
-@overload
-def partial(__func: Callable[[_T, _T2, _T3], _S], __arg: _T) -> Callable[[_T2, _T3], _S]: ...
-@overload
-def partial(__func: Callable[[_T, _T2, _T3, _T4], _S], __arg: _T) -> Callable[[_T2, _T3, _T4], _S]: ...
-@overload
-def partial(__func: Callable[[_T, _T2, _T3, _T4, _T5], _S], __arg: _T) -> Callable[[_T2, _T3, _T4, _T5], _S]: ...
-
-@overload
-def partial(__func: Callable[[_T, _T2], _S],
-            __arg1: _T,
-            __arg2: _T2) -> Callable[[], _S]: ...
-@overload
-def partial(__func: Callable[[_T, _T2, _T3], _S],
-            __arg1: _T,
-            __arg2: _T2) -> Callable[[_T3], _S]: ...
-@overload
-def partial(__func: Callable[[_T, _T2, _T3, _T4], _S],
-            __arg1: _T,
-            __arg2: _T2) -> Callable[[_T3, _T4], _S]: ...
-@overload
-def partial(__func: Callable[[_T, _T2, _T3, _T4, _T5], _S],
-            __arg1: _T,
-            __arg2: _T2) -> Callable[[_T3, _T4, _T5], _S]: ...
-
-@overload
-def partial(__func: Callable[[_T, _T2, _T3], _S],
-            __arg1: _T,
-            __arg2: _T2,
-            __arg3: _T3) -> Callable[[], _S]: ...
-@overload
-def partial(__func: Callable[[_T, _T2, _T3, _T4], _S],
-            __arg1: _T,
-            __arg2: _T2,
-            __arg3: _T3) -> Callable[[_T4], _S]: ...
-@overload
-def partial(__func: Callable[[_T, _T2, _T3, _T4, _T5], _S],
-            __arg1: _T,
-            __arg2: _T2,
-            __arg3: _T3) -> Callable[[_T4, _T5], _S]: ...
-
-@overload
-def partial(__func: Callable[[_T, _T2, _T3, _T4], _S],
-            __arg1: _T,
-            __arg2: _T2,
-            __arg3: _T3,
-            __arg4: _T4) -> Callable[[], _S]: ...
-@overload
-def partial(__func: Callable[[_T, _T2, _T3, _T4, _T5], _S],
-            __arg1: _T,
-            __arg2: _T2,
-            __arg3: _T3,
-            __arg4: _T4) -> Callable[[_T5], _S]: ...
-
-@overload
-def partial(__func: Callable[[_T, _T2, _T3, _T4, _T5], _S],
-            __arg1: _T,
-            __arg2: _T2,
-            __arg3: _T3,
-            __arg4: _T4,
-            __arg5: _T5) -> Callable[[], _S]: ...
-
-@overload
-def partial(__func: Callable[..., _S],
-            *args: Any,
-            **kwargs: Any) -> Callable[..., _S]: ...
+class partial(Generic[_T]):
+    func: Callable[..., _T]
+    args: Tuple[Any, ...]
+    keywords: Dict[str, Any]
+    def __init__(self, func: Callable[..., _T], *args: Any, **kwargs: Any) -> None: ...
+    def __call__(self, *args: Any, **kwargs: Any) -> _T: ...
 
 # With protocols, this could change into a generic protocol that defines __get__ and returns _T
 _Descriptor = Any


### PR DESCRIPTION
Reverts python/typeshed#2878

Caused problems in many real-world codebases. Proper support for `partial` will have to come from a plugin instead.

I've seen the following problems reported:
- Keyword arguments to partial() functions no longer work
- isinstance() checks on functools.partial no longer work
- Access to .func and other attributes no longer works