### PR TITLE
Refactor warnings.catch_warning to be a class.

### DIFF
--- a/stdlib/2and3/warnings.pyi
+++ b/stdlib/2and3/warnings.pyi
@@ -1,8 +1,8 @@
 # Stubs for warnings
 
 import sys
-from typing import Any, Dict, List, NamedTuple, Optional, overload, TextIO, Tuple, Type, Union, ContextManager
-from types import ModuleType
+from typing import Any, Dict, List, NamedTuple, Optional, overload, TextIO, Tuple, Type, Union
+from types import ModuleType, TracebackType
 
 if sys.version_info >= (3, 8):
     from typing import Literal
@@ -43,12 +43,20 @@ class _Record(NamedTuple):
     file: Optional[TextIO]
     line: Optional[str]
 
+class catch_warnings:
+    @overload
+    def __new__(cls, *, record: Literal[False] = ..., module: Optional[ModuleType] = ...) -> _catch_warnings_without_records: ...
+    @overload
+    def __new__(cls, *, record: Literal[True], module: Optional[ModuleType] = ...) -> _catch_warnings_with_records: ...
+    @overload
+    def __new__(cls, *, record: bool, module: Optional[ModuleType] = ...) -> catch_warnings: ...
+    def __enter__(self) -> Optional[List[_Record]]: ...
+    def __exit__(self, exc_type: Optional[Type[BaseException]],
+                 exc_val: Optional[BaseException],
+                 exc_tb: Optional[TracebackType]) -> None: ...
 
-@overload
-def catch_warnings(*, record: Literal[False] = ..., module: Optional[ModuleType] = ...) -> ContextManager[None]: ...
+class _catch_warnings_without_records(catch_warnings):
+    def __enter__(self) -> None: ...
 
-@overload
-def catch_warnings(*, record: Literal[True], module: Optional[ModuleType] = ...) -> ContextManager[List[_Record]]: ...
-
-@overload
-def catch_warnings(*, record: bool, module: Optional[ModuleType] = ...) -> ContextManager[Optional[List[_Record]]]: ...
+class _catch_warnings_with_records(catch_warnings):
+    def __enter__(self) -> List[_Record]: ...


### PR DESCRIPTION
Make `warnings.catch_warnings` to be a class, preserving benefits from #3464 