### PR TITLE
sockeserver: Add undocumented internal variables

### DIFF
--- a/stdlib/2/SocketServer.pyi
+++ b/stdlib/2/SocketServer.pyi
@@ -1,7 +1,7 @@
 # NB: SocketServer.pyi and socketserver.pyi must remain consistent!
 # Stubs for socketserver
 
-from typing import Any, BinaryIO, Callable, List, Optional, Tuple, Type, Text, Union
+from typing import Any, BinaryIO, Callable, ClassVar, List, Optional, Tuple, Type, Text, Union
 from socket import SocketType
 import sys
 import types
@@ -118,9 +118,16 @@ class BaseRequestHandler:
     def finish(self) -> None: ...
 
 class StreamRequestHandler(BaseRequestHandler):
+    rbufsize: ClassVar[int]  # Undocumented
+    wbufsize: ClassVar[int]  # Undocumented
+    timeout: ClassVar[Optional[float]]  # Undocumented
+    disable_nagle_algorithm: ClassVar[bool]  # Undocumented
+    connection: SocketType  # Undocumented
     rfile: BinaryIO
     wfile: BinaryIO
 
 class DatagramRequestHandler(BaseRequestHandler):
+    packet: SocketType  # Undocumented
+    socket: SocketType  # Undocumented
     rfile: BinaryIO
     wfile: BinaryIO

--- a/stdlib/3/http/server.pyi
+++ b/stdlib/3/http/server.pyi
@@ -27,8 +27,6 @@ class BaseHTTPRequestHandler(socketserver.StreamRequestHandler):
     path: str
     request_version: str
     headers: email.message.Message
-    rfile: BinaryIO
-    wfile: BinaryIO
     server_version: str
     sys_version: str
     error_message_format: str

--- a/stdlib/3/socketserver.pyi
+++ b/stdlib/3/socketserver.pyi
@@ -1,7 +1,7 @@
 # NB: SocketServer.pyi and socketserver.pyi must remain consistent!
 # Stubs for socketserver
 
-from typing import Any, BinaryIO, Callable, List, Optional, Tuple, Type, Text, Union
+from typing import Any, BinaryIO, Callable, ClassVar, List, Optional, Tuple, Type, Text, Union
 from socket import SocketType
 import sys
 import types
@@ -118,9 +118,16 @@ class BaseRequestHandler:
     def finish(self) -> None: ...
 
 class StreamRequestHandler(BaseRequestHandler):
+    rbufsize: ClassVar[int]  # Undocumented
+    wbufsize: ClassVar[int]  # Undocumented
+    timeout: ClassVar[Optional[float]]  # Undocumented
+    disable_nagle_algorithm: ClassVar[bool]  # Undocumented
+    connection: SocketType  # Undocumented
     rfile: BinaryIO
     wfile: BinaryIO
 
 class DatagramRequestHandler(BaseRequestHandler):
+    packet: SocketType  # Undocumented
+    socket: SocketType  # Undocumented
     rfile: BinaryIO
     wfile: BinaryIO


### PR DESCRIPTION
the `rfile` and `wfile` members are already implemented by
StreamRequestHandler. In addition to them several (undocumented)
class and instance variables exist according to
<https://github.com/python/cpython/blob/master/Lib/socketserver.py#L742>:
- `rbufsize`
- `wbufsize`
- `timeout`
- `disable_nagle_algorithm`
- `packet` and `socket` for datagrams

The already exist with Python 2.7
<https://github.com/python/cpython/blob/2.7/Lib/SocketServer.py#L677>

```mermaid
classDiagram
BaseRequestHandler <|-- DatagramRequestHandler
BaseRequestHandler <|-- StreamRequestHandler
StreamRequestHandler <|-- BaseHTTPRequestHandler
```