### PR TITLE
Fix type of typed_ast.ast27.Str.s

### DIFF
--- a/third_party/3/typed_ast/ast27.pyi
+++ b/third_party/3/typed_ast/ast27.pyi
@@ -239,7 +239,7 @@ class Num(expr):
     n: Union[int, float, complex]
 
 class Str(expr):
-    s: bytes
+    s: Union[str, bytes]
     kind: str
 
 class Attribute(expr):


### PR DESCRIPTION
The original type was too narrow.