### PR TITLE
Update int.from_bytes to allow Iterable[int]

### DIFF
--- a/stdlib/2/__builtin__.pyi
+++ b/stdlib/2/__builtin__.pyi
@@ -157,7 +157,7 @@ class int:
     if sys.version_info >= (3,):
         def to_bytes(self, length: int, byteorder: str, *, signed: bool = ...) -> bytes: ...
         @classmethod
-        def from_bytes(cls, bytes: Sequence[int], byteorder: str, *,
+        def from_bytes(cls, bytes: Union[Iterable[int], SupportsBytes], byteorder: str, *,
                        signed: bool = ...) -> int: ...  # TODO buffer object argument
 
     def __add__(self, x: int) -> int: ...

--- a/stdlib/2and3/builtins.pyi
+++ b/stdlib/2and3/builtins.pyi
@@ -157,7 +157,7 @@ class int:
     if sys.version_info >= (3,):
         def to_bytes(self, length: int, byteorder: str, *, signed: bool = ...) -> bytes: ...
         @classmethod
-        def from_bytes(cls, bytes: Sequence[int], byteorder: str, *,
+        def from_bytes(cls, bytes: Union[Iterable[int], SupportsBytes], byteorder: str, *,
                        signed: bool = ...) -> int: ...  # TODO buffer object argument
 
     def __add__(self, x: int) -> int: ...


### PR DESCRIPTION
Running `int.from_bytes(iter([1, 0]), 'little'))` returns 1 as
expected.