### PR TITLE
support pathlib.Path and other StrPaths in TarFile.add starting at python 3.6

### DIFF
--- a/stdlib/2and3/tarfile.pyi
+++ b/stdlib/2and3/tarfile.pyi
@@ -1,5 +1,5 @@
 import sys
-from _typeshed import AnyPath
+from _typeshed import AnyPath, StrPath
 from types import TracebackType
 from typing import IO, Callable, Dict, Iterable, Iterator, List, Mapping, Optional, Set, Tuple, Type, Union
 
@@ -159,12 +159,25 @@ class TarFile(Iterable[TarInfo]):
         def chown(self, tarinfo: TarInfo, targetpath: AnyPath) -> None: ...  # undocumented
     def chmod(self, tarinfo: TarInfo, targetpath: AnyPath) -> None: ...  # undocumented
     def utime(self, tarinfo: TarInfo, targetpath: AnyPath) -> None: ...  # undocumented
+    # 3.7: exclude removed
+    # 3.6: any StrPath works instead of just str (not documented)
     if sys.version_info >= (3, 7):
         def add(
             self,
-            name: str,
-            arcname: Optional[str] = ...,
+            # name and arcname get converted to str in gettarinfo(), which needs str for using os.sep
+            name: StrPath,
+            arcname: Optional[StrPath] = ...,
             recursive: bool = ...,
+            *,
+            filter: Optional[Callable[[TarInfo], Optional[TarInfo]]] = ...,
+        ) -> None: ...
+    elif sys.version_info >= (3, 6):
+        def add(
+            self,
+            name: StrPath,
+            arcname: Optional[StrPath] = ...,
+            recursive: bool = ...,
+            exclude: Optional[Callable[[str], bool]] = ...,
             *,
             filter: Optional[Callable[[TarInfo], Optional[TarInfo]]] = ...,
         ) -> None: ...


### PR DESCRIPTION
fixes #4368 