### PR TITLE
Update requests stubs with ReadTimeout exception

### DIFF
--- a/third_party/2and3/requests/__init__.pyi
+++ b/third_party/2and3/requests/__init__.pyi
@@ -14,6 +14,7 @@ from .api import (
 from .exceptions import (
     ConnectionError as ConnectionError,
     HTTPError as HTTPError,
+    ReadTimeout as ReadTimeout,
     RequestException as RequestException,
     Timeout as Timeout,
     TooManyRedirects as TooManyRedirects,


### PR DESCRIPTION
Using `requests.ReadTimeout` currently gives a TypeError. I am updating the requests stub to allow using the ReadTimeout exception.