### PR TITLE
Update orjson.pyi to support two new flags

### DIFF
--- a/third_party/3/orjson.pyi
+++ b/third_party/3/orjson.pyi
@@ -3,7 +3,7 @@ from typing import Any, Callable, Optional, Union
 __version__ = str
 
 def dumps(
-    __obj: Any,
+    obj: Any,
     default: Optional[Callable[[Any], Any]] = ...,
     option: Optional[int] = ...,
 ) -> bytes: ...
@@ -12,7 +12,9 @@ def loads(__obj: Union[bytes, bytearray, str]) -> Any: ...
 class JSONDecodeError(ValueError): ...
 class JSONEncodeError(TypeError): ...
 
+OPT_INDENT_2: int
 OPT_NAIVE_UTC: int
+OPT_NON_STR_KEYS: int
 OPT_OMIT_MICROSECONDS: int
 OPT_SERIALIZE_DATACLASS: int
 OPT_SERIALIZE_NUMPY: int


### PR DESCRIPTION
Updated orjson.pyi to support two new added flags `OPT_INDENT_2` and `OPT_NON_STR_KEYS`.
Renamed `__obj` to `obj` to allow using named parameter `obj` instead of positional, without getting errors.