### PR TITLE
[stdlib][3] Add missing typing.OrderedDict generic stub

### DIFF
--- a/stdlib/3/typing.pyi
+++ b/stdlib/3/typing.pyi
@@ -56,6 +56,9 @@ Counter = TypeAlias(object)
 Deque = TypeAlias(object)
 ChainMap = TypeAlias(object)
 
+if sys.version_info >= (3, 7):
+    OrderedDict = TypeAlias(object)
+
 # Predefined type variables.
 AnyStr = TypeVar('AnyStr', str, bytes)
 


### PR DESCRIPTION
Python 3.7.2 added missing type hint for the collections.OrderedDict which is missing the stub in the typeshed.

https://docs.python.org/3/library/typing.html#typing.OrderedDict