### PR TITLE
mypy_primer: reduce polling frequency

### DIFF
--- a/.github/workflows/mypy_primer_comment.yml
+++ b/.github/workflows/mypy_primer_comment.yml
@@ -55,15 +55,19 @@ jobs:
               return undefined
             }
 
-            const end_time = Number(new Date()) + 60 * 60 * 1000
+            // Timeout after half an hour
+            const end_time = Number(new Date()) + 30 * 60 * 1000
             let primer_run = await check_mypy_primer()
+            // Sleep longer, initially
+            let sleep = 8 * 60 * 1000
             while (!primer_run || primer_run.status != "completed" || primer_run.conclusion != "success") {
               if (Number(new Date()) > end_time) {
                 throw Error("Timed out waiting for mypy_primer")
               }
               console.log("Waiting for mypy_primer to complete...")
-              await new Promise(r => setTimeout(r, 10000))
+              await new Promise(r => setTimeout(r, sleep))
               primer_run = await check_mypy_primer()
+              sleep = 60 * 1000
             }
             console.log("Found mypy_primer run!")
             console.log(primer_run)


### PR DESCRIPTION
This should cut down the API rate limiting we see when large numbers of
PRs are submitted.

Note when we used mypyc-compiled mypy in mypy_primer, this took <10m.
This is currently not the case, but hopefully will once again be.