### PR TITLE
Removed imported symbols that are not accessed or re-exported (third_party part 4 of 4)

### DIFF
--- a/tests/pytype_exclude_list.txt
+++ b/tests/pytype_exclude_list.txt
@@ -15,6 +15,8 @@ third_party/2and3/attr/converters.pyi
 third_party/2and3/attr/filters.pyi
 third_party/2and3/attr/validators.pyi
 third_party/2and3/pynamodb/models.pyi
+third_party/3/six/__init__.pyi
+third_party/3/six/moves/__init__.pyi
 
 # anything that imports tkinter (https://github.com/google/pytype/issues/637)
 stdlib/3/tkinter/__init__.pyi

--- a/third_party/2and3/yaml/__init__.pyi
+++ b/third_party/2and3/yaml/__init__.pyi
@@ -10,7 +10,7 @@ from yaml.tokens import *  # noqa: F403
 
 from .cyaml import *
 
-from . import resolver  # Help mypy a bit; this is implied by loader and dumper
+from . import resolver as resolver  # Help mypy a bit; this is implied by loader and dumper
 
 if sys.version_info < (3,):
     _Str = Union[Text, str]

--- a/third_party/2and3/yaml/composer.pyi
+++ b/third_party/2and3/yaml/composer.pyi
@@ -1,7 +1,6 @@
 from typing import Any
 
-from yaml.error import Mark, MarkedYAMLError, YAMLError
-from yaml.nodes import CollectionNode, MappingNode, Node, ScalarNode, SequenceNode
+from yaml.error import MarkedYAMLError
 
 class ComposerError(MarkedYAMLError): ...
 

--- a/third_party/2and3/yaml/constructor.pyi
+++ b/third_party/2and3/yaml/constructor.pyi
@@ -1,8 +1,7 @@
 import sys
 from typing import Any
 
-from yaml.error import Mark, MarkedYAMLError, YAMLError
-from yaml.nodes import CollectionNode, MappingNode, Node, ScalarNode, SequenceNode
+from yaml.error import MarkedYAMLError
 
 class ConstructorError(MarkedYAMLError): ...
 

--- a/third_party/3/docutils/parsers/rst/states.pyi
+++ b/third_party/3/docutils/parsers/rst/states.pyi
@@ -1,4 +1,3 @@
-import typing
 from typing import Any
 
 class Inliner:

--- a/third_party/3/pkg_resources/py31compat.pyi
+++ b/third_party/3/pkg_resources/py31compat.pyi
@@ -1,6 +1,4 @@
 import os
-import sys
-from typing import Text
 
 needs_makedirs: bool
 

--- a/third_party/3/six/__init__.pyi
+++ b/third_party/3/six/__init__.pyi
@@ -27,7 +27,7 @@ from typing import (
     overload,
 )
 
-from . import moves
+from . import moves as moves
 
 _T = TypeVar("_T")
 _K = TypeVar("_K")

--- a/third_party/3/six/moves/__init__.pyi
+++ b/third_party/3/six/moves/__init__.pyi
@@ -2,7 +2,6 @@
 #
 # Note: Commented out items means they weren't implemented at the time.
 # Uncomment them when the modules have been added to the typeshed.
-import sys
 from builtins import filter as filter, input as input, map as map, range as xrange, zip as zip
 from collections import UserDict as UserDict, UserList as UserList, UserString as UserString
 from functools import reduce as reduce
