### PR TITLE
Fixed incompatible use of constrained TypeVar in tempfile. The TypeVa…

### DIFF
--- a/stdlib/tempfile.pyi
+++ b/stdlib/tempfile.pyi
@@ -13,8 +13,7 @@ tempdir: Optional[str]
 template: str
 
 _S = TypeVar("_S")
-_T = TypeVar("_T")  # for pytype, define typevar in same file as alias
-_DirT = Union[_T, os.PathLike[_T]]
+_DirT = Union[AnyStr, os.PathLike[AnyStr]]
 
 if sys.version_info >= (3, 8):
     @overload


### PR DESCRIPTION
…r `_T` was being used as a type argument for `PathLike`, but `PathLike` requires that its type argument be constrained to `str` or `bytes`, and `_T` didn't provide any such constraint. The easy workaround is to use the TypeVar `AnyStr` instead.