### PR TITLE
Remove consent requirement for third-party stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,14 +74,6 @@ go into `third_party`. Since these modules can behave differently for different
 versions of Python, `third_party` has version subdirectories, just like
 `stdlib`.
 
-NOTE: When you're contributing a new stub for a package that you did
-not develop, please obtain consent of the package owner (this is
-specified in [PEP
-484](https://www.python.org/dev/peps/pep-0484/#the-typeshed-repo)).
-The best way to obtain consent is to file an issue in the third-party
-package's tracker and include the link to a positive response in your PR
-for typeshed.
-
 For more information on directory structure and stub versioning, see
 [the relevant section of CONTRIBUTING.md](
 https://github.com/python/typeshed/blob/master/CONTRIBUTING.md#stub-versioning).


### PR DESCRIPTION
This was discussed a while ago on typing-sig. Consequently the
requirement of asking third-party maintainers for permission was
removed from PEP 484.