### PR TITLE
Add some urllib annotations also for Python 3

### DIFF
--- a/stdlib/2/urllib2.pyi
+++ b/stdlib/2/urllib2.pyi
@@ -22,7 +22,7 @@ class Request(object):
     type: Optional[str]
     origin_req_host = ...
     unredirected_hdrs: Dict[str, str]
-    timeout: Optional[float]  # Undocumented
+    timeout: Optional[float]  # Undocumented, only set after __init__() by OpenerDirector.open()
     def __init__(
         self,
         url: str,

--- a/stdlib/2/urllib2.pyi
+++ b/stdlib/2/urllib2.pyi
@@ -22,6 +22,7 @@ class Request(object):
     type: Optional[str]
     origin_req_host = ...
     unredirected_hdrs: Dict[str, str]
+    timeout: Optional[float]  # Undocumented
     def __init__(
         self,
         url: str,

--- a/stdlib/3/urllib/request.pyi
+++ b/stdlib/3/urllib/request.pyi
@@ -61,6 +61,7 @@ class Request:
     unredirected_hdrs: Dict[str, str]
     unverifiable: bool
     method: Optional[str]
+    timeout: Optional[float]  # Undocumented
     def __init__(
         self,
         url: str,

--- a/stdlib/3/urllib/request.pyi
+++ b/stdlib/3/urllib/request.pyi
@@ -58,6 +58,7 @@ class Request:
     selector: str
     data: Optional[bytes]
     headers: Dict[str, str]
+    unredirected_hdrs: Dict[str, str]
     unverifiable: bool
     method: Optional[str]
     def __init__(

--- a/stdlib/3/urllib/request.pyi
+++ b/stdlib/3/urllib/request.pyi
@@ -61,7 +61,7 @@ class Request:
     unredirected_hdrs: Dict[str, str]
     unverifiable: bool
     method: Optional[str]
-    timeout: Optional[float]  # Undocumented
+    timeout: Optional[float]  # Undocumented, only set after __init__() by OpenerDirector.open()
     def __init__(
         self,
         url: str,


### PR DESCRIPTION
`urllib.request::Request.unredirected_hdrs` is missing with Python 3.

<https://github.com/python/cpython/blob/d9b8f138b7df3b455b54653ca59f491b4840d6fa/Lib/urllib/request.py#L330>

See my previous conntribution 25c96400f6b9144fbc1f6dd775b60b448562f7c1 which did this for Python 2 only.