### PR TITLE
Fix missing attributes on Cookie

### DIFF
--- a/stdlib/3/http/cookiejar.pyi
+++ b/stdlib/3/http/cookiejar.pyi
@@ -91,6 +91,7 @@ class Cookie:
     value: Optional[str]
     port: Optional[str]
     path: str
+    path_specified: bool
     secure: bool
     expires: Optional[int]
     discard: bool


### PR DESCRIPTION
Documenting these aids in the creation of correct serialisation code.

There's nothing to suggest that these attributes are private, and given that they are required constructor arguments, we would need these to round-trip a Cookie through serialisation/deserialisation.