### PR TITLE
Update __import__ function annotations

### DIFF
--- a/stdlib/2/__builtin__.pyi
+++ b/stdlib/2/__builtin__.pyi
@@ -11,7 +11,7 @@ from typing import (
 )
 from abc import abstractmethod, ABCMeta
 from ast import mod, AST
-from types import TracebackType, CodeType
+from types import TracebackType, CodeType, ModuleType
 import sys
 
 if sys.version_info >= (3,):
@@ -1437,8 +1437,10 @@ else:
     def zip(__iter1: Iterable[Any], __iter2: Iterable[Any], __iter3: Iterable[Any],
             __iter4: Iterable[Any], __iter5: Iterable[Any], __iter6: Iterable[Any],
             *iterables: Iterable[Any]) -> List[Tuple[Any, ...]]: ...
-def __import__(name: Text, globals: Dict[str, Any] = ..., locals: Dict[str, Any] = ...,
-               fromlist: List[str] = ..., level: int = ...) -> Any: ...
+def __import__(name: Text, globals: Optional[Mapping[str, Any]] = ...,
+               locals: Optional[Mapping[str, Any]] = ...,
+               fromlist: Sequence[str] = ...,
+               level: int = ...) -> ModuleType: ...
 
 # Actually the type of Ellipsis is <type 'ellipsis'>, but since it's
 # not exposed anywhere under that name, we make it private here.

--- a/stdlib/2and3/builtins.pyi
+++ b/stdlib/2and3/builtins.pyi
@@ -11,7 +11,7 @@ from typing import (
 )
 from abc import abstractmethod, ABCMeta
 from ast import mod, AST
-from types import TracebackType, CodeType
+from types import TracebackType, CodeType, ModuleType
 import sys
 
 if sys.version_info >= (3,):
@@ -1437,8 +1437,10 @@ else:
     def zip(__iter1: Iterable[Any], __iter2: Iterable[Any], __iter3: Iterable[Any],
             __iter4: Iterable[Any], __iter5: Iterable[Any], __iter6: Iterable[Any],
             *iterables: Iterable[Any]) -> List[Tuple[Any, ...]]: ...
-def __import__(name: Text, globals: Dict[str, Any] = ..., locals: Dict[str, Any] = ...,
-               fromlist: List[str] = ..., level: int = ...) -> Any: ...
+def __import__(name: Text, globals: Optional[Mapping[str, Any]] = ...,
+               locals: Optional[Mapping[str, Any]] = ...,
+               fromlist: Sequence[str] = ...,
+               level: int = ...) -> ModuleType: ...
 
 # Actually the type of Ellipsis is <type 'ellipsis'>, but since it's
 # not exposed anywhere under that name, we make it private here.


### PR DESCRIPTION
Per the docs, globals/locals is an optional argument.

https://docs.python.org/3/library/functions.html#__import__
https://docs.python.org/2/library/functions.html#__import__

Additionally, globals/locals can be any mapping type, not only a dict.

Likewise, fromlist can be any sequence (the docs mention a tuple, not a
list).

The function returns a ModuleType, not Any.

Now matches the definition in stdlib/3/importlib/__init__.pyi.