### PR TITLE
Bump pyright to 1.1.126, enable 3.10 testing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,7 +92,7 @@ jobs:
     strategy:
       matrix:
         python-platform: ["Linux", "Windows", "Darwin"]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, '3.10']
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/tests/pyright_test.py
+++ b/tests/pyright_test.py
@@ -5,7 +5,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-_PYRIGHT_VERSION = "1.1.118"
+_PYRIGHT_VERSION = "1.1.126"
 _WELL_KNOWN_FILE = Path("tests", "pyright_test.py")
 
 


### PR DESCRIPTION
Pyright hasn't been updated in a while; update it.

Enable testing 3.10 with pyright; there have been some changes in typeshed recently for 3.10 that should be getting checked. We don't actually need 3.10 to be out to check these.