### PR TITLE
markdown: no assumptions about ext cfg types

### DIFF
--- a/third_party/2and3/markdown/core.pyi
+++ b/third_party/2and3/markdown/core.pyi
@@ -1,4 +1,4 @@
-from typing import BinaryIO, Mapping, Optional, Sequence, Text, TextIO, Union
+from typing import Any, BinaryIO, Mapping, Optional, Sequence, Text, TextIO, Union
 from typing_extensions import Literal
 
 from .extensions import Extension
@@ -8,13 +8,13 @@ class Markdown:
         self,
         *,
         extensions: Optional[Sequence[Union[str, Extension]]] = ...,
-        extension_configs: Optional[Mapping[str, Mapping[str, str]]] = ...,
+        extension_configs: Optional[Mapping[str, Mapping[str, Any]]] = ...,
         output_format: Optional[Literal["xhtml", "html"]] = ...,
         tab_length: Optional[int] = ...,
     ) -> None: ...
     def build_parser(self) -> Markdown: ...
     def registerExtensions(
-        self, extensions: Sequence[Union[Extension, str]], configs: Mapping[str, Mapping[str, str]]
+        self, extensions: Sequence[Union[Extension, str]], configs: Mapping[str, Mapping[str, Any]]
     ) -> Markdown: ...
     def build_extension(self, ext_name: Text, configs: Mapping[str, str]) -> Extension: ...
     def registerExtension(self, extension: Extension) -> Markdown: ...
@@ -33,7 +33,7 @@ def markdown(
     text: Text,
     *,
     extensions: Optional[Sequence[Union[str, Extension]]] = ...,
-    extension_configs: Optional[Mapping[str, Mapping[str, str]]] = ...,
+    extension_configs: Optional[Mapping[str, Mapping[str, Any]]] = ...,
     output_format: Optional[Literal["xhtml", "html"]] = ...,
     tab_length: Optional[int] = ...,
 ) -> Text: ...
@@ -43,7 +43,7 @@ def markdownFromFile(
     output: Optional[Union[str, TextIO, BinaryIO]] = ...,
     encoding: Optional[str] = ...,
     extensions: Optional[Sequence[Union[str, Extension]]] = ...,
-    extension_configs: Optional[Mapping[str, Mapping[str, str]]] = ...,
+    extension_configs: Optional[Mapping[str, Mapping[str, Any]]] = ...,
     output_format: Optional[Literal["xhtml", "html"]] = ...,
     tab_length: Optional[int] = ...,
 ) -> None: ...


### PR DESCRIPTION
`extension_configs` are by definition unpredictable and an example that
isn't str → str would be:

    extension_configs={"codehilite": {"guess_lang": False}}