### PR TITLE
ctypes.CDLL name can be None

### DIFF
--- a/stdlib/2and3/ctypes/__init__.pyi
+++ b/stdlib/2and3/ctypes/__init__.pyi
@@ -26,7 +26,7 @@ class CDLL(object):
     _FuncPtr: Type[_FuncPointer] = ...
     def __init__(
         self,
-        name: str,
+        name: Optional[str],
         mode: int = ...,
         handle: Optional[int] = ...,
         use_errno: bool = ...,


### PR DESCRIPTION
:wave: `ctypes.CDLL` first argument should be an optional string but it's currently typed as a string. Passing `None` [is a usual way of getting the current process' libc](https://bugs.python.org/issue34592).

**Repro**: 
```shell
(.venv3) ➜  mypy --command "from ctypes import CDLL; CDLL(None)"
<string>:1: error: Argument 1 to "CDLL" has incompatible type "None"; expected "str"
Found 1 error in 1 file (checked 1 source file)
```

**Versions**:
```shell
(.venv3) ➜  mypy --version
mypy 0.770
(.venv3) ➜  python3 --version
Python 3.6.10
```

Cheers!