### PR TITLE
padding can take an int or an object (PSS.MAX_LENGTH)

### DIFF
--- a/third_party/2and3/cryptography/hazmat/primitives/asymmetric/padding.pyi
+++ b/third_party/2and3/cryptography/hazmat/primitives/asymmetric/padding.pyi
@@ -1,5 +1,5 @@
 from abc import ABCMeta, abstractmethod
-from typing import ClassVar, Optional
+from typing import ClassVar, Optional, Union
 
 from cryptography.hazmat.primitives.hashes import HashAlgorithm
 
@@ -22,6 +22,6 @@ class PKCS1v15(AsymmetricPadding):
 
 class PSS(AsymmetricPadding):
     MAX_LENGTH: ClassVar[object]
-    def __init__(self, mgf: MGF1, salt_length: int) -> None: ...
+    def __init__(self, mgf: MGF1, salt_length: Union[int, object]) -> None: ...
     @property
     def name(self) -> str: ...


### PR DESCRIPTION
Not sure how to "type" this better.  The PSS interface takes salt_length as an int or an "object", which is a class variable.  I couldn't figure out any way to indicate PSS.MAX_LENGTH is the only acceptable value.

Looking for a better way to do this, but a fix is needed (MAX_LENGTH is probably a more common case then a specific int)

sample code (taken from https://cryptography.io/en/latest/hazmat/primitives/asymmetric/rsa/)
```
>>> chosen_hash = hashes.SHA256()
>>> hasher = hashes.Hash(chosen_hash, default_backend())
>>> hasher.update(b"data & ")
>>> hasher.update(b"more data")
>>> digest = hasher.finalize()
>>> public_key.verify(
...     sig,
...     digest,
...     padding.PSS(
...         mgf=padding.MGF1(hashes.SHA256()),
...         salt_length=padding.PSS.MAX_LENGTH
...     ),
...     utils.Prehashed(chosen_hash)
... )
```

Below is the implementation for PSS for reference (taken from https://cryptography.io/en/latest/_modules/cryptography/hazmat/primitives/asymmetric/padding/#AsymmetricPadding )
```
@utils.register_interface(AsymmetricPadding)
class PSS(object):
    MAX_LENGTH = object()
    name = "EMSA-PSS"

    def __init__(self, mgf, salt_length):
        self._mgf = mgf

        if (not isinstance(salt_length, six.integer_types) and
                salt_length is not self.MAX_LENGTH):
            raise TypeError("salt_length must be an integer.")

        if salt_length is not self.MAX_LENGTH and salt_length < 0:
            raise ValueError("salt_length must be zero or greater.")

        self._salt_length = salt_length

```