### PR TITLE
Add missing elements for multiprocessing.dummy

### DIFF
--- a/stdlib/3/multiprocessing/dummy/__init__.pyi
+++ b/stdlib/3/multiprocessing/dummy/__init__.pyi
@@ -4,10 +4,16 @@ import array
 import threading
 import weakref
 
-from queue import Queue
+from queue import Queue as Queue
 
 JoinableQueue = Queue
-
+Barrier = threading.Barrier
+BoundedSemaphore = threading.BoundedSemaphore
+Condition = threading.Condition
+Event = threading.Event
+Lock = threading.Lock
+RLock = threading.RLock
+Semaphore = threading.Semaphore
 
 class DummyProcess(threading.Thread):
     _children: weakref.WeakKeyDictionary[Any, Any]


### PR DESCRIPTION
`multiprocessing.dummy` exports names that were not yet listed in the typeshed stub:

```python
>>> from multiprocessing import dummy as mpdummy
>>> imported_objects = (
...     (name, obj) for name, obj in vars(mpdummy).items()
...     if name in mpdummy.__all__ and not obj.__module__.startswith("multiprocessing.dummy")
... )
>>> print(*(f"{name}: {obj.__module__}" for name, obj in sorted(imported_objects)), sep="\n")
Barrier: threading
BoundedSemaphore: threading
Condition: threading
Event: threading
JoinableQueue: queue
Lock: _thread
Queue: queue
RLock: threading
Semaphore: threading
current_process: threading
```

Of these, only `JoinableQueue` was listed.