### PR TITLE
mypy_primer: check conclusion field as well

### DIFF
--- a/.github/workflows/mypy_primer_comment.yml
+++ b/.github/workflows/mypy_primer_comment.yml
@@ -50,7 +50,7 @@ jobs:
 
             const end_time = Number(new Date()) + 60 * 60 * 1000
             let primer_run = await check_mypy_primer()
-            while (!primer_run || primer_run.status != "completed") {
+            while (!primer_run || primer_run.status != "completed" || primer_run.conclusion != "success") {
               if (Number(new Date()) > end_time) {
                 throw Error("Timed out waiting for mypy_primer")
               }

--- a/.github/workflows/mypy_primer_comment.yml
+++ b/.github/workflows/mypy_primer_comment.yml
@@ -43,7 +43,10 @@ jobs:
                 workflow_id: "mypy_primer.yml",
               })
               if (response) {
-                return response.data.workflow_runs.find(run => run.head_sha == pr_commit_sha)
+                workflow_runs = response.data.workflow_runs
+                // Sort by reverse updated_at
+                workflow_runs.sort((a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime())
+                return workflow_runs.find(run => run.head_sha == pr_commit_sha)
               }
               return undefined
             }


### PR DESCRIPTION
Fixes https://github.com/python/typeshed/issues/5270

The comment workflow waits for the mypy primer to run. I think with
Github's changes to workflow running, these runs get marked as
completed, but have the conclusion "action_required".
E.g., see https://github.com/python/typeshed/pull/5269/checks