### PR TITLE
ctypes.wintypes can be imported on linux in 3.9.1

### DIFF
--- a/tests/stubtest_whitelists/linux-py36.txt
+++ b/tests/stubtest_whitelists/linux-py36.txt
@@ -1,4 +1,5 @@
 asyncio.unix_events._UnixSelectorEventLoop.create_unix_server
+ctypes.wintypes
 pwd.getpwnam
 ssl.PROTOCOL_SSLv3
 ssl.RAND_egd

--- a/tests/stubtest_whitelists/linux-py37.txt
+++ b/tests/stubtest_whitelists/linux-py37.txt
@@ -1,3 +1,4 @@
+ctypes.wintypes
 pwd.getpwnam
 time.CLOCK_PROF
 time.CLOCK_UPTIME

--- a/tests/stubtest_whitelists/linux-py38.txt
+++ b/tests/stubtest_whitelists/linux-py38.txt
@@ -1,3 +1,4 @@
+ctypes.wintypes
 os.MFD_HUGE_32MB
 os.MFD_HUGE_512MB
 time.CLOCK_PROF

--- a/tests/stubtest_whitelists/linux.txt
+++ b/tests/stubtest_whitelists/linux.txt
@@ -38,7 +38,6 @@ _msi
 _winapi
 asyncio.windows_events
 asyncio.windows_utils
-ctypes.wintypes
 msilib(.[a-z]+)?
 msvcrt
 winreg


### PR DESCRIPTION
See https://bugs.python.org/issue16396 for the CPython change.
Fixes https://github.com/python/typeshed/pull/4857