### PR TITLE
click: Support tuples of _ParamTypes, CliRunner fixes

### DIFF
--- a/third_party/2and3/click/core.pyi
+++ b/third_party/2and3/click/core.pyi
@@ -356,7 +356,8 @@ class _ParamType:
 
 
 # This type is here to resolve https://github.com/python/mypy/issues/5275
-_ConvertibleType = Union[type, _ParamType, Tuple[type, ...], Callable[[str], Any], Callable[[Optional[str]], Any]]
+_ConvertibleType = Union[type, _ParamType, Tuple[Union[type, _ParamType], ...],
+                         Callable[[str], Any], Callable[[Optional[str]], Any]]
 
 
 class Parameter:

--- a/third_party/2and3/click/testing.pyi
+++ b/third_party/2and3/click/testing.pyi
@@ -56,7 +56,7 @@ class CliRunner:
     def make_env(self, overrides: Optional[Mapping[str, str]] = ...) -> Dict[str, str]: ...
     def isolation(
         self,
-        input: Optional[IO] = ...,
+        input: Optional[Union[bytes, Text, IO]] = ...,
         env: Optional[Mapping[str, str]] = ...,
         color: bool = ...,
     ) -> ContextManager[BinaryIO]: ...
@@ -64,7 +64,7 @@ class CliRunner:
         self,
         cli: BaseCommand,
         args: Optional[Union[str, Iterable[str]]] = ...,
-        input: Optional[IO] = ...,
+        input: Optional[Union[bytes, Text, IO]] = ...,
         env: Optional[Mapping[str, str]] = ...,
         catch_exceptions: bool = ...,
         color: bool = ...,

--- a/third_party/2and3/flask/testing.pyi
+++ b/third_party/2and3/flask/testing.pyi
@@ -4,7 +4,7 @@
 
 from click import BaseCommand
 from click.testing import CliRunner, Result
-from typing import Any, IO, Iterable, Mapping, Optional, Union, TypeVar
+from typing import Any, IO, Iterable, Mapping, Optional, Text, TypeVar, Union
 from werkzeug.test import Client
 
 def make_test_environ_builder(app: Any, path: str = ..., base_url: Optional[Any] = ..., subdomain: Optional[Any] = ..., url_scheme: Optional[Any] = ..., *args: Any, **kwargs: Any): ...
@@ -29,7 +29,7 @@ class FlaskCliRunner(CliRunner):
         self,
         cli: Optional[BaseCommand] = ...,
         args: Optional[Union[str, Iterable[str]]] = ...,
-        input: Optional[IO] = ...,
+        input: Optional[Union[bytes, IO, Text]] = ...,
         env: Optional[Mapping[str, str]] = ...,
         catch_exceptions: bool = ...,
         color: bool = ...,


### PR DESCRIPTION
These are two simple changes to the click API.

First, instead of only primitive types being convertible in tuples, this recognizes that custom types are convertible as well. [Here's](https://github.com/pallets/click/blob/master/click/types.py#L578) the relevant click code. Ideally, this would be `Tuple[_ConvertibleType]` instead, but until mypy allows recursive types this supports most common usecases.

Second, this changes the `input` parameter of `CliRunner.invoke` and `CliRunner.isolation` to support Text and bytes, to match the signature of `make_input_stream`. Under the hood, `invoke` calls `isolation` which calls `make_input_stream`, so there's no reason for `invoke` and `isolation` to have more restrictive types.