### PR TITLE
Package stdlib in its own package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,22 @@
+[build-system]
+requires = ["flit_core >=2,<3"]
+build-backend = "flit_core.buildapi"
+
+[tool.flit.metadata]
+module = "stdlib"
+dist-name = "types-stdlib"
+author = "Ethan Smith"
+author-email = "ethan@ethanhs.me"
+home-page = "https://github.com/python/typeshed"
+classifiers = ["License :: OSI Approved :: Apache Software License"]
+
+[tool.flit.sdist]
+include = ["stdlib"]
+exclude = [
+    "third_party",
+    ".travis.yml",
+]
+
 [tool.black]
 line_length = 130
 target_version = ["py37"]

--- a/stdlib/__init__.py
+++ b/stdlib/__init__.py
@@ -1,0 +1,8 @@
+"""A simple package that returns the path to the stdlib stubs folder."""
+
+__version__ = '1.0a1'
+
+import pathlib
+
+def get_stdlib_dir() -> pathlib.Path:
+    return pathlib.Path().absolute()

--- a/stdlib/__init__.py
+++ b/stdlib/__init__.py
@@ -5,4 +5,4 @@ __version__ = '1.0a1'
 import pathlib
 
 def get_stdlib_dir() -> pathlib.Path:
-    return pathlib.Path().absolute()
+    return pathlib.Path(__file__).parent


### PR DESCRIPTION
This is the ground work for step 1 from #2491.

Note I checked and the distribution "stdlib" seems to be unused, so I am not worried about a name clash. https://pypi.org/project/stdlib/

I have already registered `types-stdlib` on PyPi.