### PR TITLE
mypy_primer: speed up, clean up

### DIFF
--- a/.github/workflows/mypy_primer.yml
+++ b/.github/workflows/mypy_primer.yml
@@ -35,7 +35,7 @@ jobs:
           git rev-list --format=%s --max-count=1 upstream_master
           echo ''
           cd ..
-          ( mypy_primer --new v0.790 --old v0.790 --custom-typeshed-repo typeshed_to_test --new-typeshed $COMMIT --old-typeshed upstream_master -o concise | tee diff.txt ) || [ $? -eq 1 ]
+          ( mypy_primer --new 0.790 --old 0.790 --custom-typeshed-repo typeshed_to_test --new-typeshed $COMMIT --old-typeshed upstream_master -o concise | tee diff.txt ) || [ $? -eq 1 ]
       - name: Post comment
         uses: actions/github-script@v3
         with:

--- a/.github/workflows/mypy_primer.yml
+++ b/.github/workflows/mypy_primer.yml
@@ -35,8 +35,7 @@ jobs:
           git rev-list --format=%s --max-count=1 upstream_master
           echo ''
           cd ..
-          ( mypy_primer --new v0.790 --old v0.790 --custom-typeshed-repo typeshed_to_test --new-typeshed $COMMIT --old-typeshed upstream_master -o concise > diff.txt && rm diff.txt ) || true
-          cat diff.txt || true
+          ( mypy_primer --new v0.790 --old v0.790 --custom-typeshed-repo typeshed_to_test --new-typeshed $COMMIT --old-typeshed upstream_master -o concise | tee diff.txt ) || [ $? -eq 1 ]
       - name: Post comment
         uses: actions/github-script@v3
         with:


### PR DESCRIPTION
Use a version pip recognises so that we can install mypyc compiled mypy
from PyPI

We use tee and no longer try to delete the file based on exit code,
since we use data.trim now.
mypy_primer started failing silently because of changes in aiohttp, so
now we'll fail if the exit codes are not 0 or 1.
Note mypy_primer has --project-date to get around the problem of
breaking changes in projects, but I want to try and keep mypy_primer up
to date / get a feel for how bad this problem actually is.