### PR TITLE
Added Iterable of tuples support

### DIFF
--- a/third_party/2and3/requests/api.pyi
+++ b/third_party/2and3/requests/api.pyi
@@ -5,6 +5,7 @@ from typing import Iterable, Mapping, Optional, Text, Tuple, Union
 from .models import Response
 from .sessions import _Data
 
+_ParamsMappingKeyType = Union[Text, bytes, int, float]
 _ParamsMappingValueType = Union[Text, bytes, int, float, Iterable[Union[Text, bytes, int, float]], None]
 
 def request(method: str, url: str, **kwargs) -> Response: ...
@@ -12,13 +13,15 @@ def get(
     url: Union[Text, bytes],
     params: Optional[
         Union[
-            Mapping[Union[Text, bytes, int, float], _ParamsMappingValueType],
-            Union[Text, bytes],
-            Tuple[Union[Text, bytes, int, float], _ParamsMappingValueType],
+            # Mapping type keys are invariant
+            Mapping[_ParamsMappingKeyType, _ParamsMappingValueType],
             Mapping[Text, _ParamsMappingValueType],
             Mapping[bytes, _ParamsMappingValueType],
             Mapping[int, _ParamsMappingValueType],
             Mapping[float, _ParamsMappingValueType],
+            Tuple[_ParamsMappingKeyType, _ParamsMappingValueType],
+            Iterable[Tuple[_ParamsMappingKeyType, _ParamsMappingValueType],
+            Union[Text, bytes],
         ]
     ] = ...,
     **kwargs,

--- a/third_party/2and3/requests/api.pyi
+++ b/third_party/2and3/requests/api.pyi
@@ -1,6 +1,7 @@
 # Stubs for requests.api (Python 3)
 
-from typing import Iterable, Mapping, Optional, Text, Tuple, Union
+from _typeshed import SupportsItems
+from typing import Iterable, Optional, Text, Tuple, Union
 
 from .models import Response
 from .sessions import _Data
@@ -13,14 +14,9 @@ def get(
     url: Union[Text, bytes],
     params: Optional[
         Union[
-            # Mapping type keys are invariant
-            Mapping[_ParamsMappingKeyType, _ParamsMappingValueType],
-            Mapping[Text, _ParamsMappingValueType],
-            Mapping[bytes, _ParamsMappingValueType],
-            Mapping[int, _ParamsMappingValueType],
-            Mapping[float, _ParamsMappingValueType],
+            SupportsItems[_ParamsMappingKeyType, _ParamsMappingValueType],
             Tuple[_ParamsMappingKeyType, _ParamsMappingValueType],
-            Iterable[Tuple[_ParamsMappingKeyType, _ParamsMappingValueType],
+            Iterable[Tuple[_ParamsMappingKeyType, _ParamsMappingValueType]],
             Union[Text, bytes],
         ]
     ] = ...,


### PR DESCRIPTION
Fixes [#3218](https://github.com/python/typeshed/issues/3218)

I went through requests implementation, looks like we can replace `Mapping` with `SupportsItems`. That way we also get covariance. Let me know if I should make that change.