### PR TITLE
Update `test setup` description

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,8 @@ Run:
 ```
 $ python3.6 -m venv .venv3
 $ source .venv3/bin/activate
-(.venv3)$ pip3 install -r requirements-tests-py3.txt
+(.venv3)$ pip install -U pip
+(.venv3)$ pip install -r requirements-tests-py3.txt
 ```
 This will install mypy (you need the latest master branch from GitHub),
 typed-ast, flake8 (and plugins), pytype, black and isort.


### PR DESCRIPTION
The description, as it was, did not work with an older version of pip,
as the installation errored.

e.g. Ubuntu 18.04. ships `pip 9.0.1`, which is too old.

An updated version of pip fixes the installation problem.

modified:   README.md