### PR TITLE
Precise the type of Python 2 htmlentitydefs module

### DIFF
--- a/stdlib/2/htmlentitydefs.pyi
+++ b/stdlib/2/htmlentitydefs.pyi
@@ -1,5 +1,5 @@
-from typing import Mapping
+from typing import Dict
 
-name2codepoint: Mapping[str, int]
-codepoint2name: Mapping[int, str]
-entitydefs: Mapping[str, str]
+name2codepoint: Dict[str, int]
+codepoint2name: Dict[int, str]
+entitydefs: Dict[str, str]


### PR DESCRIPTION
The code and documentation specifies the values specifically as
dictionaries.