### PR TITLE
Update maintainers list

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -9,3 +9,9 @@ At present the active maintainers are (alphabetically):
 * Rune Tynan (@CraftSpider)
 * Aku Viljanen (@Akuli)
 * Jelle Zijlstra (@JelleZijlstra)
+
+Former and inactive maintainers include:
+* David Fisher (@ddfisher)
+* Łukasz Langa (@ambv)
+* Matthias Kramm (@matthiaskramm)
+* Greg Price (@gnprice)

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,11 +1,8 @@
-At present the maintainers are (alphabetically):
+At present the active maintainers are (alphabetically):
 
-* David Fisher (@ddfisher)
-* Łukasz Langa (@ambv)
+* Rebecca Chen (@rchen152)
 * Jukka Lehtosalo (@JukkaL)
 * Ivan Levkivskyi (@ilevkivskyi)
-* Matthias Kramm (@matthiaskramm)
-* Greg Price (@gnprice)
 * Sebastian Rittau (@srittau)
 * Guido van Rossum (@gvanrossum)
 * Shantanu (@hauntsaninja)


### PR DESCRIPTION
I removed a few people who have not been active in the typing area for a long time, and added @rchen152 who is active on the repo and has commit rights. There are a few other people who have access to the repo but are not active. Listing them here does not seem useful.