### PR TITLE
Fix attr-defined check for werkzeug.wrappers.BaseRequest (fixes #3913)

### DIFF
--- a/third_party/2and3/werkzeug/wrappers.pyi
+++ b/third_party/2and3/werkzeug/wrappers.pyi
@@ -87,11 +87,6 @@ class BaseRequest:
     is_multiprocess: bool
     is_run_once: bool
 
-    # These are not preset at runtime but we add them since monkeypatching this
-    # class is quite common.
-    def __setattr__(self, name: str, value: Any): ...
-    def __getattr__(self, name: str): ...
-
 _OnCloseT = TypeVar('_OnCloseT', bound=Callable[[], Any])
 _SelfT = TypeVar('_SelfT', bound=BaseResponse)
 


### PR DESCRIPTION
The PR #2740 added __setattr__ and __getattr__ to the
werkzeug.wrappers.BaseRequest definition to silence mypy when
monkeypatching this class.

The change disabled the errors for monkeypatching, but disabled disabled the
important check attr-defined.