### PR TITLE
Don't import enum in Python 2 stubs

### DIFF
--- a/stdlib/inspect.pyi
+++ b/stdlib/inspect.pyi
@@ -114,35 +114,34 @@ if sys.version_info >= (3, 10):
         eval_str: bool = ...,
     ) -> Signature: ...
 
-else:
+elif sys.version_info >= (3, 4):
     def signature(obj: Callable[..., Any], *, follow_wrapped: bool = ...) -> Signature: ...
+    class Signature:
+        def __init__(self, parameters: Optional[Sequence[Parameter]] = ..., *, return_annotation: Any = ...) -> None: ...
+        # TODO: can we be more specific here?
+        empty: object = ...
 
-class Signature:
-    def __init__(self, parameters: Optional[Sequence[Parameter]] = ..., *, return_annotation: Any = ...) -> None: ...
-    # TODO: can we be more specific here?
-    empty: object = ...
+        parameters: Mapping[str, Parameter]
 
-    parameters: Mapping[str, Parameter]
-
-    # TODO: can we be more specific here?
-    return_annotation: Any
-    def bind(self, *args: Any, **kwargs: Any) -> BoundArguments: ...
-    def bind_partial(self, *args: Any, **kwargs: Any) -> BoundArguments: ...
-    def replace(self, *, parameters: Optional[Sequence[Parameter]] = ..., return_annotation: Any = ...) -> Signature: ...
-    if sys.version_info >= (3, 10):
-        @classmethod
-        def from_callable(
-            cls,
-            obj: Callable[..., Any],
-            *,
-            follow_wrapped: bool = ...,
-            globals: Optional[Mapping[str, Any]] = ...,
-            locals: Optional[Mapping[str, Any]] = ...,
-            eval_str: bool = ...,
-        ) -> Signature: ...
-    else:
-        @classmethod
-        def from_callable(cls, obj: Callable[..., Any], *, follow_wrapped: bool = ...) -> Signature: ...
+        # TODO: can we be more specific here?
+        return_annotation: Any
+        def bind(self, *args: Any, **kwargs: Any) -> BoundArguments: ...
+        def bind_partial(self, *args: Any, **kwargs: Any) -> BoundArguments: ...
+        def replace(self, *, parameters: Optional[Sequence[Parameter]] = ..., return_annotation: Any = ...) -> Signature: ...
+        if sys.version_info >= (3, 10):
+            @classmethod
+            def from_callable(
+                cls,
+                obj: Callable[..., Any],
+                *,
+                follow_wrapped: bool = ...,
+                globals: Optional[Mapping[str, Any]] = ...,
+                locals: Optional[Mapping[str, Any]] = ...,
+                eval_str: bool = ...,
+            ) -> Signature: ...
+        else:
+            @classmethod
+            def from_callable(cls, obj: Callable[..., Any], *, follow_wrapped: bool = ...) -> Signature: ...
 
 if sys.version_info >= (3, 10):
     def get_annotations(
@@ -166,35 +165,29 @@ if sys.version_info >= (3, 4):
 
         if sys.version_info >= (3, 8):
             description: str
+    class Parameter:
+        def __init__(self, name: str, kind: _ParameterKind, *, default: Any = ..., annotation: Any = ...) -> None: ...
+        empty: Any = ...
+        name: str
+        default: Any
+        annotation: Any
 
-else:
-    # TODO: This actually doesn't exist on Python 2
-    _ParameterKind = int
-
-class Parameter:
-    def __init__(self, name: str, kind: _ParameterKind, *, default: Any = ..., annotation: Any = ...) -> None: ...
-    empty: Any = ...
-    name: str
-    default: Any
-    annotation: Any
-
-    kind: _ParameterKind
-    POSITIONAL_ONLY: ClassVar[Literal[_ParameterKind.POSITIONAL_ONLY]]
-    POSITIONAL_OR_KEYWORD: ClassVar[Literal[_ParameterKind.POSITIONAL_OR_KEYWORD]]
-    VAR_POSITIONAL: ClassVar[Literal[_ParameterKind.VAR_POSITIONAL]]
-    KEYWORD_ONLY: ClassVar[Literal[_ParameterKind.KEYWORD_ONLY]]
-    VAR_KEYWORD: ClassVar[Literal[_ParameterKind.VAR_KEYWORD]]
-    def replace(
-        self, *, name: Optional[str] = ..., kind: Optional[_ParameterKind] = ..., default: Any = ..., annotation: Any = ...
-    ) -> Parameter: ...
-
-class BoundArguments:
-    arguments: OrderedDict[str, Any]
-    args: Tuple[Any, ...]
-    kwargs: Dict[str, Any]
-    signature: Signature
-    def __init__(self, signature: Signature, arguments: OrderedDict[str, Any]) -> None: ...
-    def apply_defaults(self) -> None: ...
+        kind: _ParameterKind
+        POSITIONAL_ONLY: ClassVar[Literal[_ParameterKind.POSITIONAL_ONLY]]
+        POSITIONAL_OR_KEYWORD: ClassVar[Literal[_ParameterKind.POSITIONAL_OR_KEYWORD]]
+        VAR_POSITIONAL: ClassVar[Literal[_ParameterKind.VAR_POSITIONAL]]
+        KEYWORD_ONLY: ClassVar[Literal[_ParameterKind.KEYWORD_ONLY]]
+        VAR_KEYWORD: ClassVar[Literal[_ParameterKind.VAR_KEYWORD]]
+        def replace(
+            self, *, name: Optional[str] = ..., kind: Optional[_ParameterKind] = ..., default: Any = ..., annotation: Any = ...
+        ) -> Parameter: ...
+    class BoundArguments:
+        arguments: OrderedDict[str, Any]
+        args: Tuple[Any, ...]
+        kwargs: Dict[str, Any]
+        signature: Signature
+        def __init__(self, signature: Signature, arguments: OrderedDict[str, Any]) -> None: ...
+        def apply_defaults(self) -> None: ...
 
 #
 # Classes and functions

--- a/stdlib/inspect.pyi
+++ b/stdlib/inspect.pyi
@@ -167,6 +167,7 @@ if sys.version_info >= (3, 0):
 
         if sys.version_info >= (3, 8):
             description: str
+
 else:
     # TODO: This actually doesn't exist on Python 2
     _ParameterKind = int

--- a/stdlib/inspect.pyi
+++ b/stdlib/inspect.pyi
@@ -116,6 +116,8 @@ if sys.version_info >= (3, 10):
 
 elif sys.version_info >= (3, 4):
     def signature(obj: Callable[..., Any], *, follow_wrapped: bool = ...) -> Signature: ...
+
+if sys.version_info >= (3, 4):
     class Signature:
         def __init__(self, parameters: Optional[Sequence[Parameter]] = ..., *, return_annotation: Any = ...) -> None: ...
         # TODO: can we be more specific here?

--- a/stdlib/inspect.pyi
+++ b/stdlib/inspect.pyi
@@ -1,3 +1,4 @@
+import enum
 import sys
 from collections import OrderedDict
 from types import CodeType, FrameType, FunctionType, MethodType, ModuleType, TracebackType
@@ -114,36 +115,35 @@ if sys.version_info >= (3, 10):
         eval_str: bool = ...,
     ) -> Signature: ...
 
