### PR TITLE
Create overloads for asyncio.create_process_*()

### DIFF
--- a/stdlib/3/asyncio/subprocess.pyi
+++ b/stdlib/3/asyncio/subprocess.pyi
@@ -44,8 +44,8 @@ class Process(Generic[_S, _T, _U]):
 async def create_subprocess_shell(
     cmd: Union[str, bytes],  # Union used instead of AnyStr due to mypy issue  #1236
     stdin: _PIPE,
-    stdout: Union[_DEVNULL, IO[Any], None] = ...,
-    stderr: Union[_DEVNULL, _STDOUT, IO[Any], None] = ...,
+    stdout: Union[_DEVNULL, int, IO[Any], None] = ...,
+    stderr: Union[_DEVNULL, _STDOUT, int, IO[Any], None] = ...,
     loop: Optional[events.AbstractEventLoop] = ...,
     limit: int = ...,
     **kwds: Any,
@@ -53,10 +53,10 @@ async def create_subprocess_shell(
 @overload
 async def create_subprocess_shell(
     cmd: Union[str, bytes],  # Union used instead of AnyStr due to mypy issue  #1236
-    stdin: Union[_DEVNULL, IO[Any], None] = ...,
+    stdin: Union[_DEVNULL, int, IO[Any], None] = ...,
     *,
     stdout: _PIPE,
-    stderr: Union[_DEVNULL, _STDOUT, IO[Any], None] = ...,
+    stderr: Union[_DEVNULL, _STDOUT, int, IO[Any], None] = ...,
     loop: Optional[events.AbstractEventLoop] = ...,
     limit: int = ...,
     **kwds: Any,
@@ -64,8 +64,8 @@ async def create_subprocess_shell(
 @overload
 async def create_subprocess_shell(
     cmd: Union[str, bytes],  # Union used instead of AnyStr due to mypy issue  #1236
-    stdin: Union[_DEVNULL, IO[Any], None] = ...,
-    stdout: Union[_DEVNULL, IO[Any], None] = ...,
+    stdin: Union[_DEVNULL, int, IO[Any], None] = ...,
+    stdout: Union[_DEVNULL, int, IO[Any], None] = ...,
     *,
     stderr: _PIPE,
     loop: Optional[events.AbstractEventLoop] = ...,
@@ -77,7 +77,7 @@ async def create_subprocess_shell(
     cmd: Union[str, bytes],  # Union used instead of AnyStr due to mypy issue  #1236
     stdin: _PIPE,
     stdout: _PIPE,
-    stderr: Union[_DEVNULL, _STDOUT, IO[Any], None] = ...,
+    stderr: Union[_DEVNULL, _STDOUT, int, IO[Any], None] = ...,
     loop: Optional[events.AbstractEventLoop] = ...,
     limit: int = ...,
     **kwds: Any,
@@ -86,7 +86,7 @@ async def create_subprocess_shell(
 async def create_subprocess_shell(
     cmd: Union[str, bytes],  # Union used instead of AnyStr due to mypy issue  #1236
     stdin: _PIPE,
-    stdout: Union[_DEVNULL, IO[Any], None] = ...,
+    stdout: Union[_DEVNULL, int, IO[Any], None] = ...,
     *,
     stderr: _PIPE,
     loop: Optional[events.AbstractEventLoop] = ...,
@@ -96,7 +96,7 @@ async def create_subprocess_shell(
 @overload
 async def create_subprocess_shell(
     cmd: Union[str, bytes],  # Union used instead of AnyStr due to mypy issue  #1236
-    stdin: Union[_DEVNULL, IO[Any], None] = ...,
+    stdin: Union[_DEVNULL, int, IO[Any], None] = ...,
     *,
     stdout: _PIPE,
     stderr: _PIPE,
@@ -117,9 +117,9 @@ async def create_subprocess_shell(
 @overload
 async def create_subprocess_shell(
     cmd: Union[str, bytes],  # Union used instead of AnyStr due to mypy issue  #1236
-    stdin: Union[_DEVNULL, IO[Any], None] = ...,
-    stdout: Union[_DEVNULL, IO[Any], None] = ...,
-    stderr: Union[_DEVNULL, _STDOUT, IO[Any], None] = ...,
+    stdin: Union[_DEVNULL, int, IO[Any], None] = ...,
+    stdout: Union[_DEVNULL, int, IO[Any], None] = ...,
+    stderr: Union[_DEVNULL, _STDOUT, int, IO[Any], None] = ...,
     loop: Optional[events.AbstractEventLoop] = ...,
     limit: int = ...,
     **kwds: Any,
@@ -129,8 +129,8 @@ async def create_subprocess_exec(
     program: _ExecArg,
     *args: _ExecArg,
     stdin: _PIPE,
-    stdout: Union[_DEVNULL, IO[Any], None] = ...,
-    stderr: Union[_DEVNULL, _STDOUT, IO[Any], None] = ...,
+    stdout: Union[_DEVNULL, int, IO[Any], None] = ...,
+    stderr: Union[_DEVNULL, _STDOUT, int, IO[Any], None] = ...,
     loop: Optional[events.AbstractEventLoop] = ...,
     limit: int = ...,
     **kwds: Any,
@@ -139,9 +139,9 @@ async def create_subprocess_exec(
 async def create_subprocess_exec(
     program: _ExecArg,
     *args: _ExecArg,
-    stdin: Union[_DEVNULL, IO[Any], None] = ...,
+    stdin: Union[_DEVNULL, int, IO[Any], None] = ...,
     stdout: _PIPE,
-    stderr: Union[_DEVNULL, _STDOUT, IO[Any], None] = ...,
+    stderr: Union[_DEVNULL, _STDOUT, int, IO[Any], None] = ...,
     loop: Optional[events.AbstractEventLoop] = ...,
     limit: int = ...,
     **kwds: Any,
@@ -150,8 +150,8 @@ async def create_subprocess_exec(
 async def create_subprocess_exec(
     program: _ExecArg,
     *args: _ExecArg,
-    stdin: Union[_DEVNULL, IO[Any], None] = ...,
-    stdout: Union[_DEVNULL, IO[Any], None] = ...,
+    stdin: Union[_DEVNULL, int, IO[Any], None] = ...,
+    stdout: Union[_DEVNULL, int, IO[Any], None] = ...,
     stderr: _PIPE,
     loop: Optional[events.AbstractEventLoop] = ...,
     limit: int = ...,
@@ -163,7 +163,7 @@ async def create_subprocess_exec(
     *args: _ExecArg,
     stdin: _PIPE,
     stdout: _PIPE,
-    stderr: Union[_DEVNULL, _STDOUT, IO[Any], None] = ...,
+    stderr: Union[_DEVNULL, _STDOUT, int, IO[Any], None] = ...,
     loop: Optional[events.AbstractEventLoop] = ...,
     limit: int = ...,
     **kwds: Any,
@@ -173,7 +173,7 @@ async def create_subprocess_exec(
     program: _ExecArg,
     *args: _ExecArg,
     stdin: _PIPE,
-    stdout: Union[_DEVNULL, IO[Any], None] = ...,
+    stdout: Union[_DEVNULL, int, IO[Any], None] = ...,
     stderr: _PIPE,
     loop: Optional[events.AbstractEventLoop] = ...,
     limit: int = ...,
@@ -183,7 +183,7 @@ async def create_subprocess_exec(
 async def create_subprocess_exec(
     program: _ExecArg,
     *args: _ExecArg,
-    stdin: Union[_DEVNULL, IO[Any], None] = ...,
+    stdin: Union[_DEVNULL, int, IO[Any], None] = ...,
     stdout: _PIPE,
     stderr: _PIPE,
     loop: Optional[events.AbstractEventLoop] = ...,
@@ -205,9 +205,9 @@ async def create_subprocess_exec(
 async def create_subprocess_exec(
     program: _ExecArg,
     *args: _ExecArg,
-    stdin: Union[_DEVNULL, IO[Any], None] = ...,
-    stdout: Union[_DEVNULL, IO[Any], None] = ...,
-    stderr: Union[_DEVNULL, _STDOUT, IO[Any], None] = ...,
+    stdin: Union[_DEVNULL, int, IO[Any], None] = ...,
+    stdout: Union[_DEVNULL, int, IO[Any], None] = ...,
+    stderr: Union[_DEVNULL, _STDOUT, int, IO[Any], None] = ...,
     loop: Optional[events.AbstractEventLoop] = ...,
     limit: int = ...,
     **kwds: Any,

--- a/stdlib/3/asyncio/subprocess.pyi
+++ b/stdlib/3/asyncio/subprocess.pyi
@@ -40,197 +40,176 @@ class Process(Generic[_S, _T, _U]):
     def kill(self) -> None: ...
     async def communicate(self, input: Optional[bytes] = ...) -> Tuple[bytes, bytes]: ...
 
-if sys.version_info < (3, 8):
-    async def create_subprocess_shell(
-        cmd: Union[str, bytes],  # Union used instead of AnyStr due to mypy issue  #1236
-        stdin: Union[int, IO[Any], None] = ...,
-        stdout: Union[int, IO[Any], None] = ...,
-        stderr: Union[int, IO[Any], None] = ...,
-        loop: Optional[events.AbstractEventLoop] = ...,
-        limit: int = ...,
-        **kwds: Any,
-    ) -> Process[Optional[streams.StreamWriter], Optional[streams.StreamReader], Optional[streams.StreamReader]]: ...
-    async def create_subprocess_exec(
-        program: _ExecArg,
-        *args: _ExecArg,
-        stdin: Union[int, IO[Any], None] = ...,
-        stdout: Union[int, IO[Any], None] = ...,
-        stderr: Union[int, IO[Any], None] = ...,
-        loop: Optional[events.AbstractEventLoop] = ...,
-        limit: int = ...,
-        **kwds: Any,
-    ) -> Process[Optional[streams.StreamWriter], Optional[streams.StreamReader], Optional[streams.StreamReader]]: ...
-else:
-    @overload
-    async def create_subprocess_shell(
-        cmd: Union[str, bytes],  # Union used instead of AnyStr due to mypy issue  #1236
-        stdin: PIPE,
-        stdout: Union[DEVNULL, IO[Any], None] = ...,
-        stderr: Union[DEVNULL, STDOUT, IO[Any], None] = ...,
-        loop: Optional[events.AbstractEventLoop] = ...,
-        limit: int = ...,
-        **kwds: Any,
-    ) -> Process[streams.StreamWriter, None, None]: ...
-    @overload
-    async def create_subprocess_shell(
-        cmd: Union[str, bytes],  # Union used instead of AnyStr due to mypy issue  #1236
-        stdin: Union[DEVNULL, IO[Any], None] = ...,
-        *,
-        stdout: PIPE,
-        stderr: Union[DEVNULL, STDOUT, IO[Any], None] = ...,
-        loop: Optional[events.AbstractEventLoop] = ...,
-        limit: int = ...,
-        **kwds: Any,
-    ) -> Process[None, streams.StreamReader, None]: ...
-    @overload
-    async def create_subprocess_shell(
-        cmd: Union[str, bytes],  # Union used instead of AnyStr due to mypy issue  #1236
-        stdin: Union[DEVNULL, IO[Any], None] = ...,
-        stdout: Union[DEVNULL, IO[Any], None] = ...,
-        *,
-        stderr: PIPE,
-        loop: Optional[events.AbstractEventLoop] = ...,
-        limit: int = ...,
-        **kwds: Any,
-    ) -> Process[None, None, streams.StreamReader]: ...
-    @overload
-    async def create_subprocess_shell(
-        cmd: Union[str, bytes],  # Union used instead of AnyStr due to mypy issue  #1236
-        stdin: PIPE,
-        stdout: PIPE,
-        stderr: Union[DEVNULL, STDOUT, IO[Any], None] = ...,
-        loop: Optional[events.AbstractEventLoop] = ...,
-        limit: int = ...,
-        **kwds: Any,
-    ) -> Process[streams.StreamWriter, streams.StreamReader, None]: ...
-    @overload
-    async def create_subprocess_shell(
-        cmd: Union[str, bytes],  # Union used instead of AnyStr due to mypy issue  #1236
-        stdin: PIPE,
-        stdout: Union[DEVNULL, IO[Any], None] = ...,
-        *,
-        stderr: PIPE,
-        loop: Optional[events.AbstractEventLoop] = ...,
-        limit: int = ...,
-        **kwds: Any,
-    ) -> Process[streams.StreamWriter, None, streams.StreamReader]: ...
-    @overload
-    async def create_subprocess_shell(
-        cmd: Union[str, bytes],  # Union used instead of AnyStr due to mypy issue  #1236
-        stdin: Union[DEVNULL, IO[Any], None] = ...,
-        *,
-        stdout: PIPE,
-        stderr: PIPE,
-        loop: Optional[events.AbstractEventLoop] = ...,
-        limit: int = ...,
-        **kwds: Any,
-    ) -> Process[None, streams.StreamReader, streams.StreamReader]: ...
-    @overload
-    async def create_subprocess_shell(
-        cmd: Union[str, bytes],  # Union used instead of AnyStr due to mypy issue  #1236
-        stdin: PIPE,
-        stdout: PIPE,
-        stderr: PIPE,
-        loop: Optional[events.AbstractEventLoop] = ...,
-        limit: int = ...,
-        **kwds: Any,
-    ) -> Process[streams.StreamWriter, streams.StreamReader, streams.StreamReader]: ...
-    @overload
-    async def create_subprocess_shell(
-        cmd: Union[str, bytes],  # Union used instead of AnyStr due to mypy issue  #1236
-        stdin: Union[DEVNULL, IO[Any], None] = ...,
-        stdout: Union[DEVNULL, IO[Any], None] = ...,
-        stderr: Union[DEVNULL, STDOUT, IO[Any], None] = ...,
-        loop: Optional[events.AbstractEventLoop] = ...,
-        limit: int = ...,
-        **kwds: Any,
-    ) -> Process[None, None, None]: ...
+@overload
+async def create_subprocess_shell(
+    cmd: Union[str, bytes],  # Union used instead of AnyStr due to mypy issue  #1236
+    stdin: PIPE,
+    stdout: Union[DEVNULL, IO[Any], None] = ...,
+    stderr: Union[DEVNULL, STDOUT, IO[Any], None] = ...,
+    loop: Optional[events.AbstractEventLoop] = ...,
+    limit: int = ...,
+    **kwds: Any,
+) -> Process[streams.StreamWriter, None, None]: ...
+@overload
+async def create_subprocess_shell(
+    cmd: Union[str, bytes],  # Union used instead of AnyStr due to mypy issue  #1236
+    stdin: Union[DEVNULL, IO[Any], None] = ...,
+    *,
+    stdout: PIPE,
+    stderr: Union[DEVNULL, STDOUT, IO[Any], None] = ...,
+    loop: Optional[events.AbstractEventLoop] = ...,
+    limit: int = ...,
+    **kwds: Any,
+) -> Process[None, streams.StreamReader, None]: ...
+@overload
+async def create_subprocess_shell(
+    cmd: Union[str, bytes],  # Union used instead of AnyStr due to mypy issue  #1236
+    stdin: Union[DEVNULL, IO[Any], None] = ...,
+    stdout: Union[DEVNULL, IO[Any], None] = ...,
+    *,
+    stderr: PIPE,
+    loop: Optional[events.AbstractEventLoop] = ...,
+    limit: int = ...,
+    **kwds: Any,
+) -> Process[None, None, streams.StreamReader]: ...
+@overload
+async def create_subprocess_shell(
+    cmd: Union[str, bytes],  # Union used instead of AnyStr due to mypy issue  #1236
+    stdin: PIPE,
+    stdout: PIPE,
+    stderr: Union[DEVNULL, STDOUT, IO[Any], None] = ...,
+    loop: Optional[events.AbstractEventLoop] = ...,
+    limit: int = ...,
+    **kwds: Any,
+) -> Process[streams.StreamWriter, streams.StreamReader, None]: ...
+@overload
+async def create_subprocess_shell(
+    cmd: Union[str, bytes],  # Union used instead of AnyStr due to mypy issue  #1236
+    stdin: PIPE,
+    stdout: Union[DEVNULL, IO[Any], None] = ...,
+    *,
+    stderr: PIPE,
+    loop: Optional[events.AbstractEventLoop] = ...,
+    limit: int = ...,
+    **kwds: Any,
+) -> Process[streams.StreamWriter, None, streams.StreamReader]: ...
+@overload
+async def create_subprocess_shell(
+    cmd: Union[str, bytes],  # Union used instead of AnyStr due to mypy issue  #1236
+    stdin: Union[DEVNULL, IO[Any], None] = ...,
+    *,
+    stdout: PIPE,
+    stderr: PIPE,
+    loop: Optional[events.AbstractEventLoop] = ...,
+    limit: int = ...,
+    **kwds: Any,
+) -> Process[None, streams.StreamReader, streams.StreamReader]: ...
+@overload
+async def create_subprocess_shell(
+    cmd: Union[str, bytes],  # Union used instead of AnyStr due to mypy issue  #1236
+    stdin: PIPE,
+    stdout: PIPE,
+    stderr: PIPE,
+    loop: Optional[events.AbstractEventLoop] = ...,
+    limit: int = ...,
+    **kwds: Any,
+) -> Process[streams.StreamWriter, streams.StreamReader, streams.StreamReader]: ...
+@overload
+async def create_subprocess_shell(
+    cmd: Union[str, bytes],  # Union used instead of AnyStr due to mypy issue  #1236
+    stdin: Union[DEVNULL, IO[Any], None] = ...,
+    stdout: Union[DEVNULL, IO[Any], None] = ...,
+    stderr: Union[DEVNULL, STDOUT, IO[Any], None] = ...,
+    loop: Optional[events.AbstractEventLoop] = ...,
+    limit: int = ...,
+    **kwds: Any,
+) -> Process[None, None, None]: ...
 
-    @overload
-    async def create_subprocess_exec(
-        program: _ExecArg,
-        *args: _ExecArg,
-        stdin: PIPE,
-        stdout: Union[DEVNULL, IO[Any], None] = ...,
-        stderr: Union[DEVNULL, STDOUT, IO[Any], None] = ...,
-        loop: Optional[events.AbstractEventLoop] = ...,
-        limit: int = ...,
-        **kwds: Any,
-    ) -> Process[streams.StreamWriter, None, None]: ...
-    @overload
-    async def create_subprocess_exec(
-        program: _ExecArg,
-        *args: _ExecArg,
-        stdin: Union[DEVNULL, IO[Any], None] = ...,
-        stdout: PIPE,
-        stderr: Union[DEVNULL, STDOUT, IO[Any], None] = ...,
-        loop: Optional[events.AbstractEventLoop] = ...,
-        limit: int = ...,
-        **kwds: Any,
-    ) -> Process[None, streams.StreamReader, None]: ...
-    @overload
-    async def create_subprocess_exec(
-        program: _ExecArg,
-        *args: _ExecArg,
-        stdin: Union[DEVNULL, IO[Any], None] = ...,
-        stdout: Union[DEVNULL, IO[Any], None] = ...,
-        stderr: PIPE,
-        loop: Optional[events.AbstractEventLoop] = ...,
-        limit: int = ...,
-        **kwds: Any,
-    ) -> Process[None, None, streams.StreamReader]: ...
-    @overload
-    async def create_subprocess_exec(
-        program: _ExecArg,
-        *args: _ExecArg,
-        stdin: PIPE,
-        stdout: PIPE,
-        stderr: Union[DEVNULL, STDOUT, IO[Any], None] = ...,
-        loop: Optional[events.AbstractEventLoop] = ...,
-        limit: int = ...,
-        **kwds: Any,
-    ) -> Process[streams.StreamWriter, streams.StreamReader, None]: ...
-    @overload
-    async def create_subprocess_exec(
-        program: _ExecArg,
-        *args: _ExecArg,
-        stdin: PIPE,
-        stdout: Union[DEVNULL, IO[Any], None] = ...,
-        stderr: PIPE,
-        loop: Optional[events.AbstractEventLoop] = ...,
-        limit: int = ...,
-        **kwds: Any,
-    ) -> Process[streams.StreamWriter, None, streams.StreamReader]: ...
-    @overload
-    async def create_subprocess_exec(
-        program: _ExecArg,
-        *args: _ExecArg,
-        stdin: Union[DEVNULL, IO[Any], None] = ...,
-        stdout: PIPE,
-        stderr: PIPE,
-        loop: Optional[events.AbstractEventLoop] = ...,
-        limit: int = ...,
-        **kwds: Any,
-    ) -> Process[None, streams.StreamReader, streams.StreamReader]: ...
-    @overload
-    async def create_subprocess_exec(
-        program: _ExecArg,
-        *args: _ExecArg,
-        stdin: PIPE,
-        stdout: PIPE,
-        stderr: PIPE,
-        loop: Optional[events.AbstractEventLoop] = ...,
-        limit: int = ...,
-        **kwds: Any,
-    ) -> Process[streams.StreamWriter, streams.StreamReader, streams.StreamReader]: ...
-    @overload
-    async def create_subprocess_exec(
-        program: _ExecArg,
-        *args: _ExecArg,
-        stdin: Union[DEVNULL, IO[Any], None] = ...,
-        stdout: Union[DEVNULL, IO[Any], None] = ...,
-        stderr: Union[DEVNULL, STDOUT, IO[Any], None] = ...,
-        loop: Optional[events.AbstractEventLoop] = ...,
-        limit: int = ...,
-        **kwds: Any,
-    ) -> Process[None, None, None]: ...
+@overload
+async def create_subprocess_exec(
+    program: _ExecArg,
+    *args: _ExecArg,
+    stdin: PIPE,
+    stdout: Union[DEVNULL, IO[Any], None] = ...,
+    stderr: Union[DEVNULL, STDOUT, IO[Any], None] = ...,
+    loop: Optional[events.AbstractEventLoop] = ...,
+    limit: int = ...,
+    **kwds: Any,
+) -> Process[streams.StreamWriter, None, None]: ...
+@overload
+async def create_subprocess_exec(
+    program: _ExecArg,
+    *args: _ExecArg,
+    stdin: Union[DEVNULL, IO[Any], None] = ...,
+    stdout: PIPE,
+    stderr: Union[DEVNULL, STDOUT, IO[Any], None] = ...,
+    loop: Optional[events.AbstractEventLoop] = ...,
+    limit: int = ...,
+    **kwds: Any,
+) -> Process[None, streams.StreamReader, None]: ...
+@overload
+async def create_subprocess_exec(
+    program: _ExecArg,
+    *args: _ExecArg,
+    stdin: Union[DEVNULL, IO[Any], None] = ...,
+    stdout: Union[DEVNULL, IO[Any], None] = ...,
+    stderr: PIPE,
+    loop: Optional[events.AbstractEventLoop] = ...,
+    limit: int = ...,
+    **kwds: Any,
+) -> Process[None, None, streams.StreamReader]: ...
+@overload
+async def create_subprocess_exec(
+    program: _ExecArg,
+    *args: _ExecArg,
+    stdin: PIPE,
+    stdout: PIPE,
+    stderr: Union[DEVNULL, STDOUT, IO[Any], None] = ...,
+    loop: Optional[events.AbstractEventLoop] = ...,
+    limit: int = ...,
+    **kwds: Any,
+) -> Process[streams.StreamWriter, streams.StreamReader, None]: ...
+@overload
+async def create_subprocess_exec(
+    program: _ExecArg,
+    *args: _ExecArg,
+    stdin: PIPE,
+    stdout: Union[DEVNULL, IO[Any], None] = ...,
+    stderr: PIPE,
+    loop: Optional[events.AbstractEventLoop] = ...,
+    limit: int = ...,
+    **kwds: Any,
+) -> Process[streams.StreamWriter, None, streams.StreamReader]: ...
+@overload
+async def create_subprocess_exec(
+    program: _ExecArg,
+    *args: _ExecArg,
+    stdin: Union[DEVNULL, IO[Any], None] = ...,
+    stdout: PIPE,
+    stderr: PIPE,
+    loop: Optional[events.AbstractEventLoop] = ...,
+    limit: int = ...,
+    **kwds: Any,
+) -> Process[None, streams.StreamReader, streams.StreamReader]: ...
+@overload
+async def create_subprocess_exec(
+    program: _ExecArg,
+    *args: _ExecArg,
+    stdin: PIPE,
+    stdout: PIPE,
+    stderr: PIPE,
+    loop: Optional[events.AbstractEventLoop] = ...,
+    limit: int = ...,
+    **kwds: Any,
+) -> Process[streams.StreamWriter, streams.StreamReader, streams.StreamReader]: ...
+@overload
+async def create_subprocess_exec(
+    program: _ExecArg,
+    *args: _ExecArg,
+    stdin: Union[DEVNULL, IO[Any], None] = ...,
+    stdout: Union[DEVNULL, IO[Any], None] = ...,
+    stderr: Union[DEVNULL, STDOUT, IO[Any], None] = ...,
+    loop: Optional[events.AbstractEventLoop] = ...,
+    limit: int = ...,
+    **kwds: Any,
+) -> Process[None, None, None]: ...

--- a/stdlib/3/asyncio/subprocess.pyi
+++ b/stdlib/3/asyncio/subprocess.pyi
@@ -1,6 +1,6 @@
 import sys
 from asyncio import events, protocols, streams, transports
-from subprocess import DEVNULL as DEVNULL, PIPE as PIPE, STDOUT as STDOUT, _DEVNULL, _PIPE, _STDOUT
+from subprocess import _DEVNULL, _PIPE, _STDOUT, DEVNULL as DEVNULL, PIPE as PIPE, STDOUT as STDOUT
 from typing import IO, Any, Generic, Optional, Tuple, TypeVar, Union, overload
 
 if sys.version_info >= (3, 8):

--- a/stdlib/3/asyncio/subprocess.pyi
+++ b/stdlib/3/asyncio/subprocess.pyi
@@ -1,7 +1,7 @@
 import sys
 from asyncio import events, protocols, streams, transports
 from subprocess import DEVNULL, PIPE, STDOUT
-from typing import IO, Any, Generic, Literal, Optional, Tuple, TypeVar, Union, overload
+from typing import IO, Any, Generic, Optional, Tuple, TypeVar, Union, overload
 
 if sys.version_info >= (3, 8):
     from os import PathLike
@@ -49,7 +49,7 @@ if sys.version_info < (3, 8):
         loop: Optional[events.AbstractEventLoop] = ...,
         limit: int = ...,
         **kwds: Any,
-    ) -> Process: ...
+    ) -> Process[Optional[streams.StreamWriter], Optional[streams.StreamReader], Optional[streams.StreamReader]]: ...
     async def create_subprocess_exec(
         program: _ExecArg,
         *args: _ExecArg,
@@ -59,7 +59,7 @@ if sys.version_info < (3, 8):
         loop: Optional[events.AbstractEventLoop] = ...,
         limit: int = ...,
         **kwds: Any,
-    ) -> Process: ...
+    ) -> Process[Optional[streams.StreamWriter], Optional[streams.StreamReader], Optional[streams.StreamReader]]: ...
 else:
     @overload
     async def create_subprocess_shell(

--- a/stdlib/3/asyncio/subprocess.pyi
+++ b/stdlib/3/asyncio/subprocess.pyi
@@ -1,6 +1,6 @@
 import sys
 from asyncio import events, protocols, streams, transports
-from subprocess import DEVNULL as DEVNULL, PIPE as PIPE, STDOUT as STDOUT
+from subprocess import DEVNULL as DEVNULL, PIPE as PIPE, STDOUT as STDOUT, _DEVNULL, _PIPE, _STDOUT
 from typing import IO, Any, Generic, Optional, Tuple, TypeVar, Union, overload
 
 if sys.version_info >= (3, 8):
@@ -43,9 +43,9 @@ class Process(Generic[_S, _T, _U]):
 @overload
 async def create_subprocess_shell(
     cmd: Union[str, bytes],  # Union used instead of AnyStr due to mypy issue  #1236
-    stdin: PIPE,
-    stdout: Union[DEVNULL, IO[Any], None] = ...,
-    stderr: Union[DEVNULL, STDOUT, IO[Any], None] = ...,
+    stdin: _PIPE,
+    stdout: Union[_DEVNULL, IO[Any], None] = ...,
+    stderr: Union[_DEVNULL, _STDOUT, IO[Any], None] = ...,
     loop: Optional[events.AbstractEventLoop] = ...,
     limit: int = ...,
     **kwds: Any,
@@ -53,10 +53,10 @@ async def create_subprocess_shell(
 @overload
 async def create_subprocess_shell(
     cmd: Union[str, bytes],  # Union used instead of AnyStr due to mypy issue  #1236
-    stdin: Union[DEVNULL, IO[Any], None] = ...,
+    stdin: Union[_DEVNULL, IO[Any], None] = ...,
     *,
-    stdout: PIPE,
-    stderr: Union[DEVNULL, STDOUT, IO[Any], None] = ...,
+    stdout: _PIPE,
+    stderr: Union[_DEVNULL, _STDOUT, IO[Any], None] = ...,
     loop: Optional[events.AbstractEventLoop] = ...,
     limit: int = ...,
     **kwds: Any,
@@ -64,10 +64,10 @@ async def create_subprocess_shell(
 @overload
 async def create_subprocess_shell(
     cmd: Union[str, bytes],  # Union used instead of AnyStr due to mypy issue  #1236
-    stdin: Union[DEVNULL, IO[Any], None] = ...,
-    stdout: Union[DEVNULL, IO[Any], None] = ...,
+    stdin: Union[_DEVNULL, IO[Any], None] = ...,
+    stdout: Union[_DEVNULL, IO[Any], None] = ...,
     *,
-    stderr: PIPE,
+    stderr: _PIPE,
     loop: Optional[events.AbstractEventLoop] = ...,
     limit: int = ...,
     **kwds: Any,
@@ -75,9 +75,9 @@ async def create_subprocess_shell(
 @overload
 async def create_subprocess_shell(
     cmd: Union[str, bytes],  # Union used instead of AnyStr due to mypy issue  #1236
-    stdin: PIPE,
-    stdout: PIPE,
-    stderr: Union[DEVNULL, STDOUT, IO[Any], None] = ...,
+    stdin: _PIPE,
+    stdout: _PIPE,
+    stderr: Union[_DEVNULL, _STDOUT, IO[Any], None] = ...,
     loop: Optional[events.AbstractEventLoop] = ...,
     limit: int = ...,
     **kwds: Any,
@@ -85,10 +85,10 @@ async def create_subprocess_shell(
 @overload
 async def create_subprocess_shell(
     cmd: Union[str, bytes],  # Union used instead of AnyStr due to mypy issue  #1236
-    stdin: PIPE,
-    stdout: Union[DEVNULL, IO[Any], None] = ...,
+    stdin: _PIPE,
+    stdout: Union[_DEVNULL, IO[Any], None] = ...,
     *,
-    stderr: PIPE,
+    stderr: _PIPE,
     loop: Optional[events.AbstractEventLoop] = ...,
     limit: int = ...,
     **kwds: Any,
@@ -96,10 +96,10 @@ async def create_subprocess_shell(
 @overload
 async def create_subprocess_shell(
     cmd: Union[str, bytes],  # Union used instead of AnyStr due to mypy issue  #1236
-    stdin: Union[DEVNULL, IO[Any], None] = ...,
+    stdin: Union[_DEVNULL, IO[Any], None] = ...,
     *,
-    stdout: PIPE,
-    stderr: PIPE,
+    stdout: _PIPE,
+    stderr: _PIPE,
     loop: Optional[events.AbstractEventLoop] = ...,
     limit: int = ...,
     **kwds: Any,
@@ -107,9 +107,9 @@ async def create_subprocess_shell(
 @overload
 async def create_subprocess_shell(
     cmd: Union[str, bytes],  # Union used instead of AnyStr due to mypy issue  #1236
-    stdin: PIPE,
-    stdout: PIPE,
-    stderr: PIPE,
+    stdin: _PIPE,
+    stdout: _PIPE,
+    stderr: _PIPE,
     loop: Optional[events.AbstractEventLoop] = ...,
     limit: int = ...,
     **kwds: Any,
@@ -117,9 +117,9 @@ async def create_subprocess_shell(
 @overload
 async def create_subprocess_shell(
     cmd: Union[str, bytes],  # Union used instead of AnyStr due to mypy issue  #1236
-    stdin: Union[DEVNULL, IO[Any], None] = ...,
-    stdout: Union[DEVNULL, IO[Any], None] = ...,
-    stderr: Union[DEVNULL, STDOUT, IO[Any], None] = ...,
+    stdin: Union[_DEVNULL, IO[Any], None] = ...,
+    stdout: Union[_DEVNULL, IO[Any], None] = ...,
+    stderr: Union[_DEVNULL, _STDOUT, IO[Any], None] = ...,
     loop: Optional[events.AbstractEventLoop] = ...,
     limit: int = ...,
     **kwds: Any,
@@ -128,9 +128,9 @@ async def create_subprocess_shell(
 async def create_subprocess_exec(
     program: _ExecArg,
     *args: _ExecArg,
-    stdin: PIPE,
-    stdout: Union[DEVNULL, IO[Any], None] = ...,
-    stderr: Union[DEVNULL, STDOUT, IO[Any], None] = ...,
+    stdin: _PIPE,
+    stdout: Union[_DEVNULL, IO[Any], None] = ...,
+    stderr: Union[_DEVNULL, _STDOUT, IO[Any], None] = ...,
     loop: Optional[events.AbstractEventLoop] = ...,
     limit: int = ...,
     **kwds: Any,
@@ -139,9 +139,9 @@ async def create_subprocess_exec(
 async def create_subprocess_exec(
     program: _ExecArg,
     *args: _ExecArg,
-    stdin: Union[DEVNULL, IO[Any], None] = ...,
-    stdout: PIPE,
-    stderr: Union[DEVNULL, STDOUT, IO[Any], None] = ...,
+    stdin: Union[_DEVNULL, IO[Any], None] = ...,
+    stdout: _PIPE,
+    stderr: Union[_DEVNULL, _STDOUT, IO[Any], None] = ...,
     loop: Optional[events.AbstractEventLoop] = ...,
     limit: int = ...,
     **kwds: Any,
@@ -150,9 +150,9 @@ async def create_subprocess_exec(
 async def create_subprocess_exec(
     program: _ExecArg,
     *args: _ExecArg,
-    stdin: Union[DEVNULL, IO[Any], None] = ...,
-    stdout: Union[DEVNULL, IO[Any], None] = ...,
-    stderr: PIPE,
+    stdin: Union[_DEVNULL, IO[Any], None] = ...,
+    stdout: Union[_DEVNULL, IO[Any], None] = ...,
+    stderr: _PIPE,
     loop: Optional[events.AbstractEventLoop] = ...,
     limit: int = ...,
     **kwds: Any,
@@ -161,9 +161,9 @@ async def create_subprocess_exec(
 async def create_subprocess_exec(
     program: _ExecArg,
     *args: _ExecArg,
-    stdin: PIPE,
-    stdout: PIPE,
-    stderr: Union[DEVNULL, STDOUT, IO[Any], None] = ...,
+    stdin: _PIPE,
+    stdout: _PIPE,
+    stderr: Union[_DEVNULL, _STDOUT, IO[Any], None] = ...,
     loop: Optional[events.AbstractEventLoop] = ...,
     limit: int = ...,
     **kwds: Any,
@@ -172,9 +172,9 @@ async def create_subprocess_exec(
 async def create_subprocess_exec(
     program: _ExecArg,
     *args: _ExecArg,
-    stdin: PIPE,
-    stdout: Union[DEVNULL, IO[Any], None] = ...,
-    stderr: PIPE,
+    stdin: _PIPE,
+    stdout: Union[_DEVNULL, IO[Any], None] = ...,
+    stderr: _PIPE,
     loop: Optional[events.AbstractEventLoop] = ...,
     limit: int = ...,
     **kwds: Any,
@@ -183,9 +183,9 @@ async def create_subprocess_exec(
 async def create_subprocess_exec(
     program: _ExecArg,
     *args: _ExecArg,
-    stdin: Union[DEVNULL, IO[Any], None] = ...,
-    stdout: PIPE,
-    stderr: PIPE,
+    stdin: Union[_DEVNULL, IO[Any], None] = ...,
+    stdout: _PIPE,
+    stderr: _PIPE,
     loop: Optional[events.AbstractEventLoop] = ...,
     limit: int = ...,
     **kwds: Any,
@@ -194,9 +194,9 @@ async def create_subprocess_exec(
 async def create_subprocess_exec(
     program: _ExecArg,
     *args: _ExecArg,
-    stdin: PIPE,
-    stdout: PIPE,
-    stderr: PIPE,
+    stdin: _PIPE,
+    stdout: _PIPE,
+    stderr: _PIPE,
     loop: Optional[events.AbstractEventLoop] = ...,
     limit: int = ...,
     **kwds: Any,
@@ -205,9 +205,9 @@ async def create_subprocess_exec(
 async def create_subprocess_exec(
     program: _ExecArg,
     *args: _ExecArg,
-    stdin: Union[DEVNULL, IO[Any], None] = ...,
-    stdout: Union[DEVNULL, IO[Any], None] = ...,
-    stderr: Union[DEVNULL, STDOUT, IO[Any], None] = ...,
+    stdin: Union[_DEVNULL, IO[Any], None] = ...,
+    stdout: Union[_DEVNULL, IO[Any], None] = ...,
+    stderr: Union[_DEVNULL, _STDOUT, IO[Any], None] = ...,
     loop: Optional[events.AbstractEventLoop] = ...,
     limit: int = ...,
     **kwds: Any,

--- a/stdlib/3/asyncio/subprocess.pyi
+++ b/stdlib/3/asyncio/subprocess.pyi
@@ -124,7 +124,6 @@ async def create_subprocess_shell(
     limit: int = ...,
     **kwds: Any,
 ) -> Process[None, None, None]: ...
-
 @overload
 async def create_subprocess_exec(
     program: _ExecArg,

--- a/stdlib/3/asyncio/subprocess.pyi
+++ b/stdlib/3/asyncio/subprocess.pyi
@@ -3,6 +3,8 @@ from asyncio import events, protocols, streams, transports
 from subprocess import DEVNULL, PIPE, STDOUT
 from typing import IO, Any, Generic, Optional, Tuple, TypeVar, Union, overload
 
+reveal_type(DEVNULL)
+
 if sys.version_info >= (3, 8):
     from os import PathLike
 

--- a/stdlib/3/asyncio/subprocess.pyi
+++ b/stdlib/3/asyncio/subprocess.pyi
@@ -1,9 +1,7 @@
 import sys
 from asyncio import events, protocols, streams, transports
-from subprocess import DEVNULL, PIPE, STDOUT
+from subprocess import DEVNULL as DEVNULL, PIPE as PIPE, STDOUT as STDOUT
 from typing import IO, Any, Generic, Optional, Tuple, TypeVar, Union, overload
-
-reveal_type(DEVNULL)
 
 if sys.version_info >= (3, 8):
     from os import PathLike

--- a/stdlib/3/subprocess.pyi
+++ b/stdlib/3/subprocess.pyi
@@ -672,11 +672,11 @@ else:
     ) -> Any: ...  # morally: -> _TXT
 
 _PIPE = Literal[-1]
-PIPE: T_PIPE
+PIPE: _PIPE
 _STDOUT = Literal[-2]
-STDOUT: T_STDOUT
+STDOUT: _STDOUT
 _DEVNULL = Literal[-3]
-DEVNULL: T_DEVNULL
+DEVNULL: _DEVNULL
 
 class SubprocessError(Exception): ...
 

--- a/stdlib/3/subprocess.pyi
+++ b/stdlib/3/subprocess.pyi
@@ -671,9 +671,15 @@ else:
         errors: Optional[str] = ...,
     ) -> Any: ...  # morally: -> _TXT
 
-PIPE: int
-STDOUT: int
-DEVNULL: int
+if sys.version_info >= (3, 8):
+    from typing import Literal
+    PIPE: Literal[-1]
+    STDOUT: Literal[-2]
+    DEVNULL: Literal[-3]
+else:
+    PIPE: int
+    STDOUT: int
+    DEVNULL: int
 
 class SubprocessError(Exception): ...
 

--- a/stdlib/3/subprocess.pyi
+++ b/stdlib/3/subprocess.pyi
@@ -671,9 +671,12 @@ else:
         errors: Optional[str] = ...,
     ) -> Any: ...  # morally: -> _TXT
 
-PIPE: Literal[-1]
-STDOUT: Literal[-2]
-DEVNULL: Literal[-3]
+_PIPE = Literal[-1]
+PIPE: T_PIPE
+_STDOUT = Literal[-2]
+STDOUT: T_STDOUT
+_DEVNULL = Literal[-3]
+DEVNULL: T_DEVNULL
 
 class SubprocessError(Exception): ...
 

--- a/stdlib/3/subprocess.pyi
+++ b/stdlib/3/subprocess.pyi
@@ -671,15 +671,9 @@ else:
         errors: Optional[str] = ...,
     ) -> Any: ...  # morally: -> _TXT
 
-if sys.version_info >= (3, 8):
-    from typing import Literal
-    PIPE: Literal[-1]
-    STDOUT: Literal[-2]
-    DEVNULL: Literal[-3]
-else:
-    PIPE: int
-    STDOUT: int
-    DEVNULL: int
+PIPE: Literal[-1]
+STDOUT: Literal[-2]
+DEVNULL: Literal[-3]
 
 class SubprocessError(Exception): ...
 


### PR DESCRIPTION
Related to #3831 

The mypy primer errors for anyio, are caused because they use `int` for their type annotations. It's probably preferable to use `Union[PIPE, DEVNULL]` or similar. Otherwise, it allows calls with arbitrary numbers, which can fail at runtime.