### PR TITLE
Allow Python 2 unicode for some click interfaces

### DIFF
--- a/third_party/2and3/click/decorators.pyi
+++ b/third_party/2and3/click/decorators.pyi
@@ -57,7 +57,7 @@ def group(
     **kwargs: Any,
 ) -> Callable[[Callable[..., Any]], Group]: ...
 def argument(
-    *param_decls: str,
+    *param_decls: Text,
     cls: Type[Argument] = ...,
     # Argument
     required: Optional[bool] = ...,
@@ -74,7 +74,7 @@ def argument(
 ) -> _IdentityFunction: ...
 @overload
 def option(
-    *param_decls: str,
+    *param_decls: Text,
     cls: Type[Option] = ...,
     # Option
     show_default: Union[bool, Text] = ...,
@@ -87,7 +87,7 @@ def option(
     count: bool = ...,
     allow_from_autoenv: bool = ...,
     type: Optional[_ConvertibleType] = ...,
-    help: Optional[str] = ...,
+    help: Optional[Text] = ...,
     show_choices: bool = ...,
     # Parameter
     default: Optional[Any] = ...,

--- a/third_party/2and3/click/termui.pyi
+++ b/third_party/2and3/click/termui.pyi
@@ -63,8 +63,8 @@ def progressbar(
 def clear() -> None: ...
 def style(
     text: Text,
-    fg: Optional[str] = ...,
-    bg: Optional[str] = ...,
+    fg: Optional[Text] = ...,
+    bg: Optional[Text] = ...,
     bold: Optional[bool] = ...,
     dim: Optional[bool] = ...,
     underline: Optional[bool] = ...,

--- a/third_party/2and3/click/types.pyi
+++ b/third_party/2and3/click/types.pyi
@@ -1,6 +1,6 @@
 import datetime
 import uuid
-from typing import IO, Any, Callable, Generic, Iterable, List, Optional, Tuple as _PyTuple, Type, TypeVar, Union
+from typing import IO, Any, Callable, Generic, Iterable, List, Optional, Text, Tuple as _PyTuple, Type, TypeVar, Union
 
 from click.core import Context, Parameter, _ConvertibleType, _ParamType
 
@@ -31,7 +31,7 @@ class FloatRange(FloatParamType):
 class File(ParamType):
     def __init__(
         self,
-        mode: str = ...,
+        mode: Text = ...,
         encoding: Optional[str] = ...,
         errors: Optional[str] = ...,
         lazy: Optional[bool] = ...,


### PR DESCRIPTION
Helps Python 2 code using:

    form __future__ import unicode_literals

On Python 2, these interfaces are compatible with both str and unicode.