### PR TITLE
Simplify `WatchedFileHandler.__init__`

### DIFF
--- a/stdlib/2and3/logging/handlers.pyi
+++ b/stdlib/2and3/logging/handlers.pyi
@@ -29,16 +29,8 @@ SYSLOG_UDP_PORT: int
 SYSLOG_TCP_PORT: int
 
 class WatchedFileHandler(FileHandler):
-    @overload
-    def __init__(self, filename: _Path) -> None: ...
-    @overload
-    def __init__(self, filename: _Path, mode: str) -> None: ...
-    @overload
-    def __init__(self, filename: _Path, mode: str,
-                 encoding: Optional[str]) -> None: ...
-    @overload
-    def __init__(self, filename: _Path, mode: str, encoding: Optional[str],
-                 delay: bool) -> None: ...
+    def __init__(self, filename: _Path, mode: str = ..., encoding: Optional[str] = ...,
+                 delay: bool = ...) -> None: ...
 
 
 if sys.version_info >= (3,):


### PR DESCRIPTION
In 2.7 the signature is:
```python
    def __init__(self, filename, mode='a', encoding=None, delay=0):
```
And in 3.7:
```python
    def __init__(self, filename, mode='a', encoding=None, delay=False):
```

Even in 2.7 the `delay` argument is morally a bool even though it still has an int default, so I kept it as a bool.

Fixes #3502