### PR TITLE
fix types in io

### DIFF
--- a/stdlib/3/io.pyi
+++ b/stdlib/3/io.pyi
@@ -146,8 +146,7 @@ class TextIOBase(IOBase):
     def seek(self, offset: int, whence: int = ...) -> int: ...
     def tell(self) -> int: ...
 
-# TODO should extend from TextIOBase
-class TextIOWrapper(TextIO):
+class TextIOWrapper(TextIOBase):
     line_buffering: bool
     # TODO uncomment after fixing mypy about using write_through
     # def __init__(self, buffer: IO[bytes], encoding: str = ...,
@@ -156,7 +155,7 @@ class TextIOWrapper(TextIO):
     #              -> None: ...
     def __init__(
         self,
-        buffer: IO[bytes],
+        buffer: BufferedIOBase,
         encoding: Optional[str] = ...,
         errors: Optional[str] = ...,
         newline: Optional[str] = ...,

--- a/stdlib/3/io.pyi
+++ b/stdlib/3/io.pyi
@@ -155,7 +155,7 @@ class TextIOWrapper(TextIOBase):
     #              -> None: ...
     def __init__(
         self,
-        buffer: BufferedIOBase,
+        buffer: IO[bytes],
         encoding: Optional[str] = ...,
         errors: Optional[str] = ...,
         newline: Optional[str] = ...,


### PR DESCRIPTION
It's not clear to me what the relation between `BufferedIOBase` and `IO[bytes]` is, but according to the io docs the current code seems incorrect.