### PR TITLE
Removed imported symbols that are not accessed or re-exported (third_party part 1 of 4)

### DIFF
--- a/third_party/2and3/Crypto/Cipher/AES.pyi
+++ b/third_party/2and3/Crypto/Cipher/AES.pyi
@@ -1,4 +1,4 @@
-from typing import Any, Text, Union
+from typing import Text, Union
 
 from .blockalgo import BlockAlgo
 

--- a/third_party/2and3/Crypto/Cipher/ARC2.pyi
+++ b/third_party/2and3/Crypto/Cipher/ARC2.pyi
@@ -1,4 +1,4 @@
-from typing import Any, Text, Union
+from typing import Text, Union
 
 from .blockalgo import BlockAlgo
 

--- a/third_party/2and3/Crypto/Cipher/ARC4.pyi
+++ b/third_party/2and3/Crypto/Cipher/ARC4.pyi
@@ -1,4 +1,4 @@
-from typing import Any, Text, Union
+from typing import Text, Union
 
 __revision__: str
 

--- a/third_party/2and3/Crypto/Cipher/DES.pyi
+++ b/third_party/2and3/Crypto/Cipher/DES.pyi
@@ -1,4 +1,4 @@
-from typing import Any, Text, Union
+from typing import Text, Union
 
 from .blockalgo import BlockAlgo
 

--- a/third_party/2and3/Crypto/Cipher/XOR.pyi
+++ b/third_party/2and3/Crypto/Cipher/XOR.pyi
@@ -1,4 +1,4 @@
-from typing import Any, Text, Union
+from typing import Text, Union
 
 __revision__: str
 

--- a/third_party/2and3/atomicwrites/__init__.pyi
+++ b/third_party/2and3/atomicwrites/__init__.pyi
@@ -1,6 +1,5 @@
-import sys
 from _typeshed import AnyPath
-from typing import IO, Any, AnyStr, Callable, ContextManager, Generic, Optional, Text, Type, Union
+from typing import IO, Any, AnyStr, Callable, ContextManager, Optional, Text, Type
 
 def replace_atomic(src: AnyStr, dst: AnyStr) -> None: ...
 def move_atomic(src: AnyStr, dst: AnyStr) -> None: ...

--- a/third_party/2and3/bleach/sanitizer.pyi
+++ b/third_party/2and3/bleach/sanitizer.pyi
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Container, Dict, Iterable, List, Optional, Pattern, Text, Type, Union
+from typing import Any, Callable, Container, Dict, Iterable, List, Optional, Pattern, Text, Union
 
 ALLOWED_TAGS: List[Text]
 ALLOWED_ATTRIBUTES: Dict[Text, List[Text]]

--- a/third_party/2and3/boto/compat.pyi
+++ b/third_party/2and3/boto/compat.pyi
@@ -1,8 +1,6 @@
 import sys
 from typing import Any
 
-from six.moves import http_client
-
 if sys.version_info >= (3,):
     from base64 import encodebytes as encodebytes
 else:

--- a/third_party/2and3/boto/connection.pyi
+++ b/third_party/2and3/boto/connection.pyi
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Text
+from typing import Any, Optional
 
 from six.moves import http_client
 

--- a/third_party/2and3/boto/s3/bucketlistresultset.pyi
+++ b/third_party/2and3/boto/s3/bucketlistresultset.pyi
@@ -1,6 +1,5 @@
 from typing import Any, Iterable, Iterator, Optional
 
