### PR TITLE
"key" argument of builtin function sorted should be optional in python 2.7

### DIFF
--- a/stdlib/2/__builtin__.pyi
+++ b/stdlib/2/__builtin__.pyi
@@ -1390,7 +1390,7 @@ if sys.version_info >= (3,):
 else:
     def sorted(__iterable: Iterable[_T], *,
                cmp: Callable[[_T, _T], int] = ...,
-               key: Callable[[_T], Any] = ...,
+               key: Optional[Callable[[_T], Any]] = ...,
                reverse: bool = ...) -> List[_T]: ...
 @overload
 def sum(__iterable: Iterable[_T]) -> Union[_T, int]: ...

--- a/stdlib/2and3/builtins.pyi
+++ b/stdlib/2and3/builtins.pyi
@@ -1390,7 +1390,7 @@ if sys.version_info >= (3,):
 else:
     def sorted(__iterable: Iterable[_T], *,
                cmp: Callable[[_T, _T], int] = ...,
-               key: Callable[[_T], Any] = ...,
+               key: Optional[Callable[[_T], Any]] = ...,
                reverse: bool = ...) -> List[_T]: ...
 @overload
 def sum(__iterable: Iterable[_T]) -> Union[_T, int]: ...


### PR DESCRIPTION
It is correctly marked as optional in python 3+, but not in python 2.7.  

I test this with 2.7.10:

```
chad$ python
Python 2.7.10 (default, Oct  6 2017, 22:29:07) 
[GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.31)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> sorted([1,4,67,8], key=None)
[1, 4, 8, 67]
>>>
```
