### PR TITLE
Restrict shutil.move src argument to str

### DIFF
--- a/stdlib/2and3/shutil.pyi
+++ b/stdlib/2and3/shutil.pyi
@@ -102,9 +102,14 @@ else:
     def rmtree(path: _AnyPath, ignore_errors: bool = ...,
                onerror: Optional[Callable[[Any, _AnyPath, Any], Any]] = ...) -> None: ...
 
-if sys.version_info >= (3, 5):
-    _CopyFn = Union[Callable[[str, str], None], Callable[[_Path, _Path], None]]
+_CopyFn = Union[Callable[[str, str], None], Callable[[_Path, _Path], None]]
+
+if sys.version_info >= (3, 9):
     def move(src: _Path, dst: _Path,
+             copy_function: _CopyFn = ...) -> _PathReturn: ...
+elif sys.version_info >= (3, 5):
+    # See https://bugs.python.org/issue32689
+    def move(src: str, dst: _Path,
              copy_function: _CopyFn = ...) -> _PathReturn: ...
 else:
     def move(src: _Path, dst: _Path) -> _PathReturn: ...


### PR DESCRIPTION
See https://bugs.python.org/issue32689.
This bug only affects `src`s which are directory
Paths in Python 3.5 to 3.8 inclusive.
Comes at the cost of restricting
`src` to str even where a Path would work but
this might be preferable to exposing the bug.