### PR TITLE
[requests] Add _content to Response

### DIFF
--- a/third_party/2and3/requests/models.pyi
+++ b/third_party/2and3/requests/models.pyi
@@ -91,6 +91,7 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
 
 class Response:
     __attrs__: Any
+    _content: Optional[bytes]  # undocumented
     status_code: int
     headers: CaseInsensitiveDict[str]
     raw: Any


### PR DESCRIPTION
`requests` module defines `_content` as https://github.com/psf/requests/blob/8149e9fe54c36951290f198e90d83c8a0498289c/requests/models.py#L819-L836 and `pyre` was complaining about this missing

```
def foo(...) -> None:
    response = requests.Response()
    # pyre-fixme[16]: `Response` has no attribute `_content`.
    response._content = content
```