### PR TITLE
Make `FrameType.f_back` optional

### DIFF
--- a/stdlib/3/types.pyi
+++ b/stdlib/3/types.pyi
@@ -248,7 +248,7 @@ class TracebackType:
     def tb_lineno(self) -> int: ...
 
 class FrameType:
-    f_back: FrameType
+    f_back: Optional[FrameType]
     f_builtins: Dict[str, Any]
     f_code: CodeType
     f_globals: Dict[str, Any]


### PR DESCRIPTION
According to https://docs.python.org/3.8/reference/datamodel.html#frame-objects
the attribute `f_back` on a `FrameType` can be `None`.