### PR TITLE
create_subprocess_shell takes a single positional argument

### DIFF
--- a/stdlib/3/asyncio/subprocess.pyi
+++ b/stdlib/3/asyncio/subprocess.pyi
@@ -39,7 +39,7 @@ class Process:
 
 
 async def create_subprocess_shell(
-    *Args: Union[str, bytes],  # Union used instead of AnyStr due to mypy issue  #1236
+    cmd: Union[str, bytes],  # Union used instead of AnyStr due to mypy issue  #1236
     stdin: Union[int, IO[Any], None] = ...,
     stdout: Union[int, IO[Any], None] = ...,
     stderr: Union[int, IO[Any], None] = ...,


### PR DESCRIPTION
https://docs.python.org/3/library/asyncio-subprocess.html#asyncio.create_subprocess_shell

and from the code:

https://github.com/python/cpython/blob/482259d0dcf27714a84cf56b93977320bea7e093/Lib/asyncio/subprocess.py#L202