### PR TITLE
Add stubs for CGIHTTPServer

### DIFF
--- a/stdlib/2/CGIHTTPServer.pyi
+++ b/stdlib/2/CGIHTTPServer.pyi
@@ -1,0 +1,8 @@
+# Stubs for CGIHTTPServer (Python 2.7)
+
+from typing import List
+import SimpleHTTPServer
+
+class CGIHTTPRequestHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
+    cgi_directories: List[str]
+    def do_POST(self) -> None: ...

--- a/tests/mypy_selftest.py
+++ b/tests/mypy_selftest.py
@@ -11,7 +11,7 @@ import tempfile
 if __name__ == '__main__':
     with tempfile.TemporaryDirectory() as tempdir:
         dirpath = Path(tempdir)
-        subprocess.run(['/Users/bluebottle/.pyenv/versions/2.7.15/bin/python2.7', '-m', 'pip', 'install', '--user', 'typing'], check=True)
+        subprocess.run(['python2.7', '-m', 'pip', 'install', '--user', 'typing'], check=True)
         subprocess.run(['git', 'clone', '--depth', '1', 'git://github.com/python/mypy',
                         str(dirpath / 'mypy')], check=True)
         subprocess.run([sys.executable, '-m', 'pip', 'install', '-U', '-r',

--- a/tests/mypy_selftest.py
+++ b/tests/mypy_selftest.py
@@ -11,7 +11,7 @@ import tempfile
 if __name__ == '__main__':
     with tempfile.TemporaryDirectory() as tempdir:
         dirpath = Path(tempdir)
-        subprocess.run(['python2.7', '-m', 'pip', 'install', '--user', 'typing'], check=True)
+        subprocess.run(['/Users/bluebottle/.pyenv/versions/2.7.15/bin/python2.7', '-m', 'pip', 'install', '--user', 'typing'], check=True)
         subprocess.run(['git', 'clone', '--depth', '1', 'git://github.com/python/mypy',
                         str(dirpath / 'mypy')], check=True)
         subprocess.run([sys.executable, '-m', 'pip', 'install', '-U', '-r',

--- a/third_party/2/six/moves/CGIHTTPServer.pyi
+++ b/third_party/2/six/moves/CGIHTTPServer.pyi
@@ -1,0 +1,1 @@
+from CGIHTTPServer import *

--- a/third_party/2/six/moves/__init__.pyi
+++ b/third_party/2/six/moves/__init__.pyi
@@ -36,7 +36,7 @@ from . import http_client
 from . import email_mime_text
 # import email.MIMEBase as email_mime_base
 from . import BaseHTTPServer
-# import CGIHTTPServer as CGIHTTPServer
+from . import CGIHTTPServer
 from . import SimpleHTTPServer
 from . import cPickle
 from . import queue


### PR DESCRIPTION
This commit adds:
* Stubs for CGIHTTPServer in the Python 2 standard library, as requested in #1147.
* Stubs for six.moves.CGIHTTPServer in Python 2, as requested in #22.