### PR TITLE
stubtest: remove entry from whitelist for travis update

### DIFF
--- a/tests/stubtest_whitelists/py37.txt
+++ b/tests/stubtest_whitelists/py37.txt
@@ -138,4 +138,3 @@ uuid.UUID.int
 uuid.UUID.is_safe
 webbrowser.Opera.raise_opts
 xml.parsers.expat.XMLParserType.ExternalEntityParserCreate
-zipfile.ZipExtFile.__init__

--- a/tests/stubtest_whitelists/py38.txt
+++ b/tests/stubtest_whitelists/py38.txt
@@ -236,5 +236,4 @@ webbrowser.Opera.raise_opts
 xml.etree.ElementTree.XMLParser.__init__
 xml.etree.cElementTree.XMLParser.__init__
 zipfile.Path.open
-zipfile.ZipExtFile.__init__
 zipfile.ZipExtFile.seek


### PR DESCRIPTION
travis seems to have just updated from 3.7.5 to 3.7.6 and 3.8.0 to
3.8.1. The stubs match the newer versions, so we remove the previously
whitelisted error