### PR TITLE
io: loosen writelines type to iterable

### DIFF
--- a/stdlib/3/io.pyi
+++ b/stdlib/3/io.pyi
@@ -128,7 +128,7 @@ class TextIOBase(IOBase):
     def __next__(self) -> str: ...  # type: ignore
     def detach(self) -> BinaryIO: ...
     def write(self, __s: str) -> int: ...
-    def writelines(self, __lines: List[str]) -> None: ...  # type: ignore
+    def writelines(self, __lines: Iterable[str]) -> None: ...  # type: ignore
     def readline(self, __size: int = ...) -> str: ...  # type: ignore
     def readlines(self, __hint: int = ...) -> List[str]: ...  # type: ignore
     def read(self, __size: Optional[int] = ...) -> str: ...
@@ -166,7 +166,7 @@ class TextIOWrapper(TextIOBase, TextIO):
     def __enter__(self: _T) -> _T: ...
     def __iter__(self) -> Iterator[str]: ...  # type: ignore
     def __next__(self) -> str: ...  # type: ignore
-    def writelines(self, __lines: List[str]) -> None: ...  # type: ignore
+    def writelines(self, __lines: Iterable[str]) -> None: ...  # type: ignore
     def readline(self, __size: int = ...) -> str: ...  # type: ignore
     def readlines(self, __hint: int = ...) -> List[str]: ...  # type: ignore
     def seek(self, __cookie: int, __whence: int = ...) -> int: ...


### PR DESCRIPTION
This came up in https://github.com/python/mypy/pull/9275
Note that the perennial "str is an iterable of str" concern doesn't matter here, since things work even if you get it "wrong"