### PR TITLE
xml.sax.parse may also take IO[bytes]

### DIFF
--- a/stdlib/2and3/xml/sax/__init__.pyi
+++ b/stdlib/2and3/xml/sax/__init__.pyi
@@ -25,7 +25,7 @@ default_parser_list: List[str]
 
 def make_parser(parser_list: List[str] = ...) -> xml.sax.xmlreader.XMLReader: ...
 
-def parse(source: Union[str, IO[str]], handler: xml.sax.handler.ContentHandler,
+def parse(source: Union[str, IO[str], IO[bytes]], handler: xml.sax.handler.ContentHandler,
           errorHandler: xml.sax.handler.ErrorHandler = ...) -> None: ...
 
 def parseString(string: Union[bytes, Text], handler: xml.sax.handler.ContentHandler,


### PR DESCRIPTION
sample program:

```python
import io
import xml.sax.handler


class Handler(xml.sax.handler.ContentHandler):
    def startElement(self, name, attrs):
        print(f'got <{name}>')


bio = io.BytesIO(b'<x><y/></x>')
xml.sax.parse(bio, Handler())

OUTPUT = '''\
got <x>
got <y>
'''
```
```