### PR TITLE
flask: allow view func body to be dict

### DIFF
--- a/third_party/2and3/flask/app.pyi
+++ b/third_party/2and3/flask/app.pyi
@@ -43,7 +43,7 @@ _WSGICallable = Callable[[Dict[Text, Any], _StartResponse], Iterable[bytes]]
 
 _Status = Union[str, int]
 _Headers = Union[Dict[Any, Any], List[Tuple[Any, Any]]]
-_Body = Union[Text, ByteString, Response, _WSGICallable]
+_Body = Union[Text, ByteString, Dict[Text, Any], Response, _WSGICallable]
 
 _ViewFunc = Union[
     Callable[..., Text],

--- a/third_party/2and3/flask/app.pyi
+++ b/third_party/2and3/flask/app.pyi
@@ -44,13 +44,16 @@ _WSGICallable = Callable[[Dict[Text, Any], _StartResponse], Iterable[bytes]]
 _Status = Union[str, int]
 _Headers = Union[Dict[Any, Any], List[Tuple[Any, Any]]]
 _Body = Union[Text, ByteString, Dict[Text, Any], Response, _WSGICallable]
+_ViewFuncReturnType = [
+    _Body,
+    Tuple[_Body, _Status, _Headers],
+    Tuple[_Body, _Status],
+    Tuple[_Body, _Headers],
+]
 
 _ViewFunc = Union[
     Callable[..., NoReturn],
-    Callable[..., _Body],
-    Callable[..., Tuple[_Body, _Status, _Headers]],
-    Callable[..., Tuple[_Body, _Status]],
-    Callable[..., Tuple[_Body, _Headers]]
+    Callable[..., _ViewFuncReturnType],
 ]
 _VT = TypeVar('_VT', bound=_ViewFunc)
 

--- a/third_party/2and3/flask/app.pyi
+++ b/third_party/2and3/flask/app.pyi
@@ -48,12 +48,12 @@ _ViewFuncReturnType = Union[
     _Body,
     Tuple[_Body, _Status, _Headers],
     Tuple[_Body, _Status],
-    Tuple[_Body, _Headers],
+    Tuple[_Body, _Headers]
 ]
 
 _ViewFunc = Union[
     Callable[..., NoReturn],
-    Callable[..., _ViewFuncReturnType],
+    Callable[..., _ViewFuncReturnType]
 ]
 _VT = TypeVar('_VT', bound=_ViewFunc)
 

--- a/third_party/2and3/flask/app.pyi
+++ b/third_party/2and3/flask/app.pyi
@@ -48,12 +48,12 @@ _ViewFuncReturnType = Union[
     _Body,
     Tuple[_Body, _Status, _Headers],
     Tuple[_Body, _Status],
-    Tuple[_Body, _Headers]
+    Tuple[_Body, _Headers],
 ]
 
 _ViewFunc = Union[
     Callable[..., NoReturn],
-    Callable[..., _ViewFuncReturnType]
+    Callable[..., _ViewFuncReturnType],
 ]
 _VT = TypeVar('_VT', bound=_ViewFunc)
 

--- a/third_party/2and3/flask/app.pyi
+++ b/third_party/2and3/flask/app.pyi
@@ -46,11 +46,8 @@ _Headers = Union[Dict[Any, Any], List[Tuple[Any, Any]]]
 _Body = Union[Text, ByteString, Dict[Text, Any], Response, _WSGICallable]
 
 _ViewFunc = Union[
-    Callable[..., Text],
-    Callable[..., ByteString],
     Callable[..., NoReturn],
-    Callable[..., Response],
-    Callable[..., _WSGICallable],
+    Callable[..., _Body],
     Callable[..., Tuple[_Body, _Status, _Headers]],
     Callable[..., Tuple[_Body, _Status]],
     Callable[..., Tuple[_Body, _Headers]]

--- a/third_party/2and3/flask/app.pyi
+++ b/third_party/2and3/flask/app.pyi
@@ -44,7 +44,7 @@ _WSGICallable = Callable[[Dict[Text, Any], _StartResponse], Iterable[bytes]]
 _Status = Union[str, int]
 _Headers = Union[Dict[Any, Any], List[Tuple[Any, Any]]]
 _Body = Union[Text, ByteString, Dict[Text, Any], Response, _WSGICallable]
-_ViewFuncReturnType = [
+_ViewFuncReturnType = Union[
     _Body,
     Tuple[_Body, _Status, _Headers],
     Tuple[_Body, _Status],


### PR DESCRIPTION
[flask 1.1 changelog](
https://flask.palletsprojects.com/en/1.1.x/changelog/):
> Allow returning a dictionary from a view function. Similar to how returning a string will produce a text/html response, returning a dict will call jsonify to produce a application/json response.

See https://github.com/pallets/flask/pull/3111