### PR TITLE
Correct return type of click.testing.CliRunner.isolation()

### DIFF
--- a/stubs/click/click/testing.pyi
+++ b/stubs/click/click/testing.pyi
@@ -1,4 +1,5 @@
-from typing import IO, Any, BinaryIO, ContextManager, Dict, Iterable, List, Mapping, Optional, Text, Union
+import io
+from typing import IO, Any, BinaryIO, ContextManager, Dict, Iterable, List, Mapping, Optional, Text, Tuple, Union
 
 from .core import BaseCommand
 
@@ -53,7 +54,7 @@ class CliRunner:
     def make_env(self, overrides: Optional[Mapping[str, str]] = ...) -> Dict[str, str]: ...
     def isolation(
         self, input: Optional[Union[bytes, Text, IO[Any]]] = ..., env: Optional[Mapping[str, str]] = ..., color: bool = ...
-    ) -> ContextManager[BinaryIO]: ...
+    ) -> ContextManager[Tuple[io.BytesIO, io.BytesIO]]: ...
     def invoke(
         self,
         cli: BaseCommand,

--- a/stubs/click/click/testing.pyi
+++ b/stubs/click/click/testing.pyi
@@ -1,5 +1,6 @@
 import io
 from typing import IO, Any, BinaryIO, ContextManager, Dict, Iterable, List, Mapping, Optional, Text, Tuple, Union
+from typing_extensions import Literal
 
 from .core import BaseCommand
 
@@ -54,7 +55,7 @@ class CliRunner:
     def make_env(self, overrides: Optional[Mapping[str, str]] = ...) -> Dict[str, str]: ...
     def isolation(
         self, input: Optional[Union[bytes, Text, IO[Any]]] = ..., env: Optional[Mapping[str, str]] = ..., color: bool = ...
-    ) -> ContextManager[Tuple[io.BytesIO, io.BytesIO]]: ...
+    ) -> ContextManager[Tuple[io.BytesIO, Union[io.BytesIO, Literal[False]]]]: ...
     def invoke(
         self,
         cli: BaseCommand,


### PR DESCRIPTION
The method returns a tuple of io.BytesIO objects that hold the temporary
stdin and stdout. By correcting the type, it allows usages of
io.BytesIO.getvalue() to pass type checking.

The method is defined at:
https://github.com/pallets/click/blob/7.1.2/src/click/testing.py#L160

Its return is at:
https://github.com/pallets/click/blob/7.1.2/src/click/testing.py#L256

Where bytes_output is defined at:
https://github.com/pallets/click/blob/7.1.2/src/click/testing.py#L196