### PR TITLE
Include typing for Enum __order__ attribute

### DIFF
--- a/stdlib/3/enum.pyi
+++ b/stdlib/3/enum.pyi
@@ -32,6 +32,7 @@ class Enum(metaclass=EnumMeta):
         _ignore_: Union[str, List[str]]
     if sys.version_info >= (3, 6):
         _order_: str
+        __order__: str
         @classmethod
         def _missing_(cls, value: object) -> Any: ...
         @staticmethod

--- a/third_party/2/enum.pyi
+++ b/third_party/2/enum.pyi
@@ -32,6 +32,7 @@ class Enum(metaclass=EnumMeta):
         _ignore_: Union[str, List[str]]
     if sys.version_info >= (3, 6):
         _order_: str
+        __order__: str
         @classmethod
         def _missing_(cls, value: object) -> Any: ...
         @staticmethod


### PR DESCRIPTION
Based on the behavior here: https://github.com/python/cpython/blob/0b41a922f95f62b620d5a197b9f2ed8e4bb70730/Lib/enum.py#L91
the `__order__` attribute should be treated the same as `_order_`