### PR TITLE
Fixed symbol redefinition in cgi.pyi stub

### DIFF
--- a/stdlib/2and3/cgi.pyi
+++ b/stdlib/2and3/cgi.pyi
@@ -1,6 +1,6 @@
 import sys
-from builtins import type as _type
 from _typeshed import SupportsGetItem, SupportsItemAccess
+from builtins import type as _type
 from typing import IO, Any, AnyStr, Dict, Iterable, Iterator, List, Mapping, Optional, Protocol, Tuple, TypeVar, Union
 
 _T = TypeVar("_T", bound=FieldStorage)

--- a/stdlib/2and3/cgi.pyi
+++ b/stdlib/2and3/cgi.pyi
@@ -1,4 +1,5 @@
 import sys
+from builtins import type as _type
 from _typeshed import SupportsGetItem, SupportsItemAccess
 from typing import IO, Any, AnyStr, Dict, Iterable, Iterator, List, Mapping, Optional, Protocol, Tuple, TypeVar, Union
 
@@ -56,7 +57,7 @@ class MiniFieldStorage:
     def __repr__(self) -> str: ...
 
 class FieldStorage(object):
-    FieldStorageClass: Optional[type]
+    FieldStorageClass: Optional[_type]
     keep_blank_values: int
     strict_parsing: int
     qs_on_post: Optional[str]


### PR DESCRIPTION
PEP 484 says that type checkers should assume that all types used in a stub should use forward declarations even though they are not quoted. This stub is using the symbol "type" within the context of a class scope. The "type" symbol is declared within this scope, so pyright assumes that the forward declaration should be used. The solution is to define a symbol with a different name in the outer scope to avoid the name conflict.