### PR TITLE
Update orjson.pyi

### DIFF
--- a/third_party/3/orjson.pyi
+++ b/third_party/3/orjson.pyi
@@ -2,16 +2,23 @@ from typing import Any, Callable, Optional, Union
 
 __version__ = str
 
-def dumps(__obj: Any, default: Optional[Callable[[Any], Any]] = ..., option: Optional[int] = ...,) -> bytes: ...
+def dumps(
+    __obj: Any,
+    default: Optional[Callable[[Any], Any]] = ...,
+    option: Optional[int] = ...,
+) -> bytes: ...
 def loads(__obj: Union[bytes, bytearray, str]) -> Any: ...
 
 class JSONDecodeError(ValueError): ...
 class JSONEncodeError(TypeError): ...
 
+OPT_APPEND_NEWLINE: int
 OPT_INDENT_2: int
 OPT_NAIVE_UTC: int
 OPT_NON_STR_KEYS: int
 OPT_OMIT_MICROSECONDS: int
+OPT_PASSTHROUGH_DATETIME: int
+OPT_PASSTHROUGH_SUBCLASS: int
 OPT_SERIALIZE_DATACLASS: int
 OPT_SERIALIZE_NUMPY: int
 OPT_SERIALIZE_UUID: int


### PR DESCRIPTION
This PR updates orjson stub file to the latest that can be found in `orjson` repo - [here](https://github.com/ijl/orjson/blob/master/orjson.pyi)