### PR TITLE
Update orjson stub

### DIFF
--- a/third_party/3/orjson.pyi
+++ b/third_party/3/orjson.pyi
@@ -1,3 +1,5 @@
+# https://github.com/ijl/orjson/blob/master/orjson.pyi
+
 from typing import Any, Callable, Optional, Union
 
 __version__ = str

--- a/third_party/3/orjson.pyi
+++ b/third_party/3/orjson.pyi
@@ -1,14 +1,18 @@
-# https://github.com/ijl/orjson/blob/master/orjson.pyi
-
 from typing import Any, Callable, Optional, Union
 
+__version__ = str
+
 def dumps(
-    __obj: Any, default: Optional[Callable[[Any], Any]] = ..., option: Optional[int] = ...
+    __obj: Any,
+    default: Optional[Callable[[Any], Any]] = ...,
+    option: Optional[int] = ...,
 ) -> bytes: ...
-def loads(__obj: Union[bytes, str]) -> Any: ...
+def loads(__obj: Union[bytes, bytearray, str]) -> Any: ...
 
 class JSONDecodeError(ValueError): ...
 class JSONEncodeError(TypeError): ...
 
-OPT_STRICT_INTEGER: int
+OPT_SERIALIZE_DATACLASS: int
 OPT_NAIVE_UTC: int
+OPT_OMIT_MICROSECONDS: int
+OPT_STRICT_INTEGER: int


### PR DESCRIPTION
PR just updates the orjson.pyi file to the latest version from https://github.com/ijl/orjson/blob/master/orjson.pyi .  This includes new options for dumps.