### PR TITLE
Add missing default_section to RawConfigParser

### DIFF
--- a/stdlib/3/configparser.pyi
+++ b/stdlib/3/configparser.pyi
@@ -48,6 +48,7 @@ class LegacyInterpolation(Interpolation): ...
 
 class RawConfigParser(_parser):
     BOOLEAN_STATES: ClassVar[Mapping[str, bool]] = ...  # Undocumented
+    default_section: str
     def __init__(
         self,
         defaults: Optional[_section] = ...,


### PR DESCRIPTION
> When default_section is given, it specifies the name for the special section holding default values for other sections and interpolation purposes (normally named "DEFAULT"). This value can be retrieved and changed on runtime using the default_section instance attribute.
> ~ [configparser.ConfigParser](https://docs.python.org/3/library/configparser.html#configparser.ConfigParser)