### PR TITLE
Make fieldnames of csv.DictReader Optional

### DIFF
--- a/stdlib/2and3/csv.pyi
+++ b/stdlib/2and3/csv.pyi
@@ -1,22 +1,22 @@
-from collections import OrderedDict
 import sys
+from _csv import (
+    QUOTE_ALL as QUOTE_ALL,
+    QUOTE_MINIMAL as QUOTE_MINIMAL,
+    QUOTE_NONE as QUOTE_NONE,
+    QUOTE_NONNUMERIC as QUOTE_NONNUMERIC,
+    Error as Error,
+    _reader,
+    _writer,
+    field_size_limit as field_size_limit,
+    get_dialect as get_dialect,
+    list_dialects as list_dialects,
+    reader as reader,
+    register_dialect as register_dialect,
+    unregister_dialect as unregister_dialect,
+    writer as writer,
+)
+from collections import OrderedDict
 from typing import Any, Dict, Iterable, Iterator, List, Mapping, Optional, Sequence, Text, Type, Union
-
-from _csv import (_reader,
-                  _writer,
-                  reader as reader,
-                  writer as writer,
-                  register_dialect as register_dialect,
-                  unregister_dialect as unregister_dialect,
-                  get_dialect as get_dialect,
-                  list_dialects as list_dialects,
-                  field_size_limit as field_size_limit,
-                  QUOTE_ALL as QUOTE_ALL,
-                  QUOTE_MINIMAL as QUOTE_MINIMAL,
-                  QUOTE_NONE as QUOTE_NONE,
-                  QUOTE_NONNUMERIC as QUOTE_NONNUMERIC,
-                  Error as Error,
-                  )
 
 _Dialect = Union[str, Dialect, Type[Dialect]]
 _DictRow = Mapping[str, Any]
@@ -56,7 +56,6 @@ if sys.version_info >= (3, 6):
 else:
     _DRMapping = Dict[str, str]
 
-
 class DictReader(Iterator[_DRMapping]):
     restkey: Optional[str]
     restval: Optional[str]
@@ -64,24 +63,37 @@ class DictReader(Iterator[_DRMapping]):
     dialect: _Dialect
     line_num: int
     fieldnames: Sequence[str]
-    def __init__(self, f: Iterable[Text], fieldnames: Optional[Sequence[str]] = ...,
-                 restkey: Optional[str] = ..., restval: Optional[str] = ..., dialect: _Dialect = ...,
-                 *args: Any, **kwds: Any) -> None: ...
+    def __init__(
+        self,
+        f: Iterable[Text],
+        fieldnames: Optional[Sequence[str]] = ...,
+        restkey: Optional[str] = ...,
+        restval: Optional[str] = ...,
+        dialect: _Dialect = ...,
+        *args: Any,
+        **kwds: Any,
+    ) -> None: ...
     def __iter__(self) -> DictReader: ...
     if sys.version_info >= (3,):
         def __next__(self) -> _DRMapping: ...
     else:
         def next(self) -> _DRMapping: ...
 
-
 class DictWriter(object):
     fieldnames: Sequence[str]
     restval: Optional[Any]
     extrasaction: str
     writer: _writer
-    def __init__(self, f: Any, fieldnames: Iterable[str],
-                 restval: Optional[Any] = ..., extrasaction: str = ..., dialect: _Dialect = ...,
-                 *args: Any, **kwds: Any) -> None: ...
+    def __init__(
+        self,
+        f: Any,
+        fieldnames: Iterable[str],
+        restval: Optional[Any] = ...,
+        extrasaction: str = ...,
+        dialect: _Dialect = ...,
+        *args: Any,
+        **kwds: Any,
+    ) -> None: ...
     def writeheader(self) -> None: ...
     def writerow(self, rowdict: _DictRow) -> None: ...
     def writerows(self, rowdicts: Iterable[_DictRow]) -> None: ...

--- a/stdlib/2and3/csv.pyi
+++ b/stdlib/2and3/csv.pyi
@@ -64,7 +64,7 @@ class DictReader(Iterator[_DRMapping]):
     dialect: _Dialect
     line_num: int
     fieldnames: Sequence[str]
-    def __init__(self, f: Iterable[Text], fieldnames: Sequence[str] = ...,
+    def __init__(self, f: Iterable[Text], fieldnames: Optional[Sequence[str]] = ...,
                  restkey: Optional[str] = ..., restval: Optional[str] = ..., dialect: _Dialect = ...,
                  *args: Any, **kwds: Any) -> None: ...
     def __iter__(self) -> DictReader: ...


### PR DESCRIPTION
The Python docs specify that `fieldnames` in `csv.DictReader` can be set to `None` to use the
first row of a CSV file as the field names:
https://docs.python.org/3.8/library/csv.html#csv.DictReader

Therefore, this pull request changes `fieldnames: Sequence[str] = ...` to  `fieldnames: Optional[Sequence[str]] = ...`.

A `git blame` of CPython's source states it's been like
that since Python 2.4,
see https://github.com/python/cpython/blame/3.8/Lib/csv.py#L81

I've also ran the file through `black` and `isort` (so that #3329 gets slightly easier), but I've put it into a separate commit, so it is easier to see the changes I made.

## Test Case

```python3
import csv
with open("test.csv", "r") as file:
    csv.DictReader(file, fieldnames=None) #  should be valid
```
