### PR TITLE
Allow function.__code__ in Python 2

### DIFF
--- a/stdlib/2/__builtin__.pyi
+++ b/stdlib/2/__builtin__.pyi
@@ -876,9 +876,9 @@ class function:
     # TODO not defined in builtins!
     __name__: str
     __module__: str
+    __code__: CodeType
     if sys.version_info >= (3,):
         __qualname__: str
-        __code__: CodeType
         __annotations__: Dict[str, Any]
 
 class list(MutableSequence[_T], Generic[_T]):

--- a/stdlib/2and3/builtins.pyi
+++ b/stdlib/2and3/builtins.pyi
@@ -876,9 +876,9 @@ class function:
     # TODO not defined in builtins!
     __name__: str
     __module__: str
+    __code__: CodeType
     if sys.version_info >= (3,):
         __qualname__: str
-        __code__: CodeType
         __annotations__: Dict[str, Any]
 
 class list(MutableSequence[_T], Generic[_T]):


### PR DESCRIPTION
The following code works:

```py
>>> print(sys.version)
2.7.16 (default, Mar 11 2019, 18:59:25)
>>> def f(): pass
>>> print(f.__code__)
<code object f at 0x7f8534ecc8a0, file "<stdin>", line 1>
>>> isinstance(f.__code__, types.CodeType)
True
```

but it didn't type-check with `mypy --python-version 2.7`.