### PR TITLE
Type socketserver's RequestHandlerClass as a callable.

### DIFF
--- a/stdlib/2/BaseHTTPServer.pyi
+++ b/stdlib/2/BaseHTTPServer.pyi
@@ -1,6 +1,6 @@
 # Stubs for BaseHTTPServer (Python 2.7)
 
-from typing import Any, BinaryIO, Mapping, Optional, Tuple, Union
+from typing import Any, BinaryIO, Callable, Mapping, Optional, Tuple, Union
 import SocketServer
 import mimetools
 
@@ -8,9 +8,9 @@ class HTTPServer(SocketServer.TCPServer):
     server_name: str
     server_port: int
     def __init__(self, server_address: Tuple[str, int],
-                 RequestHandlerClass: type) -> None: ...
+                 RequestHandlerClass: Callable[..., BaseHTTPRequestHandler]) -> None: ...
 
-class BaseHTTPRequestHandler:
+class BaseHTTPRequestHandler(SocketServer.StreamRequestHandler):
     client_address: Tuple[str, int]
     server: SocketServer.BaseServer
     close_connection: bool

--- a/stdlib/2/SocketServer.pyi
+++ b/stdlib/2/SocketServer.pyi
@@ -1,14 +1,14 @@
 # NB: SocketServer.pyi and socketserver.pyi must remain consistent!
 # Stubs for socketserver
 
-from typing import Any, BinaryIO, Optional, Tuple, Type, Text, Union
+from typing import Any, BinaryIO, Callable, Optional, Tuple, Type, Text, Union
 from socket import SocketType
 import sys
 import types
 
 class BaseServer:
     address_family: int
-    RequestHandlerClass: type
+    RequestHandlerClass: Callable[..., BaseRequestHandler]
     server_address: Tuple[str, int]
     socket: SocketType
     allow_reuse_address: bool
@@ -16,7 +16,7 @@ class BaseServer:
     socket_type: int
     timeout: Optional[float]
     def __init__(self, server_address: Any,
-                 RequestHandlerClass: type) -> None: ...
+                 RequestHandlerClass: Callable[..., BaseRequestHandler]) -> None: ...
     def fileno(self) -> int: ...
     def handle_request(self) -> None: ...
     def serve_forever(self, poll_interval: float = ...) -> None: ...
@@ -44,23 +44,23 @@ class BaseServer:
 
 class TCPServer(BaseServer):
     def __init__(self, server_address: Tuple[str, int],
-                 RequestHandlerClass: type,
+                 RequestHandlerClass: Callable[..., BaseRequestHandler],
                  bind_and_activate: bool = ...) -> None: ...
 
 class UDPServer(BaseServer):
     def __init__(self, server_address: Tuple[str, int],
-                 RequestHandlerClass: type,
+                 RequestHandlerClass: Callable[..., BaseRequestHandler],
                  bind_and_activate: bool = ...) -> None: ...
 
 if sys.platform != 'win32':
     class UnixStreamServer(BaseServer):
         def __init__(self, server_address: Union[Text, bytes],
-                     RequestHandlerClass: type,
+                     RequestHandlerClass: Callable[..., BaseRequestHandler],
                      bind_and_activate: bool = ...) -> None: ...
 
     class UnixDatagramServer(BaseServer):
         def __init__(self, server_address: Union[Text, bytes],
-                     RequestHandlerClass: type,
+                     RequestHandlerClass: Callable[..., BaseRequestHandler],
                      bind_and_activate: bool = ...) -> None: ...
 
 class ForkingMixIn: ...

--- a/stdlib/3/http/server.pyi
+++ b/stdlib/3/http/server.pyi
@@ -1,7 +1,7 @@
 # Stubs for http.server (Python 3.4)
 
 import sys
-from typing import Any, BinaryIO, ClassVar, Dict, List, Mapping, Optional, Sequence, Tuple, Union
+from typing import Any, BinaryIO, Callable, ClassVar, Dict, List, Mapping, Optional, Sequence, Tuple, Union
 import socketserver
 import email.message
 
@@ -12,7 +12,7 @@ class HTTPServer(socketserver.TCPServer):
     server_name: str
     server_port: int
     def __init__(self, server_address: Tuple[str, int],
-                 RequestHandlerClass: type) -> None: ...
+                 RequestHandlerClass: Callable[..., BaseHTTPRequestHandler]) -> None: ...
 
 if sys.version_info >= (3, 7):
     class ThreadingHTTPServer(socketserver.ThreadingMixIn, HTTPServer):

--- a/stdlib/3/socketserver.pyi
+++ b/stdlib/3/socketserver.pyi
@@ -1,14 +1,14 @@
 # NB: SocketServer.pyi and socketserver.pyi must remain consistent!
 # Stubs for socketserver
 
-from typing import Any, BinaryIO, Optional, Tuple, Type, Text, Union
+from typing import Any, BinaryIO, Callable, Optional, Tuple, Type, Text, Union
 from socket import SocketType
 import sys
 import types
 
 class BaseServer:
     address_family: int
-    RequestHandlerClass: type
+    RequestHandlerClass: Callable[..., BaseRequestHandler]
     server_address: Tuple[str, int]
     socket: SocketType
     allow_reuse_address: bool
@@ -16,7 +16,7 @@ class BaseServer:
     socket_type: int
     timeout: Optional[float]
     def __init__(self, server_address: Any,
-                 RequestHandlerClass: type) -> None: ...
+                 RequestHandlerClass: Callable[..., BaseRequestHandler]) -> None: ...
     def fileno(self) -> int: ...
     def handle_request(self) -> None: ...
     def serve_forever(self, poll_interval: float = ...) -> None: ...
@@ -44,23 +44,23 @@ class BaseServer:
 
 class TCPServer(BaseServer):
     def __init__(self, server_address: Tuple[str, int],
-                 RequestHandlerClass: type,
+                 RequestHandlerClass: Callable[..., BaseRequestHandler],
                  bind_and_activate: bool = ...) -> None: ...
 
 class UDPServer(BaseServer):
     def __init__(self, server_address: Tuple[str, int],
-                 RequestHandlerClass: type,
+                 RequestHandlerClass: Callable[..., BaseRequestHandler],
                  bind_and_activate: bool = ...) -> None: ...
 
 if sys.platform != 'win32':
     class UnixStreamServer(BaseServer):
         def __init__(self, server_address: Union[Text, bytes],
-                     RequestHandlerClass: type,
+                     RequestHandlerClass: Callable[..., BaseRequestHandler],
                      bind_and_activate: bool = ...) -> None: ...
 
     class UnixDatagramServer(BaseServer):
         def __init__(self, server_address: Union[Text, bytes],
-                     RequestHandlerClass: type,
+                     RequestHandlerClass: Callable[..., BaseRequestHandler],
                      bind_and_activate: bool = ...) -> None: ...
 
 class ForkingMixIn: ...


### PR DESCRIPTION
It's not uncommon to pass functions rather than actual types into the servers.