### PR TITLE
Fix permissions for mypy-primer-comments

### DIFF
--- a/.github/workflows/mypy_primer_comment.yml
+++ b/.github/workflows/mypy_primer_comment.yml
@@ -10,7 +10,7 @@ on:
 
 permissions:
   contents: read
-  issues: write
+  pull-requests: write
 
 jobs:
   mypy_primer:


### PR DESCRIPTION
It was failing in #5252. Based on https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions, seems like we should give permission on `pull-requests` instead.