### PR TITLE
platform: update for py39

### DIFF
--- a/stdlib/3/platform.pyi
+++ b/stdlib/3/platform.pyi
@@ -1,7 +1,9 @@
 # Stubs for platform (Python 3.5)
 
 import sys
-from os import devnull as DEV_NULL
+
+if sys.version_info < (3, 9):
+    from os import devnull as DEV_NULL
 from typing import NamedTuple, Optional, Tuple
 
 if sys.version_info >= (3, 8):

--- a/tests/stubtest_whitelists/py39.txt
+++ b/tests/stubtest_whitelists/py39.txt
@@ -85,7 +85,7 @@ os.MFD_HUGE_512MB
 os.getgrouplist
 os.sendfile
 pickle.Pickler.reducer_override
-platform.DEV_NULL
+# platform.uname_result's processor field is now dynamically made to exist
 platform.uname_result.__new__
 platform.uname_result._fields
 platform.uname_result.processor


### PR DESCRIPTION
platform.DEVNULL seemed undocumented, but is eg, still mentioned in the
header comment of platform.py. So feels surprising this was removed
without much warning.