### PR TITLE
Allow None for click.core.Context.default_map

### DIFF
--- a/third_party/2and3/click/core.pyi
+++ b/third_party/2and3/click/core.pyi
@@ -51,7 +51,7 @@ class Context:
     args: List[str]
     protected_args: List[str]
     obj: Any
-    default_map: Mapping[str, Any]
+    default_map: Optional[Mapping[str, Any]]
     invoked_subcommand: Optional[str]
     terminal_width: Optional[int]
     max_content_width: Optional[int]


### PR DESCRIPTION
None seems to be an expected type for this variable, as can be seen from the handling here: https://github.com/pallets/click/blob/6944450c5331f2d652d342650b6d9b3b52404baa/click/core.py#L519