### PR TITLE
Use IO[bytes] instead of BytesIO for wave input signatures as it is t…

### DIFF
--- a/stdlib/2and3/wave.pyi
+++ b/stdlib/2and3/wave.pyi
@@ -2,7 +2,7 @@
 
 import sys
 from typing import (
-    Any, NamedTuple, NoReturn, Optional, Text, BinaryIO, Union, Tuple
+    Any, NamedTuple, NoReturn, Optional, Text, BinaryIO, Union, Tuple, IO
 )
 
 _File = Union[Text, IO[bytes]]

--- a/stdlib/2and3/wave.pyi
+++ b/stdlib/2and3/wave.pyi
@@ -5,7 +5,7 @@ from typing import (
     Any, NamedTuple, NoReturn, Optional, Text, BinaryIO, Union, Tuple
 )
 
-_File = Union[Text, BinaryIO]
+_File = Union[Text, IO[bytes]]
 
 class Error(Exception): ...
 


### PR DESCRIPTION
…he (slightly) more general type.

The issue here is that when running type checks, a file handle type that inherits from IO[bytes] would be considered not a BinaryIO.