### PR TITLE
Use full SHA for comment hiding

### DIFF
--- a/.github/workflows/mypy_primer_comment.yml
+++ b/.github/workflows/mypy_primer_comment.yml
@@ -113,7 +113,7 @@ jobs:
               body,
             })
 
-      - uses: kanga333/comment-hider@9141763feccc8da
+      - uses: kanga333/comment-hider@9141763feccc8da773595675adc567d6616b6e6f
         name: Hide old comments
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
For whatever reason, looks like GA mandates full SHA
This was added in #5364