### PR TITLE
Bump pyright to 1.1.140

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -93,7 +93,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: jakebailey/pyright-action@v1
         with:
-          version: 1.1.138  # Must match pyright_test.py.
+          version: 1.1.140  # Must match pyright_test.py.
           python-platform: ${{ matrix.python-platform }}
           python-version: ${{ matrix.python-version }}
           no-comments: ${{ matrix.python-version != '3.9' || matrix.python-platform != 'Linux' }}  # Having each job create the same comment is too noisy.

--- a/tests/pyright_test.py
+++ b/tests/pyright_test.py
@@ -5,7 +5,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-_PYRIGHT_VERSION = "1.1.138"  # Must match tests.yml.
+_PYRIGHT_VERSION = "1.1.140"  # Must match tests.yml.
 _WELL_KNOWN_FILE = Path("tests", "pyright_test.py")
 
 


### PR DESCRIPTION
This actually fails on my machine at the moment with a real interpreter selected due to `click` being installed globally on my Arch machine with a `py.typed` file; the fix we applied in pyright/pylance to ensure that `py.typed` libraries are picked over typeshed when possible appears to break checking typeshed itself.

I have a hunch that CI will pass (as we don't install any python-related deps in this mode), but opening as a draft to check anyway.

I'll have to look into this once I'm back on a work machine and can debug it (sending this from a personal machine...).