### PR TITLE
Remove some TODOs from IO classes

### DIFF
--- a/stdlib/3/typing.pyi
+++ b/stdlib/3/typing.pyi
@@ -468,7 +468,6 @@ Text = str
 TYPE_CHECKING = True
 
 class IO(Iterator[AnyStr], Generic[AnyStr]):
-    # TODO detach
     # TODO use abstract properties
     @property
     def mode(self) -> str: ...
@@ -484,7 +483,6 @@ class IO(Iterator[AnyStr], Generic[AnyStr]):
     def flush(self) -> None: ...
     @abstractmethod
     def isatty(self) -> bool: ...
-    # TODO what if n is None?
     @abstractmethod
     def read(self, n: int = ...) -> AnyStr: ...
     @abstractmethod
@@ -503,7 +501,6 @@ class IO(Iterator[AnyStr], Generic[AnyStr]):
     def truncate(self, size: Optional[int] = ...) -> int: ...
     @abstractmethod
     def writable(self) -> bool: ...
-    # TODO buffer objects
     @abstractmethod
     def write(self, s: AnyStr) -> int: ...
     @abstractmethod
@@ -520,9 +517,6 @@ class IO(Iterator[AnyStr], Generic[AnyStr]):
     ) -> Optional[bool]: ...
 
 class BinaryIO(IO[bytes]):
-    # TODO readinto
-    # TODO read1?
-    # TODO peek?
     @abstractmethod
     def __enter__(self) -> BinaryIO: ...
 


### PR DESCRIPTION
At this point, it is too late to add methods to these semi-protocols as
it would break lots of existing code. Additionally, we are moving away
from these classes to finer-grained protocols anyway.