### PR TITLE
Add select.epoll.register to stubtest whitelist

### DIFF
--- a/tests/stubtest_whitelists/py38.txt
+++ b/tests/stubtest_whitelists/py38.txt
@@ -70,6 +70,7 @@ pickle.Pickler.reducer_override
 platform.DEV_NULL
 queue.SimpleQueue.__init__
 secrets.SystemRandom.getstate
+select.epoll.register
 smtplib.SMTP.sendmail
 sre_constants.RANGE_IGNORE
 ssl.PROTOCOL_SSLv3


### PR DESCRIPTION
@hauntsaninja It looks this was caused by GitHub Actions upgrade from Python 3.8.4 to 3.8.5. This is one change that might be relevant:

```
-"register($self, fd, eventmask=POLLIN | POLLPRI | POLLOUT, /)\n"
+"register($self, fd,\n"
+"         eventmask=select.POLLIN | select.POLLPRI | select.POLLOUT, /)\n"
```

(Repeated a few times.)