### PR TITLE
Add `complex` in `_C`

### DIFF
--- a/stdlib/cmath.pyi
+++ b/stdlib/cmath.pyi
@@ -10,7 +10,7 @@ if sys.version_info >= (3, 6):
     nanj: complex
     tau: float
 
-_C = Union[SupportsFloat, SupportsComplex]
+_C = Union[SupportsFloat, SupportsComplex, complex]
 
 def acos(__z: _C) -> complex: ...
 def acosh(__z: _C) -> complex: ...


### PR DESCRIPTION
because `complex` doesn't have an attribute `__complex__`.

Due to this issue, I got strange diagnostics on pyright.

```py
Argument of type "complex" cannot be assigned to parameter "__z" of type "_C" in function "exp"
  Type "complex" cannot be assigned to type "_C"
    "__float__" is not present
    "__complex__" is not present
```

Reference: https://github.com/microsoft/pyright/issues/1679