@@ -24,37 +23,37 @@ from sys import intern as intern
 # import copyreg as copyreg
 # import dbm.gnu as dbm_gnu
 from . import (
-    BaseHTTPServer,
-    CGIHTTPServer,
-    SimpleHTTPServer,
-    _dummy_thread,
-    _thread,
-    builtins,
-    configparser,
-    cPickle,
-    email_mime_base,
-    email_mime_multipart,
-    email_mime_nonmultipart,
-    email_mime_text,
-    html_entities,
-    html_parser,
-    http_client,
-    http_cookiejar,
-    http_cookies,
-    queue,
-    reprlib,
-    socketserver,
-    tkinter,
-    tkinter_commondialog,
-    tkinter_constants,
-    tkinter_dialog,
-    tkinter_filedialog,
-    tkinter_tkfiledialog,
-    tkinter_ttk,
-    urllib,
-    urllib_error,
-    urllib_parse,
-    urllib_robotparser,
+    BaseHTTPServer as BaseHTTPServer,
+    CGIHTTPServer as CGIHTTPServer,
+    SimpleHTTPServer as SimpleHTTPServer,
+    _dummy_thread as _dummy_thread,
+    _thread as _thread,
+    builtins as builtins,
+    configparser as configparser,
+    cPickle as cPickle,
+    email_mime_base as email_mime_base,
+    email_mime_multipart as email_mime_multipart,
+    email_mime_nonmultipart as email_mime_nonmultipart,
+    email_mime_text as email_mime_text,
+    html_entities as html_entities,
+    html_parser as html_parser,
+    http_client as http_client,
+    http_cookiejar as http_cookiejar,
+    http_cookies as http_cookies,
+    queue as queue,
+    reprlib as reprlib,
+    socketserver as socketserver,
+    tkinter as tkinter,
+    tkinter_commondialog as tkinter_commondialog,
+    tkinter_constants as tkinter_constants,
+    tkinter_dialog as tkinter_dialog,
+    tkinter_filedialog as tkinter_filedialog,
+    tkinter_tkfiledialog as tkinter_tkfiledialog,
+    tkinter_ttk as tkinter_ttk,
+    urllib as urllib,
+    urllib_error as urllib_error,
+    urllib_parse as urllib_parse,
+    urllib_robotparser as urllib_robotparser,
 )
 
 # import xmlrpc.client as xmlrpc_client

--- a/third_party/3/six/moves/__init__.pyi
+++ b/third_party/3/six/moves/__init__.pyi
@@ -22,39 +22,5 @@ from sys import intern as intern
 # import tkinter.tix as tkinter_tix
 # import copyreg as copyreg
 # import dbm.gnu as dbm_gnu
-from . import (
-    BaseHTTPServer as BaseHTTPServer,
-    CGIHTTPServer as CGIHTTPServer,
-    SimpleHTTPServer as SimpleHTTPServer,
-    _dummy_thread as _dummy_thread,
-    _thread as _thread,
-    builtins as builtins,
-    configparser as configparser,
-    cPickle as cPickle,
-    email_mime_base as email_mime_base,
-    email_mime_multipart as email_mime_multipart,
-    email_mime_nonmultipart as email_mime_nonmultipart,
-    email_mime_text as email_mime_text,
-    html_entities as html_entities,
-    html_parser as html_parser,
-    http_client as http_client,
-    http_cookiejar as http_cookiejar,
-    http_cookies as http_cookies,
-    queue as queue,
-    reprlib as reprlib,
-    socketserver as socketserver,
-    tkinter as tkinter,
-    tkinter_commondialog as tkinter_commondialog,
-    tkinter_constants as tkinter_constants,
-    tkinter_dialog as tkinter_dialog,
-    tkinter_filedialog as tkinter_filedialog,
-    tkinter_tkfiledialog as tkinter_tkfiledialog,
-    tkinter_ttk as tkinter_ttk,
-    urllib as urllib,
-    urllib_error as urllib_error,
-    urllib_parse as urllib_parse,
-    urllib_robotparser as urllib_robotparser,
-)
-
 # import xmlrpc.client as xmlrpc_client
 # import xmlrpc.server as xmlrpc_server

--- a/third_party/3/six/moves/__init__.pyi
+++ b/third_party/3/six/moves/__init__.pyi
@@ -22,5 +22,39 @@ from sys import intern as intern
 # import tkinter.tix as tkinter_tix
 # import copyreg as copyreg
 # import dbm.gnu as dbm_gnu
