### PR TITLE
Update unused stubtest whitelist action trigger

### DIFF
--- a/.github/workflows/stubtest-unused-whitelist.yml
+++ b/.github/workflows/stubtest-unused-whitelist.yml
@@ -1,8 +1,9 @@
 name: Find unused stubtest whitelist entries
 
 on:
+  workflow_dispatch:
   schedule:
-    - cron: '0 4 * * *'
+    - cron: '0 4 * * SAT'
 
 jobs:
   stubtest:


### PR DESCRIPTION
Now runs weekly instead of daily, but also add the ability to trigger
manually.

Weekly is a more sensible interval, daily was mainly used for testing. Testing can now more easily be done by triggering actions manually.