### PR TITLE
Add pytest_mock stubs

### DIFF
--- a/third_party/3/pytest_mock/__init__.pyi
+++ b/third_party/3/pytest_mock/__init__.pyi
@@ -1,0 +1,2 @@
+from .plugin import *
+from .plugin import _get_mock_module as _get_mock_module

--- a/third_party/3/pytest_mock/_version.pyi
+++ b/third_party/3/pytest_mock/_version.pyi
@@ -1,0 +1,1 @@
+version: str

--- a/third_party/3/pytest_mock/plugin.pyi
+++ b/third_party/3/pytest_mock/plugin.pyi
@@ -14,16 +14,17 @@ def _get_mock_module(config: _Config) -> _MockModule: ...
 class MockFixture:
     mock_module: _MockModule
     patch: MockFixture._Patcher  # google/pytype#611
-    Mock = unittest.mock.Mock
-    MagicMock = unittest.mock.MagicMock
-    NonCallableMock = unittest.mock.NonCallableMock
-    PropertyMock = unittest.mock.PropertyMock
-    call = unittest.mock.call
-    ANY = unittest.mock.ANY
-    DEFAULT = unittest.mock.DEFAULT
-    create_autospec = unittest.mock.create_autospec
-    sentinel = unittest.mock.sentinel
-    mock_open = unittest.mock.mock_open
+    # The following aliases don't work due to google/pytype#612
+    Mock: Any  # actually unittest.mock.Mock
+    MagicMock: Any  # actually unittest.mock.MagicMock
+    NonCallableMock: Any  # actually unittest.mock.NonCallableMock
+    PropertyMock: Any  # actually unittest.mock.PropertyMock
+    call: Any  # actually unittest.mock.call
+    ANY: Any  # actually unittest.mock.ANY
+    DEFAULT: Any  # actually unittest.mock.DEFAULT
+    create_autospec: Any  # actually unittest.mock.create_autospec
+    sentinel: Any  # actually unittest.mock.sentinel
+    mock_open: Any  # actually unittest.mock.mock_open
     def __init__(self, config: _Config) -> None: ...
     def resetall(self) -> None: ...
     def stopall(self) -> None: ...

--- a/third_party/3/pytest_mock/plugin.pyi
+++ b/third_party/3/pytest_mock/plugin.pyi
@@ -13,7 +13,7 @@ def _get_mock_module(config: _Config) -> _MockModule: ...
 
 class MockFixture:
     mock_module: _MockModule
-    patch: _Patcher
+    patch: MockFixture._Patcher  # google/pytype#611
     Mock = unittest.mock.Mock
     MagicMock = unittest.mock.MagicMock
     NonCallableMock = unittest.mock.NonCallableMock

