### PR TITLE
Use Literal to improve tempfile.[Named]TemporaryFile.

### DIFF
--- a/stdlib/3/tempfile.pyi
+++ b/stdlib/3/tempfile.pyi
@@ -7,24 +7,80 @@ import sys
 from types import TracebackType
 from typing import Any, AnyStr, Generic, IO, Iterable, Iterator, List, Optional, overload, Tuple, Type
 
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
+
 # global variables
 TMP_MAX: int
 tempdir: Optional[str]
 template: str
 
-
+@overload
 def TemporaryFile(
-    mode: str = ..., buffering: int = ..., encoding: Optional[str] = ...,
-    newline: Optional[str] = ..., suffix: Optional[AnyStr] = ..., prefix: Optional[AnyStr] = ...,
-    dir: Optional[AnyStr] = ...
-) -> IO[Any]:
-    ...
+    mode: Literal["r", "w", "a", "x", "r+", "w+", "a+", "x+", "rt", "wt", "at", "xt", "r+t", "w+t", "a+t", "x+t"],
+    buffering: int = ...,
+    encoding: Optional[str] = ...,
+    newline: Optional[str] = ...,
+    suffix: Optional[AnyStr] = ...,
+    prefix: Optional[AnyStr] = ...,
+    dir: Optional[AnyStr] = ...,
+) -> IO[str]: ...
+@overload
+def TemporaryFile(
+    mode: Literal["rb", "wb", "ab", "xb", "r+b", "w+b", "a+b", "x+b"] = ...,
+    buffering: int = ...,
+    encoding: Optional[str] = ...,
+    newline: Optional[str] = ...,
+    suffix: Optional[AnyStr] = ...,
+    prefix: Optional[AnyStr] = ...,
+    dir: Optional[AnyStr] = ...,
+) -> IO[bytes]: ...
+@overload
+def TemporaryFile(
+    mode: str = ...,
+    buffering: int = ...,
+    encoding: Optional[str] = ...,
+    newline: Optional[str] = ...,
+    suffix: Optional[AnyStr] = ...,
+    prefix: Optional[AnyStr] = ...,
+    dir: Optional[AnyStr] = ...,
+) -> IO[Any]: ...
+
+@overload
 def NamedTemporaryFile(
-    mode: str = ..., buffering: int = ..., encoding: Optional[str] = ...,
-    newline: Optional[str] = ..., suffix: Optional[AnyStr] = ..., prefix: Optional[AnyStr] = ...,
-    dir: Optional[AnyStr] = ..., delete: bool = ...
-) -> IO[Any]:
-    ...
+    mode: Literal["r", "w", "a", "x", "r+", "w+", "a+", "x+", "rt", "wt", "at", "xt", "r+t", "w+t", "a+t", "x+t"],
+    buffering: int = ...,
+    encoding: Optional[str] = ...,
+    newline: Optional[str] = ...,
+    suffix: Optional[AnyStr] = ...,
+    prefix: Optional[AnyStr] = ...,
+    dir: Optional[AnyStr] = ...,
+    delete: bool = ...,
+) -> IO[str]: ...
+@overload
+def NamedTemporaryFile(
+    mode: Literal["rb", "wb", "ab", "xb", "r+b", "w+b", "a+b", "x+b"] = ...,
+    buffering: int = ...,
+    encoding: Optional[str] = ...,
+    newline: Optional[str] = ...,
+    suffix: Optional[AnyStr] = ...,
+    prefix: Optional[AnyStr] = ...,
+    dir: Optional[AnyStr] = ...,
+    delete: bool = ...,
+) -> IO[bytes]: ...
+@overload
+def NamedTemporaryFile(
+    mode: str = ...,
+    buffering: int = ...,
+    encoding: Optional[str] = ...,
+    newline: Optional[str] = ...,
+    suffix: Optional[AnyStr] = ...,
+    prefix: Optional[AnyStr] = ...,
+    dir: Optional[AnyStr] = ...,
+    delete: bool = ...,
+) -> IO[Any]: ...
 
 # It does not actually derive from IO[AnyStr], but it does implement the
 # protocol.


### PR DESCRIPTION
The `mode` parameter of these functions defaults to 'w+b'
(https://docs.python.org/3.7/library/tempfile.html), so I've added an
overload for explicit text mode, a second for explicit binary mode or
omitting the mode, and a third for a non-literal mode.