### PR TITLE
Revert "Remove unused stubtest whitelist entries (#4839)"

### DIFF
--- a/tests/stubtest_whitelists/linux.txt
+++ b/tests/stubtest_whitelists/linux.txt
@@ -38,6 +38,7 @@ _msi
 _winapi
 asyncio.windows_events
 asyncio.windows_utils
+ctypes.wintypes
 msilib(.[a-z]+)?
 msvcrt
 winreg


### PR DESCRIPTION
This reverts commit fcc2416d43a3d505af7ad99e90401f69a13b6ba7.