### PR TITLE
contextlib: get rid of a TODO

### DIFF
--- a/stdlib/2and3/contextlib.pyi
+++ b/stdlib/2and3/contextlib.pyi
@@ -1,19 +1,6 @@
-# ContextManager aliased here for backwards compatibility; TODO eventually remove this
 import sys
 from types import TracebackType
-from typing import (
-    IO,
-    Any,
-    Callable,
-    ContextManager as ContextManager,
-    Generic,
-    Iterable,
-    Iterator,
-    Optional,
-    Type,
-    TypeVar,
-    overload,
-)
+from typing import IO, Any, Callable, ContextManager, Generic, Iterable, Iterator, Optional, Type, TypeVar, overload
 
 if sys.version_info >= (3, 5):
     from typing import AsyncContextManager, AsyncIterator

--- a/tests/stubtest_whitelists/py3_common.txt
+++ b/tests/stubtest_whitelists/py3_common.txt
@@ -102,7 +102,6 @@ configparser.SectionProxy.__getattr__
 configparser.SectionProxy.getboolean
 configparser.SectionProxy.getfloat
 configparser.SectionProxy.getint
-contextlib.ContextManager
 csv.Dialect.delimiter
 csv.Dialect.doublequote
 csv.Dialect.lineterminator


### PR DESCRIPTION
This dates back three years to https://github.com/python/typeshed/pull/1249

It seems pretty unused in practice, so I think this is fine:
https://grep.app/search?q=from%20contextlib%20import%20ContextManager&case=true
https://grep.app/search?q=contextlib.ContextManager&case=true