### PR TITLE
Upgrade flake8-pyi to fix CI

### DIFF
--- a/requirements-tests-py3.txt
+++ b/requirements-tests-py3.txt
@@ -1,8 +1,8 @@
 git+https://github.com/python/mypy.git@master
 typed-ast>=1.0.4
 black==20.8b1
-flake8==3.8.3
+flake8==3.8.4
 flake8-bugbear==20.1.4
-flake8-pyi==20.5.0
+flake8-pyi==20.10.0
 isort[pyproject]==5.5.3
 pytype>=2020.09.16


### PR DESCRIPTION
This fixes things on Python 3.9, which we've started using since #4656