### PR TITLE
lru_cache-wrapped function args must be Hashable

### DIFF
--- a/stdlib/3/functools.pyi
+++ b/stdlib/3/functools.pyi
@@ -1,5 +1,5 @@
 import sys
-from typing import Any, Callable, Generic, Dict, Iterable, Mapping, Optional, Sequence, Tuple, Type, TypeVar, NamedTuple, Union, overload
+from typing import Any, Callable, Generic, Dict, Hashable, Iterable, Mapping, Optional, Sequence, Tuple, Type, TypeVar, NamedTuple, Union, overload
 
 _AnyCallable = Callable[..., Any]
 
@@ -21,7 +21,7 @@ class _CacheInfo(NamedTuple):
 
 class _lru_cache_wrapper(Generic[_T]):
     __wrapped__: Callable[..., _T]
-    def __call__(self, *args: Any, **kwargs: Any) -> _T: ...
+    def __call__(self, *args: Hashable, **kwargs: Hashable) -> _T: ...
     def cache_info(self) -> _CacheInfo: ...
     def cache_clear(self) -> None: ...
 


### PR DESCRIPTION
Per [docs](https://docs.python.org/3/library/functools.html#functools.lru_cache):
Since a dictionary is used to cache results, the positional and keyword arguments to the function must be hashable.