### PR TITLE
Move stubtest CI to GitHub Actions

### DIFF
--- a/.github/workflows/stubtest-unused-whitelist.yml
+++ b/.github/workflows/stubtest-unused-whitelist.yml
@@ -22,6 +22,6 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install -U pip
-          pip install -U git+git://github.com/python/mypy@b3d43984
+          pip install -U mypy==0.780
       - name: Run stubtest
         run: ./tests/stubtest_unused.py

--- a/.github/workflows/stubtest.yml
+++ b/.github/workflows/stubtest.yml
@@ -22,6 +22,6 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install -U pip
-          pip install -U git+git://github.com/python/mypy@b3d43984
+          pip install -U mypy==0.780
       - name: Run stubtest
         run: ./tests/stubtest_test.py --ignore-unused-whitelist

--- a/.github/workflows/stubtest.yml
+++ b/.github/workflows/stubtest.yml
@@ -1,0 +1,27 @@
+name: Check stubs with stubtest
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  stubtest:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: ["ubuntu-latest", "windows-latest"]
+        python-version: [3.5, 3.6, 3.7, 3.8]
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip
+          pip install -U git+git://github.com/python/mypy@b3d43984
+      - name: Run stubtest
+        run: ./tests/stubtest_test.py --ignore-unused-whitelist

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,6 @@ dist: bionic
 language: python
 python: 3.8
 
-aliases:
-  test_windows: &test_windows
-    os: windows
-    language: shell
-    env: &env_windows
-      PATH: /c/Python38:/c/Python38/Scripts:/c/Python37:/c/Python37/Scripts:/c/Python36:/c/Python36/Scripts:/c/Python35:/c/Python35/Scripts:$PATH
-    before_install:
-      - choco install python --version $PYTHON_VERSION
-      - python -m pip install -U pip
-
 jobs:
   include:
     - name: "pytype"
@@ -39,47 +29,3 @@ jobs:
     - name: "flake8"
       install: pip install -r requirements-tests-py3.txt
       script: flake8
-    - name: "stubtest py38"
-      python: 3.8
-      install: pip install -U git+git://github.com/python/mypy@b3d43984
-      script: ./tests/stubtest_test.py --ignore-unused-whitelist
-    - name: "stubtest py37"
-      python: 3.7
-      install: pip install -U git+git://github.com/python/mypy@b3d43984
-      script: ./tests/stubtest_test.py --ignore-unused-whitelist
-    - name: "stubtest py36"
-      python: 3.6
-      install: pip install -U git+git://github.com/python/mypy@b3d43984
-      script: ./tests/stubtest_test.py --ignore-unused-whitelist
-    - name: "stubtest py35"
-      python: 3.5
-      install: pip install -U git+git://github.com/python/mypy@b3d43984
-      script: ./tests/stubtest_test.py --ignore-unused-whitelist
-    - name: "stubtest py38 (Windows)"
-      <<: *test_windows
-      env:
-        <<: *env_windows
-        PYTHON_VERSION: 3.8.3
-      install: pip install -U git+git://github.com/python/mypy@b3d43984
-      script: python ./tests/stubtest_test.py --ignore-unused-whitelist
-    - name: "stubtest py37 (Windows)"
-      <<: *test_windows
-      env:
-        <<: *env_windows
-        PYTHON_VERSION: 3.7.7
-      install: pip install -U git+git://github.com/python/mypy@b3d43984
-      script: python ./tests/stubtest_test.py --ignore-unused-whitelist
-    - name: "stubtest py36 (Windows)"
-      <<: *test_windows
-      env:
-        <<: *env_windows
-        PYTHON_VERSION: 3.6.8
-      install: pip install -U git+git://github.com/python/mypy@b3d43984
-      script: python ./tests/stubtest_test.py --ignore-unused-whitelist
-    - name: "stubtest py35 (Windows)"
-      <<: *test_windows
-      env:
-        <<: *env_windows
-        PYTHON_VERSION: 3.5.4
-      install: pip install -U git+git://github.com/python/mypy@b3d43984
-      script: python ./tests/stubtest_test.py --ignore-unused-whitelist

--- a/tests/stubtest_whitelists/linux.txt
+++ b/tests/stubtest_whitelists/linux.txt
@@ -51,3 +51,7 @@ posix.[a-z]+_(param|result)._(asdict|make|replace)
 # Platform differences that cannot be captured by the type system
 fcntl.[A-Z0-9_]+
 os.SCHED_[A-Z_]+
+
+# Loadable SQLite extensions are disabled on GitHub runners
+sqlite3(.dbapi2)?.Connection.enable_load_extension
+sqlite3(.dbapi2)?.Connection.load_extension

--- a/tests/stubtest_whitelists/py38.txt
+++ b/tests/stubtest_whitelists/py38.txt
@@ -48,6 +48,7 @@ hmac.new  # Stub is a white lie; see comments in the stub
 http.client.HTTPSConnection.__init__
 http.cookiejar.DefaultCookiePolicy.__init__
 http.server.SimpleHTTPRequestHandler.__init__
+importlib.metadata.DistributionFinder.Context.pattern
 importlib.metadata.EntryPointBase
 inspect.isasyncgenfunction
 inspect.iscoroutinefunction


### PR DESCRIPTION
This ensures that the Python version used matches the one used in the
scheduled extraneous stubtest whitelist check.

See also PR #4206.