### PR TITLE
fix(stubs/click): don't force autocompleter to accept anything as context

### DIFF
--- a/stubs/click/click/decorators.pyi
+++ b/stubs/click/click/decorators.pyi
@@ -71,7 +71,7 @@ def argument(
     expose_value: bool = ...,
     is_eager: bool = ...,
     envvar: Optional[Union[str, List[str]]] = ...,
-    autocompletion: Optional[Callable[[Any, List[str], str], List[Union[str, Tuple[str, str]]]]] = ...,
+    autocompletion: Optional[Callable[[Context, List[str], str], Iterable[Union[str, Tuple[str, str]]]]] = ...,
 ) -> _IdentityFunction: ...
 @overload
 def option(

--- a/stubs/click/click/decorators.pyi
+++ b/stubs/click/click/decorators.pyi
@@ -1,5 +1,5 @@
 from distutils.version import Version
-from typing import Any, Callable, Dict, List, Optional, Protocol, Text, Tuple, Type, TypeVar, Union, overload
+from typing import Any, Callable, Dict, Iterable, List, Optional, Protocol, Text, Tuple, Type, TypeVar, Union, overload
 
 from click.core import Argument, Command, Context, Group, Option, Parameter, _ConvertibleType
 


### PR DESCRIPTION
I.e. the autocompletion function is basically guaranteed to receive `click.Context` in it's `ctx` parameter. So it doesn't have to accept `Any`.

Additionally it's enough if it's return value is `Iterable` (e.g. a generator). Because it will only be iterated over...