### PR TITLE
Use ‘exclude list’ instead of ‘blacklist’

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Run using:`(.venv3)$ python3 tests/mypy_test.py`
 
 This test is shallow — it verifies that all stubs can be
 imported but doesn't check whether stubs match their implementation
-(in the Python standard library or a third-party package). It has a blacklist of
+(in the Python standard library or a third-party package). It has an exclude list of
 modules that are not tested at all, which also lives in the tests directory.
 
 If you are in the typeshed repo that is submodule of the

--- a/tests/mypy_test.py
+++ b/tests/mypy_test.py
@@ -39,9 +39,9 @@ def log(args, *varargs):
         print(*varargs)
 
 
-def match(fn, args, blacklist):
-    if blacklist.match(fn):
-        log(args, fn, 'exluded by blacklist')
+def match(fn, args, exclude_list):
+    if exclude_list.match(fn):
+        log(args, fn, 'exluded by exclude list')
         return False
     if not args.filter and not args.exclude:
         log(args, fn, 'accept by default')
@@ -80,8 +80,8 @@ def libpath(major, minor):
 def main():
     args = parser.parse_args()
 
-    with open(os.path.join(os.path.dirname(__file__), "mypy_blacklist.txt")) as f:
-        blacklist = re.compile("(%s)$" % "|".join(
+    with open(os.path.join(os.path.dirname(__file__), "mypy_exclude_list.txt")) as f:
+        exclude_list = re.compile("(%s)$" % "|".join(
             re.findall(r"^\s*([^\s#]+)\s*(?:#.*)?$", f.read(), flags=re.M)))
 
     try:
@@ -112,7 +112,7 @@ def main():
                 if mod in seen or mod.startswith('.'):
                     continue
                 if ext in ['.pyi', '.py']:
-                    if match(full, args, blacklist):
+                    if match(full, args, exclude_list):
                         seen.add(mod)
                         files.append(full)
                 elif (os.path.isfile(os.path.join(full, '__init__.pyi')) or
@@ -124,7 +124,7 @@ def main():
                             m, x = os.path.splitext(f)
                             if x in ['.pyi', '.py']:
                                 fn = os.path.join(r, f)
-                                if match(fn, args, blacklist):
+                                if match(fn, args, exclude_list):
                                     seen.add(mod)
                                     files.append(fn)
         if files:

--- a/tests/pytype_exclude_list.txt
+++ b/tests/pytype_exclude_list.txt
@@ -1,4 +1,4 @@
-# Pytype blacklist. Files will not be tested with pytype.
+# Pytype exclude list. Files will not be tested with pytype.
 
 # pytype has its own version of these files, and thus doesn't mind if it
 # can't parse the typeshed version:

--- a/tests/pytype_test.py
+++ b/tests/pytype_test.py
@@ -4,7 +4,7 @@
 Depends on pytype being installed.
 
 If pytype is installed:
-    1. For every pyi, do nothing if it is in pytype_blacklist.txt.
+    1. For every pyi, do nothing if it is in pytype_exclude_list.txt.
     2. Otherwise, call 'pytype.io.parse_pyi'.
 Option two will load the file and all the builtins, typeshed dependencies. This
 will also discover incorrect usage of imported modules.
@@ -72,8 +72,8 @@ class PathMatcher:
         return self.matcher.search(path)
 
 
-def load_blacklist(typeshed_location: str) -> List[str]:
-    filename = os.path.join(typeshed_location, "tests", "pytype_blacklist.txt")
+def load_exclude_list(typeshed_location: str) -> List[str]:
+    filename = os.path.join(typeshed_location, "tests", "pytype_exclude_list.txt")
     skip_re = re.compile(r"^\s*([^\s#]+)\s*(?:#.*)?$")
     skip = []
 
@@ -159,10 +159,10 @@ def check_python_exes_runnable(*, python27_exe_arg: str, python36_exe_arg: str) 
 
 
 def determine_files_to_test(*, typeshed_location: str, paths: Sequence[str]) -> List[Tuple[str, int]]:
-    """Determine all files to test, checking if it's in the blacklist and which Python versions to use.
+    """Determine all files to test, checking if it's in the exclude list and which Python versions to use.
 
     Returns a list of pairs of the file path and Python version as an int."""
-    skipped = PathMatcher(load_blacklist(typeshed_location))
+    skipped = PathMatcher(load_exclude_list(typeshed_location))
     filenames = find_stubs_in_paths(paths)
     files = []
     for f in sorted(filenames):


### PR DESCRIPTION
This replaces all uses of ‘blacklist’ with ‘exclude list’. Benefits:

- It is racially neutral terminology; see e.g. [1]

- It makes the meaning more clear. In fact, with the popular Python
  autoformatter called ‘black’, also used by this project, files can be
  ‘blackened’ which is something completely different from them being on
  a blacklist.

[1] https://chromium.googlesource.com/chromium/src/+/master/styleguide/inclusive_code.md#racially-neutral