### PR TITLE
fix(stubs/click): add the `no_args_is_help` argument annotaion for click

### DIFF
--- a/stubs/click/click/core.pyi
+++ b/stubs/click/click/core.pyi
@@ -119,6 +119,7 @@ class Command(BaseCommand):
     short_help: Optional[str]
     options_metavar: str
     add_help_option: bool
+    no_args_is_help: bool
     hidden: bool
     deprecated: bool
     def __init__(
@@ -132,6 +133,7 @@ class Command(BaseCommand):
         short_help: Optional[str] = ...,
         options_metavar: str = ...,
         add_help_option: bool = ...,
+        no_args_is_help: bool = ...,
         hidden: bool = ...,
         deprecated: bool = ...,
     ) -> None: ...

--- a/stubs/click/click/decorators.pyi
+++ b/stubs/click/click/decorators.pyi
@@ -28,6 +28,7 @@ def command(
     short_help: Optional[str] = ...,
     options_metavar: str = ...,
     add_help_option: bool = ...,
+    no_args_is_help: bool = ...,
     hidden: bool = ...,
     deprecated: bool = ...,
 ) -> Callable[[Callable[..., Any]], Command]: ...


### PR DESCRIPTION
close #5113 