### PR TITLE
Travis: run mypy with Python 3.8 as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,11 @@ matrix:
       env:
         - TEST_CMD="./tests/pytype_test.py"
         - INSTALL="test"
-    - name: "mypy (3.7)"
+    - name: "mypy (typed-ast)"
       env:
         - TEST_CMD="./tests/mypy_test.py"
         - INSTALL="mypy"
-    - name: "mypy (3.8)"
+    - name: "mypy (ast)"
       python: 3.8-dev
       env:
         - TEST_CMD="./tests/mypy_test.py"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: bionic
 language: python
 python: 3.7
 
@@ -9,7 +9,12 @@ matrix:
       env:
         - TEST_CMD="./tests/pytype_test.py"
         - INSTALL="test"
-    - name: "mypy"
+    - name: "mypy (3.7)"
+      env:
+        - TEST_CMD="./tests/mypy_test.py"
+        - INSTALL="mypy"
+    - name: "mypy (3.8)"
+      python: 3.8-dev
       env:
         - TEST_CMD="./tests/mypy_test.py"
         - INSTALL="mypy"

--- a/tests/mypy_test.py
+++ b/tests/mypy_test.py
@@ -88,7 +88,7 @@ def main():
         print("Cannot import mypy. Did you install it?")
         sys.exit(1)
 
-    versions = [(3, 7), (3, 6), (3, 5), (3, 4), (2, 7)]
+    versions = [(3, 8), (3, 7), (3, 6), (3, 5), (3, 4), (2, 7)]
     if args.python_version:
         versions = [v for v in versions
                     if any(('%d.%d' % v).startswith(av) for av in args.python_version)]


### PR DESCRIPTION
This runs mypy both with Python 3.7 and 3.8. In Python 3.8,
mypy switched from using typed-ast to using Python's built-in ast.
This patch ensures that both are tested.