### PR TITLE
stubtest whitelists: clean up duplicate entries

### DIFF
--- a/tests/stubtest_whitelists/linux-py35.txt
+++ b/tests/stubtest_whitelists/linux-py35.txt
@@ -6,4 +6,3 @@ site.getuserbase
 site.getusersitepackages
 ssl.PROTOCOL_SSLv3
 ssl.RAND_egd
-typing.IO.closed

--- a/tests/stubtest_whitelists/linux-py36.txt
+++ b/tests/stubtest_whitelists/linux-py36.txt
@@ -5,4 +5,3 @@ site.getuserbase
 site.getusersitepackages
 ssl.PROTOCOL_SSLv3
 ssl.RAND_egd
-typing.IO.closed

--- a/tests/stubtest_whitelists/win32-py35.txt
+++ b/tests/stubtest_whitelists/win32-py35.txt
@@ -2,4 +2,3 @@ ntpath.splitunc
 os.path.splitunc
 os.path.splitunc
 posixpath.splitunc
-typing.IO.closed

--- a/tests/stubtest_whitelists/win32-py36.txt
+++ b/tests/stubtest_whitelists/win32-py36.txt
@@ -4,4 +4,3 @@ os.path.splitunc
 os.startfile
 os.path.splitunc
 posixpath.splitunc
-typing.IO.closed


### PR DESCRIPTION
This got duplicated a little during the merge. The source of the
confusion is that the issue was fixed in CPython and the changes were
backported to 3.7 and 3.8. However, the micro versions we currently use
in CI on Linux don't have this fix.

Typeshed policy is to support the latest micro version, so I don't want
to hardcode micro versions into .travis.yml, since they'll never get
updated.