### PR TITLE
Run the unused stubtest check only on python/typeshed

### DIFF
--- a/.github/workflows/stubtest-unused-whitelist.yml
+++ b/.github/workflows/stubtest-unused-whitelist.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   stubtest:
+    if: github.repository == 'python/typeshed'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -33,6 +34,7 @@ jobs:
           path: stubtest-output-${{ matrix.os }}-${{ matrix.python-version }}
 
   collate:
+    if: github.repository == 'python/typeshed'
     runs-on: ubuntu-latest
     needs: stubtest
     steps:


### PR DESCRIPTION
Without this check, it is run on daily on every personal fork.