+from . import (
+    BaseHTTPServer as BaseHTTPServer,
+    CGIHTTPServer as CGIHTTPServer,
+    SimpleHTTPServer as SimpleHTTPServer,
+    _dummy_thread as _dummy_thread,
+    _thread as _thread,
+    builtins as builtins,
+    configparser as configparser,
+    cPickle as cPickle,
+    email_mime_base as email_mime_base,
+    email_mime_multipart as email_mime_multipart,
+    email_mime_nonmultipart as email_mime_nonmultipart,
+    email_mime_text as email_mime_text,
+    html_entities as html_entities,
+    html_parser as html_parser,
+    http_client as http_client,
+    http_cookiejar as http_cookiejar,
+    http_cookies as http_cookies,
+    queue as queue,
+    reprlib as reprlib,
+    socketserver as socketserver,
+    tkinter as tkinter,
+    tkinter_commondialog as tkinter_commondialog,
+    tkinter_constants as tkinter_constants,
+    tkinter_dialog as tkinter_dialog,
+    tkinter_filedialog as tkinter_filedialog,
+    tkinter_tkfiledialog as tkinter_tkfiledialog,
+    tkinter_ttk as tkinter_ttk,
+    urllib as urllib,
+    urllib_error as urllib_error,
+    urllib_parse as urllib_parse,
+    urllib_robotparser as urllib_robotparser,
+)
+
 # import xmlrpc.client as xmlrpc_client
 # import xmlrpc.server as xmlrpc_server

--- a/third_party/3/typed_ast/ast27.pyi
+++ b/third_party/3/typed_ast/ast27.pyi
@@ -1,5 +1,5 @@
 import typing
-from typing import Any, Generic, Iterator, Optional, Union
+from typing import Any, Iterator, Optional, Union
 
 class NodeVisitor:
     def visit(self, node: AST) -> Any: ...

--- a/third_party/3/typed_ast/ast3.pyi
+++ b/third_party/3/typed_ast/ast3.pyi
@@ -1,5 +1,5 @@
 import typing
-from typing import Any, Generic, Iterator, Optional, Union
+from typing import Any, Iterator, Optional, Union
 
 class NodeVisitor:
     def visit(self, node: AST) -> Any: ...

--- a/third_party/3/waitress/__init__.pyi
+++ b/third_party/3/waitress/__init__.pyi
@@ -1,6 +1,6 @@
 from typing import Any, Tuple
 
-from waitress.server import create_server
+from waitress.server import create_server as create_server
 
 def serve(app: Any, **kw: Any) -> None: ...
 def serve_paste(app: Any, global_conf: Any, **kw: Any) -> int: ...

--- a/third_party/3/waitress/adjustments.pyi
+++ b/third_party/3/waitress/adjustments.pyi
@@ -1,8 +1,8 @@
 from socket import SocketType
 from typing import Any, Dict, FrozenSet, Iterable, List, Optional, Sequence, Set, Tuple, Union
 
-from .compat import HAS_IPV6, PY2, WIN, string_types
-from .proxy_headers import PROXY_HEADERS
+from .compat import HAS_IPV6 as HAS_IPV6, PY2 as PY2, WIN as WIN, string_types as string_types
+from .proxy_headers import PROXY_HEADERS as PROXY_HEADERS
 
 truthy: FrozenSet
 KNOWN_PROXY_HEADERS: FrozenSet

--- a/third_party/3/waitress/channel.pyi
+++ b/third_party/3/waitress/channel.pyi
@@ -3,11 +3,10 @@ from threading import Condition, Lock
 from typing import Mapping, Optional, Sequence, Tuple
 
 from waitress.adjustments import Adjustments
-from waitress.buffers import OverflowableBuffer, ReadOnlyFileBasedBuffer
+from waitress.buffers import OverflowableBuffer
 from waitress.parser import HTTPRequestParser
 from waitress.server import BaseWSGIServer
-from waitress.task import ErrorTask, Task, WSGITask
-from waitress.utilities import InternalServerError
+from waitress.task import ErrorTask, WSGITask
 
 from . import wasyncore as wasyncore
 

--- a/third_party/3/waitress/parser.pyi
+++ b/third_party/3/waitress/parser.pyi
@@ -2,19 +2,10 @@ from io import BytesIO
 from typing import Mapping, Optional, Pattern, Sequence, Tuple, Union
 
 from waitress.adjustments import Adjustments
-from waitress.buffers import OverflowableBuffer
-from waitress.compat import tostr, unquote_bytes_to_wsgi, urlparse
 from waitress.receiver import ChunkedReceiver, FixedStreamReceiver
