### PR TITLE
Removed imported symbols that are not accessed or re-exported (third_party part 3 of 4)

### DIFF
--- a/third_party/2and3/markupsafe/__init__.pyi
+++ b/third_party/2and3/markupsafe/__init__.pyi
@@ -1,7 +1,7 @@
 import string
 import sys
 from collections import Mapping
-from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Text, Tuple, Union
+from typing import Any, Callable, Iterable, List, Optional, Sequence, Text, Tuple, Union
 
 from markupsafe._compat import text_type
 from markupsafe._native import escape as escape, escape_silent as escape_silent, soft_unicode as soft_unicode

--- a/third_party/2and3/markupsafe/_compat.pyi
+++ b/third_party/2and3/markupsafe/_compat.pyi
@@ -1,5 +1,5 @@
 import sys
-from typing import Any, Iterator, Mapping, Text, Tuple, TypeVar
+from typing import Iterator, Mapping, Tuple, TypeVar
 
 _K = TypeVar("_K")
 _V = TypeVar("_V")

--- a/third_party/2and3/markupsafe/_constants.pyi
+++ b/third_party/2and3/markupsafe/_constants.pyi
@@ -1,3 +1,3 @@
-from typing import Any, Dict, Text
+from typing import Dict, Text
 
 HTML_ENTITIES: Dict[Text, int]

--- a/third_party/2and3/markupsafe/_native.pyi
+++ b/third_party/2and3/markupsafe/_native.pyi
@@ -1,7 +1,7 @@
 from typing import Text, Union
 
 from . import Markup
-from ._compat import string_types, text_type
+from ._compat import text_type
 
 def escape(s: Union[Markup, Text]) -> Markup: ...
 def escape_silent(s: Union[None, Markup, Text]) -> Markup: ...

--- a/third_party/2and3/markupsafe/_speedups.pyi
+++ b/third_party/2and3/markupsafe/_speedups.pyi
@@ -1,7 +1,7 @@
 from typing import Text, Union
 
 from . import Markup
-from ._compat import string_types, text_type
+from ._compat import text_type
 
 def escape(s: Union[Markup, Text]) -> Markup: ...
 def escape_silent(s: Union[None, Markup, Text]) -> Markup: ...

--- a/third_party/2and3/maxminddb/compat.pyi
+++ b/third_party/2and3/maxminddb/compat.pyi
@@ -1,4 +1,3 @@
-from ipaddress import IPv4Address, IPv6Address
 from typing import Any
 
 def compat_ip_address(address: object) -> Any: ...

--- a/third_party/2and3/nmap/nmap.pyi
+++ b/third_party/2and3/nmap/nmap.pyi
@@ -1,4 +1,3 @@
-import sys
 from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional, Text, Tuple, TypeVar
 from typing_extensions import TypedDict
 

--- a/third_party/2and3/pyVmomi/vim/__init__.pyi
+++ b/third_party/2and3/pyVmomi/vim/__init__.pyi
@@ -3,7 +3,6 @@ from enum import Enum
 from typing import Any, List
 
 from ..vmodl.query import PropertyCollector
-from . import event, fault, view
 from .event import EventManager
 from .option import OptionManager
 from .view import ViewManager

--- a/third_party/2and3/pyVmomi/vmodl/__init__.pyi
+++ b/third_party/2and3/pyVmomi/vmodl/__init__.pyi
@@ -1,7 +1,5 @@
 from typing import Any
 
-from . import fault, query
-
 class DynamicProperty:
     name: str
     val: Any

--- a/third_party/2and3/pymysql/__init__.pyi
+++ b/third_party/2and3/pymysql/__init__.pyi
@@ -1,5 +1,5 @@
 import sys
-from typing import Callable, FrozenSet, Tuple, Union
+from typing import Callable, FrozenSet, Tuple
 
 from .connections import Connection as _Connection
 from .constants import FIELD_TYPE as FIELD_TYPE

