### PR TITLE
Add stub entry for logging._srcfile

### DIFF
--- a/stdlib/2and3/logging/__init__.pyi
+++ b/stdlib/2and3/logging/__init__.pyi
@@ -29,6 +29,7 @@ raiseExceptions: bool
 logThreads: bool
 logMultiprocessing: bool
 logProcesses: bool
+_srcfile: Optional[str]
 
 def currentframe() -> FrameType: ...
 


### PR DESCRIPTION
  - While this appears to be private by convention, it's also documented as available
  to set here: https://docs.python.org/3/howto/logging.html#optimization and in source
  - Did *not* update `logging.logThreads` et al to match the
  documentation as it may be more appropriate to update the
  documentation to set to `False` rather than to `0` based on how these
  are used and I have not asked about this yet.

