### PR TITLE
Add TarFile.offset

### DIFF
--- a/stdlib/tarfile.pyi
+++ b/stdlib/tarfile.pyi
@@ -91,6 +91,7 @@ class TarFile(Iterable[TarInfo]):
     pax_headers: Optional[Mapping[str, str]]
     debug: Optional[int]
     errorlevel: Optional[int]
+    offset: int  # undocumented
     if sys.version_info < (3,):
         posix: bool
     def __init__(


### PR DESCRIPTION
Add TarFile.offset, which is an undocumented property. Fixes https://github.com/python/typeshed/issues/5209