### PR TITLE
Fix stubtest errors

### DIFF
--- a/stdlib/cgi.pyi
+++ b/stdlib/cgi.pyi
@@ -10,6 +10,7 @@ def parse(
     environ: SupportsItemAccess[str, str] = ...,
     keep_blank_values: bool = ...,
     strict_parsing: bool = ...,
+    separator: str = ...,
 ) -> dict[str, list[str]]: ...
 
 if sys.version_info < (3, 8):
@@ -18,7 +19,7 @@ if sys.version_info < (3, 8):
 
 if sys.version_info >= (3, 7):
     def parse_multipart(
-        fp: IO[Any], pdict: SupportsGetItem[str, bytes], encoding: str = ..., errors: str = ...
+        fp: IO[Any], pdict: SupportsGetItem[str, bytes], encoding: str = ..., errors: str = ..., separator: str = ...
     ) -> dict[str, list[Any]]: ...
 
 else:
@@ -95,6 +96,7 @@ class FieldStorage(object):
             encoding: str = ...,
             errors: str = ...,
             max_num_fields: Optional[int] = ...,
+            separator: str = ...,
         ) -> None: ...
     elif sys.version_info >= (3, 0):
         def __init__(

--- a/stdlib/urllib/parse.pyi
+++ b/stdlib/urllib/parse.pyi
@@ -79,32 +79,24 @@ class DefragResultBytes(_DefragResultBase[bytes], _ResultMixinBytes): ...
 class SplitResultBytes(_SplitResultBytesBase, _NetlocResultMixinBytes): ...
 class ParseResultBytes(_ParseResultBytesBase, _NetlocResultMixinBytes): ...
 
-if sys.version_info >= (3, 8):
-    def parse_qs(
-        qs: Optional[AnyStr],
-        keep_blank_values: bool = ...,
-        strict_parsing: bool = ...,
-        encoding: str = ...,
-        errors: str = ...,
-        max_num_fields: Optional[int] = ...,
-    ) -> Dict[AnyStr, List[AnyStr]]: ...
-    def parse_qsl(
-        qs: Optional[AnyStr],
-        keep_blank_values: bool = ...,
-        strict_parsing: bool = ...,
-        encoding: str = ...,
-        errors: str = ...,
-        max_num_fields: Optional[int] = ...,
-    ) -> List[Tuple[AnyStr, AnyStr]]: ...
-
-else:
-    def parse_qs(
-        qs: Optional[AnyStr], keep_blank_values: bool = ..., strict_parsing: bool = ..., encoding: str = ..., errors: str = ...
-    ) -> Dict[AnyStr, List[AnyStr]]: ...
-    def parse_qsl(
-        qs: Optional[AnyStr], keep_blank_values: bool = ..., strict_parsing: bool = ..., encoding: str = ..., errors: str = ...
-    ) -> List[Tuple[AnyStr, AnyStr]]: ...
-
+def parse_qs(
+    qs: Optional[AnyStr],
+    keep_blank_values: bool = ...,
+    strict_parsing: bool = ...,
+    encoding: str = ...,
+    errors: str = ...,
+    max_num_fields: Optional[int] = ...,
+    separator: str = ...,
+) -> Dict[AnyStr, List[AnyStr]]: ...
+def parse_qsl(
+    qs: Optional[AnyStr],
+    keep_blank_values: bool = ...,
+    strict_parsing: bool = ...,
+    encoding: str = ...,
+    errors: str = ...,
+    max_num_fields: Optional[int] = ...,
+    separator: str = ...,
+) -> List[Tuple[AnyStr, AnyStr]]: ...
 @overload
 def quote(string: str, safe: _Str = ..., encoding: Optional[str] = ..., errors: Optional[str] = ...) -> str: ...
 @overload

--- a/tests/stubtest_whitelists/py3_common.txt
+++ b/tests/stubtest_whitelists/py3_common.txt
@@ -76,6 +76,13 @@ bz2.BZ2File.readinto
 bz2.BZ2File.readlines
 bz2.BZ2File.write
 bz2.BZ2File.writelines
+# The following methods were changed in point releases from Python 3.6 to 3.9
+# as part of a security fix. These excludes can be removed when the GitHub
+# action workflow uses Python versions that include the fix (adding a
+# separator argument).
+cgi.FieldStorage.__init__
+cgi.parse
+cgi.parse_multipart
 codecs.BufferedIncrementalDecoder.decode
 codecs.CodecInfo.decode
 codecs.CodecInfo.encode
@@ -406,6 +413,12 @@ unittest.mock.patch  # It's a complicated overload and I haven't been able to fi
 urllib.error.ContentTooShortError.__init__
 urllib.error.URLError.__init__
 urllib.parse._DefragResultBase.__new__
+# The following methods were changed in point releases from Python 3.6 to 3.9
+# as part of a security fix. These excludes can be removed when the GitHub
+# action workflow uses Python versions that include the fix (adding a
+# separator argument).
+urllib.parse.parse_qs
+urllib.parse.parse_qsl
 urllib.request.BaseHandler.http_error_nnn
 urllib.request.HTTPPasswordMgrWithPriorAuth.__init__
 urllib.robotparser.RobotFileParser.can_fetch


### PR DESCRIPTION
A security fix added a "separator" argument to several URL parsing
functions and method in point releases:

* 3.6.13
* 3.7.10
* 3.8.8
* 3.9.2

Until all these versions are available on the GitHub Actions runners,
we need to whitelist the functions in the stubtests.