### PR TITLE
Add __name__ & __qualname__ to Coroutine

### DIFF
--- a/stdlib/3/typing.pyi
+++ b/stdlib/3/typing.pyi
@@ -198,6 +198,8 @@ class Awaitable(Protocol[_T_co]):
     def __await__(self) -> Generator[Any, None, _T_co]: ...
 
 class Coroutine(Awaitable[_V_co], Generic[_T_co, _T_contra, _V_co]):
+    __name__: str
+    __qualname__: str
     @property
     def cr_await(self) -> Optional[Any]: ...
     @property


### PR DESCRIPTION
Closes #3561.

I've taken a quite naive approach as I am unclear if these attributes should be applied higher up (say to `Awaitable`?). Happy to make changes if there is a better way to fix this.