### PR TITLE
Make sys.stdin/out/err Optional

### DIFF
--- a/stdlib/3/sys.pyi
+++ b/stdlib/3/sys.pyi
@@ -48,12 +48,12 @@ platform: str
 prefix: str
 ps1: str
 ps2: str
-stdin: TextIO
-stdout: TextIO
-stderr: TextIO
-__stdin__: TextIO
-__stdout__: TextIO
-__stderr__: TextIO
+stdin: Optional[TextIO]
+stdout: Optional[TextIO]
+stderr: Optional[TextIO]
+__stdin__: Optional[TextIO]
+__stdout__: Optional[TextIO]
+__stderr__: Optional[TextIO]
 # deprecated and removed in Python 3.3:
 subversion: Tuple[str, str, str]
 tracebacklimit: int


### PR DESCRIPTION
According to the Python documentation, sys.stdin/out/err can be None: https://docs.python.org/3/library/sys.html#sys.__stderr__

> Note: Under some conditions `stdin`, `stdout` and `stderr` as well as the original values `__stdin__`, `__stdout__` and `__stderr__` can be `None`. It is usually the case for Windows GUI apps that aren’t connected to a console and Python apps started with **pythonw**.

To work properly in those scenarios, code should be aware of that and check them against `None` before using them.

---

FWIW I'm not 100% sure this is a good idea - it's more correct and would've prevented my application crashing in that scenario - but at the same time, it makes things harder for people who just don't care about that scenario.