### PR TITLE
Add types for Flask().logger and flask.logging

### DIFF
--- a/stubs/Flask/flask/app.pyi
+++ b/stubs/Flask/flask/app.pyi
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from logging import Logger
 from types import TracebackType
 from typing import (
     Any,
@@ -104,7 +105,7 @@ class Flask(_PackageBoundObject):
     @property
     def preserve_context_on_exception(self): ...
     @property
-    def logger(self): ...
+    def logger(self) -> Logger: ...
     @property
     def jinja_env(self): ...
     @property

--- a/stubs/Flask/flask/logging.pyi
+++ b/stubs/Flask/flask/logging.pyi
@@ -1,8 +1,13 @@
-from typing import Any
+from typing import IO
 
-def wsgi_errors_stream(): ...
-def has_level_handler(logger: Any): ...
+from logging import Handler, Logger
 
-default_handler: Any
+from .app import Flask
 
-def create_logger(app: Any): ...
+wsgi_errors_stream: IO[str]
+
+def has_level_handler(logger: Logger) -> bool: ...
+
+default_handler: Handler
+
+def create_logger(app: Flask) -> Logger: ...

--- a/stubs/Flask/flask/logging.pyi
+++ b/stubs/Flask/flask/logging.pyi
@@ -1,6 +1,5 @@
-from typing import IO
-
 from logging import Handler, Logger
+from typing import IO
 
 from .app import Flask
 

--- a/stubs/Flask/flask/logging.pyi
+++ b/stubs/Flask/flask/logging.pyi
@@ -1,9 +1,9 @@
+from _typeshed.wsgi import ErrorStream
 from logging import Handler, Logger
-from typing import IO
 
 from .app import Flask
 
-wsgi_errors_stream: IO[str]
+wsgi_errors_stream: ErrorStream
 
 def has_level_handler(logger: Logger) -> bool: ...
 


### PR DESCRIPTION
`Flask().logging` is a pretty frequently used property (based on some data I have surrounding editor completion failures), but was missing its type. Add it; it's always a standard lib `Logger`

The `flask.logging` module it depends on is pretty small, so complete that too based on the flask docs and code. The original types seemed to be a skeleton generated from the real source code, but ignored the fact that `wsgi_errors_stream` used a werkzeug proxy decorator so is not really a function (but an IO stream at runtime).