### PR TITLE
Upgrade the pytype version to one that can parse the tkinter stubs.

### DIFF
--- a/requirements-tests-py3.txt
+++ b/requirements-tests-py3.txt
@@ -5,4 +5,4 @@ flake8==3.8.3
 flake8-bugbear==20.1.4
 flake8-pyi==20.5.0
 isort[pyproject]==5.1.1
-pytype>=2020.07.30
+pytype>=2020.08.17

--- a/stdlib/3/tkinter/__init__.pyi
+++ b/stdlib/3/tkinter/__init__.pyi
@@ -664,7 +664,7 @@ class Pack:
     # slaves = Misc.pack_slaves
     # pack_slaves = Misc.pack_slaves
 
-class _PlaceInfo(_InMiscNonTotal, total=False):  # empty dict if widget hasn't been placed
+class _PlaceInfo(_InMiscNonTotal):  # empty dict if widget hasn't been placed
     anchor: _Anchor
     bordermode: Literal["inside", "outside", "ignore"]
     width: str  # can be int()ed (even after e.g. widget.place(height='2.3c') or similar)
@@ -705,7 +705,7 @@ class Place:
     # slaves = Misc.place_slaves
     # place_slaves = Misc.place_slaves
 
-class _GridInfo(_InMiscNonTotal, total=False):  # empty dict if widget hasn't been gridded
+class _GridInfo(_InMiscNonTotal):  # empty dict if widget hasn't been gridded
     column: int
     columnspan: int
     row: int

--- a/tests/pytype_exclude_list.txt
+++ b/tests/pytype_exclude_list.txt
@@ -17,18 +17,3 @@ third_party/2and3/attr/validators.pyi
 third_party/2and3/pynamodb/models.pyi
 third_party/3/six/__init__.pyi
 third_party/3/six/moves/__init__.pyi
-
-# anything that imports tkinter
-# https://github.com/google/pytype/issues/637
-# https://github.com/google/pytype/issues/644
-stdlib/3/tkinter/__init__.pyi
-stdlib/3/tkinter/dialog.pyi
-stdlib/3/tkinter/filedialog.pyi
-stdlib/3/tkinter/font.pyi
-stdlib/3/tkinter/ttk.pyi
-third_party/3/six/moves/tkinter.pyi
-third_party/3/six/moves/tkinter_dialog.pyi
-third_party/3/six/moves/tkinter_filedialog.pyi
-third_party/3/six/moves/tkinter_tkfiledialog.pyi
-third_party/3/six/moves/tkinter_ttk.pyi
-stdlib/2and3/turtle.pyi


### PR DESCRIPTION
The latest pytype release fixes two pyi parser bugs that allow files
affected by them to be taken off the pytype exclude list. I removed two
`total=False` declarations in tkinter/__init__ that pytype does not like
(because it checks that `total` is present only when TypedDict is a
class's immediate parent) and which shouldn't be needed because
_InMiscNonTotal already specifies totality. I double-checked that mypy
reports no errors in 3.7 on a .py file containing:

  from typing_extensions import TypedDict
  Foo = TypedDict('Foo', {'x': int}, total=False)
  class Bar(Foo): pass
  x: Foo = {}

showing that it doesn't require `total` to be repeated.