### PR TITLE
Fix HTTPConnection timeout type

### DIFF
--- a/stdlib/3/http/client.pyi
+++ b/stdlib/3/http/client.pyi
@@ -126,7 +126,7 @@ class _HTTPConnectionProtocol(Protocol):
         ) -> HTTPConnection: ...
 
 class HTTPConnection:
-    timeout: float
+    timeout: Optional[float]
     host: str
     port: int
     sock: Any
@@ -134,14 +134,14 @@ class HTTPConnection:
         def __init__(
             self,
             host: str, port: Optional[int] = ...,
-            timeout: float = ...,
+            timeout: Optional[float] = ...,
             source_address: Optional[Tuple[str, int]] = ..., blocksize: int = ...
         ) -> None: ...
     else:
         def __init__(
             self,
             host: str, port: Optional[int] = ...,
-            timeout: float = ...,
+            timeout: Optional[float] = ...,
             source_address: Optional[Tuple[str, int]] = ...
         ) -> None: ...
     if sys.version_info >= (3, 6):
@@ -174,7 +174,7 @@ class HTTPSConnection(HTTPConnection):
                  host: str, port: Optional[int] = ...,
                  key_file: Optional[str] = ...,
                  cert_file: Optional[str] = ...,
-                 timeout: float = ...,
+                 timeout: Optional[float] = ...,
                  source_address: Optional[Tuple[str, int]] = ...,
                  *, context: Optional[ssl.SSLContext] = ...,
                  check_hostname: Optional[bool] = ...) -> None: ...


### PR DESCRIPTION
`HTTPConnection.timeout` is passed down to `socket.settimeout()` which supports `Optional[float]` and has a specific action for `None`.