### PR TITLE
tabulate: support dictionaries as table headers

### DIFF
--- a/third_party/2and3/tabulate.pyi
+++ b/third_party/2and3/tabulate.pyi
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Container, Iterable, List, Mapping, NamedTuple, Optional, Sequence, Union
+from typing import Any, Callable, Container, Dict, Iterable, List, Mapping, NamedTuple, Optional, Sequence, Union
 
 PRESERVE_WHITESPACE: bool
 WIDE_CHARS_MODE: bool
@@ -31,7 +31,7 @@ class TableFormat(NamedTuple):
 def simple_separated_format(separator: str) -> TableFormat: ...
 def tabulate(
     tabular_data: Union[Mapping[str, Iterable[Any]], Iterable[Iterable[Any]]],
-    headers: Union[str, Sequence[str]] = ...,
+    headers: Union[str, Dict[str, str], Sequence[str]] = ...,
     tablefmt: Union[str, TableFormat] = ...,
     floatfmt: Union[str, Iterable[str]] = ...,
     numalign: Optional[str] = ...,


### PR DESCRIPTION
[`tabulate`](https://pypi.org/project/tabulate/) supports dictionaries in the `headers` argument of `tabulate.tabulate`:

```python
import tabulate

table = [{"name": "row 1", "val": 5}, {"name": "row 2", "val": 3}]
headers = {"name": "row names", "val": "number"}

print(tabulate.tabulate(table, headers=headers))
```

Dictionaries were removed from the possible types of `headers` in #3391 (cc @ilai-deutel). This PR adds them back, as they are a [supported by `tabulate`](https://github.com/astanin/python-tabulate/blob/2552e6dfb23cac990aeabb27b86745878d62247e/tabulate.py#L1078-L1081).

fixes #4829