### PR TITLE
Overload hexlify to allow for three pattern parameters

### DIFF
--- a/stdlib/2and3/binascii.pyi
+++ b/stdlib/2and3/binascii.pyi
@@ -1,5 +1,5 @@
 import sys
-from typing import Text, Union
+from typing import Text, Union, overload
 
 if sys.version_info < (3,):
     # Python 2 accepts unicode ascii pretty much everywhere.
@@ -38,7 +38,12 @@ def crc32(__data: _Bytes, __crc: int = ...) -> int: ...
 def b2a_hex(__data: _Bytes) -> bytes: ...
 
 if sys.version_info >= (3, 8):
+    @overload
     def hexlify(data: bytes, sep: Union[str, bytes] = ..., bytes_per_sep: int = ...) -> bytes: ...
+    @overload
+    def hexlify(data: bytes, sep: Union[str, bytes] = ...) -> bytes: ...
+    @overload
+    def hexlify(data: bytes) -> bytes: ...
 
 else:
     def hexlify(__data: _Bytes) -> bytes: ...


### PR DESCRIPTION
As of now, when calling hexlify with single argument and checking the call with mypy, I get the error `Too few arguments  [call-arg]`

It seems like the arguments are sequentially optional https://docs.python.org/3/library/binascii.html#binascii.hexlify
Optional doesn't seem to be a good idea since it seems that the function allows for 1st, 1st and 2nd, or all three arguments.

So here's my attempt to solve this issue and allow for mypy to type-check and allow all three call-possibilities.