### PR TITLE
Make os.statvfs_result inherit from typing.NamedTuple.

### DIFF
--- a/stdlib/2/posix.pyi
+++ b/stdlib/2/posix.pyi
@@ -1,4 +1,4 @@
-from typing import AnyStr, Dict, List, Mapping, Tuple, Union, Sequence, IO, Optional, TypeVar
+from typing import AnyStr, Dict, IO, List, Mapping, NamedTuple, Optional, Sequence, Tuple, TypeVar, Union
 
 error = OSError
 
@@ -78,10 +78,7 @@ class stat_result(object):
     st_mtime: int
     st_ctime: int
 
-class statvfs_result(object):
-    n_fields: int
-    n_sequence_fields: int
-    n_unnamed_fields: int
+class statvfs_result(NamedTuple):
     f_bsize: int
     f_frsize: int
     f_blocks: int

--- a/stdlib/3/os/__init__.pyi
+++ b/stdlib/3/os/__init__.pyi
@@ -270,7 +270,7 @@ else:
 
 
 if sys.platform != 'win32':
-    class statvfs_result:  # Unix only
+    class statvfs_result(NamedTuple):  # Unix only
         f_bsize: int
         f_frsize: int
         f_blocks: int


### PR DESCRIPTION
https://github.com/python/cpython/blob/abdc634f337ce4943cd7d13587936837aac2ecc9/Modules/posixmodule.c#L2025
says, "This object may be accessed either as a tuple of [...] or via the
attributes [...]". Making the class a namedtuple allows tuple access.

The Python 2 stub included three undocumented attributes on
statvfs_result. These attributes were introduced by a Googler in the initial
checkin of posix.pyi without explanation
(https://github.com/python/typeshed/commit/14cbfb0dea2b1d24bba13bad9403eda8fd8e863f#diff-7f2796ce2ddcdc17984163a4a6fc4a74R80-R82),
and I don't see them used anywhere in Google's Python codebase, so my
guess is that they were added because they happen to be present at
runtime and can be removed.

Since I was modifying the typing imports line in 2/posix.pyi anyway, I
alphabetized the imports.