### PR TITLE
Add back six.StringIO (Python 2)

### DIFF
--- a/third_party/2/six/__init__.pyi
+++ b/third_party/2/six/__init__.pyi
@@ -5,7 +5,7 @@ import typing
 import unittest
 from __builtin__ import unichr as unichr
 from functools import wraps as wraps
-from StringIO import StringIO as BytesIO
+from StringIO import StringIO as BytesIO, StringIO as StringIO
 from typing import (
     Any,
     AnyStr,


### PR DESCRIPTION
This was accidentally removed in #4287.