### PR TITLE
Fix: TarFile.tarinfo is a Type instead of instance.

### DIFF
--- a/stdlib/2and3/tarfile.pyi
+++ b/stdlib/2and3/tarfile.pyi
@@ -61,7 +61,7 @@ def open(
     bufsize: int = ...,
     *,
     format: Optional[int] = ...,
-    tarinfo: Optional[TarInfo] = ...,
+    tarinfo: Optional[Type[TarInfo]] = ...,
     dereference: Optional[bool] = ...,
     ignore_zeros: Optional[bool] = ...,
     encoding: Optional[str] = ...,
@@ -77,7 +77,7 @@ class TarFile(Iterable[TarInfo]):
     mode: str
     fileobj: Optional[IO[bytes]]
     format: Optional[int]
-    tarinfo: Optional[TarInfo]
+    tarinfo: Type[TarInfo]
     dereference: Optional[bool]
     ignore_zeros: Optional[bool]
     encoding: Optional[str]
@@ -93,7 +93,7 @@ class TarFile(Iterable[TarInfo]):
         mode: str = ...,
         fileobj: Optional[IO[bytes]] = ...,
         format: Optional[int] = ...,
-        tarinfo: Optional[TarInfo] = ...,
+        tarinfo: Optional[Type[TarInfo]] = ...,
         dereference: Optional[bool] = ...,
         ignore_zeros: Optional[bool] = ...,
         encoding: Optional[str] = ...,
@@ -117,7 +117,7 @@ class TarFile(Iterable[TarInfo]):
         bufsize: int = ...,
         *,
         format: Optional[int] = ...,
-        tarinfo: Optional[TarInfo] = ...,
+        tarinfo: Optional[Type[TarInfo]] = ...,
         dereference: Optional[bool] = ...,
         ignore_zeros: Optional[bool] = ...,
         encoding: Optional[str] = ...,


### PR DESCRIPTION
``TarFile.tarinfo`` should be a type, not an instance.

Fixes:
```python
import tarfile


class CustomTarInfo(tarfile.TarInfo):
    pass

if __name__ == '__main__':
    tarfile.TarFile(tarinfo=CustomTarInfo)
```

which causes:
```
test.py:8: error: Argument "tarinfo" to "TarFile" has incompatible type "Type[CustomTarInfo]"; expected "Optional[TarInfo]"
```