### PR TITLE
Copy a better definition of abstractmethod from 3/abc to 2/abc.

### DIFF
--- a/stdlib/2/abc.pyi
+++ b/stdlib/2/abc.pyi
@@ -1,9 +1,11 @@
-from typing import Any, Dict, Set, Tuple, Type
+from typing import Any, Callable, Dict, Set, Tuple, Type, TypeVar
 import _weakrefset
+
+_FuncT = TypeVar('_FuncT', bound=Callable[..., Any])
 
 # NOTE: mypy has special processing for ABCMeta and abstractmethod.
 
-def abstractmethod(funcobj: Any) -> Any: ...
+def abstractmethod(funcobj: _FuncT) -> _FuncT: ...
 
 class ABCMeta(type):
     # TODO: FrozenSet


### PR DESCRIPTION
At this point, it only matters for a few more months, but the Python 2
definition was less precise.