### PR TITLE
Fix annotations for resource.prlimit()

### DIFF
--- a/stdlib/3/resource.pyi
+++ b/stdlib/3/resource.pyi
@@ -1,5 +1,5 @@
 import sys
-from typing import NamedTuple, Optional, Tuple
+from typing import NamedTuple, Optional, Tuple, overload
 
 RLIMIT_AS: int
 RLIMIT_CORE: int
@@ -47,6 +47,9 @@ def getrusage(__who: int) -> _RUsage: ...
 def setrlimit(__resource: int, __limits: Tuple[int, int]) -> None: ...
 
 if sys.platform == "linux":
-    def prlimit(pid: int, resource: int, limits: Optional[Tuple[int, int]]) -> Tuple[int, int]: ...
+    @overload
+    def prlimit(pid: int, resource: int, limits: Tuple[int, int]) -> Tuple[int, int]: ...
+    @overload
+    def prlimit(pid: int, resource: int) -> Tuple[int, int]: ...
 
 error = OSError


### PR DESCRIPTION
The current annotations specify the `limits` argument as an `Optional[Tuple[int, int]]`; this is incorrect. The real `resource.prlimit()` function does not accept `None` for the `limits` argument; it is only possible to avoid specifying new resource limits by omitting `limits` completely.