### PR TITLE
Use only literal overloads for ZipFile.__init__()

### DIFF
--- a/stdlib/zipfile.pyi
+++ b/stdlib/zipfile.pyi
@@ -51,7 +51,12 @@ class ZipExtFile(io.BufferedIOBase):
         ) -> None: ...
         @overload
         def __init__(
-            self, fileobj: _ZipStream, mode: str, zipinfo: ZipInfo, pwd: Optional[bytes] = ..., close_fileobj: bool = ...
+            self,
+            fileobj: _ZipStream,
+            mode: str,
+            zipinfo: ZipInfo,
+            pwd: Optional[bytes] = ...,
+            close_fileobj: Literal[False] = ...,
         ) -> None: ...
     else:
         @overload
@@ -80,7 +85,7 @@ class ZipExtFile(io.BufferedIOBase):
             mode: str,
             zipinfo: ZipInfo,
             decrypter: Optional[Callable[[Sequence[int]], bytes]] = ...,
-            close_fileobj: bool = ...,
+            close_fileobj: Literal[False] = ...,
         ) -> None: ...
     def read(self, n: Optional[int] = ...) -> bytes: ...
     def readline(self, limit: int = ...) -> bytes: ...  # type: ignore


### PR DESCRIPTION
This uses my original idea. Why this is currently doesn't work in corner cases due to a mypy bug, I think this is the best solution:

* Is it correct.
* It is very unlikely to be an issue in practice as this is an internal constructor, and the `close_fileobj` argument is most likely provided as a literal anyway.
* The mypy bug is easily worked around by using `# type: ignore` or `Literal[True, False]` in case it comes up in practice.
* We don't need to remember to fix this when mypy gets fixed.