### PR TITLE
fix buffer argument to TextIOWrapper

### DIFF
--- a/stdlib/3/io.pyi
+++ b/stdlib/3/io.pyi
@@ -156,7 +156,7 @@ class TextIOWrapper(TextIO):
     #              -> None: ...
     def __init__(
         self,
-        buffer: IO[bytes],
+        buffer: BufferedIOBase,
         encoding: Optional[str] = ...,
         errors: Optional[str] = ...,
         newline: Optional[str] = ...,


### PR DESCRIPTION
https://docs.python.org/3/library/io.html#io.TextIOWrapper specifies that this parameter should be a `BufferedIOBase` though I'm not sure when the correct time to use `IO[bytes]` is