### PR TITLE
Add more constants and attributes to posix

### DIFF
--- a/stdlib/3/posix.pyi
+++ b/stdlib/3/posix.pyi
@@ -5,8 +5,6 @@ from typing import Any, Dict, List, NamedTuple, Optional, overload
 if sys.version_info >= (3, 6):
     from builtins import _PathLike  # See comment in builtins
 
-def __getattr__(name: str) -> Any: ...  # incomplete
-
 class uname_result(NamedTuple):
     sysname: str
     nodename: str

--- a/stdlib/3/posix.pyi
+++ b/stdlib/3/posix.pyi
@@ -1,13 +1,11 @@
-# Stubs for posix
-
-# NOTE: These are incomplete!
-
 import sys
 from os import stat_result as stat_result
-from typing import List, NamedTuple, Optional, overload
+from typing import Dict, List, NamedTuple, Optional, overload
 
 if sys.version_info >= (3, 6):
     from builtins import _PathLike  # See comment in builtins
+
+def __getattr__(name: str) -> Any: ...  # incomplete
 
 class uname_result(NamedTuple):
     sysname: str
@@ -33,6 +31,11 @@ class waitid_result(NamedTuple):
 class sched_param(NamedTuple):
     sched_priority: int
 
+CLD_CONTINUED: int
+CLD_DUMPED: int
+CLD_EXITED: int
+CLD_TRAPPED: int
+
 EX_CANTCREAT: int
 EX_CONFIG: int
 EX_DATAERR: int
@@ -55,6 +58,11 @@ F_OK: int
 R_OK: int
 W_OK: int
 X_OK: int
+
+F_LOCK: int
+F_TEST: int
+F_TLOCK: int
+F_ULOCK: int
 
 if sys.version_info >= (3, 6):
     GRND_NONBLOCK: int
@@ -82,6 +90,39 @@ O_SYNC: int
 O_TRUNC: int
 O_WRONLY: int
 
+POSIX_FADV_DONTNEED: int
+POSIX_FADV_NOREUSE: int
+POSIX_FADV_NORMAL: int
+POSIX_FADV_RANDOM: int
+POSIX_FADV_SEQUENTIAL: int
+POSIX_FADV_WILLNEED: int
+
+PRIO_PGRP: int
+PRIO_PROCESS: int
+PRIO_USER: int
+
+P_ALL: int
+P_PGID: int
+P_PID: int
+
+RTLD_DEEPBIND: int
+RTLD_GLOBAL: int
+RTLD_LAZY: int
+RTLD_LOCAL: int
+RTLD_NODELETE: int
+RTLD_NOLOAD: int
+RTLD_NOW: int
+
+SCHED_BATCH: int
+SCHED_FIFO: int
+SCHED_IDLE: int
+SCHED_OTHER: int
+SCHED_RESET_ON_FORK: int
+SCHED_RR: int
+
+SEEK_DATA: int
+SEEK_HOLE: int
+
 ST_APPEND: int
 ST_MANDLOCK: int
 ST_NOATIME: int
@@ -107,6 +148,10 @@ WSTOPSIG: int
 WTERMSIG: int
 WUNTRACED: int
 
+XATTR_CREATE: int
+XATTR_REPLACE: int
+XATTR_SIZE_MAX: int
+
 if sys.version_info >= (3, 6):
     @overload
     def listdir(path: Optional[str] = ...) -> List[str]: ...
@@ -124,3 +169,8 @@ else:
     def listdir(path: bytes) -> List[bytes]: ...
     @overload
     def listdir(path: int) -> List[str]: ...
+
+if sys.platform == "win32":
+    environ: Dict[str, str]
+else:
+    environ: Dict[bytes, bytes]

--- a/stdlib/3/posix.pyi
+++ b/stdlib/3/posix.pyi
@@ -1,6 +1,6 @@
 import sys
 from os import stat_result as stat_result
-from typing import Dict, List, NamedTuple, Optional, overload
+from typing import Any, Dict, List, NamedTuple, Optional, overload
 
 if sys.version_info >= (3, 6):
     from builtins import _PathLike  # See comment in builtins


### PR DESCRIPTION
The constants were found by running dir(posix) on a Debian 10.5 (x86_64)
system.

Also mark module as incomplete.

Partly addresses #616.