### PR TITLE
Add missing default for ssl_handshake_timeout agrument

### DIFF
--- a/stdlib/3/asyncio/events.pyi
+++ b/stdlib/3/asyncio/events.pyi
@@ -139,7 +139,7 @@ class AbstractEventLoop(metaclass=ABCMeta):
         @abstractmethod
         async def create_unix_connection(self, protocol_factory: _ProtocolFactory, path: str, *, ssl: _SSLContext = ...,
                                          sock: Optional[socket] = ..., server_hostname: str = ...,
-                                         ssl_handshake_timeout: Optional[float]) -> _TransProtPair: ...
+                                         ssl_handshake_timeout: Optional[float] = ...) -> _TransProtPair: ...
         @abstractmethod
         async def create_unix_server(self, protocol_factory: _ProtocolFactory, path: str, *, sock: Optional[socket] = ...,
                                      backlog: int = ..., ssl: _SSLContext = ..., ssl_handshake_timeout: Optional[float] = ...,


### PR DESCRIPTION
`ssl_handshake_timeout` actually has `None` as the default value.