### PR TITLE
Upgrade pytype

### DIFF
--- a/requirements-tests-py3.txt
+++ b/requirements-tests-py3.txt
@@ -5,4 +5,4 @@ flake8==3.8.3
 flake8-bugbear==20.1.4
 flake8-pyi==20.5.0
 isort[pyproject]==5.1.1
-pytype>=2020.08.17
+pytype>=2020.09.14


### PR DESCRIPTION
The latest version recognizes the @runtime_checkable
decorator, required for #4442.