### PR TITLE
Fix Python 2 genericpath.commonprefix

### DIFF
--- a/stdlib/@python2/genericpath.pyi
+++ b/stdlib/@python2/genericpath.pyi
@@ -6,9 +6,9 @@ from typing_extensions import Literal
 # Iterable[T], so that Union[List[T], Literal[""]] could be used as a return
 # type. But because this only works when T is str, we need Sequence[T] instead.
 @overload
-def commonprefix(m: Sequence[Text]) -> str: ...  # type: ignore
-@overload
 def commonprefix(m: Sequence[str]) -> Union[str, Literal[""]]: ...  # type: ignore
+@overload
+def commonprefix(m: Sequence[Text]) -> Text: ...  # type: ignore
 @overload
 def commonprefix(m: Sequence[List[SupportsLessThanT]]) -> Sequence[SupportsLessThanT]: ...
 @overload


### PR DESCRIPTION
The more specific overload item should come first. Also
fix the return type.