### PR TITLE
revert orjson.pyi obj parameter

### DIFF
--- a/third_party/3/orjson.pyi
+++ b/third_party/3/orjson.pyi
@@ -3,7 +3,7 @@ from typing import Any, Callable, Optional, Union
 __version__ = str
 
 def dumps(
-    obj: Any,
+    __obj: Any,
     default: Optional[Callable[[Any], Any]] = ...,
     option: Optional[int] = ...,
 ) -> bytes: ...


### PR DESCRIPTION
After submitting a pull request to orjson repository, the author has changed the library and "obj" parameter is now positional only.
Not this behavior is aligned with the stub file and the change can be reverted.

https://github.com/ijl/orjson/releases/tag/3.0.1