### PR TITLE
Allow request.get params values to be None

### DIFF
--- a/third_party/2and3/requests/api.pyi
+++ b/third_party/2and3/requests/api.pyi
@@ -5,7 +5,7 @@ from typing import Iterable, Mapping, Optional, Text, Tuple, Union
 from .models import Response
 from .sessions import _Data
 
-_ParamsMappingValueType = Union[Text, bytes, int, float, Iterable[Union[Text, bytes, int, float]]]
+_ParamsMappingValueType = Union[Text, bytes, int, float, Iterable[Union[Text, bytes, int, float]], None]
 
 def request(method: str, url: str, **kwargs) -> Response: ...
 def get(


### PR DESCRIPTION
I was getting this error message from mypy:

`error: Argument "params" to "get" has incompatible type "Dict[str, Optional[str]]"; expected <union: 9 items>`

but it looks like requests allows this:

```python
>>> import requests
>>> resp = requests.get('https://example.com', params={'q': None, 'r': 'a'})
>>> resp.url
'https://example.com/?r=a'
```