### PR TITLE
Add SupportsIndex stub to typing_extensions

### DIFF
--- a/third_party/2and3/typing_extensions.pyi
+++ b/third_party/2and3/typing_extensions.pyi
@@ -98,3 +98,8 @@ _AnnotatedAlias: Any = ...  # undocumented
 
 # TypeAlias is a (non-subscriptable) special form.
 class TypeAlias: ...
+
+@runtime_checkable
+class SupportsIndex(Protocol, metaclass=abc.ABCMeta):
+    @abc.abstractmethod
+    def __index__(self) -> int: ...


### PR DESCRIPTION
This was added to typing_extensions in python/typing#724.