### PR TITLE
use socket.sendto argument type for DatagramTransport.sendto

### DIFF
--- a/stdlib/3/asyncio/transports.pyi
+++ b/stdlib/3/asyncio/transports.pyi
@@ -1,4 +1,5 @@
 import sys
+from socket import _Address
 from typing import Any, Mapping, List, Optional, Tuple
 from asyncio.protocols import BaseProtocol
 from asyncio.events import AbstractEventLoop
@@ -32,7 +33,7 @@ class WriteTransport(BaseTransport):
 class Transport(ReadTransport, WriteTransport): ...
 
 class DatagramTransport(BaseTransport):
-    def sendto(self, data: Any, addr: Optional[Tuple[str, int]] = ...) -> None: ...
+    def sendto(self, data: Any, addr: Optional[_Address] = ...) -> None: ...
     def abort(self) -> None: ...
 
 class SubprocessTransport(BaseTransport):


### PR DESCRIPTION
In #1447 resp. #1450, the `addr` parameter was set to `Tuple[str,int]` to support IPv4 addresses. This change was wrong, as `str` is still allowed for AF_UNIX sockets, while AF_INET6 sockets need `Tuple[str, int, int, int]`. Since this parameter is passed directly to socket.sendto, I instead suggest to use the same parameter specification.