### PR TITLE
Add OrderedDict to typing_extensions

### DIFF
--- a/stdlib/typing_extensions.pyi
+++ b/stdlib/typing_extensions.pyi
@@ -22,6 +22,7 @@ from typing import (
     TypeVar,
     Union,
     ValuesView,
+    _Alias,
     overload as overload,
 )
 
@@ -67,6 +68,8 @@ class _TypedDict(Mapping[str, object], metaclass=abc.ABCMeta):
 
 # TypedDict is a (non-subscriptable) special form.
 TypedDict: object = ...
+
+OrderedDict = _Alias()
 
 if sys.version_info >= (3, 3):
     from typing import ChainMap as ChainMap


### PR DESCRIPTION
typing_extensions 3.10 now includes OrderedDict for all Python versions