### PR TITLE
allow bytes in tkinter.PhotoImage

### DIFF
--- a/stdlib/tkinter/__init__.pyi
+++ b/stdlib/tkinter/__init__.pyi
@@ -2647,7 +2647,7 @@ class PhotoImage(Image):
         cnf: Dict[str, Any] = ...,
         master: Optional[Union[Misc, _tkinter.TkappType]] = ...,
         *,
-        data: str = ...,  # not same as data argument of put()
+        data: Union[str, bytes] = ...,  # not same as data argument of put()
         format: str = ...,
         file: AnyPath = ...,
         gamma: float = ...,
@@ -2658,7 +2658,7 @@ class PhotoImage(Image):
     def configure(
         self,
         *,
-        data: str = ...,
+        data: Union[str, bytes] = ...,
         format: str = ...,
         file: AnyPath = ...,
         gamma: float = ...,
@@ -2690,7 +2690,7 @@ class BitmapImage(Image):
         master: Optional[Union[Misc, _tkinter.TkappType]] = ...,
         *,
         background: _Color = ...,
-        data: str = ...,
+        data: Union[str, bytes] = ...,
         file: AnyPath = ...,
         foreground: _Color = ...,
         maskdata: str = ...,


### PR DESCRIPTION
Fixes #5127 

For `BitmapImage`, the data "must adhere to X11 bitmap format" (`bitmap` manual page), and that format seems to be a subset of C. I allowed bytes for that too in case someone reads a bitmap file with `open(file, "rb")` or something like that.