### PR TITLE
Add missing attributes to xml.etree.ElementTree.ParseError.

### DIFF
--- a/stdlib/2and3/xml/etree/ElementTree.pyi
+++ b/stdlib/2and3/xml/etree/ElementTree.pyi
@@ -7,7 +7,9 @@ import sys
 
 VERSION: str
 
-class ParseError(SyntaxError): ...
+class ParseError(SyntaxError):
+    code: int
+    position: Tuple[int, int]
 
 def iselement(element: object) -> bool: ...
 


### PR DESCRIPTION
`xml.etree.ElementTree.ParseError`, in addition to the attributes inherited from `SyntaxError` includes a integer `code` (from xml.parsers.expat) and a `position` tuple containing the line and column of the error.

This adds both of these missing attributes.

See https://docs.python.org/3.7/library/xml.etree.elementtree.html#xml.etree.ElementTree.ParseError

*These attributes exist (undocumented) in Python 2.7.*