### PR TITLE
sys: refine the return type of sys.exc_info()

### DIFF
--- a/stdlib/2/sys.pyi
+++ b/stdlib/2/sys.pyi
@@ -8,7 +8,7 @@ from types import FrameType, ModuleType, TracebackType, ClassType
 
 # The following type alias are stub-only and do not exist during runtime
 _ExcInfo = Tuple[Type[BaseException], BaseException, TracebackType]
-_OptExcInfo = Tuple[Optional[Type[BaseException]], Optional[BaseException], Optional[TracebackType]]
+_OptExcInfo = Union[_ExcInfo, Tuple[None, None, None]]
 
 class _flags:
     bytes_warning: int

--- a/stdlib/3/sys.pyi
+++ b/stdlib/3/sys.pyi
@@ -16,7 +16,7 @@ _T = TypeVar('_T')
 
 # The following type alias are stub-only and do not exist during runtime
 _ExcInfo = Tuple[Type[BaseException], BaseException, TracebackType]
-_OptExcInfo = Tuple[Optional[Type[BaseException]], Optional[BaseException], Optional[TracebackType]]
+_OptExcInfo = Union[_ExcInfo, Tuple[None, None, None]]
 
 # ----- sys variables -----
 abiflags: str


### PR DESCRIPTION
I believe that either all of the items are None or none of them are.
Reflect that in the type.

This was attempted initially in
https://github.com/python/typeshed/pull/246
but apparently mypy didn't allow unpacking given such a union, but it
does now (checked with mypy 0.711).

The (incorrect) TODO from that PR was removed in commit
25ac4d6af46104d0c7cb134ed09a61ca7092b62a but the commit message noted
that this change is desirable.