--- a/third_party/2and3/requests/__init__.pyi
+++ b/third_party/2and3/requests/__init__.pyi
@@ -3,7 +3,6 @@
 import logging
 from typing import Any
 
-from . import api, exceptions, models, packages, sessions, status_codes, utils
 from .api import (
     delete as delete,
     get as get,

--- a/third_party/2and3/requests/adapters.pyi
+++ b/third_party/2and3/requests/adapters.pyi
@@ -2,7 +2,7 @@
 
 from typing import Any, Container, Mapping, Optional, Text, Tuple, Union
 
-from . import auth, compat, cookies, exceptions, models, structures, utils
+from . import cookies, exceptions, models, structures, utils
 from .packages.urllib3 import exceptions as urllib3_exceptions, poolmanager, response
 from .packages.urllib3.util import retry
 

--- a/third_party/2and3/requests/api.pyi
+++ b/third_party/2and3/requests/api.pyi
@@ -1,7 +1,6 @@
 # Stubs for requests.api (Python 3)
 
-import sys
-from typing import IO, Any, Iterable, Mapping, MutableMapping, Optional, Text, Tuple, Union
+from typing import Iterable, Mapping, Optional, Text, Tuple, Union
 
 from .models import Response
 from .sessions import _Data

--- a/third_party/2and3/requests/auth.pyi
+++ b/third_party/2and3/requests/auth.pyi
@@ -2,7 +2,7 @@
 
 from typing import Any, Text, Union
 
-from . import compat, cookies, models, status_codes, utils
+from . import cookies, models, status_codes, utils
 
 extract_cookies_to_jar = cookies.extract_cookies_to_jar
 parse_dict_header = utils.parse_dict_header

--- a/third_party/2and3/requests/compat.pyi
+++ b/third_party/2and3/requests/compat.pyi
@@ -1,6 +1,5 @@
 # Stubs for requests.compat (Python 3.4)
 
 import collections
-from typing import Any
 
 OrderedDict = collections.OrderedDict

--- a/third_party/2and3/requests/cookies.pyi
+++ b/third_party/2and3/requests/cookies.pyi
@@ -1,10 +1,7 @@
 # Stubs for requests.cookies (Python 3)
 
-import collections
 import sys
 from typing import Any, MutableMapping
-
-from . import compat
 
 if sys.version_info < (3, 0):
     from cookielib import CookieJar

--- a/third_party/2and3/requests/models.pyi
+++ b/third_party/2and3/requests/models.pyi
@@ -1,10 +1,9 @@
 # Stubs for requests.models (Python 3)
 
 import datetime
-import types
-from typing import Any, Dict, Iterator, List, MutableMapping, Optional, Text, Union
+from typing import Any, Dict, Iterator, List, Optional, Text, Union
 
-from . import auth, compat, cookies, exceptions, hooks, status_codes, structures, utils
+from . import auth, cookies, exceptions, hooks, status_codes, structures, utils
 from .cookies import RequestsCookieJar
 from .packages.urllib3 import exceptions as urllib3_exceptions, fields, filepost, util
 

--- a/third_party/2and3/requests/packages/urllib3/connection.pyi
+++ b/third_party/2and3/requests/packages/urllib3/connection.pyi
@@ -4,7 +4,7 @@ import ssl
 import sys
 from typing import Any
 
-from . import exceptions, packages, util
+from . import exceptions, util
 from .packages import ssl_match_hostname
 from .util import ssl_
 

--- a/third_party/2and3/requests/packages/urllib3/connectionpool.pyi
+++ b/third_party/2and3/requests/packages/urllib3/connectionpool.pyi
@@ -1,6 +1,6 @@
 from typing import Any
 
-from . import connection, exceptions, packages, request, response
+from . import connection, exceptions, request, response
 from .connection import BaseSSLError as BaseSSLError, ConnectionError as ConnectionError, HTTPException as HTTPException
 from .packages import ssl_match_hostname
 from .util import connection as _connection, retry, timeout, url

--- a/third_party/2and3/requests/packages/urllib3/fields.pyi
+++ b/third_party/2and3/requests/packages/urllib3/fields.pyi
@@ -2,8 +2,6 @@
 
 from typing import Any
 
-from . import packages
-
 def guess_content_type(filename, default=...): ...
 def format_header_param(name, value): ...
 

--- a/third_party/2and3/requests/packages/urllib3/filepost.pyi
+++ b/third_party/2and3/requests/packages/urllib3/filepost.pyi
@@ -1,10 +1,7 @@
 from typing import Any
 
-# from .packages import six
-from . import fields, packages
+from . import fields
 
-# six = packages.six
-# b = six.b
 RequestField = fields.RequestField
 
 writer: Any

--- a/third_party/2and3/requests/packages/urllib3/util/retry.pyi
+++ b/third_party/2and3/requests/packages/urllib3/util/retry.pyi
@@ -1,6 +1,6 @@
 from typing import Any
 
-from .. import exceptions, packages
+from .. import exceptions
 
 ConnectTimeoutError = exceptions.ConnectTimeoutError
 MaxRetryError = exceptions.MaxRetryError

--- a/third_party/2and3/requests/status_codes.pyi
+++ b/third_party/2and3/requests/status_codes.pyi
@@ -1,5 +1,3 @@
 from typing import Any
 
-from .structures import LookupDict
-
 codes: Any

--- a/third_party/2and3/simplejson/decoder.pyi
+++ b/third_party/2and3/simplejson/decoder.pyi
@@ -1,4 +1,4 @@
-from typing import Any, Match
+from typing import Match
 
 class JSONDecoder(object):
     def __init__(self, **kwargs): ...

--- a/third_party/2and3/simplejson/encoder.pyi
+++ b/third_party/2and3/simplejson/encoder.pyi
@@ -1,4 +1,4 @@
-from typing import IO, Any
+from typing import Any
 
 class JSONEncoder(object):
     def __init__(self, *args, **kwargs): ...

--- a/third_party/2and3/werkzeug/contrib/fixers.pyi
+++ b/third_party/2and3/werkzeug/contrib/fixers.pyi
@@ -1,5 +1,5 @@
 from _typeshed.wsgi import StartResponse, WSGIApplication, WSGIEnvironment
-from typing import Any, Iterable, List, Mapping, Optional, Sequence, Set, Text
+from typing import Any, Iterable, List, Mapping, Optional, Set, Text
 
 from ..middleware.proxy_fix import ProxyFix as ProxyFix
 

--- a/third_party/2and3/werkzeug/contrib/testtools.pyi
+++ b/third_party/2and3/werkzeug/contrib/testtools.pyi
@@ -1,5 +1,3 @@
-from typing import Any
-
 from werkzeug.wrappers import Response
 
 class ContentAccessors:

--- a/third_party/2and3/werkzeug/datastructures.pyi
+++ b/third_party/2and3/werkzeug/datastructures.pyi
@@ -1,4 +1,3 @@
-import collections
 from _typeshed import SupportsWrite
 from typing import (
     IO,

--- a/third_party/2and3/werkzeug/middleware/dispatcher.pyi
+++ b/third_party/2and3/werkzeug/middleware/dispatcher.pyi
@@ -1,5 +1,5 @@
 from _typeshed.wsgi import StartResponse, WSGIApplication, WSGIEnvironment
-from typing import Any, Iterable, Mapping, Optional, Text
+from typing import Iterable, Mapping, Optional, Text
 
 class DispatcherMiddleware(object):
     app: WSGIApplication

--- a/third_party/2and3/werkzeug/wrappers.pyi
+++ b/third_party/2and3/werkzeug/wrappers.pyi
@@ -1,4 +1,3 @@
-import sys
 from _typeshed.wsgi import InputStream, WSGIEnvironment
 from datetime import datetime
 from typing import (


### PR DESCRIPTION
Removed imported symbols that are not accessed or re-exported within third_party stubs (part 3 of 4). These were all identified as unused symbols by the pyright type checker and language server.