### PR TITLE
Use pytype.config.Options.create() for prettier code.

### DIFF
--- a/tests/pytype_test.py
+++ b/tests/pytype_test.py
@@ -85,15 +85,12 @@ def load_blacklist(typeshed_location: str) -> List[str]:
 
 def run_pytype(*, filename: str, python_version: str, python_exe: str, typeshed_location: str) -> Optional[str]:
     """Runs pytype, returning the stderr if any."""
-    options = pytype_config.Options(
-        [
-            "--module-name={}".format(_get_module_name(filename)),
-            "--parse-pyi",
-            "-V {}".format(python_version),
-            "--python_exe={}".format(python_exe),
-            filename,
-        ]
-    )
+    options = pytype_config.Options.create(
+        filename,
+        module_name=_get_module_name(filename),
+        parse_pyi=True,
+        python_version=python_version,
+        python_exe=python_exe)
     old_typeshed_home = os.environ.get(TYPESHED_HOME, UNSET)
     os.environ[TYPESHED_HOME] = typeshed_location
     try:


### PR DESCRIPTION
This is a small cosmetic change. I want to encourage use of the
nicer-lookng pytype.config.Options.create() rather than
direct construction of the command-line args, so I'm changing
over all occurrences of the latter that I can find.