### PR TITLE
fix typing-extensions stubs shadowing typing_extensions

### DIFF
--- a/stubs/Deprecated/METADATA.toml
+++ b/stubs/Deprecated/METADATA.toml
@@ -1,3 +1,3 @@
 version = "0.1"
 python2 = true
-requires = ["types-typing-extensions"]
+requires = ["typing-extensions"]

--- a/stubs/Jinja2/METADATA.toml
+++ b/stubs/Jinja2/METADATA.toml
@@ -1,3 +1,3 @@
 version = "0.1"
 python2 = true
-requires = ["types-MarkupSafe", "types-typing-extensions"]
+requires = ["types-MarkupSafe", "typing-extensions"]

--- a/stubs/Markdown/METADATA.toml
+++ b/stubs/Markdown/METADATA.toml
@@ -1,3 +1,3 @@
 version = "0.1"
 python2 = true
-requires = ["types-typing-extensions"]
+requires = ["typing-extensions"]

--- a/stubs/Werkzeug/METADATA.toml
+++ b/stubs/Werkzeug/METADATA.toml
@@ -1,3 +1,3 @@
 version = "0.1"
 python2 = true
-requires = ["types-typing-extensions"]
+requires = ["typing-extensions"]

--- a/stubs/aiofiles/METADATA.toml
+++ b/stubs/aiofiles/METADATA.toml
@@ -1,2 +1,2 @@
 version = "0.1"
-requires = ["types-typing-extensions"]
+requires = ["typing-extensions"]

--- a/stubs/chardet/METADATA.toml
+++ b/stubs/chardet/METADATA.toml
@@ -1,3 +1,3 @@
 version = "0.1"
 python2 = true
-requires = ["types-typing-extensions"]
+requires = ["typing-extensions"]

--- a/stubs/click-spinner/METADATA.toml
+++ b/stubs/click-spinner/METADATA.toml
@@ -1,3 +1,3 @@
 version = "0.1"
 python2 = true
-requires = ["types-typing-extensions"]
+requires = ["typing-extensions"]

--- a/stubs/nmap/METADATA.toml
+++ b/stubs/nmap/METADATA.toml
@@ -1,3 +1,3 @@
 version = "0.1"
 python2 = true
-requires = ["types-typing-extensions"]
+requires = ["typing-extensions"]

--- a/stubs/pathlib2/METADATA.toml
+++ b/stubs/pathlib2/METADATA.toml
@@ -1,4 +1,4 @@
 version = "0.1"
 python2 = true
 python3 = false
-requires = ["types-typing-extensions"]
+requires = ["typing-extensions"]

--- a/stubs/protobuf/METADATA.toml
+++ b/stubs/protobuf/METADATA.toml
@@ -1,3 +1,3 @@
 version = "0.1"
 python2 = true
-requires = ["types-futures", "types-typing-extensions"]
+requires = ["types-futures", "typing-extensions"]

--- a/stubs/python-dateutil/METADATA.toml
+++ b/stubs/python-dateutil/METADATA.toml
@@ -1,3 +1,3 @@
 version = "0.1"
 python2 = true
-requires = ["types-typing-extensions"]
+requires = ["typing-extensions"]

--- a/stubs/redis/METADATA.toml
+++ b/stubs/redis/METADATA.toml
@@ -1,3 +1,3 @@
 version = "0.1"
 python2 = true
-requires = ["types-typing-extensions"]
+requires = ["typing-extensions"]

--- a/stubs/waitress/METADATA.toml
+++ b/stubs/waitress/METADATA.toml
@@ -1,2 +1,2 @@
 version = "0.1"
-requires = ["types-typing-extensions"]
+requires = ["typing-extensions"]

--- a/tests/check_consistent.py
+++ b/tests/check_consistent.py
@@ -21,6 +21,12 @@ consistent_files = [
     {"stdlib/threading.pyi", "stdlib/_dummy_threading.pyi"},
 ]
 
+ALLOWED_PACKAGES = {
+    # mypy does not support stubs for typing-extensions, so we depend on
+    # `typing-extensions` instead of `types-typing-extensions`.
+    "typing-extensions"
+}
+
 
 def assert_stubs_only(directory):
     """Check that given directory contains only valid stub files."""
@@ -167,6 +173,8 @@ def check_metadata():
         assert isinstance(data.get("python3", True), bool), f"Invalid python3 value for {distribution}"
         assert isinstance(data.get("requires", []), list), f"Invalid requires value for {distribution}"
         for dep in data.get("requires", []):
+            if dep in ALLOWED_PACKAGES:
+                continue
             assert isinstance(dep, str), f"Invalid dependency {dep} for {distribution}"
             assert dep.startswith("types-"), f"Only stub dependencies supported, got {dep}"
             dep = dep[len("types-"):]


### PR DESCRIPTION
It's not possible to use stubs that depend on `types-typing-extensions` because mypy doesn't allow stubs to override `typing-extensions`.

The solution is to require `typing-extensions` instead of `types-typing-extensions` since mypy and pyright have built in types for this package.

fixes #5065