### PR TITLE
Update sre_parse module for Python 3.8

### DIFF
--- a/stdlib/3/sre_parse.pyi
+++ b/stdlib/3/sre_parse.pyi
@@ -53,7 +53,7 @@ class SubPattern:
     width: Optional[int]
 
     if sys.version_info >= (3, 8):
-        state: State 
+        state: State
         def __init__(self, state: State, data: List[_CodeType] = ...) -> None: ...
     else:
         pattern: Pattern

--- a/stdlib/3/sre_parse.pyi
+++ b/stdlib/3/sre_parse.pyi
@@ -4,6 +4,7 @@ from typing import (
     Any, Dict, FrozenSet, Iterable, List, Match,
     Optional, Pattern as _Pattern, Tuple, Union
 )
+import sys
 from sre_constants import _NamedIntConstant as NIC, error as _Error
 
 SPECIAL_CHARS: str
@@ -20,7 +21,7 @@ GLOBAL_FLAGS: int
 
 class Verbose(Exception): ...
 
-class Pattern:
+class _State:
     flags: int
     groupdict: Dict[str, int]
     groupwidths: List[Optional[int]]
@@ -33,6 +34,11 @@ class Pattern:
     def checkgroup(self, gid: int) -> bool: ...
     def checklookbehindgroup(self, gid: int, source: Tokenizer) -> None: ...
 
+if sys.version_info >= (3, 8):
+    State = _State
+else:
+    Pattern = _State
+
 
 _OpSubpatternType = Tuple[Optional[int], int, int, SubPattern]
 _OpGroupRefExistsType = Tuple[int, SubPattern, SubPattern]
@@ -43,10 +49,16 @@ _CodeType = Tuple[NIC, _AvType]
 
 
 class SubPattern:
-    pattern: Pattern
     data: List[_CodeType]
     width: Optional[int]
-    def __init__(self, pattern: Pattern, data: List[_CodeType] = ...) -> None: ...
+
+    if sys.version_info >= (3, 8):
+        state: State 
+        def __init__(self, state: State, data: List[_CodeType] = ...) -> None: ...
+    else:
+        pattern: Pattern
+        def __init__(self, pattern: Pattern, data: List[_CodeType] = ...) -> None: ...
+
     def dump(self, level: int = ...) -> None: ...
     def __len__(self) -> int: ...
     def __delitem__(self, index: Union[int, slice]) -> None: ...
@@ -75,7 +87,11 @@ class Tokenizer:
     def error(self, msg: str, offset: int = ...) -> _Error: ...
 
 def fix_flags(src: Union[str, bytes], flag: int) -> int: ...
-def parse(str: str, flags: int = ..., pattern: Pattern = ...) -> SubPattern: ...
 _TemplateType = Tuple[List[Tuple[int, int]], List[str]]
-def parse_template(source: str, pattern: _Pattern[Any]) -> _TemplateType: ...
+if sys.version_info >= (3, 8):
+    def parse(str: str, flags: int = ..., state: State = ...) -> SubPattern: ...
+    def parse_template(source: str, state: _Pattern[Any]) -> _TemplateType: ...
+else:
+    def parse(str: str, flags: int = ..., pattern: Pattern = ...) -> SubPattern: ...
+    def parse_template(source: str, pattern: _Pattern[Any]) -> _TemplateType: ...
 def expand_template(template: _TemplateType, match: Match[Any]) -> str: ...


### PR DESCRIPTION
It seems in Python 3.8, the 'Pattern' object in the (undocumented?) sre_parse module was renamed to 'State', along with a few associated parameters. For example, try taking the diff of:

- https://github.com/python/cpython/blob/3.7/Lib/sre_parse.py
- https://github.com/python/cpython/blob/3.8/Lib/sre_parse.py