### PR TITLE
Fix stubtest unused cron job

### DIFF
--- a/.github/workflows/stubtest-unused-whitelist.yml
+++ b/.github/workflows/stubtest-unused-whitelist.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Remove entries from whitelists
         run: python scripts/update-stubtest-whitelist.py stubtest-output
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v2
+        uses: peter-evans/create-pull-request@v3
         with:
           commit-message: Remove unused stubtest whitelist entries
           title: "[gh-action] Remove unused stubtest whitelist entries"


### PR DESCRIPTION
Looks like it's failing at https://github.com/python/typeshed/runs/1434747694
I think this should fix it? At least it should get rid of the red things that say ERROR :-)