### PR TITLE
Make attributes of inspect.ArgSpec optional in Python 3

### DIFF
--- a/stdlib/3/inspect.pyi
+++ b/stdlib/3/inspect.pyi
@@ -175,8 +175,8 @@ def getclasstree(classes: List[type], unique: bool = ...) -> Any: ...
 
 class ArgSpec(NamedTuple):
     args: List[str]
-    varargs: str
-    keywords: str
+    varargs: Optional[str]
+    keywords: Optional[str]
     defaults: Tuple[Any, ...]
 
 class Arguments(NamedTuple):


### PR DESCRIPTION
This makes them consistent with Python 2 stubs.

The attributes are documented here:
https://docs.python.org/3/library/inspect.html#inspect.getargspec