### PR TITLE
Allow sequence as `names` in jinja2 Environment

### DIFF
--- a/third_party/2and3/jinja2/environment.pyi
+++ b/third_party/2and3/jinja2/environment.pyi
@@ -1,5 +1,5 @@
 import sys
-from typing import Any, Callable, Dict, Iterator, List, Optional, Text, Type, Union
+from typing import Any, Callable, Dict, Iterator, List, Optional, Sequence, Text, Type, Union
 
 from .bccache import BytecodeCache
 from .loaders import BaseLoader
@@ -133,11 +133,11 @@ class Environment:
         self, name: Union[Template, Text], parent: Optional[Text] = ..., globals: Optional[Any] = ...
     ) -> Template: ...
     def select_template(
-        self, names: List[Union[Template, Text]], parent: Optional[Text] = ..., globals: Optional[Dict[str, Any]] = ...
+        self, names: Sequence[Union[Template, Text]], parent: Optional[Text] = ..., globals: Optional[Dict[str, Any]] = ...
     ) -> Template: ...
     def get_or_select_template(
         self,
-        template_name_or_list: Union[Union[Template, Text], List[Union[Template, Text]]],
+        template_name_or_list: Union[Union[Template, Text], Sequence[Union[Template, Text]]],
         parent: Optional[Text] = ...,
         globals: Optional[Dict[str, Any]] = ...,
     ) -> Template: ...


### PR DESCRIPTION
The Environment `select_template` and `get_or_select_template` methods accept an sequence. Thus to make the following work:

```python
from typing import List
from jinja2 import Environment

names: List[str] = ['example.html']
Environment().select_template(names)
```

- [Environment.select_template](https://github.com/pallets/jinja/blob/9b718ed3d26fc2f80ab58f3249b517a65db9cc7b/src/jinja2/environment.py#L841)
- [Environment.get_or_select_template](https://github.com/pallets/jinja/blob/9b718ed3d26fc2f80ab58f3249b517a65db9cc7b/src/jinja2/environment.py#L877)

Before:

```
(venv) $ mypy test.py --custom-typeshed .
test.py:5: error: Argument 1 to "select_template" of "Environment" has incompatible type "List[str]"; expected "List[Union[Template, str]]"
test.py:5: note: "List" is invariant -- see http://mypy.readthedocs.io/en/latest/common_issues.html#variance
test.py:5: note: Consider using "Sequence" instead, which is covariant
Found 1 error in 1 file (checked 1 source file)
```

Example:

```
(venv) $ mypy test.py --custom-typeshed .
Success: no issues found in 1 source file
```