### PR TITLE
Replacing Callable[[T], T] with callback protocol in click

### DIFF
--- a/third_party/2and3/click/decorators.pyi
+++ b/third_party/2and3/click/decorators.pyi
@@ -6,7 +6,7 @@ from click.core import Command, Group, Argument, Option, Parameter, Context, _Co
 _T = TypeVar('_T')
 _F = TypeVar('_F', bound=Callable[..., Any])
 
-class IdentityFunction(Protocol):
+class _IdentityFunction(Protocol):
     def __call__(self, __x: _T) -> _T: ...
 
 
@@ -25,7 +25,7 @@ def pass_obj(_T) -> _T:
 
 def make_pass_decorator(
     object_type: type, ensure: bool = ...
-) -> IdentityFunction:
+) -> _IdentityFunction:
     ...
 
 
@@ -86,7 +86,7 @@ def argument(
     is_eager: bool = ...,
     envvar: Optional[Union[str, List[str]]] = ...,
     autocompletion: Optional[Callable[[Any, List[str], str], List[Union[str, Tuple[str, str]]]]] = ...,
-) -> IdentityFunction:
+) -> _IdentityFunction:
     ...
 
 
@@ -118,7 +118,7 @@ def option(
     envvar: Optional[Union[str, List[str]]] = ...,
     # User-defined
     **kwargs: Any,
-) -> IdentityFunction:
+) -> _IdentityFunction:
     ...
 
 
@@ -150,7 +150,7 @@ def option(
     envvar: Optional[Union[str, List[str]]] = ...,
     # User-defined
     **kwargs: Any,
-) -> IdentityFunction:
+) -> _IdentityFunction:
     ...
 
 
@@ -182,7 +182,7 @@ def option(
     envvar: Optional[Union[str, List[str]]] = ...,
     # User-defined
     **kwargs: Any,
-) -> IdentityFunction:
+) -> _IdentityFunction:
     ...
 
 
@@ -214,7 +214,7 @@ def option(
     envvar: Optional[Union[str, List[str]]] = ...,
     # User-defined
     **kwargs: Any,
-) -> IdentityFunction:
+) -> _IdentityFunction:
     ...
 
 
@@ -242,7 +242,7 @@ def confirmation_option(
     expose_value: bool = ...,
     is_eager: bool = ...,
     envvar: Optional[Union[str, List[str]]] = ...
-) -> IdentityFunction:
+) -> _IdentityFunction:
     ...
 
 
@@ -270,7 +270,7 @@ def password_option(
     expose_value: bool = ...,
     is_eager: bool = ...,
     envvar: Optional[Union[str, List[str]]] = ...
-) -> IdentityFunction:
+) -> _IdentityFunction:
     ...
 
 
@@ -301,7 +301,7 @@ def version_option(
     expose_value: bool = ...,
     is_eager: bool = ...,
     envvar: Optional[Union[str, List[str]]] = ...
-) -> IdentityFunction:
+) -> _IdentityFunction:
     ...
 
 
@@ -329,5 +329,5 @@ def help_option(
     expose_value: bool = ...,
     is_eager: bool = ...,
     envvar: Optional[Union[str, List[str]]] = ...
-) -> IdentityFunction:
+) -> _IdentityFunction:
     ...

--- a/third_party/2and3/click/decorators.pyi
+++ b/third_party/2and3/click/decorators.pyi
@@ -1,13 +1,14 @@
 from distutils.version import Version
-from typing import Any, Callable, Dict, List, Optional, Tuple, Type, TypeVar, Union, Text, overload
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type, TypeVar, Union, Text, overload, Protocol
 
 from click.core import Command, Group, Argument, Option, Parameter, Context, _ConvertibleType
 
 _T = TypeVar('_T')
 _F = TypeVar('_F', bound=Callable[..., Any])
 
