### PR TITLE
Let unittest skipping functions decorate types

### DIFF
--- a/stdlib/3/unittest/case.pyi
+++ b/stdlib/3/unittest/case.pyi
@@ -9,7 +9,7 @@ from types import TracebackType
 
 
 _E = TypeVar('_E', bound=BaseException)
-_FT = TypeVar('_FT', bound=Callable[..., Any])
+_FT = TypeVar('_FT', bound=Union[Callable[..., Any], Type])
 
 
 def expectedFailure(func: _FT) -> _FT: ...


### PR DESCRIPTION
Resolve #3221 by expanding the bounds on arguments to `unittest.skip(...)`, `unittest.skipIf(...)` and `unittest.skipUnless(...)` decorators