### PR TITLE
sys: add pycache_prefix

### DIFF
--- a/stdlib/3/sys.pyi
+++ b/stdlib/3/sys.pyi
@@ -46,6 +46,8 @@ path_hooks: List[Any]  # TODO precise type; function, path to finder
 path_importer_cache: Dict[str, Any]  # TODO precise type
 platform: str
 prefix: str
+if sys.version_info >= (3, 8):
+    pycache_prefix: Optional[str]
 ps1: str
 ps2: str
 stdin: TextIO


### PR DESCRIPTION
New in Python 3.8:
https://docs.python.org/3.8/library/sys.html#sys.pycache_prefix