### PR TITLE
Make path separator based on OS separator

### DIFF
--- a/tests/pytype_test.py
+++ b/tests/pytype_test.py
@@ -133,7 +133,7 @@ def can_run(exe: str, *, args: List[str]) -> bool:
 
 
 def _is_version(path: str, version: str) -> bool:
-    return any("{}/{}".format(d, version) in path for d in TYPESHED_SUBDIRS)
+    return any("{}{}{}".format(d, os.path.sep, version) in path for d in TYPESHED_SUBDIRS)
 
 
 def check_subdirs_discoverable(subdir_paths: List[str]) -> None:


### PR DESCRIPTION
Use the os path separator in the `_is_version` function, fixes #3373. Tested on both Win10 and Ubuntu 18, should be generic cross-platform