### PR TITLE
Add type hints for pstats.SortKey available in Python >= 3.7

### DIFF
--- a/stdlib/2and3/pstats.pyi
+++ b/stdlib/2and3/pstats.pyi
@@ -19,7 +19,6 @@ if sys.version_info >= (3, 7):
         PCALLS: str
         STDNAME: str
         TIME: str
-    def __new__(cls, *values: Tuple[str]) -> SortKey: ...
 
 class Stats:
     sort_arg_dict_default: Dict[str, Tuple[Any, str]]

--- a/stdlib/2and3/pstats.pyi
+++ b/stdlib/2and3/pstats.pyi
@@ -1,3 +1,4 @@
+import sys
 from _typeshed import AnyPath
 from cProfile import Profile as _cProfile
 from profile import Profile

--- a/stdlib/2and3/pstats.pyi
+++ b/stdlib/2and3/pstats.pyi
@@ -1,6 +1,7 @@
 import sys
 from _typeshed import AnyPath
 from cProfile import Profile as _cProfile
+from enum import Enum
 from profile import Profile
 from typing import IO, Any, Dict, Iterable, List, Optional, Text, Tuple, TypeVar, Union, overload
 
@@ -8,7 +9,7 @@ _Selector = Union[str, float, int]
 _T = TypeVar("_T", bound=Stats)
 
 if sys.version_info >= (3, 7):
-    class SortKey:
+    class SortKey(str, Enum):
         CALLS: str
         CUMULATIVE: str
         FILENAME: str
@@ -18,6 +19,9 @@ if sys.version_info >= (3, 7):
         PCALLS: str
         STDNAME: str
         TIME: str
+
+    def __new__(cls, *values: Tuple[str]) -> SortKey: ...
+
 
 class Stats:
     sort_arg_dict_default: Dict[str, Tuple[Any, str]]

--- a/stdlib/2and3/pstats.pyi
+++ b/stdlib/2and3/pstats.pyi
@@ -19,9 +19,7 @@ if sys.version_info >= (3, 7):
         PCALLS: str
         STDNAME: str
         TIME: str
-
     def __new__(cls, *values: Tuple[str]) -> SortKey: ...
-
 
 class Stats:
     sort_arg_dict_default: Dict[str, Tuple[Any, str]]

--- a/stdlib/2and3/pstats.pyi
+++ b/stdlib/2and3/pstats.pyi
@@ -6,6 +6,18 @@ from typing import IO, Any, Dict, Iterable, List, Optional, Text, Tuple, TypeVar
 _Selector = Union[str, float, int]
 _T = TypeVar("_T", bound=Stats)
 
+if sys.version_info >= (3, 7):
+    class SortKey:
+        CALLS: str
+        CUMULATIVE: str
+        FILENAME: str
+        LINE: str
+        NAME: str
+        NFL: str
+        PCALLS: str
+        STDNAME: str
+        TIME: str
+
 class Stats:
     sort_arg_dict_default: Dict[str, Tuple[Any, str]]
     def __init__(


### PR DESCRIPTION
Fixes #4521