### PR TITLE
Add type for distutils.command.install.SCHEME_KEYS

### DIFF
--- a/stdlib/3/distutils/command/install.pyi
+++ b/stdlib/3/distutils/command/install.pyi
@@ -1,5 +1,7 @@
 from distutils.cmd import Command
-from typing import Optional
+from typing import Optional, Tuple
+
+SCHEME_KEYS: Tuple[str, ...]
 
 class install(Command):
     user: bool


### PR DESCRIPTION
Used by pip, but currently requires an ignore:
https://github.com/pypa/pip/blob/20.3.3/src/pip/_internal/locations.py#L15

The distutils code:
https://github.com/python/cpython/blob/1e5d33e9b9b8631b36f061103a30208b206fd03a/Lib/distutils/command/install.py#L70