### PR TITLE
Require a more recent pytype version.

### DIFF
--- a/requirements-tests-py3.txt
+++ b/requirements-tests-py3.txt
@@ -5,4 +5,4 @@ flake8==3.7.8
 flake8-bugbear==19.8.0
 flake8-pyi==19.3.0
 isort==4.3.21
-pytype>=2019.7.30
+pytype>=2019.10.17


### PR DESCRIPTION
Yesterday's release contains a number of pyi parser fixes, such as
support for the syntax in #3321.