### PR TITLE
tkinter: allow IntVar in tkinter.Scale, ttk.Scale and ttk.Progressbar

### DIFF
--- a/stdlib/3/tkinter/__init__.pyi
+++ b/stdlib/3/tkinter/__init__.pyi
@@ -2193,7 +2193,7 @@ class Scale(Widget):
         tickinterval: float = ...,
         to: float = ...,
         troughcolor: _Color = ...,
-        variable: DoubleVar = ...,
+        variable: Union[IntVar, DoubleVar] = ...,
         width: _ScreenUnits = ...,
     ) -> None: ...
     @overload
@@ -2233,7 +2233,7 @@ class Scale(Widget):
         tickinterval: float = ...,
         to: float = ...,
         troughcolor: _Color = ...,
-        variable: DoubleVar = ...,
+        variable: Union[IntVar, DoubleVar] = ...,
         width: _ScreenUnits = ...,
     ) -> Optional[Dict[str, Tuple[str, str, str, Any, Any]]]: ...
     @overload

--- a/stdlib/3/tkinter/ttk.pyi
+++ b/stdlib/3/tkinter/ttk.pyi
@@ -582,7 +582,7 @@ class Progressbar(Widget):
         style: str = ...,
         takefocus: tkinter._TakeFocusValue = ...,
         value: float = ...,
-        variable: tkinter.DoubleVar = ...,
+        variable: Union[tkinter.IntVar, tkinter.DoubleVar] = ...,
     ) -> None: ...
     @overload
     def configure(
@@ -598,7 +598,7 @@ class Progressbar(Widget):
         style: str = ...,
         takefocus: tkinter._TakeFocusValue = ...,
         value: float = ...,
-        variable: tkinter.DoubleVar = ...,
+        variable: Union[tkinter.IntVar, tkinter.DoubleVar] = ...,
     ) -> Optional[Dict[str, Tuple[str, str, str, Any, Any]]]: ...
     @overload
     def configure(self, cnf: str) -> Tuple[str, str, str, Any, Any]: ...
@@ -671,7 +671,7 @@ class Scale(Widget, tkinter.Scale):
         takefocus: tkinter._TakeFocusValue = ...,
         to: float = ...,
         value: float = ...,
-        variable: tkinter.DoubleVar = ...,
+        variable: Union[tkinter.IntVar, tkinter.DoubleVar] = ...,
     ) -> None: ...
     @overload  # type: ignore
     def configure(
@@ -688,7 +688,7 @@ class Scale(Widget, tkinter.Scale):
         takefocus: tkinter._TakeFocusValue = ...,
         to: float = ...,
         value: float = ...,
-        variable: tkinter.DoubleVar = ...,
+        variable: Union[tkinter.IntVar, tkinter.DoubleVar] = ...,
     ) -> Optional[Dict[str, Tuple[str, str, str, Any, Any]]]: ...
     @overload
     def configure(self, cnf: str) -> Tuple[str, str, str, Any, Any]: ...
@@ -708,7 +708,7 @@ class Scale(Widget, tkinter.Scale):
         takefocus: tkinter._TakeFocusValue = ...,
         to: float = ...,
         value: float = ...,
-        variable: tkinter.DoubleVar = ...,
+        variable: Union[tkinter.IntVar, tkinter.DoubleVar] = ...,
     ) -> Optional[Dict[str, Tuple[str, str, str, Any, Any]]]: ...
     @overload
     def config(self, cnf: str) -> Tuple[str, str, str, Any, Any]: ...


### PR DESCRIPTION
Fixes #4959

I only allow `IntVar` and `DoubleVar` instead of allowing any `Variable`, because even though using `StringVar` works for this, using it is likely a programming error since the value is always a float or an int.