### PR TITLE
Remove custom _Text type

### DIFF
--- a/third_party/2and3/requests/api.pyi
+++ b/third_party/2and3/requests/api.pyi
@@ -5,36 +5,31 @@ from typing import Optional, Union, Any, Iterable, Mapping, MutableMapping, Tupl
 
 from .models import Response
 
-if sys.version_info >= (3,):
-    _Text = str
-else:
-    _Text = Union[str, Text]
-
-_ParamsMappingValueType = Union[_Text, bytes, int, float, Iterable[Union[_Text, bytes, int, float]]]
+_ParamsMappingValueType = Union[Text, bytes, int, float, Iterable[Union[Text, bytes, int, float]]]
 _Data = Union[
     None,
-    _Text,
+    Text,
     bytes,
     MutableMapping[str, Any],
     MutableMapping[Text, Any],
-    Iterable[Tuple[_Text, Optional[_Text]]],
+    Iterable[Tuple[Text, Optional[Text]]],
     IO
 ]
 
 def request(method: str, url: str, **kwargs) -> Response: ...
-def get(url: Union[_Text, bytes],
+def get(url: Union[Text, bytes],
         params: Optional[
-            Union[Mapping[Union[_Text, bytes, int, float], _ParamsMappingValueType],
-                  Union[_Text, bytes],
-                  Tuple[Union[_Text, bytes, int, float], _ParamsMappingValueType],
-                  Mapping[_Text, _ParamsMappingValueType],
+            Union[Mapping[Union[Text, bytes, int, float], _ParamsMappingValueType],
+                  Union[Text, bytes],
+                  Tuple[Union[Text, bytes, int, float], _ParamsMappingValueType],
+                  Mapping[Text, _ParamsMappingValueType],
                   Mapping[bytes, _ParamsMappingValueType],
                   Mapping[int, _ParamsMappingValueType],
                   Mapping[float, _ParamsMappingValueType]]] = ...,
         **kwargs) -> Response: ...
-def options(url: Union[_Text, bytes], **kwargs) -> Response: ...
-def head(url: Union[_Text, bytes], **kwargs) -> Response: ...
-def post(url: Union[_Text, bytes], data: _Data = ..., json=..., **kwargs) -> Response: ...
-def put(url: Union[_Text, bytes], data: _Data = ..., json=..., **kwargs) -> Response: ...
-def patch(url: Union[_Text, bytes], data: _Data = ..., json=..., **kwargs) -> Response: ...
-def delete(url: Union[_Text, bytes], **kwargs) -> Response: ...
+def options(url: Union[Text, bytes], **kwargs) -> Response: ...
+def head(url: Union[Text, bytes], **kwargs) -> Response: ...
+def post(url: Union[Text, bytes], data: _Data = ..., json=..., **kwargs) -> Response: ...
+def put(url: Union[Text, bytes], data: _Data = ..., json=..., **kwargs) -> Response: ...
+def patch(url: Union[Text, bytes], data: _Data = ..., json=..., **kwargs) -> Response: ...
+def delete(url: Union[Text, bytes], **kwargs) -> Response: ...

--- a/third_party/2and3/requests/api.pyi
+++ b/third_party/2and3/requests/api.pyi
@@ -6,27 +6,24 @@ from typing import Optional, Union, Any, Iterable, Mapping, MutableMapping, Tupl
 from .models import Response
 
 _ParamsMappingValueType = Union[Text, bytes, int, float, Iterable[Union[Text, bytes, int, float]]]
-_Data = Union[
-    None,
-    Text,
-    bytes,
-    MutableMapping[str, Any],
-    MutableMapping[Text, Any],
-    Iterable[Tuple[Text, Optional[Text]]],
-    IO
-]
+_Data = Union[None, Text, bytes, MutableMapping[str, Any], MutableMapping[Text, Any], Iterable[Tuple[Text, Optional[Text]]], IO]
 
 def request(method: str, url: str, **kwargs) -> Response: ...
-def get(url: Union[Text, bytes],
-        params: Optional[
-            Union[Mapping[Union[Text, bytes, int, float], _ParamsMappingValueType],
-                  Union[Text, bytes],
-                  Tuple[Union[Text, bytes, int, float], _ParamsMappingValueType],
-                  Mapping[Text, _ParamsMappingValueType],
-                  Mapping[bytes, _ParamsMappingValueType],
-                  Mapping[int, _ParamsMappingValueType],
-                  Mapping[float, _ParamsMappingValueType]]] = ...,
-        **kwargs) -> Response: ...
+def get(
+    url: Union[Text, bytes],
+    params: Optional[
+        Union[
+            Mapping[Union[Text, bytes, int, float], _ParamsMappingValueType],
+            Union[Text, bytes],
+            Tuple[Union[Text, bytes, int, float], _ParamsMappingValueType],
+            Mapping[Text, _ParamsMappingValueType],
+            Mapping[bytes, _ParamsMappingValueType],
+            Mapping[int, _ParamsMappingValueType],
+            Mapping[float, _ParamsMappingValueType],
+        ]
+    ] = ...,
+    **kwargs,
+) -> Response: ...
 def options(url: Union[Text, bytes], **kwargs) -> Response: ...
 def head(url: Union[Text, bytes], **kwargs) -> Response: ...
 def post(url: Union[Text, bytes], data: _Data = ..., json=..., **kwargs) -> Response: ...


### PR DESCRIPTION
Since the custom type was only used in argument types, it was effectively only an alias for `typing.Text`.

I added a second commit that runs the file through black, so it's probably easier to review the first commit.