### PR TITLE
xml.etree.ElementTree: add support for os.PathLike for py36+

### DIFF
--- a/stdlib/2and3/xml/etree/ElementTree.pyi
+++ b/stdlib/2and3/xml/etree/ElementTree.pyi
@@ -63,7 +63,11 @@ else:
     # _fixtext function in the source). Client code knows best:
     _str_result_type = Any
 
-_file_or_filename = Union[str, bytes, int, IO[Any]]
+if sys.version_info >= (3, 6):
+    from os import PathLike
+    _file_or_filename = Union[str, bytes, PathLike[str], int, IO[Any]]
+else:
+    _file_or_filename = Union[str, bytes, int, IO[Any]]
 
 if sys.version_info >= (3, 8):
     class _Writeable(Protocol):


### PR DESCRIPTION
`xml.etree.ElementTree` uses `open` on filenames (e.g. [1]), so `os.PathLike` has been supported as filenames since Python 3.6.

[1] https://github.com/python/cpython/blob/285ff63351bb5a42099527c283f65434e761be83/Lib/xml/etree/ElementTree.py#L584