### PR TITLE
Add hints for 3 globals from logging/__init__.py

### DIFF
--- a/stdlib/2and3/logging/__init__.pyi
+++ b/stdlib/2and3/logging/__init__.pyi
@@ -26,6 +26,9 @@ else:
     _Path = str
 
 raiseExceptions: bool
+logThreads: bool
+logMultiprocessing: bool
+logProcesses: bool
 
 def currentframe() -> FrameType: ...
 


### PR DESCRIPTION
- `logThreads`
- `logMultiprocessing`
- `logProcesses`

All three are publicly documented (https://docs.python.org/3/howto/logging.html#optimization)
and have existed since Python 2.  (They were int in Python 2.)  Their cousin, `raiseExceptions`, is already present in `logging/__init__.pyi`.