### PR TITLE
Make memoryview inherit from Sequence

### DIFF
--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -594,7 +594,7 @@ class bytearray(MutableSequence[int], ByteString):
     def __gt__(self, x: bytes) -> bool: ...
     def __ge__(self, x: bytes) -> bool: ...
 
-class memoryview(Sized, Container[int]):
+class memoryview(Sized, Sequence[int]):
     format: str
     itemsize: int
     shape: Optional[Tuple[int, ...]]

--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -25,7 +25,6 @@ from typing import (
     BinaryIO,
     ByteString,
     Callable,
-    Container,
     Dict,
     FrozenSet,
     Generic,


### PR DESCRIPTION
This is consistent with the runtime behaviour, where
`isinstance(memoryview(b"test"), Sequence) == True`