### PR TITLE
PathLike: make runtime_checkable

### DIFF
--- a/stdlib/2/__builtin__.pyi
+++ b/stdlib/2/__builtin__.pyi
@@ -56,6 +56,7 @@ from typing import (
     Union,
     ValuesView,
     overload,
+    runtime_checkable,
 )
 from typing_extensions import Literal
 
@@ -1211,7 +1212,7 @@ if sys.version_info < (3,):
 # but we define it here as _PathLike to avoid import cycle issues.
 # See https://github.com/python/typeshed/pull/991#issuecomment-288160993
 _AnyStr_co = TypeVar("_AnyStr_co", str, bytes, covariant=True)
-
+@runtime_checkable
 class _PathLike(Protocol[_AnyStr_co]):
     def __fspath__(self) -> _AnyStr_co: ...
 

--- a/stdlib/2and3/builtins.pyi
+++ b/stdlib/2and3/builtins.pyi
@@ -56,6 +56,7 @@ from typing import (
     Union,
     ValuesView,
     overload,
+    runtime_checkable,
 )
 from typing_extensions import Literal
 
@@ -1211,7 +1212,7 @@ if sys.version_info < (3,):
 # but we define it here as _PathLike to avoid import cycle issues.
 # See https://github.com/python/typeshed/pull/991#issuecomment-288160993
 _AnyStr_co = TypeVar("_AnyStr_co", str, bytes, covariant=True)
-
+@runtime_checkable
 class _PathLike(Protocol[_AnyStr_co]):
     def __fspath__(self) -> _AnyStr_co: ...
 


### PR DESCRIPTION
I made PathLike a protocol in #4447, but it should also be
runtime_checkable.

Caught by mypy_primer:
src/werkzeug/utils.py:646: error: Only @runtime_checkable protocols can be used with instance and class checks