### PR TITLE
Minor flake8 improvements

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -20,6 +20,6 @@ ignore = F401, F403, F405, F811, E301, E302, E305, E501, E701, E704, E741, B303,
 # We are checking with Python 3 but many of the stubs are Python 2 stubs.
 # A nice future improvement would be to provide separate .flake8
 # configurations for Python 2 and Python 3 files.
-builtins = buffer,file,long,unicode,xrange
+builtins = StandardError,apply,basestring,buffer,cmp,coerce,execfile,file,intern,long,raw_input,reduce,reload,unichr,unicode,xrange
 exclude = .venv*,@*,.git
 max-line-length = 130

--- a/.flake8
+++ b/.flake8
@@ -18,8 +18,6 @@
 [flake8]
 ignore = F401, F403, F405, F811, E301, E302, E305, E501, E701, E704, E741, B303, W504
 # We are checking with Python 3 but many of the stubs are Python 2 stubs.
-# A nice future improvement would be to provide separate .flake8
-# configurations for Python 2 and Python 3 files.
 builtins = StandardError,apply,basestring,buffer,cmp,coerce,execfile,file,intern,long,raw_input,reduce,reload,unichr,unicode,xrange
 exclude = .venv*,@*,.git
 max-line-length = 130

--- a/.flake8
+++ b/.flake8
@@ -20,6 +20,6 @@ ignore = F401, F403, F405, F811, E301, E302, E305, E501, E701, E704, E741, B303,
 # We are checking with Python 3 but many of the stubs are Python 2 stubs.
 # A nice future improvement would be to provide separate .flake8
 # configurations for Python 2 and Python 3 files.
-builtins = StandardError,apply,basestring,buffer,cmp,coerce,execfile,file,intern,long,raw_input,reduce,reload,unichr,unicode,xrange
+builtins = buffer,file,long,unicode,xrange
 exclude = .venv*,@*,.git
 max-line-length = 130

--- a/.flake8
+++ b/.flake8
@@ -5,7 +5,7 @@
 #  7155 E302 expected 2 blank lines
 #  1463 F401 imported but unused
 #   967 E701 multiple statements on one line (colon)
-#   457 F811 redefinition
+#   457 F811 redefinition (should be fixed in pyflakes 2.1.2)
 #   390 E305 expected 2 blank lines
 #     4 E741 ambiguous variable name
 

--- a/requirements-tests-py3.txt
+++ b/requirements-tests-py3.txt
@@ -2,7 +2,7 @@ git+https://github.com/python/mypy.git@master
 typed-ast>=1.0.4
 black==19.3b0
 flake8==3.7.8
-flake8-bugbear==19.3.0
+flake8-bugbear==19.8.0
 flake8-pyi==19.3.0
 isort==4.3.21
 pytype>=2019.7.30


### PR DESCRIPTION
* Limit Python 2 builtins to ones actually used.
* Update flake8-bugbear
* Leave a reminder about F811 not needed in the future (fixed in PyCQA/pyflakes#435, but not released yet).

