### PR TITLE
termios: Fix type of tcgetattr and tcsetattr attributes

### DIFF
--- a/stdlib/2and3/termios.pyi
+++ b/stdlib/2and3/termios.pyi
@@ -1,7 +1,7 @@
 from _typeshed import FileDescriptorLike
-from typing import List, Union
+from typing import Any, List, Union
 
-_Attr = List[Union[int, List[bytes]]]
+_Attr = List[Union[int, List[Union[bytes, int]]]]
 
 # TODO constants not really documented
 B0: int
@@ -236,7 +236,7 @@ VWERASE: int
 XCASE: int
 XTABS: int
 
-def tcgetattr(fd: FileDescriptorLike) -> _Attr: ...
+def tcgetattr(fd: FileDescriptorLike) -> List[Any]: ...
 def tcsetattr(fd: FileDescriptorLike, when: int, attributes: _Attr) -> None: ...
 def tcsendbreak(fd: FileDescriptorLike, duration: int) -> None: ...
 def tcdrain(fd: FileDescriptorLike) -> None: ...


### PR DESCRIPTION
Returning a union from tcgetattr forces the caller to use isinstance or
a type: ignore comment if they modify the returned list. Return
`List[Any]` instead.

The cc field has ints at `cc[termios.VTIME]` and `cc[termios.VMIN]` if
`lflag & termios.ICANON` is zero. Change _Attr to allow this.

Fixes #4661

The goal is to avoid false positives like this:
```
example.py:6: error: Unsupported operand types for & ("List[bytes]" and "int")  [operator]
        new[3] = new[3] & ~termios.ECHO          # lflags
                 ^
example.py:6: note: Left operand is of type "Union[int, List[bytes]]"
example.py:7: error: Unsupported target for indexed assignment ("Union[int, List[bytes]]")  [index]
        new[6][termios.VMIN] = 0
        ^
example.py:7: error: No overload variant of "__setitem__" of "list" matches argument types "int", "int"  [call-overload]
        new[6][termios.VMIN] = 0
        ^
example.py:7: note: Possible overload variants:
example.py:7: note:     def __setitem__(self, int, bytes) -> None
example.py:7: note:     def __setitem__(self, slice, Iterable[bytes]) -> None
Found 3 errors in 1 file (checked 1 source file)
```