### PR TITLE
threading: fix ExceptHookArgs being a function instead of a type

### DIFF
--- a/stdlib/2and3/_dummy_threading.pyi
+++ b/stdlib/2and3/_dummy_threading.pyi
@@ -155,13 +155,7 @@ class Event:
     def wait(self, timeout: Optional[float] = ...) -> bool: ...
 
 if sys.version_info >= (3, 8):
-    import _thread
-
-    # don't ask...
-    _ExceptHookArgs = _thread.ExceptHookArgs
-    ExceptHookArgs = _thread._ExceptHookArgs
-
-    excepthook: Callable[[_ExceptHookArgs], Any]
+    from _thread import _excepthook as excepthook, _ExceptHookArgs as ExceptHookArgs
 
 class Timer(Thread):
     if sys.version_info >= (3,):

--- a/stdlib/2and3/threading.pyi
+++ b/stdlib/2and3/threading.pyi
@@ -155,13 +155,7 @@ class Event:
     def wait(self, timeout: Optional[float] = ...) -> bool: ...
 
 if sys.version_info >= (3, 8):
-    import _thread
-
-    # don't ask...
-    _ExceptHookArgs = _thread.ExceptHookArgs
-    ExceptHookArgs = _thread._ExceptHookArgs
-
-    excepthook: Callable[[_ExceptHookArgs], Any]
+    from _thread import _excepthook as excepthook, _ExceptHookArgs as ExceptHookArgs
 
 class Timer(Thread):
     if sys.version_info >= (3,):

--- a/stdlib/3/_thread.pyi
+++ b/stdlib/3/_thread.pyi
@@ -1,7 +1,7 @@
 import sys
 from threading import Thread
 from types import TracebackType
-from typing import Any, Callable, Dict, NamedTuple, NoReturn, Optional, Tuple, Type
+from typing import Any, Callable, Dict, NoReturn, Optional, Tuple, Type
 
 error = RuntimeError
 
@@ -29,10 +29,13 @@ TIMEOUT_MAX: float
 
 if sys.version_info >= (3, 8):
     def get_native_id() -> int: ...  # only available on some platforms
-    class ExceptHookArgs(NamedTuple):
-        exc_type: Type[BaseException]
-        exc_value: Optional[BaseException]
-        exc_traceback: Optional[TracebackType]
-        thread: Optional[Thread]
-    def _ExceptHookArgs(args: Any) -> ExceptHookArgs: ...
-    _excepthook: Callable[[ExceptHookArgs], Any]
+    class _ExceptHookArgs(Tuple[Type[BaseException], Optional[BaseException], Optional[TracebackType], Optional[Thread]]):
+        @property
+        def exc_type(self) -> Type[BaseException]: ...
+        @property
+        def exc_value(self) -> Optional[BaseException]: ...
+        @property
+        def exc_traceback(self) -> Optional[TracebackType]: ...
+        @property
+        def thread(self) -> Optional[Thread]: ...
+    _excepthook: Callable[[_ExceptHookArgs], Any]

--- a/tests/stubtest_whitelists/py38.txt
+++ b/tests/stubtest_whitelists/py38.txt
@@ -1,5 +1,3 @@
-_thread.ExceptHookArgs
-_thread._ExceptHookArgs
 ast.Bytes.__new__
 ast.Ellipsis.__new__
 ast.NameConstant.__new__

--- a/tests/stubtest_whitelists/py39.txt
+++ b/tests/stubtest_whitelists/py39.txt
@@ -1,7 +1,5 @@
 _ast.ImportFrom.level
 _dummy_thread
-_thread.ExceptHookArgs
-_thread._ExceptHookArgs
 ast.Bytes.__new__
 ast.Ellipsis.__new__
 ast.ExtSlice.__new__


### PR DESCRIPTION
The previous typing meant `threading.ExceptHookArgs` could not be used to type a value.

The new typing follows what cpython does in the happy path (`_thread` exists rather than the pure-python fallback being used), a bit different than @srittau's suggestion in the issue.

Also, `ExceptHookArgs` is a `PyStructSequence` rather than an actual namedtuple, so stubtest complained about it. I changed it to tuple+properties instead. I can also add `n_fields`, `n_sequence_fields`, `n_unnamed_fields` properties which some other structseqs in typeshed use, but seems like obscure internal detail to me so I omitted those.

Fixes #4767.