### PR TITLE
add jinja macro fields

### DIFF
--- a/third_party/2and3/jinja2/nodes.pyi
+++ b/third_party/2and3/jinja2/nodes.pyi
@@ -1,3 +1,4 @@
+import typing
 from typing import Any, Optional
 
 class Impossible(Exception): ...
@@ -54,6 +55,10 @@ class If(Stmt):
 
 class Macro(Stmt):
     fields: Any
+    name: str
+    args: typing.List[Any]
+    defaults: typing.List[Any]
+    body: typing.List[Any]
 
 class CallBlock(Stmt):
     fields: Any


### PR DESCRIPTION
I only added the fields to `Macro` because that's all I needed (and in the interest of keeping this minimal). I'd be happy to go through and add the appropriate fields to the other node types if that's desirable - it should be pretty simple, just have to look at the `fields` in the actual jinja types.

I had to use `typing.List` because this file actually defines its own `List` - that appears to be the pattern in typeshed.