### PR TITLE
pep 484: explicit reexport as intended

### DIFF
--- a/stdlib/2/collections.pyi
+++ b/stdlib/2/collections.pyi
@@ -1,7 +1,7 @@
 # These are not exported.
 # These are exported.
 from typing import (
-    AbstractSet as Set,
+    AbstractSet,
     Any,
     Callable as Callable,
     Container as Container,
@@ -29,6 +29,8 @@ from typing import (
     ValuesView as ValuesView,
     overload,
 )
+
+Set = AbstractSet
 
 _S = TypeVar("_S")
 _T = TypeVar("_T")

--- a/stdlib/2/future_builtins.pyi
+++ b/stdlib/2/future_builtins.pyi
@@ -1,5 +1,9 @@
-from itertools import ifilter as filter, imap as map, izip as zip
+from itertools import ifilter, imap, izip
 from typing import Any
+
+filter = ifilter
+map = imap
+zip = izip
 
 def ascii(obj: Any) -> str: ...
 def hex(x: int) -> str: ...

--- a/stdlib/2/md5.pyi
+++ b/stdlib/2/md5.pyi
@@ -1,6 +1,7 @@
 # Stubs for Python 2.7 md5 stdlib module
 
-from hashlib import md5 as md5, md5 as new
+from hashlib import md5 as md5
 
+new = md5
 blocksize: int
 digest_size: int

--- a/stdlib/2/os/__init__.pyi
+++ b/stdlib/2/os/__init__.pyi
@@ -1,6 +1,6 @@
 import sys
 from _typeshed import AnyPath, FileDescriptorLike
-from builtins import OSError as error
+from builtins import OSError
 from io import TextIOWrapper as _TextIOWrapper
 from posix import listdir as listdir, stat_result as stat_result  # TODO: use this, see https://github.com/python/mypy/issues/3078
 from typing import (
@@ -34,6 +34,8 @@ _supports_unicode_filenames = path.supports_unicode_filenames
 _T = TypeVar("_T")
 
 # ----- os variables -----
+
+error = OSError
 
 if sys.version_info >= (3, 2):
     supports_bytes_environ: bool
@@ -152,7 +154,9 @@ TMP_MAX: int  # Undocumented, but used by tempfile
 
 # ----- os classes (structures) -----
 if sys.version_info >= (3, 6):
-    from builtins import _PathLike as PathLike  # See comment in builtins
+    from builtins import _PathLike
+
+    PathLike = _PathLike  # See comment in builtins
 
 class _StatVFS(NamedTuple):
     f_bsize: int

--- a/stdlib/2and3/_dummy_threading.pyi
+++ b/stdlib/2and3/_dummy_threading.pyi
@@ -155,7 +155,11 @@ class Event:
     def wait(self, timeout: Optional[float] = ...) -> bool: ...
 
 if sys.version_info >= (3, 8):
-    from _thread import ExceptHookArgs as _ExceptHookArgs, _ExceptHookArgs as ExceptHookArgs  # don't ask
+    import _thread
+
+    # don't ask...
+    _ExceptHookArgs = _thread.ExceptHookArgs
+    ExceptHookArgs = _thread._ExceptHookArgs
 
     excepthook: Callable[[_ExceptHookArgs], Any]
 

--- a/stdlib/2and3/threading.pyi
+++ b/stdlib/2and3/threading.pyi
@@ -155,7 +155,11 @@ class Event:
     def wait(self, timeout: Optional[float] = ...) -> bool: ...
 
 if sys.version_info >= (3, 8):
-    from _thread import ExceptHookArgs as _ExceptHookArgs, _ExceptHookArgs as ExceptHookArgs  # don't ask
+    import _thread
+
+    # don't ask...
+    _ExceptHookArgs = _thread.ExceptHookArgs
+    ExceptHookArgs = _thread._ExceptHookArgs
 
     excepthook: Callable[[_ExceptHookArgs], Any]
 

--- a/stdlib/3/collections/__init__.pyi
+++ b/stdlib/3/collections/__init__.pyi
@@ -1,7 +1,7 @@
 import sys
 import typing
 from typing import (
-    AbstractSet as Set,
+    AbstractSet,
     Any,
     AsyncIterable as AsyncIterable,
     AsyncIterator as AsyncIterator,
@@ -35,6 +35,8 @@ from typing import (
     ValuesView as ValuesView,
     overload,
 )
+
+Set = AbstractSet
 
 if sys.version_info >= (3, 6):
     from typing import AsyncGenerator as AsyncGenerator, Collection as Collection

--- a/stdlib/3/os/__init__.pyi
+++ b/stdlib/3/os/__init__.pyi
@@ -8,7 +8,7 @@ from _typeshed import (
     OpenBinaryModeWriting,
     OpenTextMode,
 )
-from builtins import OSError as error
+from builtins import OSError
 from io import BufferedRandom, BufferedReader, BufferedWriter, FileIO, TextIOWrapper as _TextIOWrapper
 from posix import listdir as listdir, times_result
 from typing import (
@@ -45,6 +45,8 @@ _supports_unicode_filenames = path.supports_unicode_filenames
 _T = TypeVar("_T")
 
 # ----- os variables -----
+
+error = OSError
 
 supports_bytes_environ: bool
 
@@ -268,7 +270,9 @@ class stat_result:
     st_type: int
 
 if sys.version_info >= (3, 6):
-    from builtins import _PathLike as PathLike  # See comment in builtins
+    from builtins import _PathLike
+
+    PathLike = _PathLike  # See comment in builtins
 
 _FdOrAnyPath = Union[int, AnyPath]
 

--- a/stdlib/3/platform.pyi
+++ b/stdlib/3/platform.pyi
@@ -3,7 +3,9 @@
 import sys
 
 if sys.version_info < (3, 9):
-    from os import devnull as DEV_NULL
+    import os
+
+    DEV_NULL = os.devnull
 from typing import NamedTuple, Optional, Tuple
 
 if sys.version_info >= (3, 8):

--- a/third_party/2/six/__init__.pyi
+++ b/third_party/2/six/__init__.pyi
@@ -6,8 +6,6 @@ import unittest
 from __builtin__ import unichr as unichr
 from functools import wraps as wraps
 from StringIO import StringIO as StringIO
-
-BytesIO = StringIO
 from typing import (
     Any,
     AnyStr,
@@ -30,6 +28,8 @@ from typing import (
 )
 
 from . import moves
+
+BytesIO = StringIO
 
 _T = TypeVar("_T")
 _K = TypeVar("_K")

--- a/third_party/2/six/__init__.pyi
+++ b/third_party/2/six/__init__.pyi
@@ -5,7 +5,9 @@ import typing
 import unittest
 from __builtin__ import unichr as unichr
 from functools import wraps as wraps
-from StringIO import StringIO as BytesIO, StringIO as StringIO
+from StringIO import StringIO as StringIO
+
+BytesIO = StringIO
 from typing import (
     Any,
     AnyStr,

--- a/third_party/2/six/moves/__init__.pyi
+++ b/third_party/2/six/moves/__init__.pyi
@@ -2,23 +2,34 @@
 #
 # Note: Commented out items means they weren't implemented at the time.
 # Uncomment them when the modules have been added to the typeshed.
-import __builtin__ as builtins
-from __builtin__ import (
-    intern as intern,
-    raw_input as input,
-    reduce as reduce,
-    reload as reload_module,
-    xrange as range,
-    xrange as xrange,
-)
-from cStringIO import StringIO as cStringIO
-from itertools import ifilter as filter, ifilterfalse as filterfalse, imap as map, izip as zip, izip_longest as zip_longest
-from os import getcwd as getcwdb, getcwdu as getcwd
-from pipes import quote as shlex_quote
+import __builtin__
+import itertools
+import os
+import pipes
+from __builtin__ import intern as intern, reduce as reduce, xrange as xrange
+from cStringIO import StringIO as _cStringIO
 from StringIO import StringIO as StringIO
 from UserDict import UserDict as UserDict
 from UserList import UserList as UserList
 from UserString import UserString as UserString
+
+builtins = __builtin__
+input = __builtin__.raw_input
+reload_module = __builtin__.reload
+range = __builtin__.xrange
+
+cStringIO = _cStringIO
+
+filter = itertools.ifilter
+filterfalse = itertools.ifilterfalse
+map = itertools.imap
+zip = itertools.izip
+zip_longest = itertools.izip_longest
+
+getcwdb = os.getcwd
+getcwd = os.getcwdu
+
+shlex_quote = pipes.quote
 
 # import Tkinter as tkinter
 # import Dialog as tkinter_dialog

--- a/third_party/2/six/moves/__init__.pyi
+++ b/third_party/2/six/moves/__init__.pyi
@@ -13,24 +13,6 @@ from UserDict import UserDict as UserDict
 from UserList import UserList as UserList
 from UserString import UserString as UserString
 
-builtins = __builtin__
-input = __builtin__.raw_input
-reload_module = __builtin__.reload
-range = __builtin__.xrange
-
-cStringIO = _cStringIO
-
-filter = itertools.ifilter
-filterfalse = itertools.ifilterfalse
-map = itertools.imap
-zip = itertools.izip
-zip_longest = itertools.izip_longest
-
-getcwdb = os.getcwd
-getcwd = os.getcwdu
-
-shlex_quote = pipes.quote
-
 # import Tkinter as tkinter
 # import Dialog as tkinter_dialog
 # import FileDialog as tkinter_filedialog
@@ -76,3 +58,21 @@ from . import (
 )
 
 # import SimpleXMLRPCServer as xmlrpc_server
+
+builtins = __builtin__
+input = __builtin__.raw_input
+reload_module = __builtin__.reload
+range = __builtin__.xrange
+
+cStringIO = _cStringIO
+
+filter = itertools.ifilter
+filterfalse = itertools.ifilterfalse
+map = itertools.imap
+zip = itertools.izip
+zip_longest = itertools.izip_longest
+
+getcwdb = os.getcwd
+getcwd = os.getcwdu
+
+shlex_quote = pipes.quote

--- a/third_party/2/six/moves/urllib/parse.pyi
+++ b/third_party/2/six/moves/urllib/parse.pyi
@@ -6,7 +6,6 @@ from urllib import (
     splittag as splittag,
     splituser as splituser,
     unquote as unquote,
-    unquote as unquote_to_bytes,
     unquote_plus as unquote_plus,
     urlencode as urlencode,
 )
@@ -27,3 +26,5 @@ from urlparse import (
     uses_query as uses_query,
     uses_relative as uses_relative,
 )
+
+unquote_to_bytes = unquote

--- a/third_party/3/six/moves/__init__.pyi
+++ b/third_party/3/six/moves/__init__.pyi
@@ -2,15 +2,21 @@
 #
 # Note: Commented out items means they weren't implemented at the time.
 # Uncomment them when the modules have been added to the typeshed.
-from builtins import filter as filter, input as input, map as map, range as range, range as xrange, zip as zip
+import builtins
+import importlib
+import shlex
+from builtins import filter as filter, input as input, map as map, range as range, zip as zip
 from collections import UserDict as UserDict, UserList as UserList, UserString as UserString
 from functools import reduce as reduce
-from importlib import reload as reload_module
-from io import StringIO as StringIO, StringIO as cStringIO
+from io import StringIO as StringIO
 from itertools import filterfalse as filterfalse, zip_longest as zip_longest
 from os import getcwd as getcwd, getcwdb as getcwdb
-from shlex import quote as shlex_quote
 from sys import intern as intern
+
+xrange = builtins.range
+reload_module = importlib.reload
+cStringIO = StringIO
+shlex_quote = shlex.quote
 
 # import tkinter.font as tkinter_font
 # import tkinter.messagebox as tkinter_messagebox

--- a/third_party/3/six/moves/__init__.pyi
+++ b/third_party/3/six/moves/__init__.pyi
@@ -2,7 +2,6 @@
 #
 # Note: Commented out items means they weren't implemented at the time.
 # Uncomment them when the modules have been added to the typeshed.
-import builtins
 import importlib
 import shlex
 from builtins import filter as filter, input as input, map as map, range as range, zip as zip
@@ -12,11 +11,6 @@ from io import StringIO as StringIO
 from itertools import filterfalse as filterfalse, zip_longest as zip_longest
 from os import getcwd as getcwd, getcwdb as getcwdb
 from sys import intern as intern
-
-xrange = builtins.range
-reload_module = importlib.reload
-cStringIO = StringIO
-shlex_quote = shlex.quote
 
 # import tkinter.font as tkinter_font
 # import tkinter.messagebox as tkinter_messagebox
@@ -64,3 +58,8 @@ from . import (
 
 # import xmlrpc.client as xmlrpc_client
 # import xmlrpc.server as xmlrpc_server
+
+xrange = range
+reload_module = importlib.reload
+cStringIO = StringIO
+shlex_quote = shlex.quote


### PR DESCRIPTION
See discussion on typing-sig.
This doesn't take care of some third_party libraries, will follow up on
those.