-elif sys.version_info >= (3, 4):
+else:
     def signature(obj: Callable[..., Any], *, follow_wrapped: bool = ...) -> Signature: ...
 
-if sys.version_info >= (3, 4):
-    class Signature:
-        def __init__(self, parameters: Optional[Sequence[Parameter]] = ..., *, return_annotation: Any = ...) -> None: ...
-        # TODO: can we be more specific here?
-        empty: object = ...
+class Signature:
+    def __init__(self, parameters: Optional[Sequence[Parameter]] = ..., *, return_annotation: Any = ...) -> None: ...
+    # TODO: can we be more specific here?
+    empty: object = ...
 
-        parameters: Mapping[str, Parameter]
+    parameters: Mapping[str, Parameter]
 
-        # TODO: can we be more specific here?
-        return_annotation: Any
-        def bind(self, *args: Any, **kwargs: Any) -> BoundArguments: ...
-        def bind_partial(self, *args: Any, **kwargs: Any) -> BoundArguments: ...
-        def replace(self, *, parameters: Optional[Sequence[Parameter]] = ..., return_annotation: Any = ...) -> Signature: ...
-        if sys.version_info >= (3, 10):
-            @classmethod
-            def from_callable(
-                cls,
-                obj: Callable[..., Any],
-                *,
-                follow_wrapped: bool = ...,
-                globals: Optional[Mapping[str, Any]] = ...,
-                locals: Optional[Mapping[str, Any]] = ...,
-                eval_str: bool = ...,
-            ) -> Signature: ...
-        else:
-            @classmethod
-            def from_callable(cls, obj: Callable[..., Any], *, follow_wrapped: bool = ...) -> Signature: ...
+    # TODO: can we be more specific here?
+    return_annotation: Any
+    def bind(self, *args: Any, **kwargs: Any) -> BoundArguments: ...
+    def bind_partial(self, *args: Any, **kwargs: Any) -> BoundArguments: ...
+    def replace(self, *, parameters: Optional[Sequence[Parameter]] = ..., return_annotation: Any = ...) -> Signature: ...
+    if sys.version_info >= (3, 10):
+        @classmethod
+        def from_callable(
+            cls,
+            obj: Callable[..., Any],
+            *,
+            follow_wrapped: bool = ...,
+            globals: Optional[Mapping[str, Any]] = ...,
+            locals: Optional[Mapping[str, Any]] = ...,
+            eval_str: bool = ...,
+        ) -> Signature: ...
+    else:
+        @classmethod
+        def from_callable(cls, obj: Callable[..., Any], *, follow_wrapped: bool = ...) -> Signature: ...
 
 if sys.version_info >= (3, 10):
     def get_annotations(
@@ -154,42 +154,41 @@ if sys.version_info >= (3, 10):
         eval_str: bool = ...,
     ) -> Dict[str, Any]: ...
 
