### PR TITLE
comment on memoryview.cast

### DIFF
--- a/tests/stubtest_whitelists/py3_common.txt
+++ b/tests/stubtest_whitelists/py3_common.txt
@@ -64,7 +64,7 @@ builtins.ellipsis
 builtins.function
 builtins.memoryview.__contains__
 builtins.memoryview.__iter__
-builtins.memoryview.cast
+builtins.memoryview.cast  # inspect.signature is incorrect about shape being kw-only
 builtins.object.__init__
 builtins.property.__get__
 builtins.property.fdel


### PR DESCRIPTION
In Python 3.10 these were updated to use Argument Clinic, but CPython might take a bug fix patch for 3.9 if someone wanted to try