### PR TITLE
Mark http.server.SimpleHTTPRequestHandler's `directory` arg as optional.

### DIFF
--- a/stdlib/3/http/server.pyi
+++ b/stdlib/3/http/server.pyi
@@ -62,7 +62,7 @@ class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
             request: bytes,
             client_address: Tuple[str, int],
             server: socketserver.BaseServer,
-            directory: Optional[Union[str, _PathLike[str]]],
+            directory: Optional[Union[str, _PathLike[str]]] = ...,
         ) -> None: ...
     else:
         def __init__(self, request: bytes, client_address: Tuple[str, int], server: socketserver.BaseServer) -> None: ...


### PR DESCRIPTION
`directory` has a default value:
https://docs.python.org/3/library/http.server.html#http.server.SimpleHTTPRequestHandler.