### PR TITLE
Make ProxyType and CallableProxyType Generic

### DIFF
--- a/stdlib/_weakref.pyi
+++ b/stdlib/_weakref.pyi
@@ -7,10 +7,10 @@ if sys.version_info >= (3, 9):
 _C = TypeVar("_C", bound=Callable[..., Any])
 _T = TypeVar("_T")
 
-class CallableProxyType(object):  # "weakcallableproxy"
+class CallableProxyType(Generic[_C]):  # "weakcallableproxy"
     def __getattr__(self, attr: str) -> Any: ...
 
-class ProxyType(object):  # "weakproxy"
+class ProxyType(Generic[_T]):  # "weakproxy"
     def __getattr__(self, attr: str) -> Any: ...
 
 class ReferenceType(Generic[_T]):
@@ -27,7 +27,7 @@ ref = ReferenceType
 def getweakrefcount(__object: Any) -> int: ...
 def getweakrefs(object: Any) -> List[Any]: ...
 @overload
-def proxy(object: _C, callback: Optional[Callable[[_C], Any]] = ...) -> CallableProxyType: ...
+def proxy(object: _C, callback: Optional[Callable[[_C], Any]] = ...) -> CallableProxyType[_C]: ...
 
 # Return CallableProxyType if object is callable, ProxyType otherwise
 @overload


### PR DESCRIPTION
As requested in https://github.com/python/typeshed/issues/3445.
Admittedly, it doesn't help much with type checking since typing doesn't really have a way to model a wrapper, but a mypy plugin could probably verify stuff here.