### PR TITLE
Add zipfile.ZipFile.filename

### DIFF
--- a/stdlib/2and3/zipfile.pyi
+++ b/stdlib/2and3/zipfile.pyi
@@ -24,6 +24,7 @@ error = BadZipfile
 class LargeZipFile(Exception): ...
 
 class ZipFile:
+    filename: Optional[Text]
     debug: int
     comment: bytes
     filelist: List[ZipInfo]


### PR DESCRIPTION
The `ZipFile.filename` data attribute is documented, but not included in the type stubs.