### PR TITLE
Revert "zip: add some overloads for heterogeneous tuples (#3830)"

### DIFF
--- a/stdlib/2/__builtin__.pyi
+++ b/stdlib/2/__builtin__.pyi
@@ -1581,16 +1581,6 @@ if sys.version_info < (3,):
     def unichr(__i: int) -> unicode: ...
 def vars(__object: Any = ...) -> Dict[str, Any]: ...
 if sys.version_info >= (3,):
-    # Some overloads to better support zipping heterogeneous tuples
-    @overload
-    def zip(*iterables: Tuple[_T1, _T2]) -> Tuple[Tuple[_T1, ...], Tuple[_T2, ...]]: ...  # type: ignore
-    @overload
-    def zip(*iterables: Tuple[_T1, _T2, _T3]) -> Tuple[Tuple[_T1, ...], Tuple[_T2, ...], Tuple[_T3, ...]]: ...  # type: ignore
-    @overload
-    def zip(*iterables: Tuple[_T1, _T2, _T3, _T4]) -> Tuple[Tuple[_T1, ...], Tuple[_T2, ...], Tuple[_T3, ...], Tuple[_T4, ...]]: ...  # type: ignore
-    @overload
-    def zip(*iterables: Tuple[_T1, _T2, _T3, _T4, _T5]) -> Tuple[Tuple[_T1, ...], Tuple[_T2, ...], Tuple[_T3, ...], Tuple[_T4, ...], Tuple[_T5, ...]]: ...  # type: ignore
-
     @overload
     def zip(__iter1: Iterable[_T1]) -> Iterator[Tuple[_T1]]: ...
     @overload

--- a/stdlib/2and3/builtins.pyi
+++ b/stdlib/2and3/builtins.pyi
@@ -1581,16 +1581,6 @@ if sys.version_info < (3,):
     def unichr(__i: int) -> unicode: ...
 def vars(__object: Any = ...) -> Dict[str, Any]: ...
 if sys.version_info >= (3,):
-    # Some overloads to better support zipping heterogeneous tuples
-    @overload
-    def zip(*iterables: Tuple[_T1, _T2]) -> Tuple[Tuple[_T1, ...], Tuple[_T2, ...]]: ...  # type: ignore
-    @overload
-    def zip(*iterables: Tuple[_T1, _T2, _T3]) -> Tuple[Tuple[_T1, ...], Tuple[_T2, ...], Tuple[_T3, ...]]: ...  # type: ignore
-    @overload
-    def zip(*iterables: Tuple[_T1, _T2, _T3, _T4]) -> Tuple[Tuple[_T1, ...], Tuple[_T2, ...], Tuple[_T3, ...], Tuple[_T4, ...]]: ...  # type: ignore
-    @overload
-    def zip(*iterables: Tuple[_T1, _T2, _T3, _T4, _T5]) -> Tuple[Tuple[_T1, ...], Tuple[_T2, ...], Tuple[_T3, ...], Tuple[_T4, ...], Tuple[_T5, ...]]: ...  # type: ignore
-
     @overload
     def zip(__iter1: Iterable[_T1]) -> Iterator[Tuple[_T1]]: ...
     @overload


### PR DESCRIPTION
This reverts commit e857ad6ba97dcd757b251659e5b15e2acc5a6262.

Fixes #4226.