### PR TITLE
uuid: import enum inside version check.

### DIFF
--- a/stdlib/2and3/uuid.pyi
+++ b/stdlib/2and3/uuid.pyi
@@ -1,7 +1,6 @@
 # Stubs for uuid
 
 import sys
-from enum import Enum
 from typing import Tuple, Optional, Any, Text
 
 # Because UUID has properties called int and bytes we need to rename these temporarily.
@@ -10,6 +9,7 @@ _Bytes = bytes
 _FieldsType = Tuple[int, int, int, int, int, int]
 
 if sys.version_info >= (3, 7):
+    from enum import Enum
     class SafeUUID(Enum):
         safe: int
         unsafe: int


### PR DESCRIPTION
Otherwise, pytype tries to import enum in Python 2 and complains that
the library doesn't exist.