### PR TITLE
Fix hard-coded pytype version

### DIFF
--- a/tests/pytype_test.py
+++ b/tests/pytype_test.py
@@ -13,6 +13,7 @@ will also discover incorrect usage of imported modules.
 import argparse
 import os
 import re
+import sys
 import traceback
 from typing import List, Match, Optional, Sequence, Tuple
 
@@ -173,7 +174,7 @@ def run_all_tests(*, files_to_test: Sequence[Tuple[str, int]], typeshed_location
         stderr = (
             run_pytype(
                 filename=f,
-                python_version="2.7" if version == 2 else "3.6",
+                python_version="2.7" if version == 2 else "{0.major}.{0.minor}".format(sys.version_info),
                 typeshed_location=typeshed_location,
             )
             if not dry_run


### PR DESCRIPTION
[tests/pytype_test.py](../tree/master/tests/pytype_test.py#L176) is still referencing Python `3.6` explicitly:
> python_version="2.7" if version == 2 else "3.6",

The test fails to run if `python3.6` is unavailable (for example on Debian 10 Buster, which has 3.7).

According to https://devguide.python.org/#status-of-python-branches `3.6` is still maintained until end of 2021.

`pytype` itself [claims](https://github.com/google/pytype#requirements) to run on `2.7`, `3.5`-`3.8`.

Change the script to use the version of Python from the invoking interpreter. This should work as the [hash-bang line](../tree/master/tests/pytype_test.py#L1) uses `#!/usr/bin/env python3` anyway.