### PR TITLE
Fix typing for plistlib.load{,s}

### DIFF
--- a/stdlib/2and3/plistlib.pyi
+++ b/stdlib/2and3/plistlib.pyi
@@ -1,7 +1,7 @@
 # Stubs for plistlib
 
 from typing import (
-    Any, IO, Mapping, MutableMapping, Optional, Union,
+    Any, IO, Mapping, MutableMapping, Optional, overload, Union,
     Type, TypeVar,
 )
 from typing import Dict as DictT
@@ -23,8 +23,16 @@ else:
     _Path = Union[str, unicode]
 
 if sys.version_info >= (3, 4):
+    @overload
+    def load(fp: IO[bytes], *, fmt: Optional[PlistFormat] = ...,
+             use_builtin_types: bool = ...) -> DictT[str, Any]: ...
+    @overload
     def load(fp: IO[bytes], *, fmt: Optional[PlistFormat] = ...,
              use_builtin_types: bool = ..., dict_type: Type[_D] = ...) -> _D: ...
+    @overload
+    def loads(data: bytes, *, fmt: Optional[PlistFormat] = ...,
+              use_builtin_types: bool = ...) -> DictT[str, Any]: ...
+    @overload
     def loads(data: bytes, *, fmt: Optional[PlistFormat] = ...,
               use_builtin_types: bool = ..., dict_type: Type[_D] = ...) -> _D: ...
     def dump(value: Mapping[str, Any], fp: IO[bytes], *,


### PR DESCRIPTION
### sample file

```python
import collections
import plistlib

with open('f', 'rb') as f:
    data1 = plistlib.load(f)
    reveal_type(data1)

with open('f', 'rb') as f:
    data2 = plistlib.loads(f.read())
    reveal_type(data2)

with open('f', 'rb') as f:
    data3 = plistlib.load(f, dict_type=collections.OrderedDict)
    reveal_type(data3)

with open('f', 'rb') as f:
    data4 = plistlib.loads(f.read(), dict_type=collections.OrderedDict)
    reveal_type(data4)
```

### before

```console
$ mypy t.py
t.py:5: error: Need type annotation for 'data1'
t.py:6: note: Revealed type is 'Any'
t.py:9: error: Need type annotation for 'data2'
t.py:10: note: Revealed type is 'Any'
t.py:14: note: Revealed type is 'collections.OrderedDict*[Any, Any]'
t.py:18: note: Revealed type is 'collections.OrderedDict*[Any, Any]'
Found 2 errors in 1 file (checked 1 source file)
```


### after

```console
$ mypy t.py --custom-typeshed .
t.py:6: note: Revealed type is 'builtins.dict[builtins.str, Any]'
t.py:10: note: Revealed type is 'builtins.dict[builtins.str, Any]'
t.py:14: note: Revealed type is 'collections.OrderedDict*[Any, Any]'
t.py:18: note: Revealed type is 'collections.OrderedDict*[Any, Any]'
```