### PR TITLE
Have datetime.{date,datetime} define __new__ instead of __init__.

### DIFF
--- a/stdlib/2and3/datetime.pyi
+++ b/stdlib/2and3/datetime.pyi
@@ -34,7 +34,7 @@ class date:
     max: ClassVar[date]
     resolution: ClassVar[timedelta]
 
-    def __init__(self, year: int, month: int, day: int) -> None: ...
+    def __new__(cls: Type[_S], year: int, month: int, day: int) -> _S: ...
 
     @classmethod
     def fromtimestamp(cls: Type[_S], __timestamp: float) -> _S: ...
@@ -201,13 +201,31 @@ class datetime(date):
     resolution: ClassVar[timedelta]
 
     if sys.version_info >= (3, 6):
-        def __init__(self, year: int, month: int, day: int, hour: int = ...,
-                     minute: int = ..., second: int = ..., microsecond: int = ...,
-                     tzinfo: Optional[_tzinfo] = ..., *, fold: int = ...) -> None: ...
+        def __new__(
+            cls: Type[_S],
+            year: int,
+            month: int,
+            day: int,
+            hour: int = ...,
+            minute: int = ...,
+            second: int = ...,
+            microsecond: int = ...,
+            tzinfo: Optional[_tzinfo] = ...,
+            *,
+            fold: int = ...,
+        ) -> _S: ...
     else:
-        def __init__(self, year: int, month: int, day: int, hour: int = ...,
-                     minute: int = ..., second: int = ..., microsecond: int = ...,
-                     tzinfo: Optional[_tzinfo] = ...) -> None: ...
+        def __new__(
+            cls: Type[_S],
+            year: int,
+            month: int,
+            day: int,
+            hour: int = ...,
+            minute: int = ...,
+            second: int = ...,
+            microsecond: int = ...,
+            tzinfo: Optional[_tzinfo] = ...,
+        ) -> _S: ...
 
     @property
     def year(self) -> int: ...


### PR DESCRIPTION
This is more faithful to the implementation:
https://github.com/python/cpython/blob/3.5/Lib/datetime.py.

When these classes define `__init__`, pytype has trouble type-checking
classes that inherit from datetime.datetime (done in, e.g., the third party
datetime_tz library) because it gets confused about what arguments the
constructor expects.