### PR TITLE
cryptography: Fix 'oid' field hints to ObjectIdentifier

### DIFF
--- a/third_party/2and3/cryptography/x509.pyi
+++ b/third_party/2and3/cryptography/x509.pyi
@@ -271,13 +271,13 @@ class UniformResourceIdentifier(GeneralName):
 # X.509 Extensions
 
 class ExtensionType(metaclass=ABCMeta):
-    oid: ExtensionOID
+    oid: ObjectIdentifier
 
 _T = TypeVar("_T", bound="ExtensionType")
 
 class Extension(Generic[_T]):
     critical: bool
-    oid: ExtensionOID
+    oid: ObjectIdentifier
     value: _T
 
 class Extensions(object):


### PR DESCRIPTION
The `ExtensionOID` class is simply a namespace for constants, there are no instances of that class.