### PR TITLE
BaseHTTPRequestHandler is a subclass of StreamRequestHandler

### DIFF
--- a/stdlib/3/http/server.pyi
+++ b/stdlib/3/http/server.pyi
@@ -18,7 +18,7 @@ if sys.version_info >= (3, 7):
     class ThreadingHTTPServer(socketserver.ThreadingMixIn, HTTPServer):
         daemon_threads: bool  # undocumented
 
-class BaseHTTPRequestHandler:
+class BaseHTTPRequestHandler(socketserver.StreamRequestHandler):
     client_address: Tuple[str, int]
     server: socketserver.BaseServer
     close_connection: bool


### PR DESCRIPTION
Following the merge of #3422 the following code fails to typecheck using python 3.7 (e.g with mypy .760 and .0761) 

```python
import socketserver

if __name__ == "__main__":
    import http.server
    with socketserver.TCPServer(("", 8000), http.server.SimpleHTTPRequestHandler) as httpd:
        pass
```

```
error: Argument 2 to "TCPServer" has incompatible type "Type[SimpleHTTPRequestHandler]"; expected "Callable[..., BaseRequestHandler]"
```

The change in this pr fixes that. The same change was made against `BaseHTTPRequestHandler` in the python 2 standard library as part of #3422 but it looks like it is missing from the python 3 library.