### PR TITLE
Bump pyright, disable PR/commit commenting for all but one job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -104,7 +104,7 @@ jobs:
           version: 1.1.137  # Must match pyright_test.py.
           python-platform: ${{ matrix.python-platform }}
           python-version: ${{ matrix.python-version }}
-          no-comments: ${{ matrix.python-version != '3.9' }}  # Having each job create the same comment is too noisy.
+          no-comments: ${{ matrix.python-version != '3.9' || matrix.python-platform != 'Linux' }}  # Having each job create the same comment is too noisy.
 
   stubtest:
     name: Check stdlib with stubtest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -104,7 +104,7 @@ jobs:
           version: 1.1.137  # Must match pyright_test.py.
           python-platform: ${{ matrix.python-platform }}
           python-version: ${{ matrix.python-version }}
-          no-comments: true  # Disable comments; having each job create the same comment is too noisy.
+          no-comments: ${{ matrix.python-version != '3.9' }}  # Having each job create the same comment is too noisy.
 
   stubtest:
     name: Check stdlib with stubtest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -101,9 +101,10 @@ jobs:
       - uses: actions/checkout@v2
       - uses: jakebailey/pyright-action@v1
         with:
-          version: 1.1.136  # Must match pyright_test.py.
+          version: 1.1.137  # Must match pyright_test.py.
           python-platform: ${{ matrix.python-platform }}
           python-version: ${{ matrix.python-version }}
+          no-comments: true  # Disable comments; having each job create the same comment is too noisy.
 
   stubtest:
     name: Check stdlib with stubtest

--- a/tests/pyright_test.py
+++ b/tests/pyright_test.py
@@ -5,7 +5,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-_PYRIGHT_VERSION = "1.1.136"  # Must match tests.yml.
+_PYRIGHT_VERSION = "1.1.137"  # Must match tests.yml.
 _WELL_KNOWN_FILE = Path("tests", "pyright_test.py")
 
 


### PR DESCRIPTION
Per https://github.com/jakebailey/pyright-action/issues/1, the comments are too noisy when run in a job matrix.

I added an option to disable the comments while I think about how this should actually work.