--- a/third_party/3/pytest_mock/plugin.pyi
+++ b/third_party/3/pytest_mock/plugin.pyi
@@ -1,0 +1,100 @@
+import unittest.mock
+from typing import Any, Callable, Optional, TypeVar, Union, overload
+
+from ._version import version as version
+
+_T = TypeVar("_T")
+_MockModule = Any  # usually unittest.mock
+_Config = Any  # pytest.Config
+
+__version__ = version
+
+def _get_mock_module(config: _Config) -> _MockModule: ...
+
+class MockFixture:
+    mock_module: _MockModule
+    patch: _Patcher
+    Mock = unittest.mock.Mock
+    MagicMock = unittest.mock.MagicMock
+    NonCallableMock = unittest.mock.NonCallableMock
+    PropertyMock = unittest.mock.PropertyMock
+    call = unittest.mock.call
+    ANY = unittest.mock.ANY
+    DEFAULT = unittest.mock.DEFAULT
+    create_autospec = unittest.mock.create_autospec
+    sentinel = unittest.mock.sentinel
+    mock_open = unittest.mock.mock_open
+    def __init__(self, config: _Config) -> None: ...
+    def resetall(self) -> None: ...
+    def stopall(self) -> None: ...
+    def spy(self, obj: object, name: str) -> unittest.mock.MagicMock: ...
+    def stub(self, name: Optional[str] = ...) -> unittest.mock.MagicMock: ...
+    class _Patcher:
+        mock_module: _MockModule
+        def object(
+            self,
+            target: Any,
+            attribute: str,
+            new: Optional[Any] = ...,
+            spec: Optional[Any] = ...,
+            create: bool = ...,
+            spec_set: Optional[Any] = ...,
+            autospec: Optional[Any] = ...,
+            new_callable: Optional[Any] = ...,
+            **kwargs: Any,
+        ) -> Any: ...
+        def multiple(
+            self,
+            target: Any,
+            spec: Optional[Any] = ...,
+            create: bool = ...,
+            spec_set: Optional[Any] = ...,
+            autospec: Optional[Any] = ...,
+            new_callable: Optional[Any] = ...,
+            **kwargs: Any,
+        ) -> Any: ...
+        def dict(self, in_dict: Any, values: Any = ..., clear: bool = ..., **kwargs: Any) -> Any: ...
+        @overload
+        def __call__(
+            self,
+            target: Any,
+            new: None = ...,
+            spec: Optional[Any] = ...,
+            create: bool = ...,
+            spec_set: Optional[Any] = ...,
+            autospec: Optional[Any] = ...,
+            new_callable: Optional[Any] = ...,
+            **kwargs: Any,
+        ) -> unittest.mock.MagicMock: ...
+        @overload
+        def __call__(
+            self,
+            target: Any,
+            new: _T,
+            spec: Optional[Any] = ...,
+            create: bool = ...,
+            spec_set: Optional[Any] = ...,
+            autospec: Optional[Any] = ...,
+            new_callable: Optional[Any] = ...,
+            **kwargs: Any,
+        ) -> _T: ...
+
+mocker: Any
+class_mocker: Any
+module_mocker: Any
+package_mocker: Any
+session_mocker: Any
+
+def assert_wrapper(__wrapped_mock_method__: Callable[..., Any], *args: Any, **kwargs: Any) -> None: ...
+def wrap_assert_not_called(*args: Any, **kwargs: Any) -> None: ...
+def wrap_assert_called_with(*args: Any, **kwargs: Any) -> None: ...
+def wrap_assert_called_once(*args: Any, **kwargs: Any) -> None: ...
+def wrap_assert_called_once_with(*args: Any, **kwargs: Any) -> None: ...
+def wrap_assert_has_calls(*args: Any, **kwargs: Any) -> None: ...
+def wrap_assert_any_call(*args: Any, **kwargs: Any) -> None: ...
+def wrap_assert_called(*args: Any, **kwargs: Any) -> None: ...
+def wrap_assert_methods(config: _Config) -> None: ...
+def unwrap_assert_methods() -> None: ...
+def pytest_addoption(parser) -> None: ...
+def parse_ini_boolean(value: Union[bool, str]) -> bool: ...
+def pytest_configure(config: _Config) -> None: ...

--- a/third_party/3/pytest_mock/plugin.pyi
+++ b/third_party/3/pytest_mock/plugin.pyi
@@ -12,6 +12,23 @@ __version__ = version
 def _get_mock_module(config: _Config) -> _MockModule: ...
 
 class MockFixture:
+    mock_module: _MockModule
+    patch: _Patcher
+    Mock = unittest.mock.Mock
+    MagicMock = unittest.mock.MagicMock
+    NonCallableMock = unittest.mock.NonCallableMock
+    PropertyMock = unittest.mock.PropertyMock
+    call = unittest.mock.call
+    ANY = unittest.mock.ANY
+    DEFAULT = unittest.mock.DEFAULT
+    create_autospec = unittest.mock.create_autospec
+    sentinel = unittest.mock.sentinel
+    mock_open = unittest.mock.mock_open
+    def __init__(self, config: _Config) -> None: ...
+    def resetall(self) -> None: ...
+    def stopall(self) -> None: ...
+    def spy(self, obj: object, name: str) -> unittest.mock.MagicMock: ...
+    def stub(self, name: Optional[str] = ...) -> unittest.mock.MagicMock: ...
     class _Patcher:
         mock_module: _MockModule
         def object(
@@ -61,24 +78,6 @@ class MockFixture:
             new_callable: Optional[Any] = ...,
             **kwargs: Any,
         ) -> _T: ...
