### PR TITLE
Update how mock classes alias to Any

### DIFF
--- a/stdlib/3/unittest/mock.pyi
+++ b/stdlib/3/unittest/mock.pyi
@@ -33,14 +33,14 @@ class Base:
 # TODO: Defining this and other mock classes as classes in this stub causes
 #       many false positives with mypy and production code. See if we can
 #       improve mypy somehow and use a class with an "Any" base class.
-NonCallableMock: Any
+NonCallableMock = Any
 
 class CallableMixin(Base):
     side_effect: Any
     def __init__(self, spec: Optional[Any] = ..., side_effect: Optional[Any] = ..., return_value: Any = ..., wraps: Optional[Any] = ..., name: Optional[Any] = ..., spec_set: Optional[Any] = ..., parent: Optional[Any] = ..., _spec_state: Optional[Any] = ..., _new_name: Any = ..., _new_parent: Optional[Any] = ..., **kwargs: Any) -> None: ...
     def __call__(_mock_self, *args: Any, **kwargs: Any) -> Any: ...
 
-Mock: Any
+Mock = Any
 
 class _patch:
     attribute_name: Any
@@ -94,8 +94,8 @@ patch: _patcher
 class MagicMixin:
     def __init__(self, *args: Any, **kw: Any) -> None: ...
 
-NonCallableMagicMock: Any
-MagicMock: Any
+NonCallableMagicMock = Any
+MagicMock = Any
 
 class MagicProxy:
     name: Any
@@ -140,7 +140,7 @@ class _SpecState:
 
 def mock_open(mock: Optional[Any] = ..., read_data: Any = ...) -> Any: ...
 
-PropertyMock: Any
+PropertyMock = Any
 
 if sys.version_info >= (3, 7):
     def seal(mock: Any) -> None: ...

--- a/third_party/2and3/mock.pyi
+++ b/third_party/2and3/mock.pyi
@@ -33,14 +33,14 @@ class Base:
 # TODO: Defining this and other mock classes as classes in this stub causes
 #       many false positives with mypy and production code. See if we can
 #       improve mypy somehow and use a class with an "Any" base class.
-NonCallableMock: Any
+NonCallableMock = Any
 
 class CallableMixin(Base):
     side_effect: Any
     def __init__(self, spec: Optional[Any] = ..., side_effect: Optional[Any] = ..., return_value: Any = ..., wraps: Optional[Any] = ..., name: Optional[Any] = ..., spec_set: Optional[Any] = ..., parent: Optional[Any] = ..., _spec_state: Optional[Any] = ..., _new_name: Any = ..., _new_parent: Optional[Any] = ..., **kwargs: Any) -> None: ...
     def __call__(_mock_self, *args: Any, **kwargs: Any) -> Any: ...
 
-Mock: Any
+Mock = Any
 
 class _patch:
     attribute_name: Any
@@ -94,8 +94,8 @@ patch: _patcher
 class MagicMixin:
     def __init__(self, *args: Any, **kw: Any) -> None: ...
 
-NonCallableMagicMock: Any
-MagicMock: Any
+NonCallableMagicMock = Any
+MagicMock = Any
 
 class MagicProxy:
     name: Any
@@ -140,7 +140,7 @@ class _SpecState:
 
 def mock_open(mock: Optional[Any] = ..., read_data: Any = ...) -> Any: ...
 
-PropertyMock: Any
+PropertyMock = Any
 
 if sys.version_info >= (3, 7):
     def seal(mock: Any) -> None: ...


### PR DESCRIPTION
> First, the z: Any situation looks like a bug or accidental feature to me.
This is definitely meant (and works) as a variable declaration; that it
also allows using z as a type seems wrong. I can't find any evidence in
PEP 484 that this was intended; in mypy it's likely the accidental result
of other design choices meant to shut up errors about Any.

Ideally these classes could be declared as empty class stubs, but since the comments suggest this isn't possible yet, let's update these to be type aliases to Any rather than global variables of type Any. This would avoid invalid type errors when the implementation of type checkers respect the intention that `z: Any` does not make `z` a valid type.