### PR TITLE
Make PathMatcher correctly exclude paths on windows

### DIFF
--- a/tests/pytype_test.py
+++ b/tests/pytype_test.py
@@ -61,6 +61,7 @@ def create_parser() -> argparse.ArgumentParser:
 
 class PathMatcher:
     def __init__(self, patterns: Sequence[str]) -> None:
+        patterns = [re.escape(os.path.join(*x.split("/"))) for x in patterns]
         self.matcher = re.compile(r"({})$".format("|".join(patterns))) if patterns else None
 
     def search(self, path: str) -> Optional[Match[str]]:


### PR DESCRIPTION
This should be generic, and uses re.escape because backslashes are special characters in regex. Tested locally, and with this, pytype passes on windows
closes #3836 