### PR TITLE
Add `sock` attribute for http.client.HTTPConnection in Python 3.

### DIFF
--- a/stdlib/3/http/client.pyi
+++ b/stdlib/3/http/client.pyi
@@ -129,6 +129,7 @@ class HTTPConnection:
     timeout: float
     host: str
     port: int
+    sock: Any
     if sys.version_info >= (3, 7):
         def __init__(
             self,


### PR DESCRIPTION
The equivalent httplib.HTTPConnection class already include it for Python
2, despite the attribute not being documented for either version.