### PR TITLE
fcntl: various improvements

### DIFF
--- a/stdlib/3/fcntl.pyi
+++ b/stdlib/3/fcntl.pyi
@@ -1,6 +1,6 @@
 # Stubs for fcntl
 from io import IOBase
-from typing import Any, IO, Union
+from typing import IO, Any, Union, overload
 from _types import FileDescriptorLike
 
 FASYNC: int
@@ -76,11 +76,14 @@ LOCK_SH: int
 LOCK_UN: int
 LOCK_WRITE: int
 
-# TODO All these return either int or bytes depending on the value of
-# cmd (not on the type of arg).
+@overload
 def fcntl(__fd: FileDescriptorLike,
           __cmd: int,
-          __arg: Union[int, bytes] = ...) -> Any: ...
+          __arg: int = ...) -> int: ...
+@overload
+def fcntl(__fd: FileDescriptorLike,
+          __cmd: int,
+          __arg: bytes) -> bytes: ...
 # TODO This function accepts any object supporting a buffer interface,
 # as arg, is there a better way to express this than bytes?
 def ioctl(__fd: FileDescriptorLike,

--- a/stdlib/3/fcntl.pyi
+++ b/stdlib/3/fcntl.pyi
@@ -1,4 +1,5 @@
 # Stubs for fcntl
+from array import array
 from io import IOBase
 from typing import IO, Any, Union, overload
 from _types import FileDescriptorLike
@@ -89,8 +90,8 @@ def fcntl(__fd: FileDescriptorLike,
 def fcntl(__fd: FileDescriptorLike,
           __cmd: int,
           __arg: bytes) -> bytes: ...
-# TODO This function accepts any object supporting a buffer interface,
-# as arg, is there a better way to express this than bytes?
+_ReadOnlyBuffer = bytes
+_WritableBuffer = Union[bytearray, memoryview, array]
 @overload
 def ioctl(__fd: FileDescriptorLike,
           __request: int,
@@ -99,17 +100,17 @@ def ioctl(__fd: FileDescriptorLike,
 @overload
 def ioctl(__fd: FileDescriptorLike,
           __request: int,
-          __arg: bytearray,
+          __arg: _WritableBuffer,
           __mutate_flag: Literal[True] = ...) -> int: ...
 @overload
 def ioctl(__fd: FileDescriptorLike,
           __request: int,
-          __arg: bytearray,
+          __arg: _WritableBuffer,
           __mutate_flag: Literal[False]) -> bytes: ...
 @overload
 def ioctl(__fd: FileDescriptorLike,
           __request: int,
-          __arg: bytes,
+          __arg: _ReadOnlyBuffer,
           __mutate_flag: bool) -> bytes: ...
 def flock(__fd: FileDescriptorLike, __operation: int) -> None: ...
 def lockf(__fd: FileDescriptorLike,

--- a/stdlib/3/fcntl.pyi
+++ b/stdlib/3/fcntl.pyi
@@ -78,18 +78,18 @@ LOCK_WRITE: int
 
 # TODO All these return either int or bytes depending on the value of
 # cmd (not on the type of arg).
-def fcntl(fd: FileDescriptorLike,
-          cmd: int,
-          arg: Union[int, bytes] = ...) -> Any: ...
+def fcntl(__fd: FileDescriptorLike,
+          __cmd: int,
+          __arg: Union[int, bytes] = ...) -> Any: ...
 # TODO This function accepts any object supporting a buffer interface,
 # as arg, is there a better way to express this than bytes?
-def ioctl(fd: FileDescriptorLike,
-          request: int,
-          arg: Union[int, bytes] = ...,
-          mutate_flag: bool = ...) -> Any: ...
-def flock(fd: FileDescriptorLike, operation: int) -> None: ...
-def lockf(fd: FileDescriptorLike,
-          cmd: int,
-          len: int = ...,
-          start: int = ...,
-          whence: int = ...) -> Any: ...
+def ioctl(__fd: FileDescriptorLike,
+          __request: int,
+          __arg: Union[int, bytes] = ...,
+          __mutate_flag: bool = ...) -> Any: ...
+def flock(__fd: FileDescriptorLike, __operation: int) -> None: ...
+def lockf(__fd: FileDescriptorLike,
+          __cmd: int,
+          __len: int = ...,
+          __start: int = ...,
+          __whence: int = ...) -> Any: ...

--- a/stdlib/3/fcntl.pyi
+++ b/stdlib/3/fcntl.pyi
@@ -2,6 +2,11 @@
 from io import IOBase
 from typing import IO, Any, Union, overload
 from _types import FileDescriptorLike
+import sys
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 FASYNC: int
 FD_CLOEXEC: int
@@ -86,10 +91,26 @@ def fcntl(__fd: FileDescriptorLike,
           __arg: bytes) -> bytes: ...
 # TODO This function accepts any object supporting a buffer interface,
 # as arg, is there a better way to express this than bytes?
+@overload
 def ioctl(__fd: FileDescriptorLike,
           __request: int,
-          __arg: Union[int, bytes] = ...,
-          __mutate_flag: bool = ...) -> Any: ...
+          __arg: int = ...,
+          __mutate_flag: bool = ...) -> int: ...
+@overload
+def ioctl(__fd: FileDescriptorLike,
+          __request: int,
+          __arg: bytearray,
+          __mutate_flag: Literal[True] = ...) -> int: ...
+@overload
+def ioctl(__fd: FileDescriptorLike,
+          __request: int,
+          __arg: bytearray,
+          __mutate_flag: Literal[False]) -> bytes: ...
+@overload
+def ioctl(__fd: FileDescriptorLike,
+          __request: int,
+          __arg: bytes,
+          __mutate_flag: bool) -> bytes: ...
 def flock(__fd: FileDescriptorLike, __operation: int) -> None: ...
 def lockf(__fd: FileDescriptorLike,
           __cmd: int,


### PR DESCRIPTION
- use overload for fcntl.ioctl
- use overload for fcntl.fcntl 
- mark positional-only args