### PR TITLE
Format shell commands in README consistently

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,10 @@ If you want to run the pyright tests, you need to have
 ### mypy_test.py
 
 This test requires Python 3.6 or higher; Python 3.6.1 or higher is recommended.
-Run using:`(.venv3)$ python3 tests/mypy_test.py`
+Run using:
+```
+(.venv3)$ python3 tests/mypy_test.py
+```
 
 This test is shallow — it verifies that all stubs can be
 imported but doesn't check whether stubs match their implementation
@@ -161,7 +164,10 @@ running mypy --python-version 3.9 --strict-optional # with 342 files
 This test requires Python 2.7 and Python 3.6. Pytype will
 find these automatically if they're in `PATH`, but otherwise you must point to
 them with the `--python27-exe` and `--python36-exe` arguments, respectively.
-Run using: `(.venv3)$ python3 tests/pytype_test.py`
+Run using:
+```
+(.venv3)$ python3 tests/pytype_test.py
+```
 
 This test works similarly to `mypy_test.py`, except it uses `pytype`.
 
@@ -172,14 +178,20 @@ This test requires Node.js to be installed.
 ### mypy_self_check.py
 
 This test requires Python 3.6 or higher; Python 3.6.1 or higher is recommended.
-Run using: `(.venv3)$ python3 tests/mypy_self_check.py`
+Run using:
+```
+(.venv3)$ python3 tests/mypy_self_check.py
+```
 
 This test checks mypy's code base using mypy and typeshed code in this repo.
 
 ### mypy_test_suite.py
 
 This test requires Python 3.5 or higher; Python 3.6.1 or higher is recommended.
-Run using: `(.venv3)$ python3 tests/mypy_test_suite.py`
+Run using:
+```
+(.venv3)$ python3 tests/mypy_test_suite.py
+```
 
 This test runs mypy's own test suite using the typeshed code in your repo. This
 will sometimes catch issues with incorrectly typed stubs, but is much slower
@@ -187,12 +199,18 @@ than the other tests.
 
 ### check_consistent.py
 
-Run using: `python3 tests/check_consistent.py`
+Run using:
+```
+python3 tests/check_consistent.py
+```
 
 ### stubtest_test.py
 
 This test requires Python 3.6 or higher.
-Run using `(.venv3)$ python3 tests/stubtest_test.py`
+Run using
+```
+(.venv3)$ python3 tests/stubtest_test.py
+```
 
 This test compares the stdlib stubs against the objects at runtime. Because of
 this, the output depends on which version of Python and on what kind of system
@@ -209,13 +227,20 @@ can add to the whitelists for each affected Python version in
 at [mypy](https://github.com/python/mypy/issues).
 
 To run stubtest against third party stubs, it's easiest to use stubtest
-directly, with `(.venv3)$ python3 -m mypy.stubtest --custom-typeshed-dir
-<path-to-typeshed> <third-party-module>`.
+directly, with
+```
+(.venv3)$ python3 -m mypy.stubtest \
+  --custom-typeshed-dir <path-to-typeshed> \
+  <third-party-module>
+```
 stubtest can also help you find things missing from the stubs.
 
 
 ### flake8
 
-flake8 requires Python 3.6 or higher. Run using: `(.venv3)$ flake8`
+flake8 requires Python 3.6 or higher. Run using:
+```
+(.venv3)$ flake8
+```
 
 Note typeshed uses the `flake8-pyi` and `flake8-bugbear` plugins.


### PR DESCRIPTION
Any command that includes the "(.venv3) $" prompt is hard to read when
it's set inline. So put them all into triple-backtick blocks.