### PR TITLE
Remove some spurious version checks in logging

### DIFF
--- a/stdlib/2and3/logging/__init__.pyi
+++ b/stdlib/2and3/logging/__init__.pyi
@@ -18,10 +18,7 @@ else:
     _ExcInfoType = Union[None, bool, _SysExcInfoType]
 _ArgsType = Union[Tuple[Any, ...], Mapping[str, Any]]
 _FilterType = Union[Filter, Callable[[LogRecord], int]]
-if sys.version_info >= (3, 2):
-    _Level = Union[int, Text]
-else:
-    _Level = int
+_Level = Union[int, Text]
 if sys.version_info >= (3, 6):
     from os import PathLike
     _Path = Union[str, PathLike[str]]
@@ -403,8 +400,7 @@ class FileHandler(StreamHandler):
                  encoding: Optional[str] = ..., delay: bool = ...) -> None: ...
 
 
-if sys.version_info >= (3, 1):
-    class NullHandler(Handler): ...
+class NullHandler(Handler): ...
 
 
 class PlaceHolder:


### PR DESCRIPTION
PR #3269 added some version checks for the argument type to setLevel
and the existence of NullHandler. While these features weren't present
in early versions of Python 3, they *are* present in Python 2.7, which
leads to false positives.

We could expand the check to include Python 2, but since the affected
Python 3 versions are super old and unsupported, I'm just removing the
checks.