-# Until https://github.com/python/mypy/issues/3924 is fixed you can't do the following:
-# _Decorator = Callable[[_F], _F]
+class IdentityFunction(Protocol):
+    def __call__(self, __x: _T) -> _T: ...
+
 
 _Callback = Callable[
     [Context, Union[Option, Parameter], Any],
@@ -24,7 +25,7 @@ def pass_obj(_T) -> _T:
 
 def make_pass_decorator(
     object_type: type, ensure: bool = ...
-) -> Callable[[_T], _T]:
+) -> IdentityFunction:
     ...
 
 
@@ -85,7 +86,7 @@ def argument(
     is_eager: bool = ...,
     envvar: Optional[Union[str, List[str]]] = ...,
     autocompletion: Optional[Callable[[Any, List[str], str], List[Union[str, Tuple[str, str]]]]] = ...,
-) -> Callable[[_F], _F]:
+) -> IdentityFunction:
     ...
 
 
@@ -117,7 +118,7 @@ def option(
     envvar: Optional[Union[str, List[str]]] = ...,
     # User-defined
     **kwargs: Any,
-) -> Callable[[_F], _F]:
+) -> IdentityFunction:
     ...
 
 
@@ -149,7 +150,7 @@ def option(
     envvar: Optional[Union[str, List[str]]] = ...,
     # User-defined
     **kwargs: Any,
-) -> Callable[[_F], _F]:
+) -> IdentityFunction:
     ...
 
 
@@ -181,7 +182,7 @@ def option(
     envvar: Optional[Union[str, List[str]]] = ...,
     # User-defined
     **kwargs: Any,
-) -> Callable[[_F], _F]:
+) -> IdentityFunction:
     ...
 
 
@@ -213,7 +214,7 @@ def option(
     envvar: Optional[Union[str, List[str]]] = ...,
     # User-defined
     **kwargs: Any,
-) -> Callable[[_F], _F]:
+) -> IdentityFunction:
     ...
 
 
@@ -241,7 +242,7 @@ def confirmation_option(
     expose_value: bool = ...,
     is_eager: bool = ...,
     envvar: Optional[Union[str, List[str]]] = ...
-) -> Callable[[_F], _F]:
+) -> IdentityFunction:
     ...
 
 
@@ -269,7 +270,7 @@ def password_option(
     expose_value: bool = ...,
     is_eager: bool = ...,
     envvar: Optional[Union[str, List[str]]] = ...
-) -> Callable[[_F], _F]:
+) -> IdentityFunction:
     ...
 
 
@@ -300,7 +301,7 @@ def version_option(
     expose_value: bool = ...,
     is_eager: bool = ...,
     envvar: Optional[Union[str, List[str]]] = ...
-) -> Callable[[_F], _F]:
+) -> IdentityFunction:
     ...
 
 
@@ -328,5 +329,5 @@ def help_option(
     expose_value: bool = ...,
     is_eager: bool = ...,
     envvar: Optional[Union[str, List[str]]] = ...
-) -> Callable[[_F], _F]:
+) -> IdentityFunction:
     ...


### PR DESCRIPTION
We are trying to strictify the type variable scoping semantics in Pyre such that `class`es and the parameters of `def`s are the only places in which new type variable scopes can be created.

This would mean that things like 
```	
from typing import Callable, TypeVar
T = TypeVar("T")
def produce_no_op_decorator() -> Callable[[T], T]:...
```
would be rejected with ```Invalid type variable [34]: The type variable `Variable[T]` isn't present in the function's  parameters.```

We currently don't error here, but don't handle this consistently correctly.

MyPy currently supports this (mod https://github.com/python/mypy/issues/3924), and we don't necessarily need that behavior to change.  Instead we'd just like typeshed to reflect the lowest common denominator between our two semantics: callback protocols.

For the above example, both MyPy and Pyre support this alternative spelling:

```	
from typing import Callable, TypeVar, Protocol
T = TypeVar("T")
class IdentityFunction(Protocol):
    def __call__(self, __x: T) -> T: ...
def produce_no_op_decorator() -> IdentityFunction...
```

This PR converts a series of decorators in click that look like the first example into spellings like the second example.  If this is agreeable to the community, we'd like to replicate this throughout typeshed.