### PR TITLE
Fixed a couple of type name collisions. PEP 484 indicates that all ty…

### DIFF
--- a/stdlib/3/multiprocessing/managers.pyi
+++ b/stdlib/3/multiprocessing/managers.pyi
@@ -26,6 +26,7 @@ from .context import BaseContext
 
 if sys.version_info >= (3, 8):
     from .shared_memory import _SLT, ShareableList, SharedMemory
+
     _SharedMemory = SharedMemory
     _ShareableList = ShareableList
 

--- a/stdlib/3/multiprocessing/managers.pyi
+++ b/stdlib/3/multiprocessing/managers.pyi
@@ -26,6 +26,8 @@ from .context import BaseContext
 
 if sys.version_info >= (3, 8):
     from .shared_memory import _SLT, ShareableList, SharedMemory
+    _SharedMemory = SharedMemory
+    _ShareableList = ShareableList
 
 _T = TypeVar("_T")
 _KT = TypeVar("_KT")
@@ -138,5 +140,5 @@ if sys.version_info >= (3, 8):
     class SharedMemoryServer(Server): ...
     class SharedMemoryManager(BaseManager):
         def get_server(self) -> SharedMemoryServer: ...
-        def SharedMemory(self, size: int) -> SharedMemory: ...  # noqa: F811
-        def ShareableList(self, sequence: Optional[Iterable[_SLT]]) -> ShareableList[_SLT]: ...  # noqa: F811
+        def SharedMemory(self, size: int) -> _SharedMemory: ...
+        def ShareableList(self, sequence: Optional[Iterable[_SLT]]) -> _ShareableList[_SLT]: ...

--- a/stdlib/3/sys.pyi
+++ b/stdlib/3/sys.pyi
@@ -4,6 +4,7 @@
 # based on http://docs.python.org/3.2/library/sys.html
 
 import sys
+from builtins import object as _object
 from importlib.abc import MetaPathFinder
 from types import FrameType, ModuleType, TracebackType
 from typing import Any, Callable, Dict, List, NoReturn, Optional, Sequence, TextIO, Tuple, Type, TypeVar, Union, overload
@@ -208,7 +209,7 @@ if sys.version_info >= (3, 8):
         exc_value: Optional[BaseException]
         exc_traceback: Optional[TracebackType]
         err_msg: Optional[str]
-        object: Optional[object]
+        object: Optional[_object]
     unraisablehook: Callable[[UnraisableHookArgs], Any]
     def addaudithook(hook: Callable[[str, Tuple[Any, ...]], Any]) -> None: ...
     def audit(__event: str, *args: Any) -> None: ...


### PR DESCRIPTION
…pe annotations within a stub file are supposed to be considered forward references even if they are not quoted. This means a type checker needs to use scope-based symbol resolution without regard for code flow order. Lookups will find same-named symbols within the same scope even if they are declared after the type annotation. This change fixes a couple of cases where this occurs and confuses pyright.