### PR TITLE
requests.Session.request data arg accepts an iterable of tuples

### DIFF
--- a/third_party/2and3/requests/api.pyi
+++ b/third_party/2and3/requests/api.pyi
@@ -4,9 +4,9 @@ import sys
 from typing import Optional, Union, Any, Iterable, Mapping, MutableMapping, Tuple, IO, Text
 
 from .models import Response
+from .sessions import _Data
 
 _ParamsMappingValueType = Union[Text, bytes, int, float, Iterable[Union[Text, bytes, int, float]]]
-_Data = Union[None, Text, bytes, MutableMapping[str, Any], MutableMapping[Text, Any], Iterable[Tuple[Text, Optional[Text]]], IO]
 
 def request(method: str, url: str, **kwargs) -> Response: ...
 def get(

--- a/third_party/2and3/requests/sessions.pyi
+++ b/third_party/2and3/requests/sessions.pyi
@@ -54,7 +54,7 @@ class SessionRedirectMixin:
     def rebuild_auth(self, prepared_request, response): ...
     def rebuild_proxies(self, prepared_request, proxies): ...
 
-_Data = Union[None, bytes, MutableMapping[Text, Text], IO]
+_Data = Union[None, Text, bytes, MutableMapping[str, Any], MutableMapping[Text, Any], Iterable[Tuple[Text, Optional[Text]]], IO]
 
 _Hook = Callable[[Response], Any]
 _Hooks = MutableMapping[Text, List[_Hook]]


### PR DESCRIPTION
The type signature for the data arg to the `requests.Session.request` (and `get`, `post`, etc.) call accepts an iterable of tuples.

This was already corrected in #1660 for `requests.request`.

(Is there a better place to put this definition so it doesn't get out of sync again?)