### PR TITLE
Fix kw_defaults field type for ast.argument

### DIFF
--- a/stdlib/3/_ast.pyi
+++ b/stdlib/3/_ast.pyi
@@ -366,7 +366,7 @@ class arguments(AST):
     args: typing.List[arg]
     vararg: Optional[arg]
     kwonlyargs: typing.List[arg]
-    kw_defaults: typing.List[expr]
+    kw_defaults: typing.List[Optional[expr]] 
     kwarg: Optional[arg]
     defaults: typing.List[expr]
 

--- a/stdlib/3/_ast.pyi
+++ b/stdlib/3/_ast.pyi
@@ -366,7 +366,7 @@ class arguments(AST):
     args: typing.List[arg]
     vararg: Optional[arg]
     kwonlyargs: typing.List[arg]
-    kw_defaults: typing.List[Optional[expr]] 
+    kw_defaults: typing.List[Optional[expr]]
     kwarg: Optional[arg]
     defaults: typing.List[expr]
 


### PR DESCRIPTION
Based on ast module document, None is allowed in arguments.kw_defaults list.

> `kw_defaults` is a list of default values for keyword-only arguments. If one is None, the corresponding argument is required.

 This PR fix kw_defaults annotation.