### PR TITLE
Refine types on `tornado.web.RequestHandler`

### DIFF
--- a/third_party/2and3/tornado/web.pyi
+++ b/third_party/2and3/tornado/web.pyi
@@ -16,7 +16,7 @@ else:
 
 class RequestHandler:
     SUPPORTED_METHODS: Any
-    application: "Application"
+    application: Application
     request: httputil.HTTPServerRequest
     path_args: List[str]
     path_kwargs: Dict[str, str]

--- a/third_party/2and3/tornado/web.pyi
+++ b/third_party/2and3/tornado/web.pyi
@@ -1,6 +1,6 @@
 import sys
 
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Dict, List, Optional
 from tornado import httputil
 
 MIN_SUPPORTED_SIGNED_VALUE_VERSION: Any
@@ -16,10 +16,10 @@ else:
 
 class RequestHandler:
     SUPPORTED_METHODS: Any
-    application: Any
-    request: Any
-    path_args: Any
-    path_kwargs: Any
+    application: "Application"
+    request: httputil.HTTPServerRequest
+    path_args: List[str]
+    path_kwargs: Dict[str, str]
     ui: Any
     def __init__(self, application, request, **kwargs) -> None: ...
     initialize: Callable[..., None] = ...


### PR DESCRIPTION
This diff refines the types on `RequestHandler` by porting types directly from the `tornado` repo:
https://github.com/tornadoweb/tornado/blob/712d61079defdad23b0a5e9fe0090b54e55cf7d0/tornado/web.py#L200-L201

https://github.com/tornadoweb/tornado/blob/712d61079defdad23b0a5e9fe0090b54e55cf7d0/tornado/web.py#L206-L207