### PR TITLE
Made contextvars import in asyncio.base_futures conditional

### DIFF
--- a/stdlib/3/asyncio/base_futures.pyi
+++ b/stdlib/3/asyncio/base_futures.pyi
@@ -1,6 +1,9 @@
-import contextvars
+import sys
 from typing import Any, Callable, List, Sequence, Tuple
 from typing_extensions import Literal
+
+if sys.version_info >= (3, 7):
+    from contextvars import Context
 
 from . import futures
 
@@ -9,5 +12,11 @@ _CANCELLED: Literal["CANCELLED"]  # undocumented
 _FINISHED: Literal["FINISHED"]  # undocumented
 
 def isfuture(obj: object) -> bool: ...
-def _format_callbacks(cb: Sequence[Tuple[Callable[[futures.Future[Any]], None], contextvars.Context]]) -> str: ...  # undocumented
+
+if sys.version_info >= (3, 7):
+    def _format_callbacks(cb: Sequence[Tuple[Callable[[futures.Future[Any]], None], Context]]) -> str: ...  # undocumented
+
+else:
+    def _format_callbacks(cb: Sequence[Callable[[futures.Future[Any]], None]]) -> str: ...  # undocumented
+
 def _future_repr_info(future: futures.Future[Any]) -> List[str]: ...  # undocumented


### PR DESCRIPTION
contextvars are only available in 3.7+.