### PR TITLE
update math and gzip stubs for Python 3.8

### DIFF
--- a/stdlib/2and3/math.pyi
+++ b/stdlib/2and3/math.pyi
@@ -1,5 +1,5 @@
 import sys
-from typing import Iterable, SupportsFloat, SupportsInt, Tuple, overload
+from typing import Iterable, Optional, SupportsFloat, SupportsInt, Tuple, overload
 
 e: float
 pi: float
@@ -93,6 +93,9 @@ def modf(__x: SupportsFloat) -> Tuple[float, float]: ...
 
 if sys.version_info >= (3, 9):
     def nextafter(__x: SupportsFloat, __y: SupportsFloat) -> float: ...
+
+if sys.version_info >= (3, 8):
+    def perm(__n: int, __k: Optional[int] = ...) -> int: ...
 
 def pow(__x: SupportsFloat, __y: SupportsFloat) -> float: ...
 

--- a/stdlib/3/gzip.pyi
+++ b/stdlib/3/gzip.pyi
@@ -43,6 +43,9 @@ class _PaddedFile:
     def seek(self, off: int) -> int: ...
     def seekable(self) -> bool: ...
 
+if sys.version_info >= (3, 8):
+    class BadGzipFile(OSError): ...
+
 class GzipFile(_compression.BaseStream):
     myfileobj: Optional[IO[bytes]]
     mode: str


### PR DESCRIPTION
I ran stubtest and spotted 2 things missing in 3.8 stdlib

- added `BadGzipFile` new exception for gzip:
https://docs.python.org/3/library/gzip.html#gzip.BadGzipFile

- added `math.perm()` new method:
https://docs.python.org/3/library/math.html#math.perm