### PR TITLE
argparse: fix for latest py39

### DIFF
--- a/stdlib/2and3/argparse.pyi
+++ b/stdlib/2and3/argparse.pyi
@@ -290,7 +290,6 @@ if sys.version_info >= (3, 9):
             self,
             option_strings: Sequence[str],
             dest: str,
-            const: None = ...,  # unused in implementation
             default: Union[_T, str, None] = ...,
             type: Optional[Union[Callable[[Text], _T], Callable[[str], _T], FileType]] = ...,
             choices: Optional[Iterable[_T]] = ...,


### PR DESCRIPTION
https://github.com/python/typeshed/pull/4144 and
https://github.com/python/cpython/pull/11478#pullrequestreview-423968410
resulted in the issue being fixed upstream.

A fix in time saves a branch in typeshed :-)