-if sys.version_info >= (3, 4):
-    import enum
+# The name is the same as the enum's name in CPython
+class _ParameterKind(enum.IntEnum):
+    POSITIONAL_ONLY: int
+    POSITIONAL_OR_KEYWORD: int
+    VAR_POSITIONAL: int
+    KEYWORD_ONLY: int
+    VAR_KEYWORD: int
 
-    # The name is the same as the enum's name in CPython
-    class _ParameterKind(enum.IntEnum):
-        POSITIONAL_ONLY: int
-        POSITIONAL_OR_KEYWORD: int
-        VAR_POSITIONAL: int
-        KEYWORD_ONLY: int
-        VAR_KEYWORD: int
+    if sys.version_info >= (3, 8):
+        description: str
 
-        if sys.version_info >= (3, 8):
-            description: str
-    class Parameter:
-        def __init__(self, name: str, kind: _ParameterKind, *, default: Any = ..., annotation: Any = ...) -> None: ...
-        empty: Any = ...
-        name: str
-        default: Any
-        annotation: Any
+class Parameter:
+    def __init__(self, name: str, kind: _ParameterKind, *, default: Any = ..., annotation: Any = ...) -> None: ...
+    empty: Any = ...
+    name: str
+    default: Any
+    annotation: Any
 
-        kind: _ParameterKind
-        POSITIONAL_ONLY: ClassVar[Literal[_ParameterKind.POSITIONAL_ONLY]]
-        POSITIONAL_OR_KEYWORD: ClassVar[Literal[_ParameterKind.POSITIONAL_OR_KEYWORD]]
-        VAR_POSITIONAL: ClassVar[Literal[_ParameterKind.VAR_POSITIONAL]]
-        KEYWORD_ONLY: ClassVar[Literal[_ParameterKind.KEYWORD_ONLY]]
-        VAR_KEYWORD: ClassVar[Literal[_ParameterKind.VAR_KEYWORD]]
-        def replace(
-            self, *, name: Optional[str] = ..., kind: Optional[_ParameterKind] = ..., default: Any = ..., annotation: Any = ...
-        ) -> Parameter: ...
-    class BoundArguments:
-        arguments: OrderedDict[str, Any]
-        args: Tuple[Any, ...]
-        kwargs: Dict[str, Any]
-        signature: Signature
-        def __init__(self, signature: Signature, arguments: OrderedDict[str, Any]) -> None: ...
-        def apply_defaults(self) -> None: ...
+    kind: _ParameterKind
+    POSITIONAL_ONLY: ClassVar[Literal[_ParameterKind.POSITIONAL_ONLY]]
+    POSITIONAL_OR_KEYWORD: ClassVar[Literal[_ParameterKind.POSITIONAL_OR_KEYWORD]]
+    VAR_POSITIONAL: ClassVar[Literal[_ParameterKind.VAR_POSITIONAL]]
+    KEYWORD_ONLY: ClassVar[Literal[_ParameterKind.KEYWORD_ONLY]]
+    VAR_KEYWORD: ClassVar[Literal[_ParameterKind.VAR_KEYWORD]]
+    def replace(
+        self, *, name: Optional[str] = ..., kind: Optional[_ParameterKind] = ..., default: Any = ..., annotation: Any = ...
+    ) -> Parameter: ...
+
+class BoundArguments:
+    arguments: OrderedDict[str, Any]
+    args: Tuple[Any, ...]
+    kwargs: Dict[str, Any]
+    signature: Signature
+    def __init__(self, signature: Signature, arguments: OrderedDict[str, Any]) -> None: ...
+    def apply_defaults(self) -> None: ...
 
 #
 # Classes and functions

