### PR TITLE
Remove context manager hints in multiprocessing.pool in Python 2

### DIFF
--- a/stdlib/2/multiprocessing/pool.pyi
+++ b/stdlib/2/multiprocessing/pool.pyi
@@ -14,7 +14,7 @@ class IMapIterator(Iterator[Any]):
 
 class IMapUnorderedIterator(IMapIterator): ...
 
-class Pool:
+class Pool(object):
     def __init__(self, processes: Optional[int] = ...,
                  initializer: Optional[Callable[..., None]] = ...,
                  initargs: Iterable[Any] = ...,

--- a/stdlib/2/multiprocessing/pool.pyi
+++ b/stdlib/2/multiprocessing/pool.pyi
@@ -1,7 +1,4 @@
-from typing import (
-    Any, Callable, ContextManager, Iterable, Optional, Dict, List,
-    TypeVar, Iterator,
-)
+from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional, TypeVar
 
 _T = TypeVar('_T', bound=Pool)
 
@@ -17,7 +14,7 @@ class IMapIterator(Iterator[Any]):
 
 class IMapUnorderedIterator(IMapIterator): ...
 
-class Pool(ContextManager[Pool]):
+class Pool:
     def __init__(self, processes: Optional[int] = ...,
                  initializer: Optional[Callable[..., None]] = ...,
                  initargs: Iterable[Any] = ...,
@@ -50,10 +47,8 @@ class Pool(ContextManager[Pool]):
     def close(self) -> None: ...
     def terminate(self) -> None: ...
     def join(self) -> None: ...
-    def __enter__(self: _T) -> _T: ...
 
-class ThreadPool(Pool, ContextManager[ThreadPool]):
-
+class ThreadPool(Pool):
     def __init__(self, processes: Optional[int] = ...,
                  initializer: Optional[Callable[..., Any]] = ...,
                  initargs: Iterable[Any] = ...) -> None: ...


### PR DESCRIPTION
This is opened as suggested and should be able to fix GH-4055.  Have a good weekend!