### PR TITLE
Allow datetime() with a timedelta() in assert(Not)AlmostEqual(s).

### DIFF
--- a/stdlib/2/unittest.pyi
+++ b/stdlib/2/unittest.pyi
@@ -6,6 +6,7 @@ from typing import (Any, Callable, Dict, FrozenSet, Iterable, Iterator,
                     List, NoReturn, Optional, overload, Pattern, Sequence, Set,
                     Text, TextIO, Tuple, Type, TypeVar, Union)
 from abc import abstractmethod, ABCMeta
+import datetime
 import types
 
 _T = TypeVar('_T')
@@ -96,11 +97,19 @@ class TestCase(Testable):
     def assertAlmostEqual(self, first: float, second: float, *,
                           msg: Any = ..., delta: float = ...) -> None: ...
     @overload
+    def assertAlmostEqual(self, first: datetime.datetime,
+                          second: datetime.datetime, *,
+                          msg: Any = ..., delta: datetime.timedelta = ...) -> None: ...
+    @overload
     def assertAlmostEquals(self, first: float, second: float,
                            places: int = ..., msg: Any = ...) -> None: ...
     @overload
     def assertAlmostEquals(self, first: float, second: float, *,
                            msg: Any = ..., delta: float = ...) -> None: ...
+    @overload
+    def assertAlmostEquals(self, first: datetime.datetime,
+                           second: datetime.datetime, *,
+                           msg: Any = ..., delta: datetime.timedelta = ...) -> None: ...
     def failUnlessAlmostEqual(self, first: float, second: float, places: int = ...,
                               msg: object = ...) -> None: ...
     @overload
@@ -110,11 +119,19 @@ class TestCase(Testable):
     def assertNotAlmostEqual(self, first: float, second: float, *,
                              msg: Any = ..., delta: float = ...) -> None: ...
     @overload
+    def assertNotAlmostEqual(self, first: datetime.datetime,
+                             second: datetime.datetime, *,
+                             msg: Any = ..., delta: datetime.timedelta = ...) -> None: ...
+    @overload
     def assertNotAlmostEquals(self, first: float, second: float,
                               places: int = ..., msg: Any = ...) -> None: ...
     @overload
     def assertNotAlmostEquals(self, first: float, second: float, *,
                               msg: Any = ..., delta: float = ...) -> None: ...
+    @overload
+    def assertNotAlmostEquals(self, first: datetime.datetime,
+                              second: datetime.datetime, *,
+                              msg: Any = ..., delta: datetime.timedelta = ...) -> None: ...
     def failIfAlmostEqual(self, first: float, second: float, places: int = ...,
                           msg: object = ...,
                           delta: float = ...) -> None: ...

--- a/stdlib/3/unittest/case.pyi
+++ b/stdlib/3/unittest/case.pyi
@@ -1,3 +1,4 @@
+import datetime
 import logging
 import sys
 import unittest.result
@@ -117,8 +118,13 @@ class TestCase:
         self, logger: Optional[logging.Logger] = ...,
         level: Union[int, str, None] = ...
     ) -> _AssertLogsContext: ...
+    @overload
     def assertAlmostEqual(self, first: float, second: float, places: int = ...,
                           msg: Any = ..., delta: float = ...) -> None: ...
+    @overload
+    def assertAlmostEqual(self, first: datetime.datetime, second: datetime.datetime,
+                          places: int = ..., msg: Any = ...,
+                          delta: datetime.timedelta = ...) -> None: ...
     @overload
     def assertNotAlmostEqual(self, first: float, second: float, *,
                              msg: Any = ...) -> None: ...
@@ -128,6 +134,10 @@ class TestCase:
     @overload
     def assertNotAlmostEqual(self, first: float, second: float, *,
                              msg: Any = ..., delta: float = ...) -> None: ...
+    @overload
+    def assertNotAlmostEqual(self, first: datetime.datetime, second: datetime.datetime,
+                             places: int = ..., msg: Any = ...,
+                             delta: datetime.timedelta = ...) -> None: ...
     def assertRegex(self, text: AnyStr, expected_regex: Union[AnyStr, Pattern[AnyStr]],
                     msg: Any = ...) -> None: ...
     def assertNotRegex(self, text: AnyStr, unexpected_regex: Union[AnyStr, Pattern[AnyStr]],


### PR DESCRIPTION
While the documentation does not seem to make this particularly
obvious, it is allowed.