### PR TITLE
Fix #3187 : Wrong Signatures in socketserver

### DIFF
--- a/stdlib/2/SocketServer.pyi
+++ b/stdlib/2/SocketServer.pyi
@@ -1,7 +1,7 @@
 # NB: SocketServer.pyi and socketserver.pyi must remain consistent!
 # Stubs for socketserver
 
-from typing import Any, BinaryIO, Optional, Tuple, Type
+from typing import Any, BinaryIO, Optional, Tuple, Type, AnyStr
 from socket import SocketType
 import sys
 import types
@@ -15,7 +15,7 @@ class BaseServer:
     request_queue_size: int
     socket_type: int
     timeout: Optional[float]
-    def __init__(self, server_address: Tuple[str, int],
+    def __init__(self, server_address: Any,
                  RequestHandlerClass: type) -> None: ...
     def fileno(self) -> int: ...
     def handle_request(self) -> None: ...
@@ -54,12 +54,12 @@ class UDPServer(BaseServer):
 
 if sys.platform != 'win32':
     class UnixStreamServer(BaseServer):
-        def __init__(self, server_address: Tuple[str, int],
+        def __init__(self, server_address: AnyStr,
                      RequestHandlerClass: type,
                      bind_and_activate: bool = ...) -> None: ...
 
     class UnixDatagramServer(BaseServer):
-        def __init__(self, server_address: Tuple[str, int],
+        def __init__(self, server_address: AnyStr,
                      RequestHandlerClass: type,
                      bind_and_activate: bool = ...) -> None: ...
 

--- a/stdlib/2/SocketServer.pyi
+++ b/stdlib/2/SocketServer.pyi
@@ -1,7 +1,7 @@
 # NB: SocketServer.pyi and socketserver.pyi must remain consistent!
 # Stubs for socketserver
 
-from typing import Any, BinaryIO, Optional, Tuple, Type, AnyStr
+from typing import Any, BinaryIO, Optional, Tuple, Type, Text, Union
 from socket import SocketType
 import sys
 import types
@@ -54,12 +54,12 @@ class UDPServer(BaseServer):
 
 if sys.platform != 'win32':
     class UnixStreamServer(BaseServer):
-        def __init__(self, server_address: AnyStr,
+        def __init__(self, server_address: Union[Text, bytes],
                      RequestHandlerClass: type,
                      bind_and_activate: bool = ...) -> None: ...
 
     class UnixDatagramServer(BaseServer):
-        def __init__(self, server_address: AnyStr,
+        def __init__(self, server_address: Union[Text, bytes],
                      RequestHandlerClass: type,
                      bind_and_activate: bool = ...) -> None: ...
 

--- a/stdlib/3/socketserver.pyi
+++ b/stdlib/3/socketserver.pyi
@@ -1,7 +1,7 @@
 # NB: SocketServer.pyi and socketserver.pyi must remain consistent!
 # Stubs for socketserver
 
-from typing import Any, BinaryIO, Optional, Tuple, Type
+from typing import Any, BinaryIO, Optional, Tuple, Type, AnyStr
 from socket import SocketType
 import sys
 import types
@@ -15,7 +15,7 @@ class BaseServer:
     request_queue_size: int
     socket_type: int
     timeout: Optional[float]
-    def __init__(self, server_address: Tuple[str, int],
+    def __init__(self, server_address: Any,
                  RequestHandlerClass: type) -> None: ...
     def fileno(self) -> int: ...
     def handle_request(self) -> None: ...
@@ -54,12 +54,12 @@ class UDPServer(BaseServer):
 
 if sys.platform != 'win32':
     class UnixStreamServer(BaseServer):
-        def __init__(self, server_address: Tuple[str, int],
+        def __init__(self, server_address: AnyStr,
                      RequestHandlerClass: type,
                      bind_and_activate: bool = ...) -> None: ...
 
     class UnixDatagramServer(BaseServer):
-        def __init__(self, server_address: Tuple[str, int],
+        def __init__(self, server_address: AnyStr,
                      RequestHandlerClass: type,
                      bind_and_activate: bool = ...) -> None: ...
 

--- a/stdlib/3/socketserver.pyi
+++ b/stdlib/3/socketserver.pyi
@@ -1,7 +1,7 @@
 # NB: SocketServer.pyi and socketserver.pyi must remain consistent!
 # Stubs for socketserver
 
-from typing import Any, BinaryIO, Optional, Tuple, Type, AnyStr
+from typing import Any, BinaryIO, Optional, Tuple, Type, Text, Union
 from socket import SocketType
 import sys
 import types
@@ -54,12 +54,12 @@ class UDPServer(BaseServer):
 
 if sys.platform != 'win32':
     class UnixStreamServer(BaseServer):
-        def __init__(self, server_address: AnyStr,
+        def __init__(self, server_address: Union[Text, bytes],
                      RequestHandlerClass: type,
                      bind_and_activate: bool = ...) -> None: ...
 
     class UnixDatagramServer(BaseServer):
-        def __init__(self, server_address: AnyStr,
+        def __init__(self, server_address: Union[Text, bytes],
                      RequestHandlerClass: type,
                      bind_and_activate: bool = ...) -> None: ...
 


### PR DESCRIPTION
This fixes #3187 by changing the parameter annotations of the `BaseServer`, `UnixStreamServer` and `UnixDatagramServer` in the socketserver module.

I chose `Any` for the parameter in the `BaseServer`, because the documentation lists some more protocols, that accepts different parameters, so a `Union[Tuple[str, int], AnyStr]` would only work for *TCP* and Unix sockets.