### PR TITLE
do not require running tests locally

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,8 +10,9 @@ are important to the project's success.
 
 1. Read the [README.md file](README.md).
 2. If you want, set up your environment to be able to [run tests](README.md#running-the-tests).
-    This can be useful, but usually not needed, because the tests run
-    automatically on GitHub Actions for all pull requests.
+    This can be useful for big pull requests or fixing specific errors, but
+    usually not needed, because the tests run automatically on GitHub Actions
+    for all pull requests.
 3. [Prepare your changes](#preparing-changes):
     * Small fixes and additions can be submitted directly as pull requests,
       but [contact us](#discussion) before starting significant work.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ are important to the project's success.
 1. Read the [README.md file](README.md).
 2. If you want, set up your environment to be able to [run tests](README.md#running-the-tests).
     This can be useful for big pull requests or fixing specific errors, but
-    usually not needed, because the tests run automatically on GitHub Actions
+    usually is not needed, because the tests run automatically on GitHub Actions
     for all pull requests.
 3. [Prepare your changes](#preparing-changes):
     * Small fixes and additions can be submitted directly as pull requests,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,9 @@ are important to the project's success.
 ## The contribution process at a glance
 
 1. Read the [README.md file](README.md).
-2. Set up your environment to be able to [run all tests](README.md#running-the-tests).  They should pass.
+2. If you want, set up your environment to be able to [run tests](README.md#running-the-tests).
+    This can be useful, but usually not needed, because the tests run
+    automatically on GitHub Actions for all pull requests.
 3. [Prepare your changes](#preparing-changes):
     * Small fixes and additions can be submitted directly as pull requests,
       but [contact us](#discussion) before starting significant work.

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ If you have questions related to contributing, drop by the [typing Gitter](https
 
 The tests are automatically run on every PR and push to the repo.
 Therefore you don't need to run them locally, unless you want to run
-them before making a pull request or debug some problem without
+them before making a pull request or you want to debug some problem without
 creating several small commits.
 
 There are several tests:

--- a/README.md
+++ b/README.md
@@ -100,8 +100,10 @@ If you have questions related to contributing, drop by the [typing Gitter](https
 
 ## Running the tests
 
-The tests are automatically run on every PR and push to
-the repo.
+The tests are automatically run on every PR and push to the repo.
+Therefore you don't need to run them locally, unless you want to run
+them before making a pull request or debug some problem without
+creating several small commits.
 
 There are several tests:
 - `tests/mypy_test.py`


### PR DESCRIPTION
This may be a bit controversial, but I have always found the guidelines misleading. Most pull requests we receive are small, and running many different tests locally is just unnecessary, since the CI runs them anyway.

I remember running tests locally only two times: when pytype got stuck in an infinite loop and I wanted to interrupt it with Ctrl+C, and when I was working on stubtest whitelists for Python 3.10. Most typeshed contributors never come across situations like this.

I added several reviewers, because contribution guidelines are important. Feel free to add more.