### PR TITLE
Change Response.headers from MutableMapping to CaseInsensitiveDict

### DIFF
--- a/third_party/2and3/requests/models.pyi
+++ b/third_party/2and3/requests/models.pyi
@@ -102,7 +102,7 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
 class Response:
     __attrs__: Any
     status_code: int
-    headers: MutableMapping[str, str]
+    headers: CaseInsensitiveDict[str]
     raw: Any
     url: str
     encoding: str


### PR DESCRIPTION
This fixes a type error when doing `response.headers.lower_items()`, a method
present on CaseInsensitiveDict