### PR TITLE
Switch back to installing the released version of pytype.

### DIFF
--- a/requirements-tests-py3.txt
+++ b/requirements-tests-py3.txt
@@ -5,4 +5,4 @@ flake8==3.8.4
 flake8-bugbear==20.1.4
 flake8-pyi==20.10.0
 isort[pyproject]==5.5.3
-git+https://github.com/google/pytype.git@master
+pytype>=2021.01.28


### PR DESCRIPTION
pytype-2021.01.28 contains the changes needed to support the new
typeshed directory structure.