### PR TITLE
adjust isort config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,6 @@ jobs:
     - name: "black"
       install: pip install $(grep black requirements-tests-py3.txt)
       script: black --check --diff stdlib third_party
-  allow_failures:
     - name: "isort"
       install: pip install $(grep isort requirements-tests-py3.txt)
       script: isort --check-only --diff --recursive stdlib third_party

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,3 +9,5 @@ force_grid_wrap = 0
 use_parentheses = true
 combine_as_imports = true
 line_length = 130
+default_section = "THIRDPARTY"
+known_standard_library = ["typing_extensions", "_typeshed"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,4 +10,4 @@ use_parentheses = true
 combine_as_imports = true
 line_length = 130
 default_section = "THIRDPARTY"
-known_standard_library = ["typing_extensions", "_typeshed"]
+known_standard_library = ["typing_extensions", "_typeshed", "_compression", "_markupbase", "opcode"]

--- a/stdlib/2/ConfigParser.pyi
+++ b/stdlib/2/ConfigParser.pyi
@@ -1,6 +1,5 @@
-from typing import IO, Any, Dict, List, Optional, Sequence, Tuple, Union
-
 from _typeshed import SupportsReadline
+from typing import IO, Any, Dict, List, Optional, Sequence, Tuple, Union
 
 DEFAULTSECT: str
 MAX_INTERPOLATION_DEPTH: int

--- a/stdlib/2/__builtin__.pyi
+++ b/stdlib/2/__builtin__.pyi
@@ -2,6 +2,16 @@
 # Python 3, and stub files conform to Python 3 syntax.
 
 import sys
+from _typeshed import (
+    AnyPath,
+    OpenBinaryMode,
+    OpenBinaryModeReading,
+    OpenBinaryModeUpdating,
+    OpenBinaryModeWriting,
+    OpenTextMode,
+    ReadableBuffer,
+    SupportsWrite,
+)
 from abc import ABCMeta
 from ast import AST, mod
 from io import BufferedRandom, BufferedReader, BufferedWriter, FileIO, TextIOWrapper
@@ -46,19 +56,7 @@ from typing import (
     ValuesView,
     overload,
 )
-
 from typing_extensions import Literal
-
-from _typeshed import (
-    AnyPath,
-    OpenBinaryMode,
-    OpenBinaryModeReading,
-    OpenBinaryModeUpdating,
-    OpenBinaryModeWriting,
-    OpenTextMode,
-    ReadableBuffer,
-    SupportsWrite,
-)
 
 if sys.version_info >= (3,):
     from typing import SupportsBytes, SupportsRound

--- a/stdlib/2/compileall.pyi
+++ b/stdlib/2/compileall.pyi
@@ -1,6 +1,5 @@
-from typing import Any, Optional, Pattern
-
 from _typeshed import AnyPath
+from typing import Any, Optional, Pattern
 
 # rx can be any object with a 'search' method; once we have Protocols we can change the type
 def compile_dir(

--- a/stdlib/2/fcntl.pyi
+++ b/stdlib/2/fcntl.pyi
@@ -1,6 +1,5 @@
-from typing import Any, Union
-
 from _typeshed import FileDescriptorLike
+from typing import Any, Union
 
 FASYNC: int
 FD_CLOEXEC: int

--- a/stdlib/2/json.pyi
+++ b/stdlib/2/json.pyi
@@ -1,6 +1,5 @@
-from typing import IO, Any, Callable, Dict, List, Optional, Text, Tuple, Type, Union
-
 from _typeshed import SupportsRead
+from typing import IO, Any, Callable, Dict, List, Optional, Text, Tuple, Type, Union
 
 class JSONDecodeError(ValueError):
     def dumps(self, obj: Any) -> str: ...

--- a/stdlib/2/os/__init__.pyi
+++ b/stdlib/2/os/__init__.pyi
@@ -1,4 +1,5 @@
 import sys
+from _typeshed import AnyPath
 from builtins import OSError as error
 from io import TextIOWrapper as _TextIOWrapper
 from posix import listdir as listdir, stat_result as stat_result  # TODO: use this, see https://github.com/python/mypy/issues/3078
@@ -24,8 +25,6 @@ from typing import (
     Union,
     overload,
 )
-
-from _typeshed import AnyPath
 
 from . import path as path
 

--- a/stdlib/2/os/path.pyi
+++ b/stdlib/2/os/path.pyi
@@ -1,10 +1,9 @@
 # NB: path.pyi and stdlib/2 and stdlib/3 must remain consistent!
 import os
 import sys
+from _typeshed import AnyPath, BytesPath, StrPath
 from genericpath import exists as exists
 from typing import Any, AnyStr, Callable, List, Optional, Sequence, Text, Tuple, TypeVar, overload
-
-from _typeshed import AnyPath, BytesPath, StrPath
 
 _T = TypeVar("_T")
 

--- a/stdlib/2/os2emxpath.pyi
+++ b/stdlib/2/os2emxpath.pyi
@@ -1,10 +1,9 @@
 # NB: path.pyi and stdlib/2 and stdlib/3 must remain consistent!
 import os
 import sys
+from _typeshed import AnyPath, BytesPath, StrPath
 from genericpath import exists as exists
 from typing import Any, AnyStr, Callable, List, Optional, Sequence, Text, Tuple, TypeVar, overload
-
-from _typeshed import AnyPath, BytesPath, StrPath
 
 _T = TypeVar("_T")
 

--- a/stdlib/2and3/_typeshed/__init__.pyi
+++ b/stdlib/2and3/_typeshed/__init__.pyi
@@ -16,7 +16,6 @@ import array
 import mmap
 import sys
 from typing import Protocol, Text, TypeVar, Union
-
 from typing_extensions import Literal
 
 _T_co = TypeVar("_T_co", covariant=True)

--- a/stdlib/2and3/aifc.pyi
+++ b/stdlib/2and3/aifc.pyi
@@ -1,7 +1,6 @@
 import sys
 from types import TracebackType
 from typing import IO, Any, List, NamedTuple, Optional, Text, Tuple, Type, Union, overload
-
 from typing_extensions import Literal
 
 class Error(Exception): ...

--- a/stdlib/2and3/array.pyi
+++ b/stdlib/2and3/array.pyi
@@ -4,7 +4,6 @@
 
 import sys
 from typing import Any, BinaryIO, Generic, Iterable, Iterator, List, MutableSequence, Text, Tuple, TypeVar, Union, overload
-
 from typing_extensions import Literal
 
 _IntTypeCode = Literal["b", "B", "h", "H", "i", "I", "l", "L", "q", "Q"]

--- a/stdlib/2and3/asyncore.pyi
+++ b/stdlib/2and3/asyncore.pyi
@@ -1,8 +1,7 @@
 import sys
+from _typeshed import FileDescriptorLike
 from socket import SocketType
 from typing import Any, Dict, Optional, Tuple, Union, overload
-
-from _typeshed import FileDescriptorLike
 
 # cyclic dependence with asynchat
 _maptype = Dict[int, Any]

--- a/stdlib/2and3/builtins.pyi
+++ b/stdlib/2and3/builtins.pyi
@@ -2,6 +2,16 @@
 # Python 3, and stub files conform to Python 3 syntax.
 
 import sys
+from _typeshed import (
+    AnyPath,
+    OpenBinaryMode,
+    OpenBinaryModeReading,
+    OpenBinaryModeUpdating,
+    OpenBinaryModeWriting,
+    OpenTextMode,
+    ReadableBuffer,
+    SupportsWrite,
+)
 from abc import ABCMeta
 from ast import AST, mod
 from io import BufferedRandom, BufferedReader, BufferedWriter, FileIO, TextIOWrapper
@@ -46,19 +56,7 @@ from typing import (
     ValuesView,
     overload,
 )
-
 from typing_extensions import Literal
-
-from _typeshed import (
-    AnyPath,
-    OpenBinaryMode,
-    OpenBinaryModeReading,
-    OpenBinaryModeUpdating,
-    OpenBinaryModeWriting,
-    OpenTextMode,
-    ReadableBuffer,
-    SupportsWrite,
-)
 
 if sys.version_info >= (3,):
     from typing import SupportsBytes, SupportsRound

--- a/stdlib/2and3/bz2.pyi
+++ b/stdlib/2and3/bz2.pyi
@@ -1,10 +1,8 @@
 import io
 import sys
-from typing import IO, Any, Optional, TextIO, TypeVar, Union, overload
-
-from typing_extensions import Literal
-
 from _typeshed import AnyPath
+from typing import IO, Any, Optional, TextIO, TypeVar, Union, overload
+from typing_extensions import Literal
 
 _PathOrFile = Union[AnyPath, IO[bytes]]
 _T = TypeVar("_T")

--- a/stdlib/2and3/cProfile.pyi
+++ b/stdlib/2and3/cProfile.pyi
@@ -1,7 +1,6 @@
 import sys
-from typing import Any, Callable, Dict, Optional, TypeVar, Union
-
 from _typeshed import AnyPath
+from typing import Any, Callable, Dict, Optional, TypeVar, Union
 
 def run(statement: str, filename: Optional[str] = ..., sort: Union[str, int] = ...) -> None: ...
 def runctx(

--- a/stdlib/2and3/cgitb.pyi
+++ b/stdlib/2and3/cgitb.pyi
@@ -1,7 +1,6 @@
+from _typeshed import AnyPath
 from types import FrameType, TracebackType
 from typing import IO, Any, Callable, Dict, List, Optional, Tuple, Type
-
-from _typeshed import AnyPath
 
 _ExcInfo = Tuple[Optional[Type[BaseException]], Optional[BaseException], Optional[TracebackType]]
 

--- a/stdlib/2and3/codecs.pyi
+++ b/stdlib/2and3/codecs.pyi
@@ -20,7 +20,6 @@ from typing import (
     Union,
     overload,
 )
-
 from typing_extensions import Literal
 
 # TODO: this only satisfies the most common interface, where

--- a/stdlib/2and3/fileinput.pyi
+++ b/stdlib/2and3/fileinput.pyi
@@ -1,7 +1,6 @@
 import sys
-from typing import IO, Any, AnyStr, Callable, Generic, Iterable, Iterator, Optional, Union
-
 from _typeshed import AnyPath
+from typing import IO, Any, AnyStr, Callable, Generic, Iterable, Iterator, Optional, Union
 
 if sys.version_info >= (3, 8):
     def input(

--- a/stdlib/2and3/ftplib.pyi
+++ b/stdlib/2and3/ftplib.pyi
@@ -1,4 +1,5 @@
 import sys
+from _typeshed import SupportsRead, SupportsReadline
 from socket import socket
 from ssl import SSLContext
 from types import TracebackType
@@ -19,8 +20,6 @@ from typing import (
     TypeVar,
     Union,
 )
-
-from _typeshed import SupportsRead, SupportsReadline
 
 _T = TypeVar("_T")
 _IntOrStr = Union[int, Text]

--- a/stdlib/2and3/hmac.pyi
+++ b/stdlib/2and3/hmac.pyi
@@ -1,10 +1,9 @@
 # Stubs for hmac
 
 import sys
+from _typeshed import ReadableBuffer
 from types import ModuleType
 from typing import Any, AnyStr, Callable, Optional, Union, overload
-
-from _typeshed import ReadableBuffer
 
 _B = Union[bytes, bytearray]
 

--- a/stdlib/2and3/imaplib.pyi
+++ b/stdlib/2and3/imaplib.pyi
@@ -4,7 +4,6 @@ import time
 from socket import socket as _socket
 from ssl import SSLContext, SSLSocket
 from typing import IO, Any, Callable, Dict, List, Optional, Pattern, Text, Tuple, Type, Union
-
 from typing_extensions import Literal
 
 # TODO: Commands should use their actual return types, not this type alias.

--- a/stdlib/2and3/lib2to3/pgen2/driver.pyi
+++ b/stdlib/2and3/lib2to3/pgen2/driver.pyi
@@ -1,9 +1,8 @@
+from _typeshed import StrPath
 from lib2to3.pgen2.grammar import Grammar
 from lib2to3.pytree import _NL, _Convert
 from logging import Logger
 from typing import IO, Any, Iterable, Optional, Text
-
-from _typeshed import StrPath
 
 class Driver:
     grammar: Grammar

--- a/stdlib/2and3/lib2to3/pgen2/grammar.pyi
+++ b/stdlib/2and3/lib2to3/pgen2/grammar.pyi
@@ -1,6 +1,5 @@
-from typing import Dict, List, Optional, Text, Tuple, TypeVar
-
 from _typeshed import StrPath
+from typing import Dict, List, Optional, Text, Tuple, TypeVar
 
 _P = TypeVar("_P")
 _Label = Tuple[int, Optional[Text]]

--- a/stdlib/2and3/lib2to3/pgen2/pgen.pyi
+++ b/stdlib/2and3/lib2to3/pgen2/pgen.pyi
@@ -1,8 +1,7 @@
+from _typeshed import StrPath
 from lib2to3.pgen2 import grammar
 from lib2to3.pgen2.tokenize import _TokenInfo
 from typing import IO, Any, Dict, Iterable, Iterator, List, NoReturn, Optional, Text, Tuple
-
-from _typeshed import StrPath
 
 class PgenGrammar(grammar.Grammar): ...
 

--- a/stdlib/2and3/logging/__init__.pyi
+++ b/stdlib/2and3/logging/__init__.pyi
@@ -1,5 +1,6 @@
 import sys
 import threading
+from _typeshed import StrPath
 from string import Template
 from time import struct_time
 from types import FrameType, TracebackType
@@ -19,8 +20,6 @@ from typing import (
     Union,
     overload,
 )
-
-from _typeshed import StrPath
 
 _SysExcInfoType = Union[Tuple[type, BaseException, Optional[TracebackType]], Tuple[None, None, None]]
 if sys.version_info >= (3, 5):

--- a/stdlib/2and3/logging/config.pyi
+++ b/stdlib/2and3/logging/config.pyi
@@ -1,8 +1,7 @@
 import sys
+from _typeshed import AnyPath, StrPath
 from threading import Thread
 from typing import IO, Any, Callable, Dict, Optional, Union
-
-from _typeshed import AnyPath, StrPath
 
 if sys.version_info >= (3,):
     from configparser import RawConfigParser

--- a/stdlib/2and3/logging/handlers.pyi
+++ b/stdlib/2and3/logging/handlers.pyi
@@ -1,11 +1,10 @@
 import datetime
 import ssl
 import sys
+from _typeshed import StrPath
 from logging import FileHandler, Handler, LogRecord
 from socket import SocketType
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union, overload
-
-from _typeshed import StrPath
 
 if sys.version_info >= (3, 7):
     from queue import SimpleQueue, Queue

--- a/stdlib/2and3/macpath.pyi
+++ b/stdlib/2and3/macpath.pyi
@@ -3,9 +3,8 @@
 
 import os
 import sys
-from typing import Any, AnyStr, Callable, List, Optional, Sequence, Text, Tuple, TypeVar, Union, overload
-
 from _typeshed import AnyPath, BytesPath, StrPath
+from typing import Any, AnyStr, Callable, List, Optional, Sequence, Text, Tuple, TypeVar, Union, overload
 
 if sys.version_info < (3, 8):
     _T = TypeVar("_T")

--- a/stdlib/2and3/mailbox.pyi
+++ b/stdlib/2and3/mailbox.pyi
@@ -1,4 +1,5 @@
 import email
+from _typeshed import AnyPath
 from types import TracebackType
 from typing import (
     IO,
@@ -21,10 +22,7 @@ from typing import (
     Union,
     overload,
 )
-
 from typing_extensions import Literal
-
-from _typeshed import AnyPath
 
 _T = TypeVar("_T")
 _MessageType = TypeVar("_MessageType", bound=Message)

--- a/stdlib/2and3/mmap.pyi
+++ b/stdlib/2and3/mmap.pyi
@@ -1,7 +1,6 @@
 import sys
-from typing import AnyStr, ContextManager, Generic, Iterable, Iterator, Optional, Sequence, Sized, Union, overload
-
 from _typeshed import ReadableBuffer
+from typing import AnyStr, ContextManager, Generic, Iterable, Iterator, Optional, Sequence, Sized, Union, overload
 
 ACCESS_DEFAULT: int
 ACCESS_READ: int

--- a/stdlib/2and3/msilib/__init__.pyi
+++ b/stdlib/2and3/msilib/__init__.pyi
@@ -1,7 +1,6 @@
 import sys
 from types import ModuleType
 from typing import Any, Container, Dict, Iterable, List, Optional, Sequence, Set, Tuple, Type, Union
-
 from typing_extensions import Literal
 
 if sys.platform == "win32":

--- a/stdlib/2and3/ntpath.pyi
+++ b/stdlib/2and3/ntpath.pyi
@@ -1,10 +1,9 @@
 # NB: path.pyi and stdlib/2 and stdlib/3 must remain consistent!
 import os
 import sys
+from _typeshed import AnyPath, BytesPath, StrPath
 from genericpath import exists as exists
 from typing import Any, AnyStr, Callable, List, Optional, Sequence, Text, Tuple, TypeVar, overload
-
-from _typeshed import AnyPath, BytesPath, StrPath
 
 _T = TypeVar("_T")
 

--- a/stdlib/2and3/parser.pyi
+++ b/stdlib/2and3/parser.pyi
@@ -1,7 +1,6 @@
+from _typeshed import AnyPath
 from types import CodeType
 from typing import Any, List, Sequence, Text, Tuple
-
-from _typeshed import AnyPath
 
 def expr(source: Text) -> STType: ...
 def suite(source: Text) -> STType: ...

--- a/stdlib/2and3/posixpath.pyi
+++ b/stdlib/2and3/posixpath.pyi
@@ -1,10 +1,9 @@
 # NB: path.pyi and stdlib/2 and stdlib/3 must remain consistent!
 import os
 import sys
+from _typeshed import AnyPath, BytesPath, StrPath
 from genericpath import exists as exists
 from typing import Any, AnyStr, Callable, List, Optional, Sequence, Text, Tuple, TypeVar, overload
-
-from _typeshed import AnyPath, BytesPath, StrPath
 
 _T = TypeVar("_T")
 

--- a/stdlib/2and3/profile.pyi
+++ b/stdlib/2and3/profile.pyi
@@ -1,6 +1,5 @@
-from typing import Any, Callable, Dict, Optional, TypeVar, Union
-
 from _typeshed import AnyPath
+from typing import Any, Callable, Dict, Optional, TypeVar, Union
 
 def run(statement: str, filename: Optional[str] = ..., sort: Union[str, int] = ...) -> None: ...
 def runctx(

--- a/stdlib/2and3/pstats.pyi
+++ b/stdlib/2and3/pstats.pyi
@@ -1,8 +1,7 @@
+from _typeshed import AnyPath
 from cProfile import Profile as _cProfile
 from profile import Profile
 from typing import IO, Any, Dict, Iterable, List, Optional, Text, Tuple, TypeVar, Union, overload
-
-from _typeshed import AnyPath
 
 _Selector = Union[str, float, int]
 _T = TypeVar("_T", bound=Stats)

--- a/stdlib/2and3/pydoc.pyi
+++ b/stdlib/2and3/pydoc.pyi
@@ -1,4 +1,5 @@
 import sys
+from _typeshed import SupportsWrite
 from types import FunctionType, MethodType, ModuleType, TracebackType
 from typing import (
     IO,
@@ -17,8 +18,6 @@ from typing import (
     Type,
     Union,
 )
-
-from _typeshed import SupportsWrite
 
 if sys.version_info >= (3,):
     from reprlib import Repr

--- a/stdlib/2and3/pyexpat/__init__.pyi
+++ b/stdlib/2and3/pyexpat/__init__.pyi
@@ -1,8 +1,7 @@
 import pyexpat.errors as errors
 import pyexpat.model as model
-from typing import Any, Callable, Dict, List, Optional, Text, Tuple, Union
-
 from _typeshed import SupportsRead
+from typing import Any, Callable, Dict, List, Optional, Text, Tuple, Union
 
 EXPAT_VERSION: str  # undocumented
 version_info: Tuple[int, int, int]  # undocumented

--- a/stdlib/2and3/select.pyi
+++ b/stdlib/2and3/select.pyi
@@ -1,8 +1,7 @@
 import sys
+from _typeshed import FileDescriptorLike
 from types import TracebackType
 from typing import Any, Iterable, List, Optional, Tuple, Type
-
-from _typeshed import FileDescriptorLike
 
 if sys.platform != "win32":
     PIPE_BUF: int

--- a/stdlib/2and3/shutil.pyi
+++ b/stdlib/2and3/shutil.pyi
@@ -1,5 +1,6 @@
 import os
 import sys
+from _typeshed import StrPath, SupportsRead, SupportsWrite
 from typing import (
     Any,
     AnyStr,
@@ -17,8 +18,6 @@ from typing import (
     Union,
     overload,
 )
-
-from _typeshed import StrPath, SupportsRead, SupportsWrite
 
 if sys.version_info >= (3, 6):
     _AnyStr = str

--- a/stdlib/2and3/sndhdr.pyi
+++ b/stdlib/2and3/sndhdr.pyi
@@ -1,7 +1,6 @@
 import sys
-from typing import NamedTuple, Optional, Tuple, Union
-
 from _typeshed import AnyPath
+from typing import NamedTuple, Optional, Tuple, Union
 
 if sys.version_info >= (3, 5):
     class SndHeaders(NamedTuple):

--- a/stdlib/2and3/socket.pyi
+++ b/stdlib/2and3/socket.pyi
@@ -16,7 +16,6 @@ CPython C source: https://github.com/python/cpython/blob/master/Modules/socketmo
 #   adapted for Python 2.7 by Michal Pokorny
 import sys
 from typing import Any, BinaryIO, Iterable, List, Optional, Text, TextIO, Tuple, TypeVar, Union, overload
-
 from typing_extensions import Literal
 
 # ----- Constants -----

--- a/stdlib/2and3/ssl.pyi
+++ b/stdlib/2and3/ssl.pyi
@@ -1,11 +1,9 @@
 import enum
 import socket
 import sys
-from typing import Any, Callable, ClassVar, Dict, Iterable, List, NamedTuple, Optional, Set, Text, Tuple, Type, Union, overload
-
-from typing_extensions import Literal
-
 from _typeshed import StrPath
+from typing import Any, Callable, ClassVar, Dict, Iterable, List, NamedTuple, Optional, Set, Text, Tuple, Type, Union, overload
+from typing_extensions import Literal
 
 _PCTRTT = Tuple[Tuple[str, str], ...]
 _PCTRTTT = Tuple[_PCTRTT, ...]

--- a/stdlib/2and3/tabnanny.pyi
+++ b/stdlib/2and3/tabnanny.pyi
@@ -1,6 +1,5 @@
-from typing import Iterable, Tuple
-
 from _typeshed import AnyPath
+from typing import Iterable, Tuple
 
 verbose: int
 filename_only: int

--- a/stdlib/2and3/tarfile.pyi
+++ b/stdlib/2and3/tarfile.pyi
@@ -1,8 +1,7 @@
 import sys
+from _typeshed import AnyPath
 from types import TracebackType
 from typing import IO, Callable, Dict, Iterable, Iterator, List, Mapping, Optional, Set, Tuple, Type, Union
-
-from _typeshed import AnyPath
 
 # tar constants
 NUL: bytes

--- a/stdlib/2and3/termios.pyi
+++ b/stdlib/2and3/termios.pyi
@@ -1,6 +1,5 @@
-from typing import List, Union
-
 from _typeshed import FileDescriptorLike
+from typing import List, Union
 
 _Attr = List[Union[int, List[bytes]]]
 

--- a/stdlib/2and3/trace.pyi
+++ b/stdlib/2and3/trace.pyi
@@ -1,7 +1,6 @@
 import types
-from typing import Any, Callable, Mapping, Optional, Sequence, Tuple, TypeVar, Union
-
 from _typeshed import StrPath
+from typing import Any, Callable, Mapping, Optional, Sequence, Tuple, TypeVar, Union
 
 _T = TypeVar("_T")
 _localtrace = Callable[[types.FrameType, str, Any], Callable[..., Any]]

--- a/stdlib/2and3/traceback.pyi
+++ b/stdlib/2and3/traceback.pyi
@@ -1,8 +1,7 @@
 import sys
+from _typeshed import SupportsWrite
 from types import FrameType, TracebackType
 from typing import IO, Any, Dict, Generator, Iterable, Iterator, List, Mapping, Optional, Tuple, Type
-
-from _typeshed import SupportsWrite
 
 _PT = Tuple[str, int, str, Optional[str]]
 

--- a/stdlib/2and3/warnings.pyi
+++ b/stdlib/2and3/warnings.pyi
@@ -1,7 +1,6 @@
 import sys
 from types import ModuleType, TracebackType
 from typing import Any, List, NamedTuple, Optional, TextIO, Type, Union, overload
-
 from typing_extensions import Literal
 
 from _warnings import warn as warn, warn_explicit as warn_explicit

--- a/stdlib/2and3/winsound.pyi
+++ b/stdlib/2and3/winsound.pyi
@@ -1,6 +1,5 @@
 import sys
 from typing import Optional, Union, overload
-
 from typing_extensions import Literal
 
 if sys.platform == "win32":

--- a/stdlib/2and3/wsgiref/validate.pyi
+++ b/stdlib/2and3/wsgiref/validate.pyi
@@ -1,7 +1,6 @@
 import sys
-from typing import Any, Callable, Iterable, Iterator, NoReturn, Optional
-
 from _typeshed.wsgi import ErrorStream, InputStream, WSGIApplication
+from typing import Any, Callable, Iterable, Iterator, NoReturn, Optional
 
 class WSGIWarning(Warning): ...
 

--- a/stdlib/2and3/xml/etree/ElementTree.pyi
+++ b/stdlib/2and3/xml/etree/ElementTree.pyi
@@ -1,4 +1,5 @@
 import sys
+from _typeshed import AnyPath, FileDescriptor, SupportsWrite
 from typing import (
     IO,
     Any,
@@ -19,10 +20,7 @@ from typing import (
     Union,
     overload,
 )
-
 from typing_extensions import Literal
-
-from _typeshed import AnyPath, FileDescriptor, SupportsWrite
 
 VERSION: str
 

--- a/stdlib/2and3/xml/sax/saxutils.pyi
+++ b/stdlib/2and3/xml/sax/saxutils.pyi
@@ -1,10 +1,9 @@
 import sys
+from _typeshed import SupportsWrite
 from codecs import StreamReaderWriter, StreamWriter
 from io import RawIOBase, TextIOBase
 from typing import Mapping, Optional, Text, TextIO, Union
 from xml.sax import handler, xmlreader
-
-from _typeshed import SupportsWrite
 
 def escape(data: Text, entities: Mapping[Text, Text] = ...) -> Text: ...
 def unescape(data: Text, entities: Mapping[Text, Text] = ...) -> Text: ...

--- a/stdlib/2and3/zipfile.pyi
+++ b/stdlib/2and3/zipfile.pyi
@@ -1,5 +1,6 @@
 import io
 import sys
+from _typeshed import StrPath
 from types import TracebackType
 from typing import (
     IO,
@@ -18,8 +19,6 @@ from typing import (
     Type,
     Union,
 )
-
-from _typeshed import StrPath
 
 _SZI = Union[Text, ZipInfo]
 _DT = Tuple[int, int, int, int, int, int]

--- a/stdlib/3/_sitebuiltins.pyi
+++ b/stdlib/3/_sitebuiltins.pyi
@@ -1,5 +1,4 @@
 from typing import ClassVar, Iterable, NoReturn, Optional
-
 from typing_extensions import Literal
 
 class Quitter:

--- a/stdlib/3/_winapi.pyi
+++ b/stdlib/3/_winapi.pyi
@@ -1,6 +1,5 @@
 import sys
 from typing import Any, Dict, NoReturn, Optional, Sequence, Tuple, Union, overload
-
 from typing_extensions import Literal
 
 CREATE_NEW_CONSOLE: int

--- a/stdlib/3/ast.pyi
+++ b/stdlib/3/ast.pyi
@@ -9,7 +9,6 @@
 import sys
 import typing as _typing
 from typing import Any, Iterator, Optional, TypeVar, Union, overload
-
 from typing_extensions import Literal
 
 from _ast import *  # type: ignore

--- a/stdlib/3/asyncio/base_events.pyi
+++ b/stdlib/3/asyncio/base_events.pyi
@@ -1,5 +1,6 @@
 import ssl
 import sys
+from _typeshed import FileDescriptorLike
 from abc import ABCMeta
 from asyncio.events import AbstractEventLoop, AbstractServer, Handle, TimerHandle
 from asyncio.futures import Future
@@ -8,10 +9,7 @@ from asyncio.tasks import Task
 from asyncio.transports import BaseTransport
 from socket import _Address, _RetAddress, socket
 from typing import IO, Any, Awaitable, Callable, Dict, Generator, List, Optional, Sequence, Tuple, TypeVar, Union, overload
-
 from typing_extensions import Literal
-
-from _typeshed import FileDescriptorLike
 
 if sys.version_info >= (3, 7):
     from contextvars import Context

--- a/stdlib/3/asyncio/base_futures.pyi
+++ b/stdlib/3/asyncio/base_futures.pyi
@@ -1,6 +1,5 @@
 import contextvars
 from typing import Callable, List, Sequence, Tuple
-
 from typing_extensions import Literal
 
 from . import futures

--- a/stdlib/3/asyncio/base_tasks.pyi
+++ b/stdlib/3/asyncio/base_tasks.pyi
@@ -1,7 +1,6 @@
+from _typeshed import AnyPath
 from types import FrameType
 from typing import List, Optional
-
-from _typeshed import AnyPath
 
 from . import tasks
 

--- a/stdlib/3/asyncio/events.pyi
+++ b/stdlib/3/asyncio/events.pyi
@@ -1,5 +1,6 @@
 import ssl
 import sys
+from _typeshed import FileDescriptorLike
 from abc import ABCMeta, abstractmethod
 from asyncio.futures import Future
 from asyncio.protocols import BaseProtocol
@@ -8,8 +9,6 @@ from asyncio.transports import BaseTransport
 from asyncio.unix_events import AbstractChildWatcher
 from socket import _Address, _RetAddress, socket
 from typing import IO, Any, Awaitable, Callable, Dict, Generator, List, Optional, Sequence, Tuple, TypeVar, Union, overload
-
-from _typeshed import FileDescriptorLike
 
 if sys.version_info >= (3, 7):
     from contextvars import Context

--- a/stdlib/3/asyncio/proactor_events.pyi
+++ b/stdlib/3/asyncio/proactor_events.pyi
@@ -1,6 +1,5 @@
 from socket import socket
 from typing import Any, Mapping, Optional
-
 from typing_extensions import Literal
 
 from . import base_events, constants, events, futures, streams, transports

--- a/stdlib/3/asyncio/sslproto.pyi
+++ b/stdlib/3/asyncio/sslproto.pyi
@@ -1,7 +1,6 @@
 import ssl
 import sys
 from typing import Any, Callable, ClassVar, Deque, Dict, List, Optional, Tuple
-
 from typing_extensions import Literal
 
 from . import constants, events, futures, protocols, transports

--- a/stdlib/3/asyncio/tasks.pyi
+++ b/stdlib/3/asyncio/tasks.pyi
@@ -17,7 +17,6 @@ from typing import (
     Union,
     overload,
 )
-
 from typing_extensions import Literal
 
 from .events import AbstractEventLoop

--- a/stdlib/3/compileall.pyi
+++ b/stdlib/3/compileall.pyi
@@ -1,7 +1,6 @@
 import sys
-from typing import Any, Optional, Pattern
-
 from _typeshed import AnyPath
+from typing import Any, Optional, Pattern
 
 if sys.version_info < (3, 6):
     _SuccessType = bool

--- a/stdlib/3/configparser.pyi
+++ b/stdlib/3/configparser.pyi
@@ -1,4 +1,5 @@
 import sys
+from _typeshed import AnyPath, StrPath
 from typing import (
     IO,
     AbstractSet,
@@ -20,8 +21,6 @@ from typing import (
     Union,
     overload,
 )
-
-from _typeshed import AnyPath, StrPath
 
 # Internal type aliases
 _section = Mapping[str, str]

--- a/stdlib/3/dbm/__init__.pyi
+++ b/stdlib/3/dbm/__init__.pyi
@@ -1,7 +1,6 @@
 import sys
 from types import TracebackType
 from typing import Iterator, MutableMapping, Optional, Type, Union
-
 from typing_extensions import Literal
 
 _KeyType = Union[str, bytes]

--- a/stdlib/3/faulthandler.pyi
+++ b/stdlib/3/faulthandler.pyi
@@ -1,5 +1,4 @@
 import sys
-
 from _typeshed import FileDescriptorLike
 
 def cancel_dump_traceback_later() -> None: ...

--- a/stdlib/3/fcntl.pyi
+++ b/stdlib/3/fcntl.pyi
@@ -1,9 +1,7 @@
+from _typeshed import FileDescriptorLike
 from array import array
 from typing import Any, Union, overload
-
 from typing_extensions import Literal
-
-from _typeshed import FileDescriptorLike
 
 FASYNC: int
 FD_CLOEXEC: int

--- a/stdlib/3/gettext.pyi
+++ b/stdlib/3/gettext.pyi
@@ -1,9 +1,7 @@
 import sys
-from typing import IO, Any, Container, Iterable, Optional, Sequence, Type, TypeVar, Union, overload
-
-from typing_extensions import Literal
-
 from _typeshed import StrPath
+from typing import IO, Any, Container, Iterable, Optional, Sequence, Type, TypeVar, Union, overload
+from typing_extensions import Literal
 
 class NullTranslations:
     def __init__(self, fp: Optional[IO[str]] = ...) -> None: ...

--- a/stdlib/3/gzip.pyi
+++ b/stdlib/3/gzip.pyi
@@ -1,11 +1,9 @@
 import _compression
 import sys
 import zlib
-from typing import IO, Optional, TextIO, Union, overload
-
-from typing_extensions import Literal
-
 from _typeshed import AnyPath, ReadableBuffer
+from typing import IO, Optional, TextIO, Union, overload
+from typing_extensions import Literal
 
 _OpenBinaryMode = Literal["r", "rb", "a", "ab", "w", "wb", "x", "xb"]
 _OpenTextMode = Literal["rt", "at", "wt", "xt"]

--- a/stdlib/3/hashlib.pyi
+++ b/stdlib/3/hashlib.pyi
@@ -1,9 +1,8 @@
 # Stubs for hashlib
 
 import sys
-from typing import AbstractSet, Optional, Union
-
 from _typeshed import ReadableBuffer
+from typing import AbstractSet, Optional, Union
 
 class _Hash(object):
     digest_size: int

--- a/stdlib/3/http/__init__.pyi
+++ b/stdlib/3/http/__init__.pyi
@@ -1,6 +1,5 @@
 import sys
 from enum import IntEnum
-
 from typing_extensions import Literal
 
 class HTTPStatus(IntEnum):

--- a/stdlib/3/imp.pyi
+++ b/stdlib/3/imp.pyi
@@ -1,6 +1,7 @@
 import os
 import sys
 import types
+from _typeshed import StrPath
 from typing import IO, Any, List, Optional, Tuple, TypeVar, Union
 
 from _imp import (
@@ -14,7 +15,6 @@ from _imp import (
     lock_held as lock_held,
     release_lock as release_lock,
 )
-from _typeshed import StrPath
 
 _T = TypeVar("_T")
 

--- a/stdlib/3/io.pyi
+++ b/stdlib/3/io.pyi
@@ -1,11 +1,10 @@
 import builtins
 import codecs
 import sys
+from _typeshed import ReadableBuffer, WriteableBuffer
 from mmap import mmap
 from types import TracebackType
 from typing import IO, Any, BinaryIO, Callable, Iterable, Iterator, List, Optional, TextIO, Tuple, Type, TypeVar, Union
-
-from _typeshed import ReadableBuffer, WriteableBuffer
 
 DEFAULT_BUFFER_SIZE: int
 

--- a/stdlib/3/json/__init__.pyi
+++ b/stdlib/3/json/__init__.pyi
@@ -1,7 +1,6 @@
 import sys
-from typing import IO, Any, Callable, Dict, List, Optional, Tuple, Type, Union
-
 from _typeshed import SupportsRead
+from typing import IO, Any, Callable, Dict, List, Optional, Tuple, Type, Union
 
 from .decoder import JSONDecodeError as JSONDecodeError, JSONDecoder as JSONDecoder
 from .encoder import JSONEncoder as JSONEncoder

--- a/stdlib/3/lzma.pyi
+++ b/stdlib/3/lzma.pyi
@@ -1,9 +1,7 @@
 import io
-from typing import IO, Any, Mapping, Optional, Sequence, TextIO, TypeVar, Union, overload
-
-from typing_extensions import Literal
-
 from _typeshed import AnyPath, ReadableBuffer
+from typing import IO, Any, Mapping, Optional, Sequence, TextIO, TypeVar, Union, overload
+from typing_extensions import Literal
 
 _OpenBinaryWritingMode = Literal["w", "wb", "x", "xb", "a", "ab"]
 _OpenTextWritingMode = Literal["wt", "xt", "at"]

--- a/stdlib/3/multiprocessing/__init__.pyi
+++ b/stdlib/3/multiprocessing/__init__.pyi
@@ -1,7 +1,7 @@
 import sys
 from ctypes import _CData
 from logging import Logger
-from multiprocessing import connection, pool, sharedctypes, spawn, synchronize, queues
+from multiprocessing import connection, pool, queues, sharedctypes, spawn, synchronize
 from multiprocessing.context import (
     AuthenticationError as AuthenticationError,
     BaseContext,
@@ -16,7 +16,6 @@ from multiprocessing.managers import SyncManager
 from multiprocessing.process import active_children as active_children, current_process as current_process
 from multiprocessing.spawn import freeze_support as freeze_support
 from typing import Any, Callable, Iterable, List, Optional, Sequence, Tuple, Type, Union, overload
-
 from typing_extensions import Literal
 
 if sys.version_info >= (3, 8):

--- a/stdlib/3/multiprocessing/context.pyi
+++ b/stdlib/3/multiprocessing/context.pyi
@@ -4,7 +4,6 @@ from logging import Logger
 from multiprocessing import queues, sharedctypes, synchronize
 from multiprocessing.process import BaseProcess
 from typing import Any, Callable, Iterable, List, Optional, Sequence, Type, Union, overload
-
 from typing_extensions import Literal
 
 _LockLike = Union[synchronize.Lock, synchronize.RLock]

--- a/stdlib/3/os/__init__.pyi
+++ b/stdlib/3/os/__init__.pyi
@@ -1,4 +1,5 @@
 import sys
+from _typeshed import AnyPath
 from builtins import OSError as error
 from io import TextIOWrapper as _TextIOWrapper
 from posix import listdir as listdir, times_result
@@ -24,8 +25,6 @@ from typing import (
     Union,
     overload,
 )
-
-from _typeshed import AnyPath
 
 from . import path as path
 

--- a/stdlib/3/os/path.pyi
+++ b/stdlib/3/os/path.pyi
@@ -1,10 +1,9 @@
 # NB: path.pyi and stdlib/2 and stdlib/3 must remain consistent!
 import os
 import sys
+from _typeshed import AnyPath, BytesPath, StrPath
 from genericpath import exists as exists
 from typing import Any, AnyStr, Callable, List, Optional, Sequence, Text, Tuple, TypeVar, overload
-
-from _typeshed import AnyPath, BytesPath, StrPath
 
 _T = TypeVar("_T")
 

--- a/stdlib/3/pathlib.pyi
+++ b/stdlib/3/pathlib.pyi
@@ -1,9 +1,8 @@
 import os
 import sys
+from _typeshed import OpenBinaryMode, OpenTextMode
 from types import TracebackType
 from typing import IO, Any, BinaryIO, Generator, List, Optional, Sequence, TextIO, Tuple, Type, TypeVar, Union, overload
-
-from _typeshed import OpenBinaryMode, OpenTextMode
 
 _P = TypeVar("_P", bound=PurePath)
 

--- a/stdlib/3/selectors.pyi
+++ b/stdlib/3/selectors.pyi
@@ -1,8 +1,7 @@
 import sys
+from _typeshed import FileDescriptor, FileDescriptorLike
 from abc import ABCMeta, abstractmethod
 from typing import Any, List, Mapping, NamedTuple, Optional, Tuple
-
-from _typeshed import FileDescriptor, FileDescriptorLike
 
 _EventMask = int
 

--- a/stdlib/3/subprocess.pyi
+++ b/stdlib/3/subprocess.pyi
@@ -1,10 +1,8 @@
 import sys
+from _typeshed import AnyPath
 from types import TracebackType
 from typing import IO, Any, AnyStr, Callable, Generic, Mapping, Optional, Sequence, Tuple, Type, TypeVar, Union, overload
-
 from typing_extensions import Literal
-
-from _typeshed import AnyPath
 
 # We prefer to annotate inputs to methods (eg subprocess.check_call) with these
 # union types.

--- a/stdlib/3/tempfile.pyi
+++ b/stdlib/3/tempfile.pyi
@@ -2,7 +2,6 @@ import os
 import sys
 from types import TracebackType
 from typing import IO, Any, AnyStr, Generic, Iterable, Iterator, List, Optional, Tuple, Type, TypeVar, Union, overload
-
 from typing_extensions import Literal
 
 # global variables

--- a/stdlib/3/venv/__init__.pyi
+++ b/stdlib/3/venv/__init__.pyi
@@ -1,8 +1,7 @@
 import sys
+from _typeshed import AnyPath
 from types import SimpleNamespace
 from typing import Optional, Sequence
-
-from _typeshed import AnyPath
 
 class EnvBuilder:
     system_site_packages: bool

--- a/stdlib/3/xmlrpc/client.pyi
+++ b/stdlib/3/xmlrpc/client.pyi
@@ -3,13 +3,11 @@ import http.client
 import io
 import sys
 import time
+from _typeshed import SupportsRead, SupportsWrite
 from datetime import datetime
 from types import TracebackType
 from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Protocol, Tuple, Type, Union, overload
-
 from typing_extensions import Literal
-
-from _typeshed import SupportsRead, SupportsWrite
 
 class _SupportsTimeTuple(Protocol):
     def timetuple(self) -> time.struct_time: ...

--- a/third_party/2/pathlib2.pyi
+++ b/third_party/2/pathlib2.pyi
@@ -1,9 +1,8 @@
 import os
 import sys
+from _typeshed import OpenBinaryMode, OpenTextMode
 from types import TracebackType
 from typing import IO, Any, BinaryIO, Generator, List, Optional, Sequence, TextIO, Tuple, Type, TypeVar, Union, overload
-
-from _typeshed import OpenBinaryMode, OpenTextMode
 
 _P = TypeVar("_P", bound=PurePath)
 

--- a/third_party/2and3/atomicwrites/__init__.pyi
+++ b/third_party/2and3/atomicwrites/__init__.pyi
@@ -1,7 +1,6 @@
 import sys
-from typing import IO, Any, AnyStr, Callable, ContextManager, Generic, Optional, Text, Type, Union
-
 from _typeshed import AnyPath
+from typing import IO, Any, AnyStr, Callable, ContextManager, Generic, Optional, Text, Type, Union
 
 def replace_atomic(src: AnyStr, dst: AnyStr) -> None: ...
 def move_atomic(src: AnyStr, dst: AnyStr) -> None: ...

--- a/third_party/2and3/chardet/universaldetector.pyi
+++ b/third_party/2and3/chardet/universaldetector.pyi
@@ -1,7 +1,6 @@
 import sys
 from logging import Logger
 from typing import Dict, Optional, Pattern
-
 from typing_extensions import TypedDict
 
 class _FinalResultType(TypedDict):

--- a/third_party/2and3/dateutil/easter.pyi
+++ b/third_party/2and3/dateutil/easter.pyi
@@ -1,5 +1,4 @@
 from datetime import date
-
 from typing_extensions import Literal
 
 EASTER_JULIAN: Literal[1]

--- a/third_party/2and3/flask/testing.pyi
+++ b/third_party/2and3/flask/testing.pyi
@@ -6,7 +6,6 @@ from typing import IO, Any, Iterable, Mapping, Optional, Text, TypeVar, Union
 
 from click import BaseCommand
 from click.testing import CliRunner, Result
-
 from werkzeug.test import Client
 
 def make_test_environ_builder(

--- a/third_party/2and3/jinja2/utils.pyi
+++ b/third_party/2and3/jinja2/utils.pyi
@@ -1,8 +1,7 @@
+from _typeshed import AnyPath
 from typing import IO, Any, Callable, Iterable, Optional, Protocol, Text, TypeVar, Union
-
 from typing_extensions import Literal
 
-from _typeshed import AnyPath
 from markupsafe import Markup as Markup, escape as escape, soft_unicode as soft_unicode
 
 missing: Any

--- a/third_party/2and3/toml.pyi
+++ b/third_party/2and3/toml.pyi
@@ -1,8 +1,7 @@
 import datetime
 import sys
-from typing import IO, Any, List, Mapping, MutableMapping, Optional, Text, Type, Union
-
 from _typeshed import StrPath, SupportsWrite
+from typing import IO, Any, List, Mapping, MutableMapping, Optional, Text, Type, Union
 
 if sys.version_info >= (3, 6):
     _PathLike = StrPath

--- a/third_party/2and3/werkzeug/contrib/fixers.pyi
+++ b/third_party/2and3/werkzeug/contrib/fixers.pyi
@@ -1,6 +1,5 @@
-from typing import Any, Iterable, List, Mapping, Optional, Sequence, Set, Text
-
 from _typeshed.wsgi import StartResponse, WSGIApplication, WSGIEnvironment
+from typing import Any, Iterable, List, Mapping, Optional, Sequence, Set, Text
 
 from ..middleware.proxy_fix import ProxyFix as ProxyFix
 

--- a/third_party/2and3/werkzeug/contrib/profiler.pyi
+++ b/third_party/2and3/werkzeug/contrib/profiler.pyi
@@ -1,6 +1,5 @@
-from typing import AnyStr, Generic, Tuple
-
 from _typeshed import SupportsWrite
+from typing import AnyStr, Generic, Tuple
 
 from ..middleware.profiler import *
 

--- a/third_party/2and3/werkzeug/datastructures.pyi
+++ b/third_party/2and3/werkzeug/datastructures.pyi
@@ -1,4 +1,5 @@
 import collections
+from _typeshed import SupportsWrite
 from typing import (
     IO,
     Any,
@@ -20,8 +21,6 @@ from typing import (
     Union,
     overload,
 )
-
-from _typeshed import SupportsWrite
 
 _K = TypeVar("_K")
 _V = TypeVar("_V")

--- a/third_party/2and3/werkzeug/exceptions.pyi
+++ b/third_party/2and3/werkzeug/exceptions.pyi
@@ -1,7 +1,7 @@
 import datetime
+from _typeshed.wsgi import StartResponse, WSGIEnvironment
 from typing import Any, Dict, Iterable, List, NoReturn, Optional, Protocol, Text, Tuple, Type, Union
 
-from _typeshed.wsgi import StartResponse, WSGIEnvironment
 from werkzeug.wrappers import Response
 
 class _EnvironContainer(Protocol):

--- a/third_party/2and3/werkzeug/formparser.pyi
+++ b/third_party/2and3/werkzeug/formparser.pyi
@@ -1,3 +1,4 @@
+from _typeshed.wsgi import WSGIEnvironment
 from typing import (
     IO,
     Any,
@@ -14,8 +15,6 @@ from typing import (
     TypeVar,
     Union,
 )
-
-from _typeshed.wsgi import WSGIEnvironment
 
 from .datastructures import Headers
 

--- a/third_party/2and3/werkzeug/http.pyi
+++ b/third_party/2and3/werkzeug/http.pyi
@@ -1,4 +1,5 @@
 import sys
+from _typeshed.wsgi import WSGIEnvironment
 from datetime import datetime, timedelta
 from typing import (
     Any,
@@ -16,8 +17,6 @@ from typing import (
     Union,
     overload,
 )
-
-from _typeshed.wsgi import WSGIEnvironment
 
 from .datastructures import (
     Accept,

--- a/third_party/2and3/werkzeug/middleware/dispatcher.pyi
+++ b/third_party/2and3/werkzeug/middleware/dispatcher.pyi
@@ -1,6 +1,5 @@
-from typing import Any, Iterable, Mapping, Optional, Text
-
 from _typeshed.wsgi import StartResponse, WSGIApplication, WSGIEnvironment
+from typing import Any, Iterable, Mapping, Optional, Text
 
 class DispatcherMiddleware(object):
     app: WSGIApplication

--- a/third_party/2and3/werkzeug/middleware/http_proxy.pyi
+++ b/third_party/2and3/werkzeug/middleware/http_proxy.pyi
@@ -1,6 +1,5 @@
-from typing import Any, Dict, Iterable, Mapping, MutableMapping, Text
-
 from _typeshed.wsgi import StartResponse, WSGIApplication, WSGIEnvironment
+from typing import Any, Dict, Iterable, Mapping, MutableMapping, Text
 
 _Opts = Mapping[Text, Any]
 _MutableOpts = MutableMapping[Text, Any]

--- a/third_party/2and3/werkzeug/middleware/lint.pyi
+++ b/third_party/2and3/werkzeug/middleware/lint.pyi
@@ -1,8 +1,7 @@
 import sys
-from typing import Any, Iterable, Iterator, List, Mapping, Optional, Protocol, Tuple
-
 from _typeshed import SupportsWrite
 from _typeshed.wsgi import StartResponse, WSGIApplication, WSGIEnvironment
+from typing import Any, Iterable, Iterator, List, Mapping, Optional, Protocol, Tuple
 
 from ..datastructures import Headers
 

--- a/third_party/2and3/werkzeug/middleware/profiler.pyi
+++ b/third_party/2and3/werkzeug/middleware/profiler.pyi
@@ -1,6 +1,5 @@
-from typing import IO, Iterable, List, Optional, Text, Tuple, Union
-
 from _typeshed.wsgi import StartResponse, WSGIApplication, WSGIEnvironment
+from typing import IO, Iterable, List, Optional, Text, Tuple, Union
 
 class ProfilerMiddleware(object):
     def __init__(

--- a/third_party/2and3/werkzeug/middleware/proxy_fix.pyi
+++ b/third_party/2and3/werkzeug/middleware/proxy_fix.pyi
@@ -1,6 +1,5 @@
-from typing import Iterable, Optional
-
 from _typeshed.wsgi import StartResponse, WSGIApplication, WSGIEnvironment
+from typing import Iterable, Optional
 
 class ProxyFix(object):
     app: WSGIApplication

--- a/third_party/2and3/werkzeug/middleware/shared_data.pyi
+++ b/third_party/2and3/werkzeug/middleware/shared_data.pyi
@@ -1,7 +1,6 @@
 import datetime
-from typing import IO, Callable, Iterable, List, Mapping, Optional, Text, Tuple, Union
-
 from _typeshed.wsgi import StartResponse, WSGIApplication, WSGIEnvironment
+from typing import IO, Callable, Iterable, List, Mapping, Optional, Text, Tuple, Union
 
 _V = Union[Tuple[Text, Text], Text]
 

--- a/third_party/2and3/werkzeug/test.pyi
+++ b/third_party/2and3/werkzeug/test.pyi
@@ -1,9 +1,7 @@
 import sys
-from typing import Any, Generic, Optional, Text, Tuple, Type, TypeVar, overload
-
-from typing_extensions import Literal
-
 from _typeshed.wsgi import WSGIEnvironment
+from typing import Any, Generic, Optional, Text, Tuple, Type, TypeVar, overload
+from typing_extensions import Literal
 
 if sys.version_info < (3,):
     from urllib2 import Request as U2Request

--- a/third_party/2and3/werkzeug/wrappers.pyi
+++ b/third_party/2and3/werkzeug/wrappers.pyi
@@ -1,4 +1,5 @@
 import sys
+from _typeshed.wsgi import InputStream, WSGIEnvironment
 from datetime import datetime
 from typing import (
     Any,
@@ -16,10 +17,7 @@ from typing import (
     Union,
     overload,
 )
-
 from typing_extensions import Literal
-
-from _typeshed.wsgi import InputStream, WSGIEnvironment
 
 from .datastructures import (
     Accept,

--- a/third_party/2and3/werkzeug/wsgi.pyi
+++ b/third_party/2and3/werkzeug/wsgi.pyi
@@ -1,7 +1,6 @@
-from typing import Any, Iterable, Optional, Text
-
 from _typeshed import SupportsRead
 from _typeshed.wsgi import InputStream, WSGIEnvironment
+from typing import Any, Iterable, Optional, Text
 
 from .middleware.dispatcher import DispatcherMiddleware as DispatcherMiddleware
 from .middleware.http_proxy import ProxyMiddleware as ProxyMiddleware

--- a/third_party/2and3/yaml/cyaml.pyi
+++ b/third_party/2and3/yaml/cyaml.pyi
@@ -1,6 +1,6 @@
+from _typeshed import SupportsRead
 from typing import IO, Any, Mapping, Optional, Sequence, Text, Union
 
-from _typeshed import SupportsRead
 from yaml.constructor import BaseConstructor, Constructor, SafeConstructor
 from yaml.representer import BaseRepresenter, Representer, SafeRepresenter
 from yaml.resolver import BaseResolver, Resolver

--- a/third_party/3/waitress/trigger.pyi
+++ b/third_party/3/waitress/trigger.pyi
@@ -2,7 +2,6 @@ import sys
 from socket import SocketType
 from threading import Lock
 from typing import Callable, Mapping, Optional
-
 from typing_extensions import Literal
 
 from . import wasyncore as wasyncore


### PR DESCRIPTION
Fixes #4288.

- Default imports to THIRD_PARTY, so in effect we merge the FIRST_PARTY and THIRD_PARTY stubs. This means
  import order is no longer affected by whether typing_extensions is installed locally.
- Treat typing_extensions and _typeshed as standard library modules.

Note that isort master is very different from the latest release; we'll have to do something
different if and when the next isort release comes out.