### PR TITLE
stdlib: csv.DictReader.fieldnames should be Optional[Sequence[str]]

### DIFF
--- a/stdlib/2and3/csv.pyi
+++ b/stdlib/2and3/csv.pyi
@@ -55,7 +55,7 @@ class DictReader(Iterator[_DRMapping]):
     reader: _reader
     dialect: _DialectLike
     line_num: int
-    fieldnames: Sequence[str]
+    fieldnames: Optional[Sequence[str]]
     def __init__(
         self,
         f: Iterable[Text],


### PR DESCRIPTION
Fixes #3713.

Copied offending test code from issue above and ran `mypy test.py --warn-unreachable --custom-typeshed-dir .` => no issues found.