### PR TITLE
Fix ast.Constant availability

### DIFF
--- a/stdlib/3/_ast.pyi
+++ b/stdlib/3/_ast.pyi
@@ -269,7 +269,7 @@ class Bytes(expr):  # Deprecated in 3.8; use Constant
 class NameConstant(expr):
     value: Any
 
-if sys.version_info >= (3, 5, 2):
+if sys.version_info >= (3, 6):
     class Constant(expr):
         value: Any  # None, str, bytes, bool, int, float, complex, Ellipsis
         kind: Optional[str]

--- a/stdlib/3/_ast.pyi
+++ b/stdlib/3/_ast.pyi
@@ -269,7 +269,7 @@ class Bytes(expr):  # Deprecated in 3.8; use Constant
 class NameConstant(expr):
     value: Any
 
-if sys.version_info >= (3, 8):
+if sys.version_info >= (3, 5, 2):
     class Constant(expr):
         value: Any  # None, str, bytes, bool, int, float, complex, Ellipsis
         kind: Optional[str]
@@ -277,6 +277,7 @@ if sys.version_info >= (3, 8):
         s: Any
         n: complex
 
+if sys.version_info >= (3, 8):
     class NamedExpr(expr):
         target: expr
         value: expr


### PR DESCRIPTION
It has been introduced in 3.5.2 in https://github.com/python/cpython/commit/f2c1aa1661edb3e14ff8b7b9995f93e303c8acbb