-from waitress.utilities import (
-    BadRequest,
-    Error,
-    RequestEntityTooLarge,
-    RequestHeaderFieldsTooLarge,
-    ServerNotImplemented,
-    find_double_newline,
-)
+from waitress.utilities import Error
 
-from .rfc7230 import HEADER_FIELD
+from .rfc7230 import HEADER_FIELD as HEADER_FIELD
 
 class ParsingError(Exception): ...
 class TransferEncodingNotImplemented(Exception): ...

--- a/third_party/3/waitress/proxy_headers.pyi
+++ b/third_party/3/waitress/proxy_headers.pyi
@@ -2,7 +2,7 @@ from collections import namedtuple
 from logging import Logger
 from typing import Any, Callable, Mapping, Optional, Sequence, Set
 
-from .utilities import BadRequest
+from .utilities import BadRequest as BadRequest
 
 PROXY_HEADERS: frozenset
 

--- a/third_party/3/waitress/receiver.pyi
+++ b/third_party/3/waitress/receiver.pyi
@@ -2,7 +2,7 @@ from io import BytesIO
 from typing import Optional
 
 from waitress.buffers import OverflowableBuffer
-from waitress.utilities import BadRequest, find_double_newline
+from waitress.utilities import BadRequest
 
 class FixedStreamReceiver:
     completed: bool = ...

--- a/third_party/3/waitress/rfc7230.pyi
+++ b/third_party/3/waitress/rfc7230.pyi
@@ -1,6 +1,6 @@
 from typing import Pattern
 
-from .compat import tobytes
+from .compat import tobytes as tobytes
 
 WS: str
 OWS: str

--- a/third_party/3/waitress/runner.pyi
+++ b/third_party/3/waitress/runner.pyi
@@ -1,8 +1,6 @@
 from io import TextIOWrapper
 from typing import Any, Callable, Optional, Pattern, Sequence, Tuple
 
-from waitress import serve
-
 HELP: str
 RUNNER_PATTERN: Pattern
 

--- a/third_party/3/waitress/server.pyi
+++ b/third_party/3/waitress/server.pyi
@@ -3,12 +3,9 @@ from typing import Any, Optional, Sequence, Tuple, Union
 
 from waitress.adjustments import Adjustments
 from waitress.channel import HTTPChannel
-from waitress.compat import IPPROTO_IPV6, IPV6_V6ONLY
 from waitress.task import Task, ThreadedTaskDispatcher
-from waitress.utilities import cleanup_unix_socket
 
 from . import wasyncore
-from .proxy_headers import proxy_headers_middleware
 
 def create_server(
     application: Any,

--- a/third_party/3/waitress/task.pyi
+++ b/third_party/3/waitress/task.pyi
@@ -2,9 +2,7 @@ from logging import Logger
 from threading import Condition, Lock
 from typing import Any, Deque, Mapping, Optional, Sequence, Set, Tuple
 
-from .buffers import ReadOnlyFileBasedBuffer
 from .channel import HTTPChannel
-from .compat import reraise, tobytes
 from .utilities import Error
 
 rename_headers: Mapping[str, str]

--- a/third_party/3/waitress/utilities.pyi
+++ b/third_party/3/waitress/utilities.pyi
@@ -1,7 +1,7 @@
 from logging import Logger
 from typing import Any, Callable, Mapping, Match, Pattern, Sequence, Tuple
 
-from .rfc7230 import OBS_TEXT, VCHAR
+from .rfc7230 import OBS_TEXT as OBS_TEXT, VCHAR as VCHAR
 
 logger: Logger
 queue_logger: Logger

--- a/third_party/3/waitress/wasyncore.pyi
+++ b/third_party/3/waitress/wasyncore.pyi
@@ -3,7 +3,7 @@ from logging import Logger
 from socket import SocketType
 from typing import Any, Callable, Mapping, Optional, Tuple
 
-from . import compat, utilities
+from . import compat as compat, utilities as utilities
 
 socket_map: Mapping[int, SocketType]
 map: Mapping[int, SocketType]


### PR DESCRIPTION
Removed imported symbols that are not accessed or re-exported within third_party stubs (part 4 of 4). These were all identified as unused symbols by the pyright type checker and language server.