### PR TITLE
added multiprocessing.connection.Connection constructor definition

### DIFF
--- a/stdlib/3/multiprocessing/connection.pyi
+++ b/stdlib/3/multiprocessing/connection.pyi
@@ -1,4 +1,4 @@
-from typing import Any, Iterable, List, Optional, Tuple, Type, Union
+from typing import Any, Iterable, List, Optional, Tuple, Type, Union, SupportsIndex
 import socket
 import sys
 import types
@@ -7,7 +7,7 @@ import types
 _Address = Union[str, Tuple[str, int]]
 
 class _ConnectionBase:
-    def __init__(self, handle: int, readable: bool = ..., writable: bool = ...) -> None: ...
+    def __init__(self, handle: SupportsIndex, readable: bool = ..., writable: bool = ...) -> None: ...
     @property
     def closed(self) -> bool: ...  # undocumented
     @property

--- a/stdlib/3/multiprocessing/connection.pyi
+++ b/stdlib/3/multiprocessing/connection.pyi
@@ -7,7 +7,7 @@ import types
 _Address = Union[str, Tuple[str, int]]
 
 class _ConnectionBase:
-    def __init__(self, handle: int, readable: bool = True, writable: bool = True) -> None: ...
+    def __init__(self, handle: int, readable: bool = ..., writable: bool = ...) -> None: ...
     @property
     def closed(self) -> bool: ...  # undocumented
     @property

--- a/stdlib/3/multiprocessing/connection.pyi
+++ b/stdlib/3/multiprocessing/connection.pyi
@@ -7,6 +7,7 @@ import types
 _Address = Union[str, Tuple[str, int]]
 
 class _ConnectionBase:
+    def __init__(self, handle: int = ..., readable: bool = True, writable: bool = True) -> None: ...
     @property
     def closed(self) -> bool: ...  # undocumented
     @property

--- a/stdlib/3/multiprocessing/connection.pyi
+++ b/stdlib/3/multiprocessing/connection.pyi
@@ -7,7 +7,7 @@ import types
 _Address = Union[str, Tuple[str, int]]
 
 class _ConnectionBase:
-    def __init__(self, handle: int = ..., readable: bool = ..., writable: bool = ...) -> None: ...
+    def __init__(self, handle: int, readable: bool = True, writable: bool = True) -> None: ...
     @property
     def closed(self) -> bool: ...  # undocumented
     @property

--- a/stdlib/3/multiprocessing/connection.pyi
+++ b/stdlib/3/multiprocessing/connection.pyi
@@ -3,11 +3,18 @@ import socket
 import sys
 import types
 
+if sys.version_info >= (3, 8):
+    from typing import SupportsIndex
+
 # https://docs.python.org/3/library/multiprocessing.html#address-formats
 _Address = Union[str, Tuple[str, int]]
 
 class _ConnectionBase:
-    def __init__(self, handle: int, readable: bool = ..., writable: bool = ...) -> None: ...
+    if sys.version_info >= (3, 8):
+        def __init__(self, handle: SupportsIndex, readable: bool = ..., writable: bool = ...) -> None: ...
+    else:
+        def __init__(self, handle: int, readable: bool = ..., writable: bool = ...) -> None: ...
+            
     @property
     def closed(self) -> bool: ...  # undocumented
     @property

--- a/stdlib/3/multiprocessing/connection.pyi
+++ b/stdlib/3/multiprocessing/connection.pyi
@@ -7,7 +7,7 @@ import types
 _Address = Union[str, Tuple[str, int]]
 
 class _ConnectionBase:
-    def __init__(self, handle: int = ..., readable: bool = True, writable: bool = True) -> None: ...
+    def __init__(self, handle: int = ..., readable: bool = ..., writable: bool = ...) -> None: ...
     @property
     def closed(self) -> bool: ...  # undocumented
     @property

--- a/stdlib/3/multiprocessing/connection.pyi
+++ b/stdlib/3/multiprocessing/connection.pyi
@@ -1,4 +1,4 @@
-from typing import Any, Iterable, List, Optional, Tuple, Type, Union, SupportsIndex
+from typing import Any, Iterable, List, Optional, Tuple, Type, Union
 import socket
 import sys
 import types
@@ -7,7 +7,7 @@ import types
 _Address = Union[str, Tuple[str, int]]
 
 class _ConnectionBase:
-    def __init__(self, handle: SupportsIndex, readable: bool = ..., writable: bool = ...) -> None: ...
+    def __init__(self, handle: int, readable: bool = ..., writable: bool = ...) -> None: ...
     @property
     def closed(self) -> bool: ...  # undocumented
     @property

--- a/stdlib/3/multiprocessing/connection.pyi
+++ b/stdlib/3/multiprocessing/connection.pyi
@@ -14,7 +14,7 @@ class _ConnectionBase:
         def __init__(self, handle: SupportsIndex, readable: bool = ..., writable: bool = ...) -> None: ...
     else:
         def __init__(self, handle: int, readable: bool = ..., writable: bool = ...) -> None: ...
-            
+
     @property
     def closed(self) -> bool: ...  # undocumented
     @property


### PR DESCRIPTION
`multiprocessing.connection.Connection` definition is not complete and causes errors when creating an instance with a named parameter:
```python
multiprocessing.connection.Connection(handle=10)
```