### PR TITLE
Added additional attributes to re.error

### DIFF
--- a/stdlib/3/re.pyi
+++ b/stdlib/3/re.pyi
@@ -76,7 +76,16 @@ if sys.version_info < (3, 7):
     # undocumented
     _pattern_type: type
 
-class error(Exception): ...
+if sys.version_info < (3, 5):
+    class error(Exception): ...
+
+else:
+    class error(Exception):
+        msg: str
+        pattern: str
+        pos: Optional[int]
+        lineno: Optional[int]
+        colno: Optional[int]
 
 @overload
 def compile(pattern: AnyStr, flags: _FlagsType = ...) -> Pattern[AnyStr]: ...

--- a/stdlib/3/re.pyi
+++ b/stdlib/3/re.pyi
@@ -76,16 +76,12 @@ if sys.version_info < (3, 7):
     # undocumented
     _pattern_type: type
 
-if sys.version_info < (3, 5):
-    class error(Exception): ...
-
-else:
-    class error(Exception):
-        msg: str
-        pattern: str
-        pos: Optional[int]
-        lineno: Optional[int]
-        colno: Optional[int]
+class error(Exception):
+    msg: str
+    pattern: str
+    pos: Optional[int]
+    lineno: Optional[int]
+    colno: Optional[int]
 
 @overload
 def compile(pattern: AnyStr, flags: _FlagsType = ...) -> Pattern[AnyStr]: ...


### PR DESCRIPTION
No prior issue was created as this seems like a simple fix to an obvious mistake (or probably just forgetting to update)

Adds
* `msg`
* `pattern`
* `pos`
* `lineno`
* `colno`

https://docs.python.org/3/library/re.html#re.error

These were all added in Python 3.5