### PR TITLE
Update for Flask 1.1

### DIFF
--- a/third_party/2and3/flask/app.pyi
+++ b/third_party/2and3/flask/app.pyi
@@ -53,7 +53,8 @@ _ViewFunc = Union[
     Callable[..., _WSGICallable],
     Callable[..., Tuple[_Body, _Status, _Headers]],
     Callable[..., Tuple[_Body, _Status]],
-    Callable[..., Tuple[_Body, _Headers]]
+    Callable[..., Tuple[_Body, _Headers]],
+    Callable[..., Dict[Any, Any]]
 ]
 _VT = TypeVar('_VT', bound=_ViewFunc)
 


### PR DESCRIPTION
According to the Changelog:

> Allow returning a dictionary from a view function. Similar to how returning a string will produce a text/html response, returning a dict will call jsonify to produce a application/json response. :pr:`3111`