### PR TITLE
Markdown:  Add missing processor attributes

### DIFF
--- a/third_party/2and3/markdown/core.pyi
+++ b/third_party/2and3/markdown/core.pyi
@@ -2,8 +2,13 @@ from typing import Any, BinaryIO, Mapping, Optional, Sequence, Text, TextIO, Uni
 from typing_extensions import Literal
 
 from .extensions import Extension
+from .util import Registry
 
 class Markdown:
+    preprocessors: Registry
+    inlinePatterns: Registry
+    treeprocessors: Registry
+    postprocessors: Registry
     def __init__(
         self,
         *,


### PR DESCRIPTION
These are defined in https://github.com/Python-Markdown/markdown/blob/6b6cd8bc2f0a870ed309f8b8036492af535e75a1/markdown/core.py#L103-L107, and are required when creating extensions.