### PR TITLE
[stdlib] Add MININT and MAXINT for xmlrpc.client

### DIFF
--- a/stdlib/xmlrpc/client.pyi
+++ b/stdlib/xmlrpc/client.pyi
@@ -19,6 +19,9 @@ _HostType = Union[Tuple[str, Dict[str, str]], str]
 
 def escape(s: str) -> str: ...  # undocumented
 
+MAXINT: int  # undocumented
+MININT: int  # undocumented
+
 PARSE_ERROR: int  # undocumented
 SERVER_ERROR: int  # undocumented
 APPLICATION_ERROR: int  # undocumented


### PR DESCRIPTION
These constants are in this module since Python3.0.