### PR TITLE
Improve requests.Session.headers typing

### DIFF
--- a/third_party/2and3/requests/sessions.pyi
+++ b/third_party/2and3/requests/sessions.pyi
@@ -46,7 +46,6 @@ class SessionRedirectMixin:
     def rebuild_proxies(self, prepared_request, proxies): ...
 
 _Data = Union[None, Text, bytes, Mapping[str, Any], Mapping[Text, Any], Iterable[Tuple[Text, Optional[Text]]], IO]
-_Headers = Union[Mapping[Text, Text], CaseInsensitiveDict[Text]]
 
 _Hook = Callable[[Response], Any]
 _Hooks = MutableMapping[Text, List[_Hook]]
@@ -54,7 +53,7 @@ _HooksInput = MutableMapping[Text, Union[Iterable[_Hook], _Hook]]
 
 class Session(SessionRedirectMixin):
     __attrs__: Any
-    headers: _Headers
+    headers: Union[Mapping[Text, Text], CaseInsensitiveDict[Text]]
     auth: Union[None, Tuple[Text, Text], _auth.AuthBase, Callable[[Request], Request]]
     proxies: MutableMapping[Text, Text]
     hooks: _Hooks
@@ -77,7 +76,7 @@ class Session(SessionRedirectMixin):
         url: Union[str, bytes, Text],
         params: Union[None, bytes, MutableMapping[Text, Text]] = ...,
         data: _Data = ...,
-        headers: _Headers = ...,
+        headers: Union[None, Mapping[Text, Text], CaseInsensitiveDict[Text]] = ...,
         cookies: Union[None, RequestsCookieJar, MutableMapping[Text, Text]] = ...,
         files: Optional[MutableMapping[Text, IO[Any]]] = ...,
         auth: Union[None, Tuple[Text, Text], _auth.AuthBase, Callable[[Request], Request]] = ...,

--- a/third_party/2and3/requests/sessions.pyi
+++ b/third_party/2and3/requests/sessions.pyi
@@ -46,6 +46,7 @@ class SessionRedirectMixin:
     def rebuild_proxies(self, prepared_request, proxies): ...
 
 _Data = Union[None, Text, bytes, Mapping[str, Any], Mapping[Text, Any], Iterable[Tuple[Text, Optional[Text]]], IO]
+_Headers = Union[Mapping[Text, Text], CaseInsensitiveDict[Text]]
 
 _Hook = Callable[[Response], Any]
 _Hooks = MutableMapping[Text, List[_Hook]]
@@ -53,7 +54,7 @@ _HooksInput = MutableMapping[Text, Union[Iterable[_Hook], _Hook]]
 
 class Session(SessionRedirectMixin):
     __attrs__: Any
-    headers: CaseInsensitiveDict[Text]
+    headers: _Headers
     auth: Union[None, Tuple[Text, Text], _auth.AuthBase, Callable[[Request], Request]]
     proxies: MutableMapping[Text, Text]
     hooks: _Hooks
@@ -76,7 +77,7 @@ class Session(SessionRedirectMixin):
         url: Union[str, bytes, Text],
         params: Union[None, bytes, MutableMapping[Text, Text]] = ...,
         data: _Data = ...,
-        headers: Optional[MutableMapping[Text, Text]] = ...,
+        headers: _Headers = ...,
         cookies: Union[None, RequestsCookieJar, MutableMapping[Text, Text]] = ...,
         files: Optional[MutableMapping[Text, IO[Any]]] = ...,
         auth: Union[None, Tuple[Text, Text], _auth.AuthBase, Callable[[Request], Request]] = ...,

--- a/third_party/2and3/requests/sessions.pyi
+++ b/third_party/2and3/requests/sessions.pyi
@@ -76,7 +76,7 @@ class Session(SessionRedirectMixin):
         url: Union[str, bytes, Text],
         params: Union[None, bytes, MutableMapping[Text, Text]] = ...,
         data: _Data = ...,
-        headers: Union[None, Mapping[Text, Text], CaseInsensitiveDict[Text]] = ...,
+        headers: Optional[MutableMapping[Text, Text]] = ...,
         cookies: Union[None, RequestsCookieJar, MutableMapping[Text, Text]] = ...,
         files: Optional[MutableMapping[Text, IO[Any]]] = ...,
         auth: Union[None, Tuple[Text, Text], _auth.AuthBase, Callable[[Request], Request]] = ...,


### PR DESCRIPTION
headers can be passed/assigned either as a CaseInsensitiveDict instance or a regular Mapping.