### PR TITLE
flake8 updates and cleanups

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,22 +1,24 @@
 # Some PEP8 deviations are considered irrelevant to stub files:
-# (error counts as of 2017-05-22)
-# 17952 E704 multiple statements on one line (def)
-# 12197 E301 expected 1 blank line
-#  7155 E302 expected 2 blank lines
-#  1463 F401 imported but unused
-#   967 E701 multiple statements on one line (colon)
-#   457 F811 redefinition (should be fixed in pyflakes 2.1.2)
-#   390 E305 expected 2 blank lines
-#     4 E741 ambiguous variable name
+#       E301 expected 1 blank line
+#       E302 expected 2 blank lines
+#       E305 expected 2 blank lines
+#       E701 multiple statements on one line (colon)
+#       E741 ambiguous variable name
+#       F401 imported but unused
+#       F403 import *' used; unable to detect undefined names
+#       F405 defined from star imports
+#       F811 redefinition (should be fixed in pyflakes 2.1.2)
 
 # Nice-to-haves ignored for now
-#  2307 E501 line too long
+#       E501 line too long
 
 # Other ignored warnings
 #       W504 line break after binary operator
 
 [flake8]
-ignore = F401, F403, F405, F811, E301, E302, E305, E501, E701, E704, E741, B303, W504
+per-file-ignores =
+  *.pyi: E301, E302, E305, E501, E701, E741, F401, F403, F405, F811
+
 # We are checking with Python 3 but many of the stubs are Python 2 stubs.
 builtins = StandardError,apply,basestring,buffer,cmp,coerce,execfile,file,intern,long,raw_input,reduce,reload,unichr,unicode,xrange
 exclude = .venv*,@*,.git

--- a/.flake8
+++ b/.flake8
@@ -8,13 +8,14 @@
 #       F403 import *' used; unable to detect undefined names
 #       F405 defined from star imports
 #       F811 redefinition (should be fixed in pyflakes 2.1.2)
+#       F822 undefined name in __all__
 
 # Nice-to-haves ignored for now
 #       E501 line too long
 
 [flake8]
 per-file-ignores =
-  *.pyi: E301, E302, E305, E501, E701, E741, F401, F403, F405, F811
+  *.pyi: E301, E302, E305, E501, E701, E741, F401, F403, F405, F811, F822
 
 # We are checking with Python 3 but many of the stubs are Python 2 stubs.
 builtins = StandardError,apply,basestring,buffer,cmp,coerce,execfile,file,intern,long,raw_input,reduce,reload,unichr,unicode,xrange

--- a/.flake8
+++ b/.flake8
@@ -12,9 +12,6 @@
 # Nice-to-haves ignored for now
 #       E501 line too long
 
-# Other ignored warnings
-#       W504 line break after binary operator
-
 [flake8]
 per-file-ignores =
   *.pyi: E301, E302, E305, E501, E701, E741, F401, F403, F405, F811

--- a/requirements-tests-py3.txt
+++ b/requirements-tests-py3.txt
@@ -1,8 +1,8 @@
 git+https://github.com/python/mypy.git@master
 typed-ast>=1.0.4
 black==19.3b0
-flake8==3.7.8
-flake8-bugbear==19.8.0
+flake8==3.7.9
+flake8-bugbear==20.1.4
 flake8-pyi==19.3.0
 isort==4.3.21
 pytype>=2020.01.08

--- a/tests/check_consistent.py
+++ b/tests/check_consistent.py
@@ -31,6 +31,7 @@ consistent_files = [
     {'stdlib/2and3/threading.pyi', 'stdlib/2and3/_dummy_threading.pyi'}
 ]
 
+
 def main():
     files = [os.path.join(root, file) for root, dir, files in os.walk('.') for file in files]
     no_symlink = 'You cannot use symlinks in typeshed, please copy {} to its link.'
@@ -44,6 +45,7 @@ def main():
             f2 = os.path.join(os.getcwd(), file2)
             if not filecmp.cmp(f1, f2):
                 raise ValueError('File {f1} does not match file {f2}. Please copy it to {f2}'.format(f1=file1, f2=file2))
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
* Update to flake8 3.7.9.
* Update to flake8-bugbear 20.1.4.
* Only ignore errors in stub files.
* Remove obsolete error counts.
* Sort error codes alphabetically.
* Don't ignore the following errors (unneeded):
    * E704 Multiple statements on one line (def)
    * W504 Line break occurred after a binary operator
    * B303 `__metaclass__` used
