### PR TITLE
Fix annotation of re.Match 'lastindex' and 'lastgroup' in Python 3

### DIFF
--- a/stdlib/3/typing.pyi
+++ b/stdlib/3/typing.pyi
@@ -517,8 +517,8 @@ class ByteString(Sequence[int], metaclass=ABCMeta): ...
 class Match(Generic[AnyStr]):
     pos = 0
     endpos = 0
-    lastindex = 0
-    lastgroup: AnyStr
+    lastindex: Optional[int]
+    lastgroup: Optional[AnyStr]
     string: AnyStr
 
     # The regular expression object whose match() or search() method produced


### PR DESCRIPTION
Both are `None` if there were no groups matched. Also `lastgroup` will be `None` if the matched group was nameless.

The Python 2 versions of these annotations already used `Optional`.