### PR TITLE
Use pyright-action to run pyright, bump pyright

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -99,11 +99,11 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-      - uses: actions/setup-node@v2
+      - uses: jakebailey/pyright-action@main
         with:
-          node-version: '14'
-      - run: ./tests/pyright_test.py --pythonplatform ${{ matrix.python-platform }} --pythonversion ${{ matrix.python-version }}
+          version: 1.1.136  # Must match pyright_test.py.
+          python-platform: ${{ matrix.python-platform }}
+          python-version: ${{ matrix.python-version }}
 
   stubtest:
     name: Check stdlib with stubtest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -99,7 +99,7 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v2
-      - uses: jakebailey/pyright-action@main
+      - uses: jakebailey/pyright-action@v1
         with:
           version: 1.1.136  # Must match pyright_test.py.
           python-platform: ${{ matrix.python-platform }}

--- a/tests/pyright_test.py
+++ b/tests/pyright_test.py
@@ -5,7 +5,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-_PYRIGHT_VERSION = "1.1.126"
+_PYRIGHT_VERSION = "1.1.136"  # Must match tests.yml.
 _WELL_KNOWN_FILE = Path("tests", "pyright_test.py")
 
 


### PR DESCRIPTION
I recently published https://github.com/marketplace/actions/run-pyright, which wraps pyright and uses GHA magic to leave diagnostics on commits / PRs (like https://github.com/jakebailey/pyright-action-test/pull/1/files), plus a faster startup time thanks to GHA tool caching and piggy backing off of the `node` install used in GHA itself (so no `setup-node` needed).

This PR switches to that action and leaves a comment noting that the version number is pinned in two places.

This action is a prototype, but I'm pretty confident in it so far.