### PR TITLE
Remove BinaryIO.write()

### DIFF
--- a/stdlib/3/typing.pyi
+++ b/stdlib/3/typing.pyi
@@ -515,13 +515,6 @@ class BinaryIO(IO[bytes]):
     # TODO readinto
     # TODO read1?
     # TODO peek?
-    @overload
-    @abstractmethod
-    def write(self, s: bytearray) -> int: ...
-    @overload
-    @abstractmethod
-    def write(self, s: bytes) -> int: ...
-
     @abstractmethod
     def __enter__(self) -> BinaryIO: ...
 


### PR DESCRIPTION
write() is inherited from IO[bytes], where it's defined as
`def write(self, s: AnyStr) -> int: ...`. If AnyStr is bytes,
this should accept bytes, bytearray, and memoryview, so the
overload is unnecessary.

Closes: #4201