### PR TITLE
retry: loosen type for backoff, correct type for jitter

### DIFF
--- a/third_party/2and3/retry/api.pyi
+++ b/third_party/2and3/retry/api.pyi
@@ -13,8 +13,8 @@ def retry_call(
     tries: int = ...,
     delay: float = ...,
     max_delay: Optional[float] = ...,
-    backoff: int = ...,
-    jitter: int = ...,
+    backoff: float = ...,
+    jitter: Union[Tuple[float, float], float] = ...,
     logger: Optional[Logger] = ...,
 ) -> _R: ...
 def retry(
@@ -22,7 +22,7 @@ def retry(
     tries: int = ...,
     delay: float = ...,
     max_delay: Optional[float] = ...,
-    backoff: int = ...,
-    jitter: int = ...,
+    backoff: float = ...,
+    jitter: Union[Tuple[float, float], float] = ...,
     logger: Optional[Logger] = ...,
 ) -> _Decorator: ...


### PR DESCRIPTION
## Problem
When checking `retry()` with `backoff` as a float, it gives an error:

```
error: Argument "backoff" to "retry" has incompatible type "float"; expected "int"  [arg-type]
```

After [looking at the code](https://github.com/invl/retry/blob/master/retry/api.py), `backoff` is not limited to `int`, so the use of `float` is permitted, which means the error is a false-positive.

While checking out the code vs the stubs I also noticed that the argument for `jitter` accepts `(float, float)` tuples (and is also not limited to `int`). 