### PR TITLE
more permissive type for tkinter font descriptions

### DIFF
--- a/stdlib/3/tkinter/font.pyi
+++ b/stdlib/3/tkinter/font.pyi
@@ -23,7 +23,7 @@ _TkinterSequence = Union[List[_T], Tuple[_T, ...]]
 # See 'FONT DESCRIPTIONS' in font man page. This uses str because Literal
 # inside Tuple doesn't work.
 _FontDescription = Union[
-    str, Font, Tuple[str, int], Tuple[str, int, _TkinterSequence[str]],
+    str, Font, Tuple[str, int], Tuple[str, int, str], Tuple[str, int, _TkinterSequence[str]],
 ]
 
 class _FontDict(TypedDict):


### PR DESCRIPTION
It's possibly to specify e.g. `('Helvetica', 12, 'bold italic')` instead of `('Helvetica', 12, ['bold', 'italic'])`