### PR TITLE
Change some tkinter function parameter types from bool to int.

### DIFF
--- a/stdlib/3/tkinter/__init__.pyi
+++ b/stdlib/3/tkinter/__init__.pyi
@@ -106,7 +106,7 @@ _Padding = Union[
 _Relief = Literal["raised", "sunken", "flat", "ridge", "solid", "groove"]  # manual page: Tk_GetRelief
 _ScreenUnits = Union[str, float]  # manual page: Tk_GetPixels
 _XYScrollCommand = Union[str, Callable[[float, float], Any]]  # -xscrollcommand and -yscrollcommand in 'options' manual page
-_TakeFocusValue = Union[Literal[""], Callable[[str], Optional[int]]]  # -takefocus in manual page named 'options'
+_TakeFocusValue = Union[bool, Literal[""], Callable[[str], Optional[int]]]  # -takefocus in manual page named 'options'
 
 class EventType(str, Enum):
     Activate: str = ...

--- a/stdlib/3/tkinter/__init__.pyi
+++ b/stdlib/3/tkinter/__init__.pyi
@@ -106,7 +106,7 @@ _Padding = Union[
 _Relief = Literal["raised", "sunken", "flat", "ridge", "solid", "groove"]  # manual page: Tk_GetRelief
 _ScreenUnits = Union[str, float]  # manual page: Tk_GetPixels
 _XYScrollCommand = Union[str, Callable[[float, float], Any]]  # -xscrollcommand and -yscrollcommand in 'options' manual page
-_TakeFocusValue = Union[bool, Literal[""], Callable[[str], Optional[bool]]]  # -takefocus in manual page named 'options'
+_TakeFocusValue = Union[Literal[""], Callable[[str], Optional[int]]]  # -takefocus in manual page named 'options'
 
 class EventType(str, Enum):
     Activate: str = ...
@@ -642,7 +642,7 @@ class Pack:
         after: Misc = ...,
         anchor: _Anchor = ...,
         before: Misc = ...,
-        expand: bool = ...,
+        expand: int = ...,
         fill: Literal["none", "x", "y", "both"] = ...,
         side: Literal["left", "right", "top", "bottom"] = ...,
         ipadx: Union[_ScreenUnits, Tuple[_ScreenUnits, _ScreenUnits]] = ...,
@@ -1685,7 +1685,7 @@ class Listbox(Widget, XView, YView):
         borderwidth: _ScreenUnits = ...,
         cursor: _Cursor = ...,
         disabledforeground: _Color = ...,
-        exportselection: bool = ...,
+        exportselection: int = ...,
         fg: _Color = ...,
         font: _FontDescription = ...,
         foreground: _Color = ...,
@@ -1831,7 +1831,7 @@ class Menu(Widget):
         relief: _Relief = ...,
         selectcolor: _Color = ...,
         takefocus: _TakeFocusValue = ...,
-        tearoff: bool = ...,
+        tearoff: int = ...,
         # I guess tearoffcommand arguments are supposed to be widget objects,
         # but they are widget name strings. Use nametowidget() to handle the
         # arguments of tearoffcommand.

--- a/stdlib/3/tkinter/__init__.pyi
+++ b/stdlib/3/tkinter/__init__.pyi
@@ -106,7 +106,7 @@ _Padding = Union[
 _Relief = Literal["raised", "sunken", "flat", "ridge", "solid", "groove"]  # manual page: Tk_GetRelief
 _ScreenUnits = Union[str, float]  # manual page: Tk_GetPixels
 _XYScrollCommand = Union[str, Callable[[float, float], Any]]  # -xscrollcommand and -yscrollcommand in 'options' manual page
-_TakeFocusValue = Union[bool, Literal[""], Callable[[str], Optional[int]]]  # -takefocus in manual page named 'options'
+_TakeFocusValue = Union[int, Literal[""], Callable[[str], Optional[bool]]]  # -takefocus in manual page named 'options'
 
 class EventType(str, Enum):
     Activate: str = ...


### PR DESCRIPTION
I'm in the process of pulling a newer version of typeshed into Google
and seeing a lot of new errors due to code that passes 0 or 1 into
functions that are annotated as expecting bools.

Based on the fact that tk.{YES,NO,TRUE,FALSE} are defined as ints
(https://github.com/python/typeshed/blob/20a847218ac085ad691ea8d99155ee8ac7005479/stdlib/3/tkinter/constants.pyi#L3-L6)
and that the usage example in the source code also uses an int as a bool
(https://github.com/python/cpython/blob/cc75ab791dd5ae2cb9f6e0c3c5f734a6ae1eb2a9/Lib/tkinter/__init__.py#L25),
I think the annotations should be expanded.