### PR TITLE
Update the werkzeug InternalServerError constructor to match 1.0.0 API

### DIFF
--- a/third_party/2and3/werkzeug/exceptions.pyi
+++ b/third_party/2and3/werkzeug/exceptions.pyi
@@ -147,6 +147,12 @@ class UnavailableForLegalReasons(HTTPException):
     description: Text
 
 class InternalServerError(HTTPException):
+    def __init__(
+        self,
+        description: Optional[Text] = ...,
+        response: Optional[Response] = ...,
+        original_exception: Optional[Exception] = ...,
+    ) -> None: ...
     code: int
     description: Text
 


### PR DESCRIPTION
Match the 1.0.0 API: https://werkzeug.palletsprojects.com/en/1.0.x/exceptions/#werkzeug.exceptions.InternalServerError

Correct:
```
Unexpected keyword argument "original_exception" for "InternalServerError"mypy(error)
```

Question: what about legacy compliance with werkzeug <1.0.0, this field will be visible in the stub even if it actually does not exist ?