### PR TITLE
Declare asyncio.as_completed() as taking an Iterable

### DIFF
--- a/stdlib/3/asyncio/tasks.pyi
+++ b/stdlib/3/asyncio/tasks.pyi
@@ -21,7 +21,7 @@ FIRST_EXCEPTION: str
 FIRST_COMPLETED: str
 ALL_COMPLETED: str
 
-def as_completed(fs: Sequence[_FutureT[_T]], *, loop: Optional[AbstractEventLoop] = ...,
+def as_completed(fs: Iterable[_FutureT[_T]], *, loop: Optional[AbstractEventLoop] = ...,
                  timeout: Optional[float] = ...) -> Iterator[Future[_T]]: ...
 def ensure_future(coro_or_future: _FutureT[_T],
                   *, loop: Optional[AbstractEventLoop] = ...) -> Future[_T]: ...


### PR DESCRIPTION
The stub for asyncio.as_completed declared it as taking a Sequence of
Futures. This was unnecessarily strict.

Just like asyncio.wait, asyncio.as_completed can be declared to take
an Iterable of Futures instead. Both these functions iterate over
their argument only once to store its items in a set, so an Iterable
is sufficiently strict. This has been true since the initial
implementation of the functions.