### PR TITLE
subprocess: Make stdin, stdout & stderr Optional for py3 to match py2

### DIFF
--- a/stdlib/3/subprocess.pyi
+++ b/stdlib/3/subprocess.pyi
@@ -832,9 +832,9 @@ class CalledProcessError(Exception):
 
 class Popen(Generic[AnyStr]):
     args: _CMD
-    stdin: IO[AnyStr]
-    stdout: IO[AnyStr]
-    stderr: IO[AnyStr]
+    stdin: Optional[IO[AnyStr]]
+    stdout: Optional[IO[AnyStr]]
+    stderr: Optional[IO[AnyStr]]
     pid: int
     returncode: int
 


### PR DESCRIPTION
This addresses this issue:

https://github.com/python/typeshed/issues/3646

Jase