### PR TITLE
mypy_test_suite: run a subset of tests

### DIFF
--- a/tests/mypy_test_suite.py
+++ b/tests/mypy_test_suite.py
@@ -10,15 +10,16 @@ from pathlib import Path
 if __name__ == "__main__":
     with tempfile.TemporaryDirectory() as tempdir:
         dirpath = Path(tempdir)
+        subprocess.run(["git", "clone", "--depth", "1", "git://github.com/python/mypy", dirpath / "mypy"], check=True)
+
         subprocess.run(["python2.7", "-m", "pip", "install", "--user", "typing"], check=True)
-        subprocess.run(["git", "clone", "--depth", "1", "git://github.com/python/mypy", str(dirpath / "mypy")], check=True)
         subprocess.run(
-            [sys.executable, "-m", "pip", "install", "-U", "-r", str(dirpath / "mypy/test-requirements.txt")], check=True
+            [sys.executable, "-m", "pip", "install", "-U", "-r", dirpath / "mypy/test-requirements.txt"], check=True
         )
-        shutil.copytree("stdlib", str(dirpath / "mypy/mypy/typeshed/stdlib"))
-        shutil.copytree("third_party", str(dirpath / "mypy/mypy/typeshed/third_party"))
+        shutil.copytree("stdlib", dirpath / "mypy/mypy/typeshed/stdlib")
+        shutil.copytree("third_party", dirpath / "mypy/mypy/typeshed/third_party")
         try:
-            subprocess.run(["pytest", "-n12"], cwd=str(dirpath / "mypy"), check=True)
+            subprocess.run([sys.executable, "runtests.py", "typeshed-ci"], cwd=dirpath / "mypy", check=True)
         except subprocess.CalledProcessError as e:
             print("mypy tests failed", file=sys.stderr)
             sys.exit(e.returncode)


### PR DESCRIPTION
Only a subset of mypy's test suite should be relevant to typeshed:
https://github.com/python/mypy/pull/9638
This should make things faster.
(Also the -n12 argument to pytest is weird; note mypy's pytest.ini
automatically specificies -nauto which is what we should want)

Resolves https://github.com/python/typeshed/issues/4333