--- a/stdlib/inspect.pyi
+++ b/stdlib/inspect.pyi
@@ -154,16 +154,22 @@ if sys.version_info >= (3, 10):
         eval_str: bool = ...,
     ) -> Dict[str, Any]: ...
 
-# The name is the same as the enum's name in CPython
-class _ParameterKind(enum.IntEnum):
-    POSITIONAL_ONLY: int
-    POSITIONAL_OR_KEYWORD: int
-    VAR_POSITIONAL: int
-    KEYWORD_ONLY: int
-    VAR_KEYWORD: int
+if sys.version_info >= (3, 0):
+    import enum
 
-    if sys.version_info >= (3, 8):
-        description: str
+    # The name is the same as the enum's name in CPython
+    class _ParameterKind(enum.IntEnum):
+        POSITIONAL_ONLY: int
+        POSITIONAL_OR_KEYWORD: int
+        VAR_POSITIONAL: int
+        KEYWORD_ONLY: int
+        VAR_KEYWORD: int
+
+        if sys.version_info >= (3, 8):
+            description: str
+else:
+    # TODO: This actually doesn't exist on Python 2
+    _ParameterKind = int
 
 class Parameter:
     def __init__(self, name: str, kind: _ParameterKind, *, default: Any = ..., annotation: Any = ...) -> None: ...

--- a/stdlib/inspect.pyi
+++ b/stdlib/inspect.pyi
@@ -1,4 +1,3 @@
-import enum
 import sys
 from collections import OrderedDict
 from types import CodeType, FrameType, FunctionType, MethodType, ModuleType, TracebackType
@@ -154,7 +153,7 @@ if sys.version_info >= (3, 10):
         eval_str: bool = ...,
     ) -> Dict[str, Any]: ...
 
-if sys.version_info >= (3, 0):
+if sys.version_info >= (3, 4):
     import enum
 
     # The name is the same as the enum's name in CPython

--- a/stdlib/py_compile.pyi
+++ b/stdlib/py_compile.pyi
@@ -1,4 +1,3 @@
-import enum
 import sys
 from typing import AnyStr, List, Optional, Text, Type, Union
 
@@ -12,6 +11,8 @@ class PyCompileError(Exception):
     def __init__(self, exc_type: Type[BaseException], exc_value: BaseException, file: str, msg: str = ...) -> None: ...
 
 if sys.version_info >= (3, 7):
+    import enum
+
     class PycInvalidationMode(enum.Enum):
         TIMESTAMP: int = ...
         CHECKED_HASH: int = ...

--- a/stdlib/py_compile.pyi
+++ b/stdlib/py_compile.pyi
@@ -12,7 +12,6 @@ class PyCompileError(Exception):
 
 if sys.version_info >= (3, 7):
     import enum
-
     class PycInvalidationMode(enum.Enum):
         TIMESTAMP: int = ...
         CHECKED_HASH: int = ...

--- a/stdlib/ssl.pyi
+++ b/stdlib/ssl.pyi
@@ -1,9 +1,11 @@
-import enum
 import socket
 import sys
 from _typeshed import StrPath
 from typing import Any, Callable, ClassVar, Dict, Iterable, List, NamedTuple, Optional, Set, Text, Tuple, Type, Union, overload
 from typing_extensions import Literal
+
+if sys.version_info >= (3, 0):
+    import enum
 
 _PCTRTT = Tuple[Tuple[str, str], ...]
 _PCTRTTT = Tuple[_PCTRTT, ...]

--- a/stdlib/ssl.pyi
+++ b/stdlib/ssl.pyi
@@ -4,7 +4,7 @@ from _typeshed import StrPath
 from typing import Any, Callable, ClassVar, Dict, Iterable, List, NamedTuple, Optional, Set, Text, Tuple, Type, Union, overload
 from typing_extensions import Literal
 
-if sys.version_info >= (3, 0):
+if sys.version_info >= (3, 4):
     import enum
 
 _PCTRTT = Tuple[Tuple[str, str], ...]
@@ -230,7 +230,7 @@ class _ASN1Object(NamedTuple):
     longname: str
     oid: str
 
-if sys.version_info >= (3, 0):
+if sys.version_info >= (3, 4):
     class Purpose(_ASN1Object, enum.Enum):
         SERVER_AUTH: _ASN1Object
         CLIENT_AUTH: _ASN1Object


### PR DESCRIPTION
Python 2.7 doesn't have enum in the stdlib, in particular, so we
shouldn't import it.

It would probably be a better long-term fix to move the Python 2 stubs
to `@python2` and simplify them there.