### PR TITLE
Revert __import__ function annotation to return type back to Any

### DIFF
--- a/stdlib/2/__builtin__.pyi
+++ b/stdlib/2/__builtin__.pyi
@@ -11,7 +11,7 @@ from typing import (
 )
 from abc import abstractmethod, ABCMeta
 from ast import mod, AST
-from types import TracebackType, CodeType, ModuleType
+from types import TracebackType, CodeType
 import sys
 
 if sys.version_info >= (3,):
@@ -1455,7 +1455,7 @@ else:
 def __import__(name: Text, globals: Optional[Mapping[str, Any]] = ...,
                locals: Optional[Mapping[str, Any]] = ...,
                fromlist: Sequence[str] = ...,
-               level: int = ...) -> ModuleType: ...
+               level: int = ...) -> Any: ...
 
 # Actually the type of Ellipsis is <type 'ellipsis'>, but since it's
 # not exposed anywhere under that name, we make it private here.

--- a/stdlib/2and3/builtins.pyi
+++ b/stdlib/2and3/builtins.pyi
@@ -11,7 +11,7 @@ from typing import (
 )
 from abc import abstractmethod, ABCMeta
 from ast import mod, AST
-from types import TracebackType, CodeType, ModuleType
+from types import TracebackType, CodeType
 import sys
 
 if sys.version_info >= (3,):
@@ -1455,7 +1455,7 @@ else:
 def __import__(name: Text, globals: Optional[Mapping[str, Any]] = ...,
                locals: Optional[Mapping[str, Any]] = ...,
                fromlist: Sequence[str] = ...,
-               level: int = ...) -> ModuleType: ...
+               level: int = ...) -> Any: ...
 
 # Actually the type of Ellipsis is <type 'ellipsis'>, but since it's
 # not exposed anywhere under that name, we make it private here.


### PR DESCRIPTION
From python/mypy#7582.

This partially reverts back the change in
0ee7c3c to have `__import__` return
`Any` instead of `ModuleType`.