### PR TITLE
don't require isort[pyproject]

### DIFF
--- a/requirements-tests-py3.txt
+++ b/requirements-tests-py3.txt
@@ -4,5 +4,5 @@ black==20.8b1
 flake8==3.8.4
 flake8-bugbear==20.1.4
 flake8-pyi==20.10.0
-isort[pyproject]==5.5.3
+isort==5.5.3
 pytype>=2021.01.28


### PR DESCRIPTION
Not a big deal, but when running `pip install -r requirements-tests-py3.txt`, I got:

```
  WARNING: isort 5.5.3 does not provide the extra 'pyproject'
```