### PR TITLE
stubtest: fix whitelists

### DIFF
--- a/tests/stubtest_whitelists/py35.txt
+++ b/tests/stubtest_whitelists/py35.txt
@@ -28,6 +28,7 @@ collections.UserString.maketrans
 contextlib._GeneratorContextManager.__init__
 ctypes.CDLL.__init__
 fractions.Fraction.__new__  # private _normalize param was made keyword-only in Python 3.6
+hmac.HMAC.__init__
 importlib.metadata
 importlib.resources
 io.StringIO.readline
@@ -44,6 +45,8 @@ os.DirEntry
 os.utime
 plistlib.Dict.__init__
 pyexpat.XMLParserType.ExternalEntityParserCreate
+random.Random.randrange  # missing undocumented arg _int
+random.randrange  # missing undocumented arg _int
 smtpd.SMTPChannel.__init__
 smtpd.SMTPServer.__init__
 sre_compile.dis

--- a/tests/stubtest_whitelists/py36.txt
+++ b/tests/stubtest_whitelists/py36.txt
@@ -24,6 +24,7 @@ copy.PyStringMap
 ctypes.CDLL.__init__
 email.message.MIMEPart.as_string
 enum.Enum._generate_next_value_
+hmac.HMAC.__init__
 importlib.metadata
 importlib.resources
 io.StringIO.readline
@@ -35,6 +36,8 @@ nntplib._NNTPBase.starttls
 os.utime
 plistlib.Dict.__init__
 pyexpat.XMLParserType.ExternalEntityParserCreate
+random.Random.randrange  # missing undocumented arg _int
+random.randrange  # missing undocumented arg _int
 secrets.SystemRandom.getstate
 smtplib.SMTP.sendmail
 sre_compile.dis

--- a/tests/stubtest_whitelists/py37.txt
+++ b/tests/stubtest_whitelists/py37.txt
@@ -31,6 +31,7 @@ dataclasses.Field.__init__
 dataclasses.field
 email.message.MIMEPart.as_string
 enum.Enum._generate_next_value_
+hmac.HMAC.__init__
 http.client.HTTPSConnection.__init__
 http.server.SimpleHTTPRequestHandler.__init__
 importlib.metadata
@@ -42,6 +43,8 @@ nntplib._NNTPBase.starttls
 os.utime
 pyexpat.XMLParserType.ExternalEntityParserCreate
 queue.SimpleQueue.__init__
+random.Random.randrange  # missing undocumented arg _int
+random.randrange  # missing undocumented arg _int
 secrets.SystemRandom.getstate
 smtplib.SMTP.sendmail
 sre_constants.RANGE_IGNORE

--- a/tests/stubtest_whitelists/py38.txt
+++ b/tests/stubtest_whitelists/py38.txt
@@ -66,6 +66,8 @@ nntplib._NNTPBase.starttls
 pickle.Pickler.reducer_override
 platform.DEV_NULL
 queue.SimpleQueue.__init__
+random.Random.randrange  # missing undocumented arg _int
+random.randrange  # missing undocumented arg _int
 secrets.SystemRandom.getstate
 select.epoll.register
 smtplib.SMTP.sendmail


### PR DESCRIPTION
Downstream of the reintroduction of py39 to CI / running the unused whitelist entry flow in #4512