-
-    mock_module: _MockModule
-    patch: _Patcher
-    Mock = unittest.mock.Mock
-    MagicMock = unittest.mock.MagicMock
-    NonCallableMock = unittest.mock.NonCallableMock
-    PropertyMock = unittest.mock.PropertyMock
-    call = unittest.mock.call
-    ANY = unittest.mock.ANY
-    DEFAULT = unittest.mock.DEFAULT
-    create_autospec = unittest.mock.create_autospec
-    sentinel = unittest.mock.sentinel
-    mock_open = unittest.mock.mock_open
-    def __init__(self, config: _Config) -> None: ...
-    def resetall(self) -> None: ...
-    def stopall(self) -> None: ...
-    def spy(self, obj: object, name: str) -> unittest.mock.MagicMock: ...
-    def stub(self, name: Optional[str] = ...) -> unittest.mock.MagicMock: ...
 
 mocker: Any
 class_mocker: Any

--- a/third_party/3/pytest_mock/plugin.pyi
+++ b/third_party/3/pytest_mock/plugin.pyi
@@ -12,23 +12,6 @@ __version__ = version
 def _get_mock_module(config: _Config) -> _MockModule: ...
 
 class MockFixture:
-    mock_module: _MockModule
-    patch: _Patcher
-    Mock = unittest.mock.Mock
-    MagicMock = unittest.mock.MagicMock
-    NonCallableMock = unittest.mock.NonCallableMock
-    PropertyMock = unittest.mock.PropertyMock
-    call = unittest.mock.call
-    ANY = unittest.mock.ANY
-    DEFAULT = unittest.mock.DEFAULT
-    create_autospec = unittest.mock.create_autospec
-    sentinel = unittest.mock.sentinel
-    mock_open = unittest.mock.mock_open
-    def __init__(self, config: _Config) -> None: ...
-    def resetall(self) -> None: ...
-    def stopall(self) -> None: ...
-    def spy(self, obj: object, name: str) -> unittest.mock.MagicMock: ...
-    def stub(self, name: Optional[str] = ...) -> unittest.mock.MagicMock: ...
     class _Patcher:
         mock_module: _MockModule
         def object(
@@ -78,6 +61,24 @@ class MockFixture:
             new_callable: Optional[Any] = ...,
             **kwargs: Any,
         ) -> _T: ...
+
+    mock_module: _MockModule
+    patch: _Patcher
+    Mock = unittest.mock.Mock
+    MagicMock = unittest.mock.MagicMock
+    NonCallableMock = unittest.mock.NonCallableMock
+    PropertyMock = unittest.mock.PropertyMock
+    call = unittest.mock.call
+    ANY = unittest.mock.ANY
+    DEFAULT = unittest.mock.DEFAULT
+    create_autospec = unittest.mock.create_autospec
+    sentinel = unittest.mock.sentinel
+    mock_open = unittest.mock.mock_open
+    def __init__(self, config: _Config) -> None: ...
+    def resetall(self) -> None: ...
+    def stopall(self) -> None: ...
+    def spy(self, obj: object, name: str) -> unittest.mock.MagicMock: ...
+    def stub(self, name: Optional[str] = ...) -> unittest.mock.MagicMock: ...
 
 mocker: Any
 class_mocker: Any


### PR DESCRIPTION
These can certainly be improved in the future, especially since `unittest.mock` can be improved as well.

See pytest-dev/pytest-mock#152 for a discussion on adding stubs to pytest-mock directly: It will most likely happen when they drop support for Python 2.