### PR TITLE
Distinguish between bool/int in logging globals

### DIFF
--- a/stdlib/2and3/logging/__init__.pyi
+++ b/stdlib/2and3/logging/__init__.pyi
@@ -25,10 +25,16 @@ if sys.version_info >= (3, 6):
 else:
     _Path = str
 
-raiseExceptions: bool
-logThreads: bool
-logMultiprocessing: bool
-logProcesses: bool
+if sys.version_info >= (3, 5):
+    raiseExceptions: bool
+    logThreads: bool
+    logMultiprocessing: bool
+    logProcesses: bool
+else:
+    raiseExceptions: int
+    logThreads: int
+    logMultiprocessing: int
+    logProcesses: int
 
 def currentframe() -> FrameType: ...
 


### PR DESCRIPTION
It seemed like the court was still out on this in discussion from #3159, so no hard feelings if it's decided that this can be kept as is.

```
This is a follow-up to commit d0f403d/PR #3159.

The logging/__init__.py globals raiseExceptions, logThreads,
logMultiprocessing, and logProcesses were `int` in
Python 2.7 (despite having intended meaning as boolean values).
They were initialized as `bool` starting in 3.4.

The goal here is to prevent a false positive type checking
error.
```