### PR TITLE
warnings: ignore the type of category when message is a Warning

### DIFF
--- a/stdlib/2and3/warnings.pyi
+++ b/stdlib/2and3/warnings.pyi
@@ -1,11 +1,19 @@
 # Stubs for warnings
 
-from typing import Any, Dict, List, NamedTuple, Optional, TextIO, Tuple, Type, Union
+from typing import Any, Dict, List, NamedTuple, Optional, overload, TextIO, Tuple, Type, Union
 from types import ModuleType, TracebackType
 
-def warn(message: Union[str, Warning], category: Optional[Type[Warning]] = ...,
-         stacklevel: int = ...) -> None: ...
-def warn_explicit(message: Union[str, Warning], category: Type[Warning],
+@overload
+def warn(message: str, category: Optional[Type[Warning]] = ..., stacklevel: int = ...) -> None: ...
+@overload
+def warn(message: Warning, category: Any = ..., stacklevel: int = ...) -> None: ...
+@overload
+def warn_explicit(message: str, category: Type[Warning],
+                  filename: str, lineno: int, module: Optional[str] = ...,
+                  registry: Optional[Dict[Union[str, Tuple[str, Type[Warning], int]], int]] = ...,
+                  module_globals: Optional[Dict[str, Any]] = ...) -> None: ...
+@overload
+def warn_explicit(message: Warning, category: Any,
                   filename: str, lineno: int, module: Optional[str] = ...,
                   registry: Optional[Dict[Union[str, Tuple[str, Type[Warning], int]], int]] = ...,
                   module_globals: Optional[Dict[str, Any]] = ...) -> None: ...


### PR DESCRIPTION
See https://docs.python.org/3.7/library/warnings.html#warnings.warn_explicit

This fixes code which does

    warnings.warn_explicit(warning, category=None, ...)

The stub for `warn` is already OK, but I think it's clearer to have an
overload there too.