### PR TITLE
Fixed issue in type alias definition for _DirT in tempfile.pyi

### DIFF
--- a/stdlib/3/tempfile.pyi
+++ b/stdlib/3/tempfile.pyi
@@ -12,7 +12,7 @@ template: str
 _S = TypeVar("_S")
 _T = TypeVar("_T")  # for pytype, define typevar in same file as alias
 if sys.version_info >= (3, 6):
-    _DirT = Union[_T, os.PathLike[_T]]
+    _DirT = Union[AnyStr, os.PathLike[AnyStr]]
 else:
     _DirT = Union[_T]
 


### PR DESCRIPTION
Fixed issue in type alias definition for _DirT in tempfile.pyi. It was using an unconstrained TypeVar _T as a type argument for a class (PathLike) that requires constraints. Pyright reports an error in this case because the TypeVar _T doesn't satisfy the constraints.