### PR TITLE
Add mistakenly removed constants back to tokenize.

### DIFF
--- a/stdlib/3/tokenize.pyi
+++ b/stdlib/3/tokenize.pyi
@@ -3,6 +3,11 @@ from builtins import open as _builtin_open
 import sys
 from token import *  # noqa: F403
 
+if sys.version_info < (3, 7):
+    COMMENT: int
+    NL: int
+    ENCODING: int
+
 cookie_re: Pattern[str]
 blank_re: Pattern[bytes]
 


### PR DESCRIPTION
These constants were removed in
https://github.com/python/typeshed/pull/3839 because they are imported
from token. However, that is only true in Python 3.7+.