### PR TITLE
Add a version guard for importing enum in pstats.

### DIFF
--- a/stdlib/2and3/pstats.pyi
+++ b/stdlib/2and3/pstats.pyi
@@ -4,13 +4,11 @@ from cProfile import Profile as _cProfile
 from profile import Profile
 from typing import IO, Any, Dict, Iterable, List, Optional, Text, Tuple, TypeVar, Union, overload
 
-if sys.version_info >= (3, 4):
-    from enum import Enum
-
 _Selector = Union[str, float, int]
 _T = TypeVar("_T", bound=Stats)
 
 if sys.version_info >= (3, 7):
+    from enum import Enum
     class SortKey(str, Enum):
         CALLS: str
         CUMULATIVE: str

--- a/stdlib/2and3/pstats.pyi
+++ b/stdlib/2and3/pstats.pyi
@@ -1,9 +1,11 @@
 import sys
 from _typeshed import AnyPath
 from cProfile import Profile as _cProfile
-from enum import Enum
 from profile import Profile
 from typing import IO, Any, Dict, Iterable, List, Optional, Text, Tuple, TypeVar, Union, overload
+
+if sys.version_info >= (3, 4):
+    from enum import Enum
 
 _Selector = Union[str, float, int]
 _T = TypeVar("_T", bound=Stats)


### PR DESCRIPTION
I'm trying to pull the latest version of typeshed into Google, and
pytype chokes on pstats in Python 2 because the enum module was
introduced in 3.4.