### PR TITLE
SyntaxError's filename and lineno may be undefined.

### DIFF
--- a/stdlib/2/__builtin__.pyi
+++ b/stdlib/2/__builtin__.pyi
@@ -1570,10 +1570,10 @@ if sys.version_info >= (3, 5):
         value: Any
 class SyntaxError(_StandardError):
     msg: str
-    lineno: int
+    lineno: Optional[int]
     offset: Optional[int]
     text: Optional[str]
-    filename: str
+    filename: Optional[str]
 class SystemError(_StandardError): ...
 class TypeError(_StandardError): ...
 class ValueError(_StandardError): ...

--- a/stdlib/2and3/builtins.pyi
+++ b/stdlib/2and3/builtins.pyi
@@ -1570,10 +1570,10 @@ if sys.version_info >= (3, 5):
         value: Any
 class SyntaxError(_StandardError):
     msg: str
-    lineno: int
+    lineno: Optional[int]
     offset: Optional[int]
     text: Optional[str]
-    filename: str
+    filename: Optional[str]
 class SystemError(_StandardError): ...
 class TypeError(_StandardError): ...
 class ValueError(_StandardError): ...


### PR DESCRIPTION
The Python source (Objects/exceptions.c) explicitly checks for null
pointers before using the filename and lineno members. Some libraries,
e.g. pkg_resources, set filename and lineno to undefined values if
indeed none are appropriate.

Thanks in advance for your time, and keep up the great work!