### PR TITLE
Add support for json.detect_encoding

### DIFF
--- a/stdlib/json/__init__.pyi
+++ b/stdlib/json/__init__.pyi
@@ -55,3 +55,4 @@ def load(
     object_pairs_hook: Optional[Callable[[List[Tuple[Any, Any]]], Any]] = ...,
     **kwds: Any,
 ) -> Any: ...
+def detect_encoding(b: bytes) -> str: ...  # undocumented


### PR DESCRIPTION
`json.detect_encoding` is undocumented but first appeared in v3.6.0