### PR TITLE
Update stub for CodeGeneratorResponse protobuf message

### DIFF
--- a/third_party/2and3/google/protobuf/compiler/plugin_pb2.pyi
+++ b/third_party/2and3/google/protobuf/compiler/plugin_pb2.pyi
@@ -2,6 +2,7 @@ from typing import Iterable, Optional, Text
 
 from google.protobuf.descriptor_pb2 import FileDescriptorProto
 from google.protobuf.internal.containers import RepeatedCompositeFieldContainer, RepeatedScalarFieldContainer
+from google.protobuf.internal.enum_type_wrapper import EnumTypeWrapper
 from google.protobuf.message import Message
 
 class Version(Message):
@@ -36,6 +37,13 @@ class CodeGeneratorResponse(Message):
         def __init__(
             self, name: Optional[Text] = ..., insertion_point: Optional[Text] = ..., content: Optional[Text] = ...
         ) -> None: ...
+    class _Feature(EnumTypeWrapper):
+        FEATURE_NONE: int
+        FEATURE_PROTO_3_OPTIONAL: int
+    Feature: CodeGeneratorResponse._Feature
+    FEATURE_NONE: int
+    FEATURE_PROTO_3_OPTIONAL: int
+    supported_features: int
     error: Text
     @property
     def file(self) -> RepeatedCompositeFieldContainer[CodeGeneratorResponse.File]: ...


### PR DESCRIPTION
Add `Feature` enum and `supported_features` field to CodeGeneratorResponse

These are related to the optional proto3 fields introduced in 3.12.0, see https://github.com/protocolbuffers/protobuf/releases/tag/v3.12.0 and https://github.com/protocolbuffers/protobuf/blob/214c77e1b76e63e512bd675d1c300c80438642b6/src/google/protobuf/compiler/plugin.proto#L112

Note that I've typed this differently than the stubs for other enums in `google.protobuf`. As pointed out in https://github.com/python/typeshed/issues/2521, the current enum stubs are incorrect. I can however change it if you would prefer these stubs to be consistent with the existing ones and fixed together with those at a later point.