### PR TITLE
Add sys.flags.utf8_mode.

### DIFF
--- a/stdlib/3/sys.pyi
+++ b/stdlib/3/sys.pyi
@@ -83,6 +83,7 @@ class _flags:
     hash_randomization: int
     if sys.version_info >= (3, 7):
         dev_mode: int
+        utf8_mode: int
 
 float_info: _float_info
 class _float_info:


### PR DESCRIPTION
This is new in Python 3.7:
https://docs.python.org/3/library/sys.html#sys.flags