### PR TITLE
Add missing tag attribute to TypeIgnore stub

### DIFF
--- a/stdlib/_ast.pyi
+++ b/stdlib/_ast.pyi
@@ -25,7 +25,8 @@ class mod(AST): ...
 
 if sys.version_info >= (3, 8):
     class type_ignore(AST): ...
-    class TypeIgnore(type_ignore): ...
+    class TypeIgnore(type_ignore):
+        tag: str
     class FunctionType(mod):
         argtypes: typing.List[expr]
         returns: expr


### PR DESCRIPTION
This attribute was [added in 3.8]. This change lets mypy resolve the
type correctly instead of failing with an attr-defined error.

[added in 3.8]: https://github.com/python/cpython/pull/13479