### PR TITLE
fcntl: Add fcntl.F_OFD_XXXX constants

### DIFF
--- a/stdlib/3/fcntl.pyi
+++ b/stdlib/3/fcntl.pyi
@@ -34,7 +34,7 @@ F_SETLK: int
 F_SETLK64: int
 F_SETLKW: int
 F_SETLKW64: int
-if sys.version_info >= (3, 9):
+if sys.version_info >= (3, 9) and sys.platform == "linux":
     F_OFD_GETLK: int
     F_OFD_SETLK: int
     F_OFD_SETLKW: int

--- a/stdlib/3/fcntl.pyi
+++ b/stdlib/3/fcntl.pyi
@@ -1,3 +1,4 @@
+import sys
 from _typeshed import FileDescriptorLike
 from array import array
 from typing import Any, Union, overload
@@ -33,6 +34,10 @@ F_SETLK: int
 F_SETLK64: int
 F_SETLKW: int
 F_SETLKW64: int
+if sys.version_info >= (3, 9):
+    F_OFD_GETLK: int
+    F_OFD_SETLK: int
+    F_OFD_SETLKW: int
 F_SETOWN: int
 F_SETSIG: int
 F_SHLCK: int


### PR DESCRIPTION
Add support for the following open file description lock constants:

  - F_OFD_GETLK
  - F_OFD_SETLK
  - F_OFD_SETLKW