### PR TITLE
Fix errors discovered by running typeshed check on Windows

### DIFF
--- a/stdlib/2and3/formatter.pyi
+++ b/stdlib/2and3/formatter.pyi
@@ -2,7 +2,7 @@
 # and https://github.com/python/cpython/blob/master/Lib/formatter.py
 from typing import Any, IO, List, Optional, Tuple
 
-AS_IS = None
+AS_IS: None
 _FontType = Tuple[str, bool, bool, bool]
 _StylesType = Tuple[Any, ...]
 

--- a/stdlib/3/asyncio/__init__.pyi
+++ b/stdlib/3/asyncio/__init__.pyi
@@ -109,11 +109,9 @@ if sys.version_info >= (3, 7):
         run as run,
     )
 
-
-# TODO: It should be possible to instantiate these classes, but mypy
-# currently disallows this.
-# See https://github.com/python/mypy/issues/1843
-SelectorEventLoop: Type[AbstractEventLoop]
+if sys.platform != 'win32':
+    # This is already imported above on Windows.
+    SelectorEventLoop: Type[AbstractEventLoop]
 
 # TODO: AbstractChildWatcher (UNIX only)
 


### PR DESCRIPTION
Fix errors discovered by running typeshed check on Windows. This is a temporary fix for https://github.com/python/typeshed/issues/3446 (in long term we should figure out why these were not caught by typeshed CI).

I also remove an outdated comment while I am at it.