### PR TITLE
fix incorrect param name in FileIO

### DIFF
--- a/stdlib/3/io.pyi
+++ b/stdlib/3/io.pyi
@@ -66,7 +66,7 @@ class FileIO(RawIOBase):
     name: Union[int, str]
     def __init__(
         self,
-        name: Union[str, bytes, int],
+        file: Union[str, bytes, int],
         mode: str = ...,
         closefd: bool = ...,
         opener: Optional[Callable[[Union[int, str], str], int]] = ...


### PR DESCRIPTION
`io.FileIO` has a `name` parameter with is the path to the file to operate on: https://docs.python.org/3.7/library/io.html#io.FileIO

In practice this doesn't seem to exist and the parameter is actually named `file`: https://github.com/python/cpython/blob/master/Modules/_io/clinic/fileio.c.h#L52

```
In [1]: import io

In [2]: io.FileIO(name="test", mode="wb")
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-2-0ef63f53ae00> in <module>
----> 1 io.FileIO(name="test", mode="wb")
```