### PR TITLE
make tkinter.BitmapImage keyword arguments optional

### DIFF
--- a/stdlib/3/tkinter/__init__.pyi
+++ b/stdlib/3/tkinter/__init__.pyi
@@ -2690,12 +2690,12 @@ class BitmapImage(Image):
         cnf: Dict[str, Any] = ...,
         master: Optional[Union[Misc, _tkinter.TkappType]] = ...,
         *,
-        background: _Color,
-        data: str,
-        file: AnyPath,
-        foreground: _Color,
-        maskdata: str,
-        maskfile: AnyPath,
+        background: _Color = ...,
+        data: str = ...,
+        file: AnyPath = ...,
+        foreground: _Color = ...,
+        maskdata: str = ...,
+        maskfile: AnyPath = ...,
     ) -> None: ...
 
 def image_names() -> Tuple[str, ...]: ...


### PR DESCRIPTION
Fixes a typo introduced in #4923 

Without `= ...`, these arguments would be keyword-only and **required**, but all of them should be optional. I think `mypy_primer` didn't complain because `BitmapImage` seems to be old and not very commonly used.