### PR TITLE
Fix protobuf json_format signatures.

### DIFF
--- a/stubs/protobuf/google/protobuf/json_format.pyi
+++ b/stubs/protobuf/google/protobuf/json_format.pyi
@@ -1,5 +1,6 @@
-from typing import Any, Dict, Text, TypeVar, Union
+from typing import Any, Dict, Optional, Text, TypeVar, Union
 
+from google.protobuf.descriptor_pool import DescriptorPool
 from google.protobuf.message import Message
 
 _MessageT = TypeVar("_MessageT", bound=Message)
@@ -15,12 +16,26 @@ def MessageToJson(
     indent: int = ...,
     sort_keys: bool = ...,
     use_integers_for_enums: bool = ...,
+    descriptor_pool: Optional[DescriptorPool] = ...,
+    float_precision: Optional[int] = ...,
 ) -> str: ...
 def MessageToDict(
     message: Message,
     including_default_value_fields: bool = ...,
     preserving_proto_field_name: bool = ...,
     use_integers_for_enums: bool = ...,
+    descriptor_pool: Optional[DescriptorPool] = ...,
+    float_precision: Optional[int] = ...,
 ) -> Dict[Text, Any]: ...
-def Parse(text: Union[bytes, Text], message: _MessageT, ignore_unknown_fields: bool = ...) -> _MessageT: ...
-def ParseDict(js_dict: Any, message: _MessageT, ignore_unknown_fields: bool = ...) -> _MessageT: ...
+def Parse(
+    text: Union[bytes, Text],
+    message: _MessageT,
+    ignore_unknown_fields: bool = ...,
+    descriptor_pool: Optional[DescriptorPool] = ...,
+) -> _MessageT: ...
+def ParseDict(
+    js_dict: Any,
+    message: _MessageT,
+    ignore_unknown_fields: bool = ...,
+    descriptor_pool: Optional[DescriptorPool] = ...,
+) -> _MessageT: ...


### PR DESCRIPTION
Add arguments: `descriptor_pool ` and `float_precision`

Closes #5225

References:

* https://github.com/protocolbuffers/protobuf/blob/d16bf914bc5ba569d2b70376051d15f68ce4322d/python/google/protobuf/json_format.py
* https://github.com/protocolbuffers/protobuf/blob/d16bf914bc5ba569d2b70376051d15f68ce4322d/python/google/protobuf/internal/json_format_test.py#L862