### PR TITLE
Add a few attributes to distutils.ccompiler.CCompiler

### DIFF
--- a/stdlib/2and3/distutils/ccompiler.pyi
+++ b/stdlib/2and3/distutils/ccompiler.pyi
@@ -19,6 +19,16 @@ def new_compiler(plat: Optional[str] = ..., compiler: Optional[str] = ...,
 def show_compilers() -> None: ...
 
 class CCompiler:
+    dry_run: int
+    force: int
+    verbose: int
+    output_dir: str
+    macros: List[_Macro]
+    include_dirs: List[str]
+    libraries: List[str]
+    library_dirs: List[str]
+    runtime_library_dirs: List[str]
+    objects: List[str]
     def __init__(self, verbose: int = ..., dry_run: int = ...,
                  force: int = ...) -> None: ...
     def add_include_dir(self, dir: str) -> None: ...

--- a/stdlib/2and3/distutils/ccompiler.pyi
+++ b/stdlib/2and3/distutils/ccompiler.pyi
@@ -3,7 +3,7 @@
 from typing import Any, Callable, List, Optional, Tuple, Union
 
 
-_Macro = Union[Tuple[str], Tuple[str, str]]
+_Macro = Union[Tuple[str], Tuple[str, Optional[str]]]
 
 
 def gen_lib_options(compiler: CCompiler, library_dirs: List[str],
@@ -19,10 +19,10 @@ def new_compiler(plat: Optional[str] = ..., compiler: Optional[str] = ...,
 def show_compilers() -> None: ...
 
 class CCompiler:
-    dry_run: int
-    force: int
-    verbose: int
-    output_dir: str
+    dry_run: bool
+    force: bool
+    verbose: bool
+    output_dir: Optional[str]
     macros: List[_Macro]
     include_dirs: List[str]
     libraries: List[str]


### PR DESCRIPTION
Source: https://github.com/python/cpython/blob/a4ba8a3983356fceb4aedabe0c338180666a79aa/Lib/distutils/ccompiler.py#L86-L116

I only needed `library_dirs` but figured I'd add the others in that area as well