### PR TITLE
Changed type of fieldname parameter in DictWriter __init__ method

### DIFF
--- a/stdlib/2and3/csv.pyi
+++ b/stdlib/2and3/csv.pyi
@@ -79,7 +79,7 @@ class DictWriter(object):
     restval: Optional[Any]
     extrasaction: str
     writer: _writer
-    def __init__(self, f: Any, fieldnames: Sequence[str],
+    def __init__(self, f: Any, fieldnames: Iterable[str],
                  restval: Optional[Any] = ..., extrasaction: str = ..., dialect: _Dialect = ...,
                  *args: Any, **kwds: Any) -> None: ...
     def writeheader(self) -> None: ...


### PR DESCRIPTION
Changed type of fieldname parameter in DictWriter __init__ method from Sequence[str] to Iterable[str]. This allows it to work with the following code:
my_dict = dict(a=2, b=3)
a = DictWriter(my_file, my_dict.keys())