### PR TITLE
Fix show_default type in click.option signatures

### DIFF
--- a/third_party/2and3/click/decorators.pyi
+++ b/third_party/2and3/click/decorators.pyi
@@ -94,7 +94,7 @@ def option(
     *param_decls: str,
     cls: Type[Option] = ...,
     # Option
-    show_default: bool = ...,
+    show_default: Union[bool, Text] = ...,
     prompt: Union[bool, Text] = ...,
     confirmation_prompt: bool = ...,
     hide_input: bool = ...,
@@ -126,7 +126,7 @@ def option(
     *param_decls: str,
     cls: Type[Option] = ...,
     # Option
-    show_default: bool = ...,
+    show_default: Union[bool, Text] = ...,
     prompt: Union[bool, Text] = ...,
     confirmation_prompt: bool = ...,
     hide_input: bool = ...,
@@ -158,7 +158,7 @@ def option(
     *param_decls: str,
     cls: Type[Option] = ...,
     # Option
-    show_default: bool = ...,
+    show_default: Union[bool, Text] = ...,
     prompt: Union[bool, Text] = ...,
     confirmation_prompt: bool = ...,
     hide_input: bool = ...,
@@ -190,7 +190,7 @@ def option(
     *param_decls: str,
     cls: Type[Option] = ...,
     # Option
-    show_default: bool = ...,
+    show_default: Union[bool, Text] = ...,
     prompt: Union[bool, Text] = ...,
     confirmation_prompt: bool = ...,
     hide_input: bool = ...,
@@ -221,7 +221,7 @@ def confirmation_option(
     *param_decls: str,
     cls: Type[Option] = ...,
     # Option
-    show_default: bool = ...,
+    show_default: Union[bool, Text] = ...,
     prompt: Union[bool, Text] = ...,
     confirmation_prompt: bool = ...,
     hide_input: bool = ...,
@@ -249,7 +249,7 @@ def password_option(
     *param_decls: str,
     cls: Type[Option] = ...,
     # Option
-    show_default: bool = ...,
+    show_default: Union[bool, Text] = ...,
     prompt: Union[bool, Text] = ...,
     confirmation_prompt: bool = ...,
     hide_input: bool = ...,
@@ -280,7 +280,7 @@ def version_option(
     # Option
     prog_name: Optional[str] = ...,
     message: Optional[str] = ...,
-    show_default: bool = ...,
+    show_default: Union[bool, Text] = ...,
     prompt: Union[bool, Text] = ...,
     confirmation_prompt: bool = ...,
     hide_input: bool = ...,
@@ -308,7 +308,7 @@ def help_option(
     *param_decls: str,
     cls: Type[Option] = ...,
     # Option
-    show_default: bool = ...,
+    show_default: Union[bool, Text] = ...,
     prompt: Union[bool, Text] = ...,
     confirmation_prompt: bool = ...,
     hide_input: bool = ...,


### PR DESCRIPTION
Similar to https://github.com/python/typeshed/issues/1693 / https://github.com/python/typeshed/pull/1699, but for `show_default`...

Using `show_default='not a bool'` should be permitted according to [the Click documentation](https://click.palletsprojects.com/en/7.x/options/#dynamic-defaults-for-prompts); however, Mypy trips on it:
```
error: No overload variant of "option" matches argument types "str", "str", "int", "Path", "str", "str"
note: Possible overload variants:
note:     def option(*param_decls: str, cls: Type[Option] = ..., show_default: bool = ..., prompt: Union[bool, str] = ..., confirmation_prompt: bool = ..., hide_input: bool = ..., is_flag: Optional[bool] = ..., flag_value: Optional[Any] = ..., multiple: bool = ..., count: bool = ..., allow_from_autoenv: bool = ..., type: Union[type, _ParamType, Tuple[type, ...], Callable[[str], Any], Callable[[Optional[str]], Any], None] = ..., help: Optional[str] = ..., show_choices: bool = ..., default: Optional[Any] = ..., required: bool = ..., callback: Optional[Callable[[Context, Union[Option, Parameter], Any], Any]] = ..., nargs: Optional[int] = ..., metavar: Optional[str] = ..., expose_value: bool = ..., is_eager: bool = ..., envvar: Union[str, List[str], None] = ..., **kwargs: Any) -> Callable[[_F], _F]
note:     def [_T] option(*param_decls: str, cls: Type[Option] = ..., show_default: bool = ..., prompt: Union[bool, str] = ..., confirmation_prompt: bool = ..., hide_input: bool = ..., is_flag: Optional[bool] = ..., flag_value: Optional[Any] = ..., multiple: bool = ..., count: bool = ..., allow_from_autoenv: bool = ..., type: _T = ..., help: Optional[str] = ..., show_choices: bool = ..., default: Optional[Any] = ..., required: bool = ..., callback: Optional[Callable[[Context, Union[Option, Parameter], Union[bool, int, str]], _T]] = ..., nargs: Optional[int] = ..., metavar: Optional[str] = ..., expose_value: bool = ..., is_eager: bool = ..., envvar: Union[str, List[str], None] = ..., **kwargs: Any) -> Callable[[_F], _F]
note:     <2 more similar overloads not shown, out of 4 total overloads>
```