### PR TITLE
fix stubtest-unused-whitelist permissions

### DIFF
--- a/.github/workflows/stubtest-unused-whitelist.yml
+++ b/.github/workflows/stubtest-unused-whitelist.yml
@@ -5,10 +5,6 @@ on:
   schedule:
     - cron: '0 4 * * *'
 
-permissions:
-  contents: read
-  pull-requests: write
-
 jobs:
   stubtest:
     if: github.repository == 'python/typeshed'

--- a/.github/workflows/stubtest-unused-whitelist.yml
+++ b/.github/workflows/stubtest-unused-whitelist.yml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron: '0 4 * * *'
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   stubtest:
     if: github.repository == 'python/typeshed'


### PR DESCRIPTION
After creating #5401, I found a way to run the action manually (click "Actions" at top, then "Select workflow"). Turns out that the permissions we have are not enough for `create-pull-request` action. Minimal example:

```yaml
on:
  workflow_dispatch:

# Try deleting these
permissions:
  contents: read
  pull-requests: write

jobs:
  foobar:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v2
      - run: |
          echo lol > foo
      - name: Create pull request
        uses: peter-evans/create-pull-request@v3.8.2
        with:
          commit-message: Asdf
          title: Asdf2
```

Deleting the `permissions:` part makes this work.

@srittau Permissions were added in #5255. Why? I understand restricting permissions of stuff that runs when people make pull requests, but why also do it for something that can be started with cron or a maintainer?