### PR TITLE
dateutil.rrule.rrule can take dates

### DIFF
--- a/third_party/2and3/dateutil/rrule.pyi
+++ b/third_party/2and3/dateutil/rrule.pyi
@@ -35,11 +35,11 @@ class rrulebase:
 class rrule(rrulebase):
     def __init__(self,
                  freq,
-                 dtstart: Optional[datetime.datetime] = ...,
+                 dtstart: Optional[datetime.date] = ...,
                  interval: int = ...,
                  wkst: Optional[Union[weekday, int]] = ...,
                  count: Optional[int] = ...,
-                 until: Optional[Union[datetime.datetime, int]] = ...,
+                 until: Optional[Union[datetime.date, int]] = ...,
                  bysetpos: Optional[Union[int, Iterable[int]]] = ...,
                  bymonth: Optional[Union[int, Iterable[int]]] = ...,
                  bymonthday: Optional[Union[int, Iterable[int]]] = ...,


### PR DESCRIPTION
`dateutil.rrule.rrule`'s `dtstart` and `until` flags are both compatible with `date` as well as `datetime` and will convert from the former to the latter. See [here](https://github.com/dateutil/dateutil/blob/master/dateutil/rrule.py#L439). 

I'm assuming that the typeshed should reflect the types as actually implemented, as opposed to how they're documented - `dtstart` is passingly referred to in the docs as a "date", which is a bit ambiguous but doesn't create any problems. But `until` is mis-documented, saying:
> If given, this must be a datetime instance specifying the upper-bound limit of the recurrence.

... even though the code will happily convert from a date to a datetime.