### PR TITLE
Restore default value to click.echo_via_pager

### DIFF
--- a/third_party/2and3/click/termui.pyi
+++ b/third_party/2and3/click/termui.pyi
@@ -62,7 +62,7 @@ def get_terminal_size() -> Tuple[int, int]:
 
 def echo_via_pager(
     text_or_generator: Union[str, Iterable[str], Callable[[], Generator[str, None, None]]],
-    color: Optional[bool]
+    color: Optional[bool] = ...,
 ) -> None:
     ...
 


### PR DESCRIPTION
This resolves #3089, by restoring the default value to the `color` argument.