### PR TITLE
Update pyright CI test to use the latest version of pyright (1.1.118).

### DIFF
--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -76,8 +76,12 @@
     "reportUnboundVariable": "error",
     "reportInvalidStubStatement": "error",
     "reportUnsupportedDunderAll": "error",
-    "reportInvalidTypeVarUse": "none",
-    "reportOverlappingOverload": "none",
-    "reportPropertyTypeMismatch": "none",
-    "reportSelfClsParameterName": "none"
+    "reportInvalidTypeVarUse": "error",
+    "reportPropertyTypeMismatch": "error",
+    "reportSelfClsParameterName": "error",
+    // Overloapping overloads cannot be enabled at this time because
+    // of the "factions.Fraction.__pow__" method and "tasks.gather" function.
+    // Mypy's overlapping overload logic misses these issues (see mypy
+    // issue #10143 and #10157).
+    "reportOverlappingOverload": "none"
 }

--- a/stdlib/weakref.pyi
+++ b/stdlib/weakref.pyi
@@ -76,7 +76,7 @@ class WeakValueDictionary(MutableMapping[_KT, _VT]):
 
 class KeyedRef(ref[_T], Generic[_KT, _T]):
     key: _KT
-    def __new__(type, ob: _T, callback: Callable[[_T], Any], key: _KT) -> KeyedRef[_KT, _T]: ...
+    def __new__(type, ob: _T, callback: Callable[[_T], Any], key: _KT) -> KeyedRef[_KT, _T]: ...  # type: ignore
     def __init__(self, ob: _T, callback: Callable[[_T], Any], key: _KT) -> None: ...
 
 class WeakKeyDictionary(MutableMapping[_KT, _VT]):

--- a/tests/pyright_test.py
+++ b/tests/pyright_test.py
@@ -5,7 +5,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-_PYRIGHT_VERSION = "1.1.115"
+_PYRIGHT_VERSION = "1.1.118"
 _WELL_KNOWN_FILE = Path("tests", "pyright_test.py")
 
 


### PR DESCRIPTION
Enable all but one of pyright's strictest checks. Add a "# type: ignore" to `__new__` method in `weakref.KeyRef` because it uses a non-standard name for the `cls` parameter, which is flagged as an error by pyright.