### PR TITLE
fix type for xmlrpc.client.Fault.faultCode

### DIFF
--- a/stdlib/xmlrpc/client.pyi
+++ b/stdlib/xmlrpc/client.pyi
@@ -47,9 +47,9 @@ class ResponseError(Error): ...
 
 class Fault(Error):
 
-    faultCode: str
+    faultCode: int
     faultString: str
-    def __init__(self, faultCode: str, faultString: str, **extra: Any) -> None: ...
+    def __init__(self, faultCode: int, faultString: str, **extra: Any) -> None: ...
 
 boolean = bool
 Boolean = bool


### PR DESCRIPTION
The type of `faultCode` was declared as `str`, but it has to be an `int`.

see e.g. http://xmlrpc.com/spec.md

The wrong typing may have slipped in, as the Python's official
documentation also erroneously claims it has to be a string.

This has been wrong since at least 2007 (the initial checkin of the
documentation).

There is an open issue on the cpython issue tracker:
https://bugs.python.org/issue43354

Right after this commit/PR, a PR to the official Python documentation
will be created and there is already approval by a cypthon core dev, so
the PR for cpython will be merged then.