### PR TITLE
Allow Warning message in showwarning and formatwarning

### DIFF
--- a/stdlib/2and3/warnings.pyi
+++ b/stdlib/2and3/warnings.pyi
@@ -1,15 +1,15 @@
 import sys
 from types import ModuleType, TracebackType
-from typing import Any, List, NamedTuple, Optional, TextIO, Type, overload
+from typing import Any, List, NamedTuple, Optional, TextIO, Type, Union, overload
 
 from typing_extensions import Literal
 
 from _warnings import warn as warn, warn_explicit as warn_explicit
 
 def showwarning(
-    message: str, category: Type[Warning], filename: str, lineno: int, file: Optional[TextIO] = ..., line: Optional[str] = ...
+    message: Union[Warning, str], category: Type[Warning], filename: str, lineno: int, file: Optional[TextIO] = ..., line: Optional[str] = ...
 ) -> None: ...
-def formatwarning(message: str, category: Type[Warning], filename: str, lineno: int, line: Optional[str] = ...) -> str: ...
+def formatwarning(message: Union[Warning, str], category: Type[Warning], filename: str, lineno: int, line: Optional[str] = ...) -> str: ...
 def filterwarnings(
     action: str, message: str = ..., category: Type[Warning] = ..., module: str = ..., lineno: int = ..., append: bool = ...
 ) -> None: ...
@@ -19,7 +19,7 @@ def resetwarnings() -> None: ...
 class _OptionError(Exception): ...
 
 class WarningMessage:
-    message: Warning
+    message: Union[Warning, str]
     category: Type[Warning]
     filename: str
     lineno: int
@@ -29,7 +29,7 @@ class WarningMessage:
         source: Optional[Any]
         def __init__(
             self,
-            message: Warning,
+            message: Union[Warning, str],
             category: Type[Warning],
             filename: str,
             lineno: int,
@@ -40,7 +40,7 @@ class WarningMessage:
     else:
         def __init__(
             self,
-            message: Warning,
+            message: Union[Warning, str],
             category: Type[Warning],
             filename: str,
             lineno: int,


### PR DESCRIPTION
### Changes

- `warnings.WarningMessage` message argument accepts both `str` and `Warning`
- `warnings.showwarning` message argument accepts both `str` and `Warning`
- `warnings.formatwarning` message argument accepts both `str` and `Warning`

Resolves #4211 
