### PR TITLE
Make the type of `timeout` Optional[float] everywhere in subprocess.

### DIFF
--- a/stdlib/3/subprocess.pyi
+++ b/stdlib/3/subprocess.pyi
@@ -451,7 +451,7 @@ def call(args: _CMD,
          restore_signals: bool = ...,
          start_new_session: bool = ...,
          pass_fds: Any = ...,
-         timeout: float = ...) -> int: ...
+         timeout: Optional[float] = ...) -> int: ...
 
 # Same args as Popen.__init__
 def check_call(args: _CMD,
@@ -471,7 +471,7 @@ def check_call(args: _CMD,
                restore_signals: bool = ...,
                start_new_session: bool = ...,
                pass_fds: Any = ...,
-               timeout: float = ...) -> int: ...
+               timeout: Optional[float] = ...) -> int: ...
 
 if sys.version_info >= (3, 7):
     # 3.7 added text
@@ -493,7 +493,7 @@ if sys.version_info >= (3, 7):
                      start_new_session: bool = ...,
                      pass_fds: Any = ...,
                      *,
-                     timeout: float = ...,
+                     timeout: Optional[float] = ...,
                      input: _TXT = ...,
                      encoding: Optional[str] = ...,
                      errors: Optional[str] = ...,
@@ -517,7 +517,7 @@ if sys.version_info >= (3, 7):
                      start_new_session: bool = ...,
                      pass_fds: Any = ...,
                      *,
-                     timeout: float = ...,
+                     timeout: Optional[float] = ...,
                      input: _TXT = ...,
                      encoding: str,
                      errors: Optional[str] = ...,
@@ -541,7 +541,7 @@ if sys.version_info >= (3, 7):
                      start_new_session: bool = ...,
                      pass_fds: Any = ...,
                      *,
-                     timeout: float = ...,
+                     timeout: Optional[float] = ...,
                      input: _TXT = ...,
                      encoding: Optional[str] = ...,
                      errors: str,
@@ -566,7 +566,7 @@ if sys.version_info >= (3, 7):
                      start_new_session: bool = ...,
                      pass_fds: Any = ...,
                      # where the real keyword only ones start
-                     timeout: float = ...,
+                     timeout: Optional[float] = ...,
                      input: _TXT = ...,
                      encoding: Optional[str] = ...,
                      errors: Optional[str] = ...,
@@ -590,7 +590,7 @@ if sys.version_info >= (3, 7):
                      start_new_session: bool = ...,
                      pass_fds: Any = ...,
                      *,
-                     timeout: float = ...,
+                     timeout: Optional[float] = ...,
                      input: _TXT = ...,
                      encoding: None = ...,
                      errors: None = ...,
@@ -614,7 +614,7 @@ if sys.version_info >= (3, 7):
                      start_new_session: bool = ...,
                      pass_fds: Any = ...,
                      *,
-                     timeout: float = ...,
+                     timeout: Optional[float] = ...,
                      input: _TXT = ...,
                      encoding: Optional[str] = ...,
                      errors: Optional[str] = ...,
@@ -640,7 +640,7 @@ elif sys.version_info >= (3, 6):
                      start_new_session: bool = ...,
                      pass_fds: Any = ...,
                      *,
-                     timeout: float = ...,
+                     timeout: Optional[float] = ...,
                      input: _TXT = ...,
                      encoding: str,
                      errors: Optional[str] = ...,
@@ -663,7 +663,7 @@ elif sys.version_info >= (3, 6):
                      start_new_session: bool = ...,
                      pass_fds: Any = ...,
                      *,
-                     timeout: float = ...,
+                     timeout: Optional[float] = ...,
                      input: _TXT = ...,
                      encoding: Optional[str] = ...,
                      errors: str,
@@ -686,7 +686,7 @@ elif sys.version_info >= (3, 6):
                      pass_fds: Any = ...,
                      *,
                      universal_newlines: Literal[True],
-                     timeout: float = ...,
+                     timeout: Optional[float] = ...,
                      input: _TXT = ...,
                      encoding: Optional[str] = ...,
                      errors: Optional[str] = ...,
@@ -709,7 +709,7 @@ elif sys.version_info >= (3, 6):
                      start_new_session: bool = ...,
                      pass_fds: Any = ...,
                      *,
-                     timeout: float = ...,
+                     timeout: Optional[float] = ...,
                      input: _TXT = ...,
                      encoding: None = ...,
                      errors: None = ...,
@@ -732,7 +732,7 @@ elif sys.version_info >= (3, 6):
                      start_new_session: bool = ...,
                      pass_fds: Any = ...,
                      *,
-                     timeout: float = ...,
+                     timeout: Optional[float] = ...,
                      input: _TXT = ...,
                      encoding: Optional[str] = ...,
                      errors: Optional[str] = ...,
@@ -754,7 +754,7 @@ else:
                      restore_signals: bool = ...,
                      start_new_session: bool = ...,
                      pass_fds: Any = ...,
-                     timeout: float = ...,
+                     timeout: Optional[float] = ...,
                      input: _TXT = ...,
                      *,
                      universal_newlines: Literal[True],
@@ -776,7 +776,7 @@ else:
                      restore_signals: bool = ...,
                      start_new_session: bool = ...,
                      pass_fds: Any = ...,
-                     timeout: float = ...,
+                     timeout: Optional[float] = ...,
                      input: _TXT = ...,
                      ) -> bytes: ...
     @overload
@@ -796,7 +796,7 @@ else:
                      restore_signals: bool = ...,
                      start_new_session: bool = ...,
                      pass_fds: Any = ...,
-                     timeout: float = ...,
+                     timeout: Optional[float] = ...,
                      input: _TXT = ...,
                      ) -> Any: ...  # morally: -> _TXT
 


### PR DESCRIPTION
In https://docs.python.org/3/library/subprocess.html, the default value
of `timeout` is always None, so its type should be Optional[float], not
float. The one exception is that I left the type as float in
TimeoutExpired because (I assume) a timeout of None does not expire.