### PR TITLE
Remove unnecessary overloads from _patch.__init__()

### DIFF
--- a/stdlib/3/unittest/mock.pyi
+++ b/stdlib/3/unittest/mock.pyi
@@ -164,63 +164,20 @@ class _patch(Generic[_T]):
     autospec: Any
     kwargs: Mapping[str, Any]
     additional_patchers: Any
-    if sys.version_info >= (3, 8):
-        @overload
-        def __init__(
-            self: _patch[Union[MagicMock, AsyncMock]],
-            getter: Callable[[], Any],
-            attribute: str,
-            *,
-            spec: Optional[Any],
-            create: bool,
-            spec_set: Optional[Any],
-            autospec: Optional[Any],
-            new_callable: Optional[Any],
-            kwargs: Mapping[str, Any],
-        ) -> None: ...
-        # This overload also covers the case, where new==DEFAULT. In this case, self is _patch[Any].
-        # Ideally we'd be able to add an overload for it so that self is _patch[MagicMock],
-        # but that's impossible with the current type system.
-        @overload
-        def __init__(
-            self: _patch[_T],
-            getter: Callable[[], Any],
-            attribute: str,
-            new: _T,
-            spec: Optional[Any],
-            create: bool,
-            spec_set: Optional[Any],
-            autospec: Optional[Any],
-            new_callable: Optional[Any],
-            kwargs: Mapping[str, Any],
-        ) -> None: ...
-    else:
-        @overload
-        def __init__(
-            self: _patch[MagicMock],
-            getter: Callable[[], Any],
-            attribute: str,
-            *,
-            spec: Optional[Any],
-            create: bool,
-            spec_set: Optional[Any],
-            autospec: Optional[Any],
-            new_callable: Optional[Any],
-            kwargs: Mapping[str, Any],
-        ) -> None: ...
-        @overload
-        def __init__(
-            self: _patch[_T],
-            getter: Callable[[], Any],
-            attribute: str,
-            new: _T,
-            spec: Optional[Any],
-            create: bool,
-            spec_set: Optional[Any],
-            autospec: Optional[Any],
-            new_callable: Optional[Any],
-            kwargs: Mapping[str, Any],
-        ) -> None: ...
+    # If new==DEFAULT, self is _patch[Any]. Ideally we'd be able to add an overload for it so that self is _patch[MagicMock],
+    # but that's impossible with the current type system.
+    def __init__(
+        self: _patch[_T],
+        getter: Callable[[], Any],
+        attribute: str,
+        new: _T,
+        spec: Optional[Any],
+        create: bool,
+        spec_set: Optional[Any],
+        autospec: Optional[Any],
+        new_callable: Optional[Any],
+        kwargs: Mapping[str, Any],
+    ) -> None: ...
     def copy(self) -> _patch[_T]: ...
     def __call__(self, func: Callable[..., _R]) -> Callable[..., _R]: ...
     def decorate_class(self, klass: _TT) -> _TT: ...


### PR DESCRIPTION
None of the arguments to `__init__()` are optional, so leaving out `new` is not possible.