### PR TITLE
Use __new__ for datetime.timedelta

### DIFF
--- a/stdlib/@python2/datetime.pyi
+++ b/stdlib/@python2/datetime.pyi
@@ -99,8 +99,8 @@ class timedelta(SupportsAbs[timedelta]):
     min: ClassVar[timedelta]
     max: ClassVar[timedelta]
     resolution: ClassVar[timedelta]
-    def __init__(
-        self,
+    def __new__(
+        cls: Type[_S],
         days: float = ...,
         seconds: float = ...,
         microseconds: float = ...,
@@ -108,7 +108,7 @@ class timedelta(SupportsAbs[timedelta]):
         minutes: float = ...,
         hours: float = ...,
         weeks: float = ...,
-    ) -> None: ...
+    ) -> _S: ...
     @property
     def days(self) -> int: ...
     @property

--- a/stdlib/datetime.pyi
+++ b/stdlib/datetime.pyi
@@ -139,8 +139,8 @@ class timedelta(SupportsAbs[timedelta]):
     min: ClassVar[timedelta]
     max: ClassVar[timedelta]
     resolution: ClassVar[timedelta]
-    def __init__(
-        self,
+    def __new__(
+        cls: Type[_S],
         days: float = ...,
         seconds: float = ...,
         microseconds: float = ...,
@@ -148,9 +148,7 @@ class timedelta(SupportsAbs[timedelta]):
         minutes: float = ...,
         hours: float = ...,
         weeks: float = ...,
-        *,
-        fold: int = ...,
-    ) -> None: ...
+    ) -> _S: ...
     @property
     def days(self) -> int: ...
     @property


### PR DESCRIPTION
* Use `__new__` instead of `__init__` for `datetime.timedelta`
* Remove invalid parameter

Closes #5529 