### PR TITLE
Add back six.moves.urllib.parse.unquote (Python 2)

### DIFF
--- a/third_party/2/six/moves/urllib/parse.pyi
+++ b/third_party/2/six/moves/urllib/parse.pyi
@@ -5,6 +5,7 @@ from urllib import (
     splitquery as splitquery,
     splittag as splittag,
     splituser as splituser,
+    unquote as unquote,
     unquote as unquote_to_bytes,
     unquote_plus as unquote_plus,
     urlencode as urlencode,


### PR DESCRIPTION
This was accidentally removed in #4287.