### PR TITLE
Removed imported symbols that are not accessed or re-exported (third_party part 2 of 4)

### DIFF
--- a/third_party/2and3/flask/app.pyi
+++ b/third_party/2and3/flask/app.pyi
@@ -22,24 +22,11 @@ from typing import (
 )
 
 from .blueprints import Blueprint
-from .config import Config, ConfigAttribute
-from .ctx import AppContext, RequestContext, _AppCtxGlobals
-from .helpers import (
-    _PackageBoundObject,
-    find_package,
-    get_debug_flag,
-    get_env,
-    get_flashed_messages,
-    get_load_dotenv,
-    locked_cached_property,
-    url_for,
-)
-from .logging import create_logger
-from .sessions import SecureCookieSessionInterface
-from .signals import appcontext_tearing_down, got_request_exception, request_finished, request_started, request_tearing_down
-from .templating import DispatchingJinjaLoader, Environment
+from .config import Config
+from .ctx import AppContext, RequestContext
+from .helpers import _PackageBoundObject
 from .testing import FlaskClient
-from .wrappers import Request, Response
+from .wrappers import Response
 
 def setupmethod(f: Any): ...
 

--- a/third_party/2and3/flask/cli.pyi
+++ b/third_party/2and3/flask/cli.pyi
@@ -6,9 +6,6 @@ from typing import Any, Optional
 
 import click
 
-from .globals import current_app
-from .helpers import get_debug_flag, get_env, get_load_dotenv
-
 class NoAppException(click.UsageError): ...
 
 def find_best_app(script_info: Any, module: Any): ...

--- a/third_party/2and3/flask/ctx.pyi
+++ b/third_party/2and3/flask/ctx.pyi
@@ -4,9 +4,6 @@
 
 from typing import Any, Optional
 
-from .globals import _app_ctx_stack, _request_ctx_stack
-from .signals import appcontext_popped, appcontext_pushed
-
 class _AppCtxGlobals:
     def get(self, name: Any, default: Optional[Any] = ...): ...
     def pop(self, name: Any, default: Any = ...): ...

--- a/third_party/2and3/flask/debughelpers.pyi
+++ b/third_party/2and3/flask/debughelpers.pyi
@@ -4,10 +4,6 @@
 
 from typing import Any
 
-from .app import Flask
-from .blueprints import Blueprint
-from .globals import _request_ctx_stack
-
 class UnexpectedUnicodeError(AssertionError, UnicodeError): ...
 
 class DebugFilesKeyError(KeyError, AssertionError):

--- a/third_party/2and3/flask/helpers.pyi
+++ b/third_party/2and3/flask/helpers.pyi
@@ -5,8 +5,6 @@
 from typing import Any, Optional
 
 from .cli import AppGroup
-from .globals import _app_ctx_stack, _request_ctx_stack, current_app, request, session
-from .signals import message_flashed
 from .wrappers import Response
 
 def get_env(): ...

--- a/third_party/2and3/flask/logging.pyi
+++ b/third_party/2and3/flask/logging.pyi
@@ -4,8 +4,6 @@
 
 from typing import Any
 
-from .globals import request
-
 def wsgi_errors_stream(): ...
 def has_level_handler(logger: Any): ...
 

--- a/third_party/2and3/flask/templating.pyi
+++ b/third_party/2and3/flask/templating.pyi
@@ -6,9 +6,6 @@ from typing import Any, Iterable, Text, Union
 
 from jinja2 import BaseLoader, Environment as BaseEnvironment
 
-from .globals import _app_ctx_stack, _request_ctx_stack
-from .signals import before_render_template, template_rendered
-
 class Environment(BaseEnvironment):
     app: Any = ...
     def __init__(self, app: Any, **options: Any) -> None: ...

--- a/third_party/2and3/flask/views.pyi
+++ b/third_party/2and3/flask/views.pyi
@@ -4,8 +4,6 @@
 
 from typing import Any
 
-from .globals import request
-
 http_method_funcs: Any
 
 class View:

--- a/third_party/2and3/google/protobuf/descriptor_pb2.pyi
+++ b/third_party/2and3/google/protobuf/descriptor_pb2.pyi
@@ -1,4 +1,4 @@
-from typing import Iterable, List, Optional, Text, Tuple, cast
+from typing import Iterable, List, Optional, Text, Tuple
 
 from google.protobuf.internal.containers import RepeatedCompositeFieldContainer, RepeatedScalarFieldContainer
 from google.protobuf.message import Message

