### PR TITLE
Add _Pickler and _Unpickler to stdlib/pickle

### DIFF
--- a/stdlib/pickle.pyi
+++ b/stdlib/pickle.pyi
@@ -184,3 +184,6 @@ if sys.version_info >= (3, 4):
 
 def encode_long(x: int) -> bytes: ...  # undocumented
 def decode_long(data: bytes) -> int: ...  # undocumented
+
+_Pickler = Pickler  # undocumented
+_Unpickler = Unpickler  # undocumented


### PR DESCRIPTION
These are the pure-Python pickle implementation, and are sometimes used
by code that wants to extend or override parts of the
pickling/unpickling process.