### PR TITLE
Broaden _Serialized type in protobufs to ByteString.

### DIFF
--- a/third_party/2and3/google/protobuf/message.pyi
+++ b/third_party/2and3/google/protobuf/message.pyi
@@ -1,6 +1,6 @@
 import sys
 
-from typing import Any, Sequence, Optional, Tuple, Type, TypeVar, Union
+from typing import Any, ByteString, Sequence, Optional, Tuple, Type, TypeVar, Union
 
 from .descriptor import DescriptorBase, FieldDescriptor
 
@@ -17,7 +17,7 @@ _T = TypeVar("_T")
 if sys.version_info < (3,):
     _Serialized = Union[bytes, buffer, unicode]
 else:
-    _Serialized = bytes
+    _Serialized = ByteString
 
 class Message:
     DESCRIPTOR: Any


### PR DESCRIPTION
From my experiments (protobuf 3.8.0), `MergeFromString` accepts `bytes`, `bytearray`, and `memoryview` objects in Python 3.

I've reflected this in the types by using `typing`'s `ByteString` alias (which is effectively `Sequence[int]`, thus capturing `memoryview[int]`, and explicitly includes `bytes` and `bytearray`).