### PR TITLE
zipfile: fix ZipExtFile parameter

### DIFF
--- a/stdlib/2and3/zipfile.pyi
+++ b/stdlib/2and3/zipfile.pyi
@@ -36,14 +36,24 @@ class ZipExtFile(io.BufferedIOBase):
     newlines: Optional[List[bytes]]
     mode: str
     name: str
-    def __init__(
-        self,
-        fileobj: IO[bytes],
-        mode: str,
-        zipinfo: ZipInfo,
-        decrypter: Optional[Callable[[Sequence[int]], bytes]] = ...,
-        close_fileobj: bool = ...,
-    ) -> None: ...
+    if sys.version_info >= (3, 7):
+        def __init__(
+            self,
+            fileobj: IO[bytes],
+            mode: str,
+            zipinfo: ZipInfo,
+            pwd: Optional[bytes] = ...,
+            close_fileobj: bool = ...,
+        ) -> None: ...
+    else:
+        def __init__(
+            self,
+            fileobj: IO[bytes],
+            mode: str,
+            zipinfo: ZipInfo,
+            decrypter: Optional[Callable[[Sequence[int]], bytes]] = ...,
+            close_fileobj: bool = ...,
+        ) -> None: ...
     def __repr__(self) -> str: ...
     def peek(self, n: int = ...) -> bytes: ...
     def read1(self, n: Optional[int]) -> bytes: ...  # type: ignore


### PR DESCRIPTION
This was changed in bpo-38334 and backported to Python 3.7.6 and 3.8.1
Not quite sure on what our policy on backports to patch releases is, but
don't think ZipExtFile isn't really meant to be external facing, so it
shouldn't matter much.

I found this while making improvements to mypy's scripts/stubtest.py