### PR TITLE
concurrent.futures: add _work_queue property to ThreadPoolExecutor

### DIFF
--- a/stdlib/3/concurrent/futures/thread.pyi
+++ b/stdlib/3/concurrent/futures/thread.pyi
@@ -13,6 +13,7 @@ if sys.version_info >= (3, 9):
 _S = TypeVar("_S")
 
 class ThreadPoolExecutor(Executor):
+    _work_queue: Any
     if sys.version_info >= (3, 7):
         def __init__(
             self,

--- a/stdlib/3/concurrent/futures/thread.pyi
+++ b/stdlib/3/concurrent/futures/thread.pyi
@@ -1,5 +1,6 @@
 import sys
 from typing import Any, Callable, Generic, Iterable, Mapping, Optional, Tuple, TypeVar
+import queue
 
 from ._base import Executor, Future
 
@@ -13,7 +14,10 @@ if sys.version_info >= (3, 9):
 _S = TypeVar("_S")
 
 class ThreadPoolExecutor(Executor):
-    _work_queue: Any
+    if sys.version_info >= (3, 7):
+        _work_queue: queue.SimpleQueue
+    else:
+        _work_queue: queue.Queue
     if sys.version_info >= (3, 7):
         def __init__(
             self,

--- a/stdlib/3/concurrent/futures/thread.pyi
+++ b/stdlib/3/concurrent/futures/thread.pyi
@@ -1,6 +1,6 @@
+import queue
 import sys
 from typing import Any, Callable, Generic, Iterable, Mapping, Optional, Tuple, TypeVar
-import queue
 
 from ._base import Executor, Future
 


### PR DESCRIPTION
`ThreadPoolExecutor` assigns a `queue.SimpleQueue` to `_work_queue` in
it's `__init__` method.

https://github.com/python/cpython/blob/7cf0aad96d1d20f07d7f0e374885f327c2d5ff27/Lib/concurrent/futures/thread.py#L144