### PR TITLE
Small cryptography fix

### DIFF
--- a/third_party/2and3/cryptography/x509.pyi
+++ b/third_party/2and3/cryptography/x509.pyi
@@ -14,8 +14,8 @@ from cryptography.hazmat.primitives.hashes import HashAlgorithm
 from cryptography.hazmat.primitives.serialization import Encoding
 
 class ObjectIdentifier(object):
+    dotted_string: str
     def __init__(self, dotted_string: str) -> None: ...
-    def dotted_string(self) -> str: ...
 
 class CRLEntryExtensionOID(object):
     CERTIFICATE_ISSUER: ClassVar[ObjectIdentifier]


### PR DESCRIPTION
A small fix for the cryptography library:

`dotted_string` on `x509.ObjectIdentifier`  is a string property, not a method:

https://cryptography.io/en/latest/x509/reference/?highlight=ObjectIdentifier#cryptography.x509.ObjectIdentifier

The problem:
```
from cryptography import x509


def get_extension_name(oid: x509.ObjectIdentifier):
    oid_names = {"1.2.3": "testname"}
    return oid_names[oid.dotted_string]
```

```
testulf.py:6: error: Invalid index type "Callable[[], str]" for "Dict[str, str]"; expected type "str"
```