### PR TITLE
Add undocumented attribute queue.Queue.queue with type Any.

### DIFF
--- a/stdlib/3/queue.pyi
+++ b/stdlib/3/queue.pyi
@@ -3,7 +3,7 @@
 # NOTE: These are incomplete!
 
 from threading import Condition, Lock
-from typing import Any, Deque, TypeVar, Generic, Optional
+from typing import Any, TypeVar, Generic, Optional
 import sys
 
 _T = TypeVar('_T')
@@ -19,6 +19,7 @@ class Queue(Generic[_T]):
     not_full: Condition  # undocumented
     all_tasks_done: Condition  # undocumented
     unfinished_tasks: int  # undocumented
+    queue: Any  # undocumented
 
     def __init__(self, maxsize: int = ...) -> None: ...
     def _init(self, maxsize: int) -> None: ...


### PR DESCRIPTION
This attribute was removed in
https://github.com/python/typeshed/pull/3879 because it is undocumented
and was annotated incorrectly. Unfortunately, a surprising (?) amount of
Google code uses this attribute and assumes it is a deque, so it needs
to exist but can't have a more general annotation like Collection[Any].

I also removed a no-longer-used typing.Deque import.