### PR TITLE
[pyre] Fix typo in click/decorators

### DIFF
--- a/third_party/2and3/click/decorators.pyi
+++ b/third_party/2and3/click/decorators.pyi
@@ -14,11 +14,11 @@ _Callback = Callable[
     Any
 ]
 
-def pass_context(_T) -> _T:
+def pass_context(__f: _T) -> _T:
     ...
 
 
-def pass_obj(_T) -> _T:
+def pass_obj(__f: _T) -> _T:
     ...
 
 


### PR DESCRIPTION
This is currently encoding 
```
def pass_context(_T: Any) -> _T:
```