### PR TITLE
Remove unnecessary quotes around forward references.

### DIFF
--- a/stdlib/2and3/argparse.pyi
+++ b/stdlib/2and3/argparse.pyi
@@ -5,7 +5,7 @@ from typing import (
 import sys
 
 _T = TypeVar('_T')
-_ActionT = TypeVar('_ActionT', bound='Action')
+_ActionT = TypeVar('_ActionT', bound=Action)
 _N = TypeVar('_N')
 
 if sys.version_info >= (3,):

--- a/stdlib/2and3/cProfile.pyi
+++ b/stdlib/2and3/cProfile.pyi
@@ -5,7 +5,7 @@ from typing import Any, Callable, Dict, Optional, Text, TypeVar, Union
 def run(statement: str, filename: Optional[str] = ..., sort: Union[str, int] = ...) -> None: ...
 def runctx(statement: str, globals: Dict[str, Any], locals: Dict[str, Any], filename: Optional[str] = ..., sort: Union[str, int] = ...) -> None: ...
 
-_SelfT = TypeVar('_SelfT', bound='Profile')
+_SelfT = TypeVar('_SelfT', bound=Profile)
 _T = TypeVar('_T')
 if sys.version_info >= (3, 6):
     _Path = Union[bytes, Text, os.PathLike[Any]]

--- a/stdlib/2and3/contextlib.pyi
+++ b/stdlib/2and3/contextlib.pyi
@@ -61,7 +61,7 @@ if sys.version_info >= (3,):
     class ContextDecorator:
         def __call__(self, func: Callable[..., None]) -> Callable[..., ContextManager[None]]: ...
 
-    _U = TypeVar('_U', bound='ExitStack')
+    _U = TypeVar('_U', bound=ExitStack)
 
     class ExitStack(ContextManager[ExitStack]):
         def __init__(self) -> None: ...
@@ -79,7 +79,7 @@ if sys.version_info >= (3,):
 if sys.version_info >= (3, 7):
     from typing import Awaitable
 
-    _S = TypeVar('_S', bound='AsyncExitStack')
+    _S = TypeVar('_S', bound=AsyncExitStack)
 
     _ExitCoroFunc = Callable[[Optional[Type[BaseException]],
                               Optional[BaseException],

--- a/stdlib/2and3/distutils/version.pyi
+++ b/stdlib/2and3/distutils/version.pyi
@@ -2,7 +2,7 @@ import sys
 from abc import abstractmethod
 from typing import Any, Optional, TypeVar, Union, Pattern, Text, Tuple
 
-_T = TypeVar('_T', bound='Version')
+_T = TypeVar('_T', bound=Version)
 
 class Version:
     def __repr__(self) -> str: ...

--- a/stdlib/2and3/profile.pyi
+++ b/stdlib/2and3/profile.pyi
@@ -5,7 +5,7 @@ from typing import Any, Callable, Dict, Optional, Text, TypeVar, Union
 def run(statement: str, filename: Optional[str] = ..., sort: Union[str, int] = ...) -> None: ...
 def runctx(statement: str, globals: Dict[str, Any], locals: Dict[str, Any], filename: Optional[str] = ..., sort: Union[str, int] = ...) -> None: ...
 
-_SelfT = TypeVar('_SelfT', bound='Profile')
+_SelfT = TypeVar('_SelfT', bound=Profile)
 _T = TypeVar('_T')
 if sys.version_info >= (3, 6):
     _Path = Union[bytes, Text, os.PathLike[Any]]

--- a/stdlib/2and3/pstats.pyi
+++ b/stdlib/2and3/pstats.pyi
@@ -5,7 +5,7 @@ import sys
 from typing import Any, Dict, IO, Iterable, List, Text, Tuple, TypeVar, Union, overload
 
 _Selector = Union[str, float, int]
-_T = TypeVar('_T', bound='Stats')
+_T = TypeVar('_T', bound=Stats)
 if sys.version_info >= (3, 6):
     _Path = Union[bytes, Text, os.PathLike[Any]]
 else:

--- a/stdlib/3/io.pyi
+++ b/stdlib/3/io.pyi
@@ -16,7 +16,7 @@ SEEK_SET: int
 SEEK_CUR: int
 SEEK_END: int
 
-_T = TypeVar('_T', bound='IOBase')
+_T = TypeVar('_T', bound=IOBase)
 
 open = builtins.open
 

--- a/stdlib/3/multiprocessing/pool.pyi
+++ b/stdlib/3/multiprocessing/pool.pyi
@@ -4,7 +4,7 @@ from typing import (
 )
 from types import TracebackType
 
-_PT = TypeVar('_PT', bound='Pool')
+_PT = TypeVar('_PT', bound=Pool)
 _S = TypeVar('_S')
 _T = TypeVar('_T')
 

--- a/stdlib/3/pathlib.pyi
+++ b/stdlib/3/pathlib.pyi
@@ -3,7 +3,7 @@ from types import TracebackType
 import os
 import sys
 
-_P = TypeVar('_P', bound='PurePath')
+_P = TypeVar('_P', bound=PurePath)
 
 if sys.version_info >= (3, 6):
     _PurePathBase = os.PathLike[str]

--- a/third_party/2/pathlib2.pyi
+++ b/third_party/2/pathlib2.pyi
@@ -3,7 +3,7 @@ from types import TracebackType
 import os
 import sys
 
-_P = TypeVar('_P', bound='PurePath')
+_P = TypeVar('_P', bound=PurePath)
 
 if sys.version_info >= (3, 6):
     _PurePathBase = os.PathLike[str]

--- a/third_party/2and3/pynamodb/attributes.pyi
+++ b/third_party/2and3/pynamodb/attributes.pyi
@@ -5,7 +5,7 @@ from datetime import datetime
 _T = TypeVar('_T')
 _KT = TypeVar('_KT')
 _VT = TypeVar('_VT')
-_MT = TypeVar('_MT', bound='MapAttribute')
+_MT = TypeVar('_MT', bound=MapAttribute)
 
 class Attribute(Generic[_T]):
     attr_name: Optional[Text]


### PR DESCRIPTION
I happened to notice these while working on an unrelated change to pytype's pyi parser.