### PR TITLE
Require the newest pytype version, with a pyi parser fix.

### DIFF
--- a/requirements-tests-py3.txt
+++ b/requirements-tests-py3.txt
@@ -5,4 +5,4 @@ flake8==3.7.8
 flake8-bugbear==19.3.0
 flake8-pyi==19.3.0
 isort==4.3.21
-pytype>=2019.7.11
+pytype>=2019.7.30


### PR DESCRIPTION
For https://github.com/python/typeshed/pull/3149.