### PR TITLE
Add sys.orig_argv for Python 3.10

### DIFF
--- a/stdlib/sys.pyi
+++ b/stdlib/sys.pyi
@@ -61,6 +61,8 @@ maxsize: int
 maxunicode: int
 meta_path: List[_MetaPathFinder]
 modules: Dict[str, ModuleType]
+if sys.version_info >= (3, 10):
+    orig_argv: List[str]
 path: List[str]
 path_hooks: List[Any]  # TODO precise type; function, path to finder
 path_importer_cache: Dict[str, Optional[PathEntryFinder]]


### PR DESCRIPTION
`sys.orig_argv` is a new addition in Python 3.10

- [`sys.orig_argv` in Python 3.10 documentation][1]
- [bpo-23427][2]: Add sys.orig_argv: original command line arguments passed to the Python executable
- PR python/cpython#20729: Add sys.orig_argv attribute

[1]: https://docs.python.org/3.10/library/sys.html#sys.orig_argv
[2]: https://bugs.python.org/issue23427