### PR TITLE
Small fixes for Python 3.10

### DIFF
--- a/stdlib/shelve.pyi
+++ b/stdlib/shelve.pyi
@@ -1,7 +1,7 @@
-import collections
+import collections.abc
 from typing import Any, Dict, Iterator, Optional, Tuple
 
-class Shelf(collections.MutableMapping[Any, Any]):
+class Shelf(collections.abc.MutableMapping[Any, Any]):
     def __init__(
         self, dict: Dict[bytes, Any], protocol: Optional[int] = ..., writeback: bool = ..., keyencoding: str = ...
     ) -> None: ...

--- a/stdlib/types.pyi
+++ b/stdlib/types.pyi
@@ -331,4 +331,6 @@ if sys.version_info >= (3, 10):
     class NoneType:
         def __bool__(self) -> Literal[False]: ...
     EllipsisType = ellipsis  # noqa F811 from builtins
+    from builtins import _NotImplementedType
+
     NotImplementedType = _NotImplementedType  # noqa F811 from builtins


### PR DESCRIPTION
This is enough to get stubtest working (note that it's a little annoying
to install mypy currently since typed-ast seems to have broken again on
Python 3.10)