### PR TITLE
configparser: add undocumented parameter to SectionProxy.get

### DIFF
--- a/stdlib/3/configparser.pyi
+++ b/stdlib/3/configparser.pyi
@@ -160,7 +160,7 @@ class SectionProxy(MutableMapping[str, str]):
     def parser(self) -> RawConfigParser: ...
     @property
     def name(self) -> str: ...
-    def get(self, option: str, fallback: Optional[str] = ..., *, raw: bool = ..., vars: Optional[_section] = ..., **kwargs: Any) -> str: ...  # type: ignore
+    def get(self, option: str, fallback: Optional[str] = ..., *, raw: bool = ..., vars: Optional[_section] = ..., _impl: Optional[Any] = ..., **kwargs: Any) -> str: ...  # type: ignore
 
     # These are partially-applied version of the methods with the same names in
     # RawConfigParser; the stubs should be kept updated together


### PR DESCRIPTION
It's technically an Optional callback protocol, but the return type of the callback affects this return type. Since it's undocumented, seems easier to call it Optional[Any]