### PR TITLE
Add `ssl.PROTOCOL_TLS` for Python 2.7

### DIFF
--- a/stdlib/2and3/ssl.pyi
+++ b/stdlib/2and3/ssl.pyi
@@ -134,7 +134,9 @@ PROTOCOL_SSLv3: int
 PROTOCOL_TLSv1: int
 PROTOCOL_TLSv1_1: int
 PROTOCOL_TLSv1_2: int
-if sys.version_info >= (3, 5) or (2, 7, 13) <= sys.version_info < (3, 0):
+if sys.version_info >= (3, 5):
+    PROTOCOL_TLS: int
+if (2, 7, 13) <= sys.version_info < (3, 0):
     PROTOCOL_TLS: int
 if sys.version_info >= (3, 6):
     PROTOCOL_TLS_CLIENT: int

--- a/stdlib/2and3/ssl.pyi
+++ b/stdlib/2and3/ssl.pyi
@@ -134,7 +134,7 @@ PROTOCOL_SSLv3: int
 PROTOCOL_TLSv1: int
 PROTOCOL_TLSv1_1: int
 PROTOCOL_TLSv1_2: int
-if sys.version_info >= (3, 5):
+if sys.version_info >= (3, 5) or (2, 7, 13) <= sys.version_info < (3, 0):
     PROTOCOL_TLS: int
 if sys.version_info >= (3, 6):
     PROTOCOL_TLS_CLIENT: int

--- a/stdlib/2and3/ssl.pyi
+++ b/stdlib/2and3/ssl.pyi
@@ -136,7 +136,7 @@ PROTOCOL_TLSv1_1: int
 PROTOCOL_TLSv1_2: int
 if sys.version_info >= (3, 5):
     PROTOCOL_TLS: int
-if (2, 7, 13) <= sys.version_info < (3, 0):
+elif sys.version_info < (3, 0):
     PROTOCOL_TLS: int
 if sys.version_info >= (3, 6):
     PROTOCOL_TLS_CLIENT: int

--- a/stdlib/2and3/ssl.pyi
+++ b/stdlib/2and3/ssl.pyi
@@ -134,10 +134,7 @@ PROTOCOL_SSLv3: int
 PROTOCOL_TLSv1: int
 PROTOCOL_TLSv1_1: int
 PROTOCOL_TLSv1_2: int
-if sys.version_info >= (3, 5):
-    PROTOCOL_TLS: int
-elif sys.version_info < (3, 0):
-    PROTOCOL_TLS: int
+PROTOCOL_TLS: int
 if sys.version_info >= (3, 6):
     PROTOCOL_TLS_CLIENT: int
     PROTOCOL_TLS_SERVER: int


### PR DESCRIPTION
Hi there!

This PR makes `typeshed` aware of `ssl.PROTOCOL_TLS` for Python 2.7.

Indeed, `ssl.PROTOCOL_TLS` was added in Python 3.5, and then [backported in Python 2.7.13](https://docs.python.org/2/library/ssl.html#ssl.PROTOCOL_TLS). Since I assume most Python 2 codebases nowadays are on 2.7.13+, and as per the guidelines [here](https://github.com/python/typeshed/blob/master/CONTRIBUTING.md#stub-versioning), it should be fine to add `ssl.PROTOCOL_TLS` for Python 2.7 as a whole, so that we can use it on Python 2/3 codebases that target eg 2.7.17. (Currently we need to `# type: ignore` when running in `--py2` mode.)

Let me know if there's anything I should add to the test setup for this :-)