-from .bucket import Bucket
 from .key import Key
 
 def bucket_lister(

--- a/third_party/2and3/chardet/universaldetector.pyi
+++ b/third_party/2and3/chardet/universaldetector.pyi
@@ -1,4 +1,3 @@
-import sys
 from logging import Logger
 from typing import Dict, Optional, Pattern
 from typing_extensions import TypedDict

--- a/third_party/2and3/click/_termui_impl.pyi
+++ b/third_party/2and3/click/_termui_impl.pyi
@@ -1,4 +1,4 @@
-from typing import ContextManager, Generic, Iterator, Optional, TypeVar
+from typing import Generic, Optional, TypeVar
 
 _T = TypeVar("_T")
 

--- a/third_party/2and3/click/core.pyi
+++ b/third_party/2and3/click/core.pyi
@@ -3,7 +3,6 @@ from typing import (
     Callable,
     ContextManager,
     Dict,
-    Generator,
     Iterable,
     List,
     Mapping,

--- a/third_party/2and3/click/termui.pyi
+++ b/third_party/2and3/click/termui.pyi
@@ -1,4 +1,4 @@
-from typing import IO, Any, Callable, Generator, Iterable, List, Optional, Text, Tuple, TypeVar, Union, overload
+from typing import IO, Any, Callable, Generator, Iterable, Optional, Text, Tuple, TypeVar, Union, overload
 
 from click._termui_impl import ProgressBar as _ProgressBar
 from click.core import _ConvertibleType

--- a/third_party/2and3/click/testing.pyi
+++ b/third_party/2and3/click/testing.pyi
@@ -1,4 +1,4 @@
-from typing import IO, Any, BinaryIO, ContextManager, Dict, Iterable, List, Mapping, Optional, Text, Tuple, Union
+from typing import IO, Any, BinaryIO, ContextManager, Dict, Iterable, List, Mapping, Optional, Text, Union
 
 from .core import BaseCommand
 

--- a/third_party/2and3/click/utils.pyi
+++ b/third_party/2and3/click/utils.pyi
@@ -1,4 +1,4 @@
-from typing import IO, Any, AnyStr, Callable, Generic, Iterator, List, Optional, Text, TypeVar, Union
+from typing import IO, Any, AnyStr, Generic, Iterator, List, Optional, Text, TypeVar
 
 _T = TypeVar("_T")
 

--- a/third_party/2and3/cryptography/hazmat/primitives/asymmetric/utils.pyi
+++ b/third_party/2and3/cryptography/hazmat/primitives/asymmetric/utils.pyi
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple
+from typing import Tuple
 
 from cryptography.hazmat.primitives.hashes import HashAlgorithm
 

--- a/third_party/2and3/cryptography/hazmat/primitives/poly1305.pyi
+++ b/third_party/2and3/cryptography/hazmat/primitives/poly1305.pyi
@@ -1,6 +1,3 @@
-from cryptography.hazmat.backends.interfaces import HMACBackend
-from cryptography.hazmat.primitives.hashes import HashAlgorithm
-
 class Poly1305(object):
     def __init__(self, key: bytes) -> None: ...
     def finalize(self) -> bytes: ...

--- a/third_party/2and3/datetimerange/__init__.pyi
+++ b/third_party/2and3/datetimerange/__init__.pyi
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any, Iterable, Optional, Union
+from typing import Iterable, Optional, Union
 
 from dateutil.relativedelta import relativedelta
 

--- a/third_party/2and3/dateutil/parser.pyi
+++ b/third_party/2and3/dateutil/parser.pyi
@@ -1,5 +1,5 @@
 from datetime import datetime, tzinfo
-from typing import IO, Any, Callable, Dict, List, Mapping, Optional, Text, Tuple, Union
+from typing import IO, Any, Dict, List, Mapping, Optional, Text, Tuple, Union
 
 _FileOrStr = Union[bytes, Text, IO[str], IO[Any]]
 

--- a/third_party/2and3/dateutil/relativedelta.pyi
+++ b/third_party/2and3/dateutil/relativedelta.pyi
@@ -1,5 +1,5 @@
 from datetime import date, datetime, timedelta
-from typing import Any, List, Optional, SupportsFloat, TypeVar, Union, overload
+from typing import Optional, SupportsFloat, TypeVar, Union, overload
 
 from ._common import weekday
 

--- a/third_party/2and3/singledispatch.pyi
+++ b/third_party/2and3/singledispatch.pyi
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Generic, Mapping, Optional, TypeVar, overload
+from typing import Any, Callable, Generic, Mapping, TypeVar, overload
 
 _T = TypeVar("_T")
 

--- a/third_party/2and3/toml.pyi
+++ b/third_party/2and3/toml.pyi
@@ -1,7 +1,6 @@
-import datetime
 import sys
 from _typeshed import StrPath, SupportsWrite
-from typing import IO, Any, List, Mapping, MutableMapping, Optional, Text, Type, Union
+from typing import IO, Any, List, Mapping, MutableMapping, Text, Type, Union
 
 if sys.version_info >= (3, 6):
     _PathLike = StrPath

--- a/third_party/2and3/ujson.pyi
+++ b/third_party/2and3/ujson.pyi
@@ -1,6 +1,6 @@
 # Stubs for ujson
 # See: https://pypi.python.org/pypi/ujson
-from typing import IO, Any, AnyStr, Optional
+from typing import IO, Any, AnyStr
 
 __version__: str
 


### PR DESCRIPTION
Removed imported symbols that are not accessed or re-exported from within third_party stubs (part 1 of 4). These were all identified as unused symbols by the pyright type checker and language server.