### PR TITLE
VERSIONS: add typing-extensions

### DIFF
--- a/stdlib/VERSIONS
+++ b/stdlib/VERSIONS
@@ -233,6 +233,7 @@ tty: 2.7
 turtle: 2.7
 types: 3.6
 typing: 3.6
+typing-extensions: 2.7
 unicodedata: 2.7
 unittest: 3.6
 urllib: 3.6


### PR DESCRIPTION
tests/mypy_test.py fails for me locally... not sure exactly how it
passes in CI. This fixes it and also fixes stubtest.