### PR TITLE
Move some constants from tokenize to token in Python 3.7+.

### DIFF
--- a/stdlib/2and3/token.pyi
+++ b/stdlib/2and3/token.pyi
@@ -65,6 +65,10 @@ ERRORTOKEN: int
 N_TOKENS: int
 NT_OFFSET: int
 tok_name: Dict[int, str]
+if sys.version_info >= (3, 7):
+    COMMENT: int
+    NL: int
+    ENCODING: int
 
 def ISTERMINAL(x: int) -> bool: ...
 def ISNONTERMINAL(x: int) -> bool: ...

--- a/stdlib/3/tokenize.pyi
+++ b/stdlib/3/tokenize.pyi
@@ -3,9 +3,10 @@ from builtins import open as _builtin_open
 import sys
 from token import *  # noqa: F403
 
-COMMENT: int
-NL: int
-ENCODING: int
+if sys.version_info < (3, 7):
+    COMMENT: int
+    NL: int
+    ENCODING: int
 
 _Position = Tuple[int, int]
 


### PR DESCRIPTION
In Python 3.7, tokenize.{COMMENT,NL,ENCODING} were moved to token and
imported into tokenize rather than defined there.

(https://docs.python.org/3.7/library/token.html#token.COMMENT)