### PR TITLE
Use Literals for logging constants

### DIFF
--- a/stdlib/logging/__init__.pyi
+++ b/stdlib/logging/__init__.pyi
@@ -6,7 +6,6 @@ from string import Template
 from time import struct_time
 from types import FrameType, TracebackType
 from typing import IO, Any, Optional, Tuple, Union
-
 from typing_extensions import Literal
 
 _SysExcInfoType = Union[Tuple[type, BaseException, Optional[TracebackType]], Tuple[None, None, None]]

--- a/stdlib/logging/__init__.pyi
+++ b/stdlib/logging/__init__.pyi
@@ -245,10 +245,10 @@ class Logger(Filterer):
     def hasHandlers(self) -> bool: ...
 
 CRITICAL: Literal[50]
-FATAL = CRITICAL
+FATAL: Literal[50]
 ERROR: Literal[40]
 WARNING: Literal[30]
-WARN = WARNING
+WARN: Literal[30]
 INFO: Literal[20]
 DEBUG: Literal[10]
 NOTSET: Literal[0]

--- a/stdlib/logging/__init__.pyi
+++ b/stdlib/logging/__init__.pyi
@@ -7,6 +7,8 @@ from time import struct_time
 from types import FrameType, TracebackType
 from typing import IO, Any, Optional, Tuple, Union
 
+from typing_extensions import Literal
+
 _SysExcInfoType = Union[Tuple[type, BaseException, Optional[TracebackType]], Tuple[None, None, None]]
 _ExcInfoType = Union[None, bool, _SysExcInfoType, BaseException]
 _ArgsType = Union[Tuple[Any, ...], Mapping[str, Any]]
@@ -242,14 +244,14 @@ class Logger(Filterer):
     ) -> LogRecord: ...
     def hasHandlers(self) -> bool: ...
 
-CRITICAL: int
-FATAL: int
-ERROR: int
-WARNING: int
-WARN: int
-INFO: int
-DEBUG: int
-NOTSET: int
+CRITICAL: Literal[50]
+FATAL = CRITICAL
+ERROR: Literal[40]
+WARNING: Literal[30]
+WARN = WARNING
+INFO: Literal[20]
+DEBUG: Literal[10]
+NOTSET: Literal[0]
 
 class Handler(Filterer):
     level: int  # undocumented


### PR DESCRIPTION
Allows for restricting param types to the union of logging values.
So something like `with logging_timer(level=logging.INFO):` would be able
to ensure that only logging constants are passed in.

https://github.com/python/cpython/blob/a02683ac38183fa3a45c32319dfd329c5e622f0e/Lib/logging/__init__.py#L91-L98