--- a/third_party/2and3/google/protobuf/internal/containers.pyi
+++ b/third_party/2and3/google/protobuf/internal/containers.pyi
@@ -1,7 +1,6 @@
 from typing import (
     Any,
     Callable,
-    Generic,
     Iterable,
     Iterator,
     List,
@@ -17,7 +16,6 @@ from typing import (
 from google.protobuf.descriptor import Descriptor
 from google.protobuf.internal.message_listener import MessageListener
 from google.protobuf.internal.python_message import GeneratedProtocolMessageType
-from google.protobuf.message import Message
 
 _T = TypeVar("_T")
 _K = TypeVar("_K")

--- a/third_party/2and3/google/protobuf/internal/enum_type_wrapper.pyi
+++ b/third_party/2and3/google/protobuf/internal/enum_type_wrapper.pyi
@@ -1,4 +1,4 @@
-from typing import Any, Generic, List, Tuple, TypeVar
+from typing import Generic, List, Tuple, TypeVar
 
 from google.protobuf.descriptor import EnumDescriptor
 

--- a/third_party/2and3/google/protobuf/json_format.pyi
+++ b/third_party/2and3/google/protobuf/json_format.pyi
@@ -1,4 +1,3 @@
-import sys
 from typing import Any, Dict, Text, TypeVar, Union
 
 from google.protobuf.message import Message

--- a/third_party/2and3/google/protobuf/map_proto2_unittest_pb2.pyi
+++ b/third_party/2and3/google/protobuf/map_proto2_unittest_pb2.pyi
@@ -1,4 +1,4 @@
-from typing import List, Mapping, MutableMapping, Optional, Text, Tuple, cast
+from typing import List, Mapping, MutableMapping, Optional, Text, Tuple
 
 from google.protobuf.message import Message
 from google.protobuf.unittest_import_pb2 import ImportEnumForMap

--- a/third_party/2and3/google/protobuf/map_unittest_pb2.pyi
+++ b/third_party/2and3/google/protobuf/map_unittest_pb2.pyi
@@ -1,4 +1,4 @@
-from typing import List, Mapping, MutableMapping, Optional, Text, Tuple, cast
+from typing import List, Mapping, MutableMapping, Optional, Text, Tuple
 
 from google.protobuf.message import Message
 from google.protobuf.unittest_no_arena_pb2 import ForeignMessage

--- a/third_party/2and3/google/protobuf/message.pyi
+++ b/third_party/2and3/google/protobuf/message.pyi
@@ -1,5 +1,5 @@
 import sys
-from typing import Any, ByteString, Optional, Sequence, Tuple, Type, TypeVar, Union
+from typing import Any, ByteString, Sequence, Tuple, Type, TypeVar, Union
 
 from .descriptor import Descriptor, DescriptorBase, FieldDescriptor
 

--- a/third_party/2and3/google/protobuf/struct_pb2.pyi
+++ b/third_party/2and3/google/protobuf/struct_pb2.pyi
@@ -1,4 +1,4 @@
-from typing import Iterable, List, Mapping, MutableMapping, Optional, Text, Tuple, cast
+from typing import Iterable, List, Mapping, MutableMapping, Optional, Text, Tuple
 
 from google.protobuf.internal import well_known_types
 from google.protobuf.internal.containers import RepeatedCompositeFieldContainer

--- a/third_party/2and3/google/protobuf/test_messages_proto2_pb2.pyi
+++ b/third_party/2and3/google/protobuf/test_messages_proto2_pb2.pyi
@@ -1,5 +1,4 @@
-import builtins
-from typing import Iterable, List, Mapping, MutableMapping, Optional, Text, Tuple, cast
+from typing import Iterable, List, Mapping, MutableMapping, Optional, Text, Tuple
 
 from google.protobuf.internal.containers import RepeatedCompositeFieldContainer, RepeatedScalarFieldContainer
 from google.protobuf.message import Message

--- a/third_party/2and3/google/protobuf/test_messages_proto3_pb2.pyi
+++ b/third_party/2and3/google/protobuf/test_messages_proto3_pb2.pyi
@@ -1,4 +1,4 @@
-from typing import Iterable, List, Mapping, MutableMapping, Optional, Text, Tuple, cast
+from typing import Iterable, List, Mapping, MutableMapping, Optional, Text, Tuple
 
 from google.protobuf.any_pb2 import Any
 from google.protobuf.duration_pb2 import Duration

--- a/third_party/2and3/google/protobuf/type_pb2.pyi
+++ b/third_party/2and3/google/protobuf/type_pb2.pyi
@@ -1,4 +1,4 @@
-from typing import Iterable, List, Optional, Text, Tuple, cast
+from typing import Iterable, List, Optional, Text, Tuple
 
 from google.protobuf.any_pb2 import Any
 from google.protobuf.internal.containers import RepeatedCompositeFieldContainer, RepeatedScalarFieldContainer

--- a/third_party/2and3/google/protobuf/unittest_custom_options_pb2.pyi
+++ b/third_party/2and3/google/protobuf/unittest_custom_options_pb2.pyi
@@ -1,4 +1,4 @@
-from typing import Iterable, List, Optional, Text, Tuple, cast
+from typing import Iterable, List, Optional, Text, Tuple
 
 from google.protobuf.descriptor_pb2 import FileOptions
 from google.protobuf.internal.containers import RepeatedCompositeFieldContainer, RepeatedScalarFieldContainer

--- a/third_party/2and3/google/protobuf/unittest_import_pb2.pyi
+++ b/third_party/2and3/google/protobuf/unittest_import_pb2.pyi
@@ -1,4 +1,4 @@
-from typing import List, Optional, Tuple, cast
+from typing import List, Optional, Tuple
 
 from google.protobuf.message import Message
 

--- a/third_party/2and3/google/protobuf/unittest_mset_pb2.pyi
+++ b/third_party/2and3/google/protobuf/unittest_mset_pb2.pyi
@@ -1,4 +1,3 @@
-import builtins
 from typing import Iterable, Optional, Text
 
 from google.protobuf.internal.containers import RepeatedCompositeFieldContainer

--- a/third_party/2and3/google/protobuf/unittest_no_arena_pb2.pyi
+++ b/third_party/2and3/google/protobuf/unittest_no_arena_pb2.pyi
@@ -1,4 +1,4 @@
-from typing import Iterable, List, Optional, Text, Tuple, cast
+from typing import Iterable, List, Optional, Text, Tuple
 
 from google.protobuf.internal.containers import RepeatedCompositeFieldContainer, RepeatedScalarFieldContainer
 from google.protobuf.message import Message

--- a/third_party/2and3/google/protobuf/unittest_no_generic_services_pb2.pyi
+++ b/third_party/2and3/google/protobuf/unittest_no_generic_services_pb2.pyi
@@ -1,4 +1,4 @@
-from typing import List, Optional, Tuple, cast
+from typing import List, Optional, Tuple
 
 from google.protobuf.message import Message
 

--- a/third_party/2and3/google/protobuf/unittest_pb2.pyi
+++ b/third_party/2and3/google/protobuf/unittest_pb2.pyi
@@ -1,4 +1,4 @@
-from typing import Iterable, List, Mapping, MutableMapping, Optional, Text, Tuple, cast
+from typing import Iterable, List, Mapping, MutableMapping, Optional, Text, Tuple
 
 from google.protobuf.internal.containers import RepeatedCompositeFieldContainer, RepeatedScalarFieldContainer
 from google.protobuf.message import Message

--- a/third_party/2and3/google/protobuf/unittest_proto3_arena_pb2.pyi
+++ b/third_party/2and3/google/protobuf/unittest_proto3_arena_pb2.pyi
@@ -1,4 +1,4 @@
-from typing import Iterable, List, Optional, Text, Tuple, cast
+from typing import Iterable, List, Optional, Text, Tuple
 
 from google.protobuf.internal.containers import RepeatedCompositeFieldContainer, RepeatedScalarFieldContainer
 from google.protobuf.message import Message

--- a/third_party/2and3/google/protobuf/util/json_format_proto3_pb2.pyi
+++ b/third_party/2and3/google/protobuf/util/json_format_proto3_pb2.pyi
@@ -1,4 +1,4 @@
-from typing import Iterable, List, Mapping, MutableMapping, Optional, Text, Tuple, cast
+from typing import Iterable, List, Mapping, MutableMapping, Optional, Text, Tuple
 
 from google.protobuf.any_pb2 import Any
 from google.protobuf.duration_pb2 import Duration

--- a/third_party/2and3/jinja2/_compat.pyi
+++ b/third_party/2and3/jinja2/_compat.pyi
@@ -2,10 +2,8 @@ import sys
 from typing import Any, Optional
 
 if sys.version_info[0] >= 3:
-    from io import BytesIO
     from urllib.parse import quote_from_bytes as url_quote
 else:
-    from cStringIO import StringIO as BytesIO
     from urllib import quote as url_quote
 
 PY2: Any


### PR DESCRIPTION
Removed imported symbols that are not accessed or re-exported within third_party stubs (part 2 of 4). These were all identified as unused symbols by the pyright type checker and language server.