### PR TITLE
threading: properly export excepthook, ExceptHookArgs

### DIFF
--- a/stdlib/2and3/_dummy_threading.pyi
+++ b/stdlib/2and3/_dummy_threading.pyi
@@ -155,7 +155,10 @@ class Event:
     def wait(self, timeout: Optional[float] = ...) -> bool: ...
 
 if sys.version_info >= (3, 8):
-    from _thread import _excepthook as excepthook, _ExceptHookArgs as ExceptHookArgs
+    from _thread import _excepthook, _ExceptHookArgs
+
+    excepthook = _excepthook
+    ExceptHookArgs = _ExceptHookArgs
 
 class Timer(Thread):
     if sys.version_info >= (3,):

--- a/stdlib/2and3/threading.pyi
+++ b/stdlib/2and3/threading.pyi
@@ -155,7 +155,10 @@ class Event:
     def wait(self, timeout: Optional[float] = ...) -> bool: ...
 
 if sys.version_info >= (3, 8):
-    from _thread import _excepthook as excepthook, _ExceptHookArgs as ExceptHookArgs
+    from _thread import _excepthook, _ExceptHookArgs
+
+    excepthook = _excepthook
+    ExceptHookArgs = _ExceptHookArgs
 
 class Timer(Thread):
     if sys.version_info >= (3,):


### PR DESCRIPTION
Fixes the issue pointed out in https://github.com/python/typeshed/pull/4768#issuecomment-736782337

---

An `import X as Y` where X != Y no longer exports, so 27a45df479ff2685e376d04894fffdacc3fcaa7e caused them to be un-exported.