### PR TITLE
fix tkinter master attributes

### DIFF
--- a/stdlib/3/tkinter/__init__.pyi
+++ b/stdlib/3/tkinter/__init__.pyi
@@ -225,6 +225,7 @@ getdouble: Any
 def getboolean(s): ...
 
 class Misc:
+    master: Optional[Misc]
     tk: _tkinter.TkappType
     def destroy(self): ...
     def deletecommand(self, name): ...
@@ -536,7 +537,7 @@ _TkOptionName = Literal[
 ]
 
 class Tk(Misc, Wm):
-    master: Optional[Any]
+    master: None
     children: Dict[str, Any]
     def __init__(
         self,
@@ -758,6 +759,7 @@ class Grid:
     # grid_slaves = Misc.grid_slaves
 
 class BaseWidget(Misc):
+    master: Misc
     widgetName: Any
     def __init__(self, master, widgetName, cnf=..., kw=..., extra=...): ...
     def destroy(self): ...


### PR DESCRIPTION
All tkinter widgets have a master attribute. Tk is the only widget whose master attribute can be None (and Tk's master is always None). This is because of the way master widgets work in Tcl/Tk: a widget whose name in Tcl is `.foo.bar` has a master named `.foo`, and the master of `.foo` is the root widget named `.`, corresponding to an instance of `tkinter.Tk`.

You can also try running this to see the master attributes:

```
import tkinter.ttk

print(tkinter.Tk().master)
print(tkinter.Toplevel().master)
print(tkinter.Button().master)
print(tkinter.Canvas().master)
print(tkinter.Checkbutton().master)
print(tkinter.Entry().master)
print(tkinter.Frame().master)
print(tkinter.Label().master)
print(tkinter.Listbox().master)
print(tkinter.Menu().master)
print(tkinter.Menubutton().master)
print(tkinter.Message().master)
print(tkinter.Radiobutton().master)
print(tkinter.Scale().master)
print(tkinter.Scrollbar().master)
print(tkinter.Text().master)
print(tkinter.OptionMenu(None, tkinter.StringVar(), 'foo').master)
print(tkinter.Spinbox().master)
print(tkinter.LabelFrame().master)
print(tkinter.PanedWindow().master)
print(tkinter.ttk.Button().master)
print(tkinter.ttk.Checkbutton().master)
print(tkinter.ttk.Entry().master)
print(tkinter.ttk.Combobox().master)
print(tkinter.ttk.Frame().master)
print(tkinter.ttk.Label().master)
print(tkinter.ttk.Labelframe().master)
print(tkinter.ttk.Menubutton().master)
print(tkinter.ttk.Notebook().master)
print(tkinter.ttk.Panedwindow().master)
print(tkinter.ttk.Progressbar().master)
print(tkinter.ttk.Radiobutton().master)
print(tkinter.ttk.Scale().master)
print(tkinter.ttk.Scrollbar().master)
print(tkinter.ttk.Separator().master)
print(tkinter.ttk.Sizegrip().master)
print(tkinter.ttk.Treeview().master)
print(tkinter.ttk.LabeledScale().master)
print(tkinter.ttk.OptionMenu(None, tkinter.StringVar(), 'foo').master)
```

To verify that the stubs are correct, replace all prints with `reveal_type` and then mypying.

If something can be any widget, then the correct type for it is `Misc`, and that's why there's now a `master` attribute in `Misc` as well. So, `if some_misc_instance.master is None` is equivalent to (but more readable than) `if isinstance(some_misc_instance, tkinter.Tk)`.