### PR TITLE
Mark click.ParamType.fail() as NoReturn

### DIFF
--- a/third_party/2and3/click/core.pyi
+++ b/third_party/2and3/click/core.pyi
@@ -351,7 +351,7 @@ class _ParamType:
     def split_envvar_value(self, rv: str) -> List[str]:
         ...
 
-    def fail(self, message: str, param: Optional[Parameter] = ..., ctx: Optional[Context] = ...) -> None:
+    def fail(self, message: str, param: Optional[Parameter] = ..., ctx: Optional[Context] = ...) -> NoReturn:
         ...
 
 


### PR DESCRIPTION
[Here's](https://github.com/pallets/click/blob/master/click/types.py#L67-L69) the relevant source code in Click:
```
def fail(self, message, param=None, ctx=None):
    """Helper method to fail with an invalid value message."""
    raise BadParameter(message, ctx=ctx, param=param)
```

This function just raises an exception with the supplied arguments, so we should mark it as such.