### PR TITLE
stubtest unused: match stubtest version, add fix

### DIFF
--- a/.github/workflows/stubtest-unused-whitelist.yml
+++ b/.github/workflows/stubtest-unused-whitelist.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install -U pip
-          pip install -U mypy==0.790
+          pip install -U git+git://github.com/python/mypy@af3c8be98f
       - name: Run stubtest
         shell: bash
         run: ./tests/stubtest_unused.py | tee stubtest-output-${{ matrix.os }}-${{ matrix.python-version }} || true

--- a/tests/stubtest_unused.py
+++ b/tests/stubtest_unused.py
@@ -7,7 +7,7 @@ import os.path
 import subprocess
 import sys
 
-_UNUSED_NOTE = "note: unused whitelist entry "
+_UNUSED_NOTE = "note: unused allowlist entry "
 _WHITELIST_PATH = os.path.join("tests", "stubtest_whitelists")
 
 


### PR DESCRIPTION
In #4696 I bumped stubtest to a commit that hasn't been released. We
should have these stubtest versions match. In
https://github.com/python/mypy/pull/9426 I changed the output of
stubtest here; it's good to get this change in before I forget and this
action silently stops working.