### PR TITLE
Make unittest.FunctionTestCase inherit from TestCase in Python 2.

### DIFF
--- a/stdlib/2/unittest.pyi
+++ b/stdlib/2/unittest.pyi
@@ -207,12 +207,11 @@ class TestCase(Testable):
     def _formatMessage(self, msg: Optional[Text], standardMsg: Text) -> str: ...  # undocumented
     def _getAssertEqualityFunc(self, first: Any, second: Any) -> Callable[..., None]: ...  # undocumented
 
-class FunctionTestCase(Testable):
+class FunctionTestCase(TestCase):
     def __init__(self, testFunc: Callable[[], None],
                  setUp: Optional[Callable[[], None]] = ...,
                  tearDown: Optional[Callable[[], None]] = ...,
                  description: Optional[str] = ...) -> None: ...
-    def run(self, result: TestResult) -> None: ...
     def debug(self) -> None: ...
     def countTestCases(self) -> int: ...
 


### PR DESCRIPTION
This makes the pyi file match the implementation:
https://github.com/python/cpython/blob/249706c1fbce04125d81bd9993e6c010ae30f8e4/Lib/unittest/case.py#L1019.

I also removed a now-redundant `run` method from FunctionTestCase
because the mypy test complained about it having a different signature
from TestCase.run().

Context:
https://github.com/python/typeshed/pull/3550#issuecomment-572702513.