### PR TITLE
Add stubs for `docopt` package

### DIFF
--- a/stubs/docopt/METADATA.toml
+++ b/stubs/docopt/METADATA.toml
@@ -1,0 +1,3 @@
+# Prior to v0.6, docopt() had only 3 optional args
+version = "0.6"
+python2 = true

--- a/stubs/docopt/docopt.pyi
+++ b/stubs/docopt/docopt.pyi
@@ -1,0 +1,11 @@
+from typing import Any, Iterable, Optional
+
+__version__: str
+
+def docopt(
+    doc: str,
+    argv: Optional[Iterable[str]] = ...,
+    help: bool = ...,
+    version: Optional[Any] = ...,
+    options_first: bool = ...,
+) -> dict[str, Any]: ...  # Really should be dict[str, Union[str, bool]]

--- a/stubs/docopt/docopt.pyi
+++ b/stubs/docopt/docopt.pyi
@@ -1,10 +1,12 @@
-from typing import Any, Iterable, Optional
+from typing import Any, Iterable, Optional, Union
 
 __version__: str
 
+_Argv = Union[Iterable[str], str]
+
 def docopt(
     doc: str,
-    argv: Optional[Iterable[str]] = ...,
+    argv: Optional[_Argv] = ...,
     help: bool = ...,
     version: Optional[Any] = ...,
     options_first: bool = ...,


### PR DESCRIPTION
Add the single stub for the simple, but fairly well-used
[docopt](https://github.com/docopt/docopt) package.
It looks like that project is not very well maintained,
so I thought it would be easier to add the type annotations
here, as opposed to there, upstream. This has even been requested a few
times in https://github.com/docopt/docopt/issues/471. It appeared to me
that only the `docopt()` function is the public API, so I didn't include
the rest of the module's functions and attributes.

I believe that this stub is totally correct, except for one edge case: In https://github.com/docopt/docopt/blob/20b9c4ffec71d17cee9fd963238c8ec240905b65/docopt.py#L569
you can see that the `argv` argument can not only be a list, but `argv`
could also be a type which supports a `split()` function:

```
from typing_extensions import Protocol

class _SplittableToStr(Protocol):
    def split(self, *args: Any, **kwargs: Any) -> Iterable[str]: ...
```

However, I'm not sure I got that correct, and I decided (it's a guess)
that not many users would use anything but a `list[str]` for `argv`, so
I just kept it simple and didn't include that Protocol stuff.