### PR TITLE
non-string fieldnames for csv.DictReader and csv.DictWriter

### DIFF
--- a/stdlib/csv.pyi
+++ b/stdlib/csv.pyi
@@ -89,7 +89,7 @@ class DictWriter(Generic[_T]):
     def __init__(
         self,
         f: Any,
-        fieldnames: Iterable[_T],
+        fieldnames: Sequence[_T],
         restval: Optional[Any] = ...,
         extrasaction: str = ...,
         dialect: _DialectLike = ...,

--- a/stdlib/csv.pyi
+++ b/stdlib/csv.pyi
@@ -17,7 +17,7 @@ from _csv import (
     unregister_dialect as unregister_dialect,
     writer as writer,
 )
-from typing import Any, Dict, Generic, Iterable, Iterator, List, Mapping, Optional, Sequence, Text, Type, TypeVar, overload
+from typing import Any, Generic, Iterable, Iterator, List, Mapping, Optional, Sequence, Text, Type, TypeVar, overload
 
 if sys.version_info >= (3, 8) or sys.version_info < (3, 6):
     from typing import Dict as _DictReadMapping
@@ -75,7 +75,7 @@ class DictReader(Generic[_T], Iterator[_DictReadMapping[_T, str]]):
         *args: Any,
         **kwds: Any,
     ) -> None: ...
-    def __iter__(self) -> DictReader: ...
+    def __iter__(self) -> DictReader[_T]: ...
     if sys.version_info >= (3,):
         def __next__(self) -> _DictReadMapping[_T, str]: ...
     else:

--- a/stdlib/csv.pyi
+++ b/stdlib/csv.pyi
@@ -18,9 +18,9 @@ from _csv import (
     writer as writer,
 )
 from collections import OrderedDict
-from typing import Any, Dict, Iterable, Iterator, List, Mapping, Optional, Sequence, Text, Type
+from typing import Any, Dict, Generic, Iterable, Iterator, List, Mapping, Optional, Sequence, Text, Type, TypeVar
 
-_DictRow = Mapping[str, Any]
+_T = TypeVar("_T")
 
 class excel(Dialect):
     delimiter: str
@@ -42,13 +42,12 @@ if sys.version_info >= (3,):
         lineterminator: str
         quoting: int
 
-if sys.version_info >= (3, 8):
+if sys.version_info >= (3, 8) or sys.version_info < (3, 6):
     _DRMapping = Dict[str, str]
-elif sys.version_info >= (3, 6):
-    _DRMapping = OrderedDict[str, str]
 else:
-    _DRMapping = Dict[str, str]
+    _DRMapping = OrderedDict[str, str]
 
+# TODO: make keys generic, defaulting to string if no fieldnames are given (#4800)
 class DictReader(Iterator[_DRMapping]):
     restkey: Optional[str]
     restval: Optional[str]
@@ -72,15 +71,15 @@ class DictReader(Iterator[_DRMapping]):
     else:
         def next(self) -> _DRMapping: ...
 
-class DictWriter(object):
-    fieldnames: Sequence[str]
+class DictWriter(Generic[_T]):
+    fieldnames: Sequence[_T]
     restval: Optional[Any]
     extrasaction: str
     writer: _writer
     def __init__(
         self,
         f: Any,
-        fieldnames: Iterable[str],
+        fieldnames: Iterable[_T],
         restval: Optional[Any] = ...,
         extrasaction: str = ...,
         dialect: _DialectLike = ...,
@@ -91,8 +90,8 @@ class DictWriter(object):
         def writeheader(self) -> Any: ...
     else:
         def writeheader(self) -> None: ...
-    def writerow(self, rowdict: _DictRow) -> Any: ...
-    def writerows(self, rowdicts: Iterable[_DictRow]) -> None: ...
+    def writerow(self, rowdict: Mapping[_T, Any]) -> Any: ...
+    def writerows(self, rowdicts: Iterable[Mapping[_T, Any]]) -> None: ...
 
 class Sniffer(object):
     preferred: List[str]


### PR DESCRIPTION
Fixes #4800 

To check that this works:

```python
import csv
import enum
from typing import TYPE_CHECKING

class Foo(enum.Enum):
    X = 1
    Y = 2

def main() -> None:
    with open('foo.csv', 'w') as file:
        writer = csv.DictWriter(file, list(Foo))
        writer.writeheader()
        writer.writerow({Foo.X: "lol", Foo.Y: "wat"})

    with open('foo.csv', 'r') as file:
        foo_reader = csv.DictReader(file, list(Foo))
        print(list(foo_reader))
        if TYPE_CHECKING:
            reveal_type(next(foo_reader))

    with open('foo.csv', 'r') as file:
        string_reader = csv.DictReader(file)
        print(list(string_reader))
        if TYPE_CHECKING:
            reveal_type(next(string_reader))

main()
```

Output: 

```
[{Foo.X: 'X', Foo.Y: 'Y'}, {Foo.X: 'lol', Foo.Y: 'wat'}]
[{'X': 'lol', 'Y': 'wat'}]
```

mypy on master:

```
foo.py:13: error: Dict entry 0 has incompatible type "Foo": "str"; expected "str": "Any"
foo.py:13: error: Dict entry 1 has incompatible type "Foo": "str"; expected "str": "Any"
foo.py:19: note: Revealed type is "builtins.dict*[builtins.str, builtins.str]"
foo.py:25: note: Revealed type is "builtins.dict*[builtins.str, builtins.str]"
Found 2 errors in 1 file (checked 1 source file)
```

mypy after this PR:

```
foo.py:19: note: Revealed type is "builtins.dict*[foo.Foo*, builtins.str]"
foo.py:25: note: Revealed type is "builtins.dict*[builtins.str*, builtins.str]"
```