### PR TITLE
add f_fsid: int to os.statvfs_result for >= 3.7

### DIFF
--- a/stdlib/3/os/__init__.pyi
+++ b/stdlib/3/os/__init__.pyi
@@ -270,17 +270,33 @@ else:
 
 
 if sys.platform != 'win32':
-    class statvfs_result(NamedTuple):  # Unix only
-        f_bsize: int
-        f_frsize: int
-        f_blocks: int
-        f_bfree: int
-        f_bavail: int
-        f_files: int
-        f_ffree: int
-        f_favail: int
-        f_flag: int
-        f_namemax: int
+    if sys.version_info >= (3, 7):
+        # f_fsid was added in https://github.com/python/cpython/pull/4571
+        class statvfs_result(NamedTuple):  # Unix only
+            f_bsize: int
+            f_frsize: int
+            f_blocks: int
+            f_bfree: int
+            f_bavail: int
+            f_files: int
+            f_ffree: int
+            f_favail: int
+            f_flag: int
+            f_namemax: int
+            f_fsid: int
+    else:
+        class statvfs_result(NamedTuple):  # Unix only
+            f_bsize: int
+            f_frsize: int
+            f_blocks: int
+            f_bfree: int
+            f_bavail: int
+            f_files: int
+            f_ffree: int
+            f_favail: int
+            f_flag: int
+            f_namemax: int
+
 
 # ----- os function stubs -----
 if sys.version_info >= (3, 6):


### PR DESCRIPTION
This adds `f_fsid: int` to the stub for `os.statvfs_result` for Python >= 3.7. This attribute was added to cPython in https://github.com/python/cpython/pull/4571.