### PR TITLE
Allow requests to have timeout: Tuple[float, None]

### DIFF
--- a/third_party/2and3/requests/adapters.pyi
+++ b/third_party/2and3/requests/adapters.pyi
@@ -47,7 +47,7 @@ class BaseAdapter:
     def send(self,
              request: PreparedRequest,
              stream: bool = ...,
-             timeout: Union[None, float, Tuple[float, float]] = ...,
+             timeout: Union[None, float, Tuple[float, float], Tuple[float, None]] = ...,
              verify: Union[bool, str] = ...,
              cert: Union[None, Union[bytes, Text], Container[Union[bytes, Text]]] = ...,
              proxies: Optional[Mapping[str, str]] = ...) -> Response: ...
@@ -73,7 +73,7 @@ class HTTPAdapter(BaseAdapter):
     def send(self,
              request: PreparedRequest,
              stream: bool = ...,
-             timeout: Union[None, float, Tuple[float, float]] = ...,
+             timeout: Union[None, float, Tuple[float, float], Tuple[float, None]] = ...,
              verify: Union[bool, str] = ...,
              cert: Union[None, Union[bytes, Text], Container[Union[bytes, Text]]] = ...,
              proxies: Optional[Mapping[str, str]] = ...) -> Response: ...

--- a/third_party/2and3/requests/sessions.pyi
+++ b/third_party/2and3/requests/sessions.pyi
@@ -86,7 +86,7 @@ class Session(SessionRedirectMixin):
                 cookies: Union[None, RequestsCookieJar, MutableMapping[Text, Text]] = ...,
                 files: Optional[MutableMapping[Text, IO[Any]]] = ...,
                 auth: Union[None, Tuple[Text, Text], _auth.AuthBase, Callable[[Request], Request]] = ...,
-                timeout: Union[None, float, Tuple[float, float]] = ...,
+                timeout: Union[None, float, Tuple[float, float], Tuple[float, None]] = ...,
                 allow_redirects: Optional[bool] = ...,
                 proxies: Optional[MutableMapping[Text, Text]] = ...,
                 hooks: Optional[_HooksInput] = ...,


### PR DESCRIPTION
`timeout=(5.0, None)`, set a 5s connect timeout and an unlimited read timeout. This is useful in some corner cases. Setting the second parameter to 0 doesn't do the same as requests then throws a `ValueError`. (special float values like `nan`, `inf`, etc also don't work)

This is based on `urllib3.util.timeout`. Reading the docs for that also suggets that `(None, None)` is valid, but that is the same as a single `None` and doesn't make a lot of sense in practice. It also says int's instead of float's are valid, but as casting int to float is easy that's less of a practical issue.

Another option would be to define a `timeout_value` to be `Union[float, int, None]` and then have something like `timeout: Union[timeout_value, Tuple[timeout_value, timeout_value]]`.

Ref:
* https://requests.readthedocs.io/en/master/user/advanced/#timeouts
* https://urllib3.readthedocs.io/en/latest/reference/urllib3.util.html#module-urllib3.util.timeout

```
>>> import requests
>>> requests.get('https://httpbin.org/status/200')
<Response [200]>
>>> requests.get('https://httpbin.org/status/200', timeout=1)
<Response [200]>
>>> requests.get('https://httpbin.org/status/200', timeout=(1, 1))
<Response [200]>
>>> requests.get('https://httpbin.org/status/200', timeout=(1, None))
<Response [200]>
>>> requests.get('https://httpbin.org/status/200', timeout=None)
<Response [200]>
>>> try:
...     requests.get('https://httpbin.org/status/200', timeout=0)
... except ValueError as e:
...     print(e)
...
Attempted to set connect timeout to 0, but the timeout cannot be set to a value less than or equal to 0.
>>> try:
...     requests.get('https://httpbin.org/status/200', timeout=(1, 0))
... except ValueError as e:
...     print(e)
...
Invalid timeout (1, 0). Pass a (connect, read) timeout tuple, or a single float to set both timeouts to the same value
```