### PR TITLE
Move code of conduct to separate file

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,5 @@
+Everyone participating in the typeshed community, and in particular in
+our issue tracker, pull requests, and Gitter channel, is expected to treat
+other people with respect and more generally to follow the guidelines
+articulated in the [Python Community Code of
+Conduct](https://www.python.org/psf/codeofconduct/).

--- a/README.md
+++ b/README.md
@@ -54,11 +54,3 @@ For less formal discussion, try the typing chat room on
 are almost always present; feel free to find us there and we're happy
 to chat.  Substantive technical discussion will be directed to the
 issue tracker.
-
-## Code of Conduct
-
-Everyone participating in the typeshed community, and in particular in
-our issue tracker, pull requests, and Gitter channel, is expected to treat
-other people with respect and more generally to follow the guidelines
-articulated in the [Python Community Code of
-Conduct](https://www.python.org/psf/codeofconduct/).


### PR DESCRIPTION
The file CODE_OF_CONDUCT.md is the standard location for it and
is treated specially by GitHub, for example by linking to it directly
when opening issues and PRs.