### PR TITLE
pkgutil, sys: make types more precise

### DIFF
--- a/stdlib/2and3/pkgutil.pyi
+++ b/stdlib/2and3/pkgutil.pyi
@@ -1,21 +1,23 @@
 # Stubs for pkgutil
 
 import sys
-from typing import IO, Any, Callable, Generator, Iterable, NamedTuple, Optional, Tuple
+from typing import IO, Any, Callable, Iterable, Iterator, NamedTuple, Optional, Tuple, Union
 
 if sys.version_info >= (3,):
-    from importlib.abc import Loader
+    from importlib.abc import Loader, MetaPathFinder, PathEntryFinder
 else:
     Loader = Any
+    MetaPathFinder = Any
+    PathEntryFinder = Any
 
 if sys.version_info >= (3, 6):
     class ModuleInfo(NamedTuple):
-        module_finder: Any
+        module_finder: Union[MetaPathFinder, PathEntryFinder]
         name: str
         ispkg: bool
-    _YMFNI = Generator[ModuleInfo, None, None]
+    _ModuleInfoLike = ModuleInfo
 else:
-    _YMFNI = Generator[Tuple[Any, str, bool], None, None]
+    _ModuleInfoLike = Tuple[Union[MetaPathFinder, PathEntryFinder], str, bool]
 
 def extend_path(path: Iterable[str], name: str) -> Iterable[str]: ...
 
@@ -26,11 +28,11 @@ class ImpLoader:
     def __init__(self, fullname: str, file: IO[str], filename: str, etc: Tuple[str, str, int]) -> None: ...
 
 def find_loader(fullname: str) -> Optional[Loader]: ...
-def get_importer(path_item: str) -> Any: ...  # TODO precise type
+def get_importer(path_item: str) -> Optional[PathEntryFinder]: ...
 def get_loader(module_or_name: str) -> Loader: ...
-def iter_importers(fullname: str = ...) -> Generator[Any, None, None]: ...  # TODO precise type
-def iter_modules(path: Optional[Iterable[str]] = ..., prefix: str = ...) -> _YMFNI: ...  # TODO precise type
+def iter_importers(fullname: str = ...) -> Iterator[Union[MetaPathFinder, PathEntryFinder]]: ...
+def iter_modules(path: Optional[Iterable[str]] = ..., prefix: str = ...) -> Iterator[_ModuleInfoLike]: ...
 def walk_packages(
     path: Optional[Iterable[str]] = ..., prefix: str = ..., onerror: Optional[Callable[[str], None]] = ...
-) -> _YMFNI: ...
+) -> Iterator[_ModuleInfoLike]: ...
 def get_data(package: str, resource: str) -> Optional[bytes]: ...

--- a/stdlib/3/sys.pyi
+++ b/stdlib/3/sys.pyi
@@ -5,7 +5,7 @@
 
 import sys
 from builtins import object as _object
-from importlib.abc import MetaPathFinder
+from importlib.abc import MetaPathFinder, PathEntryFinder
 from types import FrameType, ModuleType, TracebackType
 from typing import Any, Callable, Dict, List, NoReturn, Optional, Sequence, TextIO, Tuple, Type, TypeVar, Union, overload
 
@@ -42,7 +42,7 @@ meta_path: List[MetaPathFinder]
 modules: Dict[str, ModuleType]
 path: List[str]
 path_hooks: List[Any]  # TODO precise type; function, path to finder
-path_importer_cache: Dict[str, Any]  # TODO precise type
+path_importer_cache: Dict[str, Optional[PathEntryFinder]]
 platform: str
 if sys.version_info >= (3, 9):
     platlibdir: str


### PR DESCRIPTION
I think the Union type is what we want here? At least for
iter_importers. Maybe for ModuleInfo people sometimes assume they're
going to get a FileFinder.

My experience with pkgutil is fairly limited, happy to make changes.