### PR TITLE
Update array with more precise type for typecodes

### DIFF
--- a/stdlib/2and3/array.pyi
+++ b/stdlib/2and3/array.pyi
@@ -10,7 +10,7 @@ from typing_extensions import Literal
 _IntTypeCode = Literal['b', 'B', 'h', 'H', 'i', 'I', 'l', 'L', 'q', 'Q']
 _FloatTypeCode = Literal['f', 'd']
 _UnicodeTypeCode = Literal['u']
-_TypeCode = Literal[_IntTypeCode, _FloatTypeCode, _UnicodeTypeCode]
+_TypeCode = Union[_IntTypeCode, _FloatTypeCode, _UnicodeTypeCode]
 
 _T = TypeVar('_T', int, float, Text)
 

--- a/stdlib/2and3/array.pyi
+++ b/stdlib/2and3/array.pyi
@@ -7,27 +7,30 @@ from typing import (Any, BinaryIO, Generic, Iterable, Iterator, List, MutableSeq
                     overload, Text, Tuple, TypeVar, Union)
 from typing_extensions import Literal
 
-IntTypeCodes = Literal['b', 'B', 'h', 'H', 'i', 'I', 'l', 'L', 'q', 'Q']
-FloatTypeCodes = Literal['f', 'd']
-UnicodeTypeCodes = Literal['u']
-TypeCodes = Literal[IntTypeCodes, FloatTypeCodes, UnicodeTypeCodes]
+IntTypeCode = Literal['b', 'B', 'h', 'H', 'i', 'I', 'l', 'L', 'q', 'Q']
+FloatTypeCode = Literal['f', 'd']
+UnicodeTypeCode = Literal['u']
+TypeCode = Literal[IntTypeCode, FloatTypeCode, UnicodeTypeCode]
 
 _T = TypeVar('_T', int, float, Text)
 
 if sys.version_info >= (3,):
-    typecodes: TypeCodes
+    typecodes: str
 
 class array(MutableSequence[_T], Generic[_T]):
-    typecode: TypeCodes
+    typecode: TypeCode
     itemsize: int
     @overload
-    def __init__(self: array[int], typecode: IntTypeCodes,
+    def __init__(self: array[int], typecode: IntTypeCode,
                  __initializer: Union[bytes, Iterable[_T]] = ...) -> None: ...
     @overload
-    def __init__(self: array[float], typecode: FloatTypeCodes,
+    def __init__(self: array[float], typecode: FloatTypeCode,
                  __initializer: Union[bytes, Iterable[_T]] = ...) -> None: ...
     @overload
-    def __init__(self: array[Text], typecode: UnicodeTypeCodes,
+    def __init__(self: array[Text], typecode: UnicodeTypeCode,
+                 __initializer: Union[bytes, Iterable[_T]] = ...) -> None: ...
+    @overload
+    def __init__(self, typecode: str,
                  __initializer: Union[bytes, Iterable[_T]] = ...) -> None: ...
     def append(self, __v: _T) -> None: ...
     def buffer_info(self) -> Tuple[int, int]: ...

--- a/stdlib/2and3/array.pyi
+++ b/stdlib/2and3/array.pyi
@@ -5,16 +5,29 @@
 import sys
 from typing import (Any, BinaryIO, Generic, Iterable, Iterator, List, MutableSequence,
                     overload, Text, Tuple, TypeVar, Union)
+from typing_extensions import Literal
+
+IntTypeCodes = Literal['b', 'B', 'h', 'H', 'i', 'I', 'l', 'L', 'q', 'Q']
+FloatTypeCodes = Literal['f', 'd']
+UnicodeTypeCodes = Literal['u']
+TypeCodes = Literal[IntTypeCodes, FloatTypeCodes, UnicodeTypeCodes]
 
 _T = TypeVar('_T', int, float, Text)
 
 if sys.version_info >= (3,):
-    typecodes: str
+    typecodes: TypeCodes
 
 class array(MutableSequence[_T], Generic[_T]):
-    typecode: str
+    typecode: TypeCodes
     itemsize: int
-    def __init__(self, typecode: str,
+    @overload
+    def __init__(self: array[int], typecode: IntTypeCodes,
+                 __initializer: Union[bytes, Iterable[_T]] = ...) -> None: ...
+    @overload
+    def __init__(self: array[float], typecode: FloatTypeCodes,
+                 __initializer: Union[bytes, Iterable[_T]] = ...) -> None: ...
+    @overload
+    def __init__(self: array[Text], typecode: UnicodeTypeCodes,
                  __initializer: Union[bytes, Iterable[_T]] = ...) -> None: ...
     def append(self, __v: _T) -> None: ...
     def buffer_info(self) -> Tuple[int, int]: ...

--- a/stdlib/2and3/array.pyi
+++ b/stdlib/2and3/array.pyi
@@ -7,10 +7,10 @@ from typing import (Any, BinaryIO, Generic, Iterable, Iterator, List, MutableSeq
                     overload, Text, Tuple, TypeVar, Union)
 from typing_extensions import Literal
 
-IntTypeCode = Literal['b', 'B', 'h', 'H', 'i', 'I', 'l', 'L', 'q', 'Q']
-FloatTypeCode = Literal['f', 'd']
-UnicodeTypeCode = Literal['u']
-TypeCode = Literal[IntTypeCode, FloatTypeCode, UnicodeTypeCode]
+_IntTypeCode = Literal['b', 'B', 'h', 'H', 'i', 'I', 'l', 'L', 'q', 'Q']
+_FloatTypeCode = Literal['f', 'd']
+_UnicodeTypeCode = Literal['u']
+_TypeCode = Literal[_IntTypeCode, _FloatTypeCode, _UnicodeTypeCode]
 
 _T = TypeVar('_T', int, float, Text)
 
@@ -18,16 +18,16 @@ if sys.version_info >= (3,):
     typecodes: str
 
 class array(MutableSequence[_T], Generic[_T]):
-    typecode: TypeCode
+    typecode: _TypeCode
     itemsize: int
     @overload
-    def __init__(self: array[int], typecode: IntTypeCode,
+    def __init__(self: array[int], typecode: _IntTypeCode,
                  __initializer: Union[bytes, Iterable[_T]] = ...) -> None: ...
     @overload
-    def __init__(self: array[float], typecode: FloatTypeCode,
+    def __init__(self: array[float], typecode: _FloatTypeCode,
                  __initializer: Union[bytes, Iterable[_T]] = ...) -> None: ...
     @overload
-    def __init__(self: array[Text], typecode: UnicodeTypeCode,
+    def __init__(self: array[Text], typecode: _UnicodeTypeCode,
                  __initializer: Union[bytes, Iterable[_T]] = ...) -> None: ...
     @overload
     def __init__(self, typecode: str,


### PR DESCRIPTION
Allows for the following:

```
reveal_type(array('d')) # note: Revealed type is 'array.array[builtins.float]'
reveal_type(array('b')) # note: Revealed type is 'array.array[builtins.int]'
reveal_type(array('u')) # note: Revealed type is 'array.array[builtins.str]'
reveal_type(array('foo-bar')) # note: Revealed type is 'array.array[builtins.int*]'
```

Uses https://mypy.readthedocs.io/en/stable/more_types.html#advanced-self

fixes: https://github.com/python/typeshed/issues/3946
rel: http://docs.python.org/3.6/library/array.html