### PR TITLE
CI: remove py39

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,10 +39,6 @@ jobs:
     - name: "flake8"
       install: pip install -r requirements-tests-py3.txt
       script: flake8
-    - name: "stubtest py39"
-      python: 3.9-dev
-      install: pip install -U git+git://github.com/python/mypy@b3d43984
-      script: ./tests/stubtest_test.py
     - name: "stubtest py38"
       python: 3.8
       install: pip install -U git+git://github.com/python/mypy@b3d43984


### PR DESCRIPTION
I can't find a way to pin it to beta, and if they're going to make
changes that will break typeshed CI we shouldn't run it in CI.

I would like to make this run with Travis' allow_failures, but I can't
seem to make it work.