### PR TITLE
socket: Add missing CAN_BCM option flag constants

### DIFF
--- a/stdlib/2and3/socket.pyi
+++ b/stdlib/2and3/socket.pyi
@@ -322,6 +322,20 @@ if sys.platform == 'linux' and sys.version_info >= (3,):
 
     CAN_RAW_FD_FRAMES: int
 
+if sys.platform == 'linux' and sys.version_info >= (3, 8):
+    CAN_BCM_SETTIMER: int
+    CAN_BCM_STARTTIMER: int
+    CAN_BCM_TX_COUNTEVT: int
+    CAN_BCM_TX_ANNOUNCE: int
+    CAN_BCM_TX_CP_CAN_ID: int
+    CAN_BCM_RX_FILTER_ID: int
+    CAN_BCM_RX_CHECK_DLC: int
+    CAN_BCM_RX_NO_AUTOTIMER: int
+    CAN_BCM_RX_ANNOUNCE_RESUME: int
+    CAN_BCM_TX_RESET_MULTI_IDX: int
+    CAN_BCM_RX_RTR_FRAME: int
+    CAN_BCM_CAN_FD_FRAME: int
+
 if sys.platform == 'linux' and sys.version_info >= (3, 7):
     CAN_ISOTP: int
 


### PR DESCRIPTION
The SocketCAN BCM option flag constants were added in version 3.9,
and only backported to version 3.8, despite the documentation's claims
of supporting all BCM-related constants starting from version 3.4.

Note: The CAN_FD_FRAME flag option was only introduced in the 4.8.x
kernel series, while the rest of the constants were available since the
Broadcast Manager was mainlined in the kernel as part of the SocketCAN
patches.