### PR TITLE
Make dataclasses.Field.metadata non-optional

### DIFF
--- a/stdlib/3.7/dataclasses.pyi
+++ b/stdlib/3.7/dataclasses.pyi
@@ -34,7 +34,7 @@ class Field(Generic[_T]):
     hash: Optional[bool]
     init: bool
     compare: bool
-    metadata: Optional[Mapping[str, Any]]
+    metadata: Mapping[str, Any]
 
 
 # NOTE: Actual return type is 'Field[_T]', but we want to help type checkers

--- a/third_party/3/dataclasses.pyi
+++ b/third_party/3/dataclasses.pyi
@@ -34,7 +34,7 @@ class Field(Generic[_T]):
     hash: Optional[bool]
     init: bool
     compare: bool
-    metadata: Optional[Mapping[str, Any]]
+    metadata: Mapping[str, Any]
 
 
 # NOTE: Actual return type is 'Field[_T]', but we want to help type checkers


### PR DESCRIPTION
If `metadata` is `None` the Field constructor replaces it with an empty mapping object, so this value can never be None.

https://github.com/python/cpython/blob/v3.7.3/Lib/dataclasses.py#L243