### PR TITLE
Fix signature of assertRaisesRegexp in unittest

### DIFF
--- a/stdlib/3/unittest/case.pyi
+++ b/stdlib/3/unittest/case.pyi
@@ -198,7 +198,7 @@ class TestCase:
     def assertRaisesRegexp(self,  # type: ignore
                            exception: Union[Type[BaseException], Tuple[Type[BaseException], ...]],
                            expected_regex: Union[str, bytes, Pattern[str], Pattern[bytes]],
-                           callable: Callable[..., Any] = ...,
+                           callable: Callable[..., Any],
                            *args: Any, **kwargs: Any) -> None: ...
     @overload
     def assertRaisesRegexp(self,


### PR DESCRIPTION
Fixes mypy false positive `"None" has noattribute "__enter__"` here:

```
class Foo(unittest.TestCase):
    def test_foo(self) -> None:
        with self.assertRaisesRegexp(Exception, "foo"):
            1 / 0
```

Fixes regression introduced in e6c467af8260d9569ca1d3bcb40c3b4bea3fe606.