### PR TITLE
Improve PathLike handling for subprocess cmd/env

### DIFF
--- a/stdlib/subprocess.pyi
+++ b/stdlib/subprocess.pyi
@@ -23,10 +23,16 @@ if sys.version_info >= (3, 9):
 #    reveal_type(e.cmd)  # Any, but morally is _CMD
 _FILE = Union[None, int, IO[Any]]
 _TXT = Union[bytes, str]
-# Python 3.6 does't support _CMD being a single PathLike.
-# See: https://bugs.python.org/issue31961
-_CMD = Union[_TXT, Sequence[AnyPath]]
-_ENV = Union[Mapping[bytes, _TXT], Mapping[str, _TXT]]
+if sys.version_info < (3, 8):
+    # Python 3.6 doesn't support _CMD being a single PathLike.
+    # See: https://bugs.python.org/issue31961
+    _CMD = Union[_TXT, Sequence[AnyPath]]
+else:
+    _CMD = Union[AnyPath, Sequence[AnyPath]]
+if sys.platform == "win32":
+    _ENV = Mapping[str, str]
+else:
+    _ENV = Union[Mapping[bytes, AnyPath], Mapping[str, AnyPath]]
 
 _S = TypeVar("_S")
 _T = TypeVar("_T")


### PR DESCRIPTION
- Python 3.8 and later allow a single PathLike for the subprocess cmd
- Windows subprocess env only allows str
- POSIX subprocess env allows any combination of str/bytes/Pathlike

Created to solve #5181