### PR TITLE
cyptography: Add default, optional to few remaining backend= arguments

### DIFF
--- a/stubs/cryptography/cryptography/hazmat/primitives/serialization/__init__.pyi
+++ b/stubs/cryptography/cryptography/hazmat/primitives/serialization/__init__.pyi
@@ -28,7 +28,7 @@ def load_der_public_key(
     data: bytes, backend: Optional[DERSerializationBackend] = ...
 ) -> Any: ...  # actually Union[RSAPublicKey, DSAPublicKey, DHPublicKey, EllipticCurvePublicKey]
 def load_ssh_public_key(
-    data: bytes, backend: Union[RSABackend, DSABackend, EllipticCurveBackend, None]
+    data: bytes, backend: Union[RSABackend, DSABackend, EllipticCurveBackend, None] = ...
 ) -> Any: ...  # actually Union[RSAPublicKey, DSAPublicKey, DHPublicKey, EllipticCurvePublicKey, Ed25519PublicKey]
 
 class Encoding(Enum):

--- a/stubs/cryptography/cryptography/hazmat/primitives/twofactor/hotp.pyi
+++ b/stubs/cryptography/cryptography/hazmat/primitives/twofactor/hotp.pyi
@@ -5,7 +5,12 @@ from cryptography.hazmat.primitives.hashes import HashAlgorithm
 
 class HOTP(object):
     def __init__(
-        self, key: bytes, length: int, algorithm: HashAlgorithm, backend: HMACBackend, enforce_key_length: bool = ...
+        self,
+        key: bytes,
+        length: int,
+        algorithm: HashAlgorithm,
+        backend: Optional[HMACBackend] = ...,
+        enforce_key_length: bool = ...,
     ): ...
     def generate(self, counter: int) -> bytes: ...
     def get_provisioning_uri(self, account_name: str, counter: int, issuer: Optional[str]) -> str: ...

--- a/stubs/cryptography/cryptography/hazmat/primitives/twofactor/totp.pyi
+++ b/stubs/cryptography/cryptography/hazmat/primitives/twofactor/totp.pyi
@@ -10,7 +10,7 @@ class TOTP(object):
         length: int,
         algorithm: HashAlgorithm,
         time_step: int,
-        backend: HMACBackend,
+        backend: Optional[HMACBackend] = ...,
         enforce_key_length: bool = ...,
     ): ...
     def generate(self, time: int) -> bytes: ...


### PR DESCRIPTION
This was changed in cryptography 3.1: https://cryptography.io/en/latest/changelog.html#v3-1

Most places in typeshed were already correct, fixed few remaining omissions.
