### PR TITLE
Allow None in fp argument to HTTPError

### DIFF
--- a/stdlib/3/urllib/error.pyi
+++ b/stdlib/3/urllib/error.pyi
@@ -1,4 +1,4 @@
-from typing import IO, Mapping, Union
+from typing import IO, Mapping, Optional, Union
 from urllib.response import addinfourl
 
 # Stubs for urllib.error
@@ -8,6 +8,6 @@ class URLError(IOError):
 
 class HTTPError(URLError, addinfourl):
     code: int
-    def __init__(self, url: str, code: int, msg: str, hdrs: Mapping[str, str], fp: IO[bytes]) -> None: ...
+    def __init__(self, url: str, code: int, msg: str, hdrs: Mapping[str, str], fp: Optional[IO[bytes]]) -> None: ...
 
 class ContentTooShortError(URLError): ...


### PR DESCRIPTION
## Problem

The fifth argument to `HTTPError.__init__()`, `fp`, can be `None`, according to [the source code](https://github.com/python/cpython/blob/3.7/Lib/urllib/error.py#L49-L50). Right now, passing `None` results in this error:

```
error: Argument 5 to "HTTPError" has incompatible type "None"; expected "IO[bytes]"  [arg-type]
```