### PR TITLE
distutils.fancy_getopt short option is optional

### DIFF
--- a/stdlib/2and3/distutils/fancy_getopt.pyi
+++ b/stdlib/2and3/distutils/fancy_getopt.pyi
@@ -5,7 +5,7 @@ from typing import (
     TypeVar, overload,
 )
 
-_Option = Tuple[str, str, str]
+_Option = Tuple[str, Optional[str], str]
 _GR = Tuple[List[str], OptionDummy]
 
 def fancy_getopt(options: List[_Option],


### PR DESCRIPTION
Per [`distutils.fancy_getopt`](https://github.com/python/cpython/blob/143a97f64128070386b12a0ee589bdaad5e51f40/Lib/distutils/fancy_getopt.py#L47-L49) sources.