### PR TITLE
Type annotated `click.FloatRange`'s constructor

### DIFF
--- a/third_party/2and3/click/types.pyi
+++ b/third_party/2and3/click/types.pyi
@@ -71,7 +71,13 @@ class FloatParamType(ParamType):
 
 
 class FloatRange(FloatParamType):
-    ...
+    def __init__(
+        self,
+        min: Optional[float] = ...,
+        max: Optional[float] = ...,
+        clamp: bool = ...,
+    ) -> None:
+        ...
 
 
 class File(ParamType):


### PR DESCRIPTION
This just adds the constructor arguments to `click.FloatRange`.