### PR TITLE
Add sys.stdlib_module_names for Python 3.10

### DIFF
--- a/stdlib/sys.pyi
+++ b/stdlib/sys.pyi
@@ -8,6 +8,7 @@ from typing import (
     AsyncGenerator,
     Callable,
     Dict,
+    FrozenSet,
     List,
     NoReturn,
     Optional,
@@ -74,6 +75,8 @@ ps2: str
 stdin: TextIO
 stdout: TextIO
 stderr: TextIO
+if sys.version_info >= (3, 10):
+    stdlib_module_names: FrozenSet[str]
 __stdin__: TextIO
 __stdout__: TextIO
 __stderr__: TextIO


### PR DESCRIPTION
`sys.stdlib_module_names` was introduced in Python 3.10

- [bpo-42955][1]: Add sys.stdlib_module_names: list of stdlib module names (Python and extension modules)
- PR1 python/cpython#24238: Add sys.modules_names
- PR2 python/cpython#24332: Rename module_names to sys.stdlib_module_names

[1]: https://bugs.python.org/issue42955