### PR TITLE
Update stubs for tabulate

### DIFF
--- a/third_party/2and3/tabulate.pyi
+++ b/third_party/2and3/tabulate.pyi
@@ -1,18 +1,44 @@
-# Stub for tabulate: https://bitbucket.org/astanin/python-tabulate
-from typing import Any, Dict, Iterable, Sequence, Union
+# Stub for tabulate: https://github.com/astanin/python-tabulate
+from typing import Any, Callable, Container, Iterable, List, Mapping, NamedTuple, Optional, Sequence, Union
 
+PRESERVE_WHITESPACE: bool
+WIDE_CHARS_MODE: bool
+tabulate_formats: List[str]
 
-def __getattr__(name: str) -> Any: ...
+class Line(NamedTuple):
+    begin: str
+    hline: str
+    sep: str
+    end: str
 
+class DataRow(NamedTuple):
+    begin: str
+    sep: str
+    end: str
+
+_TableFormatLine = Union[None, Line, Callable[[List[int], List[str]], str]]
+_TableFormatRow = Union[None, DataRow, Callable[[List[Any], List[int], List[str]], str]]
+
+class TableFormat(NamedTuple):
+    lineabove: _TableFormatLine
+    linebelowheader: _TableFormatLine
+    linebetweenrows: _TableFormatLine
+    linebelow: _TableFormatLine
+    headerrow: _TableFormatRow
+    datarow: _TableFormatRow
+    padding: int
+    with_header_hide: Optional[Container[str]]
+
+def simple_separated_format(separator: str) -> TableFormat: ...
 def tabulate(
-    tabular_data: Iterable[Iterable[Any]],
-    headers: Union[str, Dict[str, str], Sequence[str]] = ...,
-    tablefmt: str = ...,
-    floatfmt: str = ...,
-    numalign: str = ...,
-    stralign: str = ...,
-    missingval: str = ...,
-    showindex: str = ...,
-    disable_numparse: bool = ...
-) -> str:
-    ...
+    tabular_data: Union[Mapping[str, Iterable[Any]], Iterable[Iterable[Any]]],
+    headers: Union[str, Sequence[str]] = ...,
+    tablefmt: Union[str, TableFormat] = ...,
+    floatfmt: Union[str, Iterable[str]] = ...,
+    numalign: Optional[str] = ...,
+    stralign: Optional[str] = ...,
+    missingval: Union[str, Iterable[str]] = ...,
+    showindex: Union[str, bool, Iterable[Any]] = ...,
+    disable_numparse: Union[bool, Iterable[int]] = ...,
+    colalign: Optional[Iterable[Optional[str]]] = ...,
+) -> str: ...


### PR DESCRIPTION
Updates the stubs for the `tabulate` module. In particular, the main function (`tabulate()`) was missing several possible types for its arguments.