### PR TITLE
CONTRIBUTING.md: explicitly avoid --amend

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,7 @@ processed incorrectly by a type checker. It is also helpful to add
 links to online documentation or to the implementation of the code
 you are changing.
 
-Also, do not squash your commits after you have submitted a pull request, as this
+Also, do not squash your commits or use `git commit --amend` after you have submitted a pull request, as this
 erases context during review. We will squash commits when the pull request is merged.
 
 At present the maintainers are (alphabetically):

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,8 @@ you are changing.
 
 Also, do not squash your commits or use `git commit --amend` after you have submitted a pull request, as this
 erases context during review. We will squash commits when the pull request is merged.
+This way, your pull request will appear as a single commit in our git history, even
+if it consisted of several smaller commits.
 
 At present the maintainers are (alphabetically):
 * David Fisher (@ddfisher)


### PR DESCRIPTION
To me, it seems like many new contributors don't realize that `--amend` is called "squashing" in our CONTRIBUTING.md. See #5248 and #5370 for example. I tried to clarify it a bit.