### PR TITLE
New attributes and types on `HTTPServerRequest`

### DIFF
--- a/third_party/2and3/tornado/httputil.pyi
+++ b/third_party/2and3/tornado/httputil.pyi
@@ -1,4 +1,4 @@
-from typing import Any, Dict, NamedTuple
+from typing import Any, Dict, List, NamedTuple, Optional
 
 from tornado.util import ObjectDict
 
@@ -29,19 +29,21 @@ class HTTPHeaders(Dict[Any, Any]):
     def __deepcopy__(self, memo_dict): ...
 
 class HTTPServerRequest:
-    method: Any
-    uri: Any
-    version: Any
-    headers: Any
-    body: Any
+    path: str
+    query: str
+    method: Optional[str]
+    uri: Optional[str]
+    version: str
+    headers: HTTPHeaders
+    body: bytes
     remote_ip: Any
     protocol: Any
-    host: Any
-    files: Any
-    connection: Any
-    arguments: Any
-    query_arguments: Any
-    body_arguments: Any
+    host: str
+    files: Dict[str, List[HTTPFile]]
+    connection: Optional[HTTPConnection]
+    arguments: Dict[str, List[bytes]]
+    query_arguments: Dict[str, List[bytes]]
+    body_arguments: Dict[str, List[bytes]]
     def __init__(self, method=..., uri=..., version=..., headers=..., body=..., host=..., files=..., connection=...,
                  start_line=...) -> None: ...
     def supports_http_1_1(self): ...


### PR DESCRIPTION
Porting type information directly from the tornado repository:
https://github.com/tornadoweb/tornado/blob/712d61079defdad23b0a5e9fe0090b54e55cf7d0/tornado/httputil.py#L340-L384