### PR TITLE
Adds `posonlyargs` property to `arguments` for python3.8+

### DIFF
--- a/stdlib/3/_ast.pyi
+++ b/stdlib/3/_ast.pyi
@@ -389,6 +389,8 @@ class ExceptHandler(excepthandler):
 
 
 class arguments(AST):
+    if sys.version_info >= (3, 8):
+        posonlyargs: typing.List[arg]
     args: typing.List[arg]
     vararg: Optional[arg]
     kwonlyargs: typing.List[arg]


### PR DESCRIPTION
I have decided to put it on top to follow the implementation order.