### PR TITLE
Update shutil.unpack_archive for 3.7 and up

### DIFF
--- a/stdlib/2and3/shutil.pyi
+++ b/stdlib/2and3/shutil.pyi
@@ -132,9 +132,13 @@ def register_archive_format(name: str, function: Callable[..., Any],
 def unregister_archive_format(name: str) -> None: ...
 
 if sys.version_info >= (3,):
-    # Should be _Path once http://bugs.python.org/issue30218 is fixed
-    def unpack_archive(filename: str, extract_dir: Optional[_Path] = ...,
-                       format: Optional[str] = ...) -> None: ...
+    if sys.version_info >= (3, 7):
+        def unpack_archive(filename: _Path, extract_dir: Optional[_Path] = ...,
+                           format: Optional[str] = ...) -> None: ...
+    else:
+        # See http://bugs.python.org/issue30218
+        def unpack_archive(filename: str, extract_dir: Optional[_Path] = ...,
+                           format: Optional[str] = ...) -> None: ...
     def register_unpack_format(name: str, extensions: List[str], function: Any,
                                extra_args: Sequence[Tuple[str, Any]] = ...,
                                description: str = ...) -> None: ...


### PR DESCRIPTION
unpack_archive accepts a PathLike object as of 3.7.