### PR TITLE
allowlist ctypes.wintypes

### DIFF
--- a/tests/stubtest_whitelists/linux-py38.txt
+++ b/tests/stubtest_whitelists/linux-py38.txt
@@ -1,3 +1,4 @@
+ctypes.wintypes
 os.MFD_HUGE_32MB
 os.MFD_HUGE_512MB
 time.CLOCK_PROF


### PR DESCRIPTION
The unused cronjob removed this for unclear reasons in #4935