### PR TITLE
Add cmdclass to distutils.dist.Distribution

### DIFF
--- a/stdlib/2and3/distutils/dist.pyi
+++ b/stdlib/2and3/distutils/dist.pyi
@@ -1,10 +1,11 @@
 # Stubs for distutils.dist
 from distutils.cmd import Command
 
-from typing import Any, Mapping, Optional, Dict, Tuple, Iterable, Text
+from typing import Any, Dict, Mapping, Optional, Dict, Tuple, Iterable, Text, Type
 
 
 class Distribution:
+    cmdclass: Dict[str, Type[Command]]
     def __init__(self, attrs: Optional[Mapping[str, Any]] = ...) -> None: ...
     def get_option_dict(self, command: str) -> Dict[str, Tuple[str, Text]]: ...
     def parse_config_files(self, filenames: Optional[Iterable[Text]] = ...) -> None: ...


### PR DESCRIPTION
I was going to add more options but there were far too many in `__init__`