### PR TITLE
markdown: Add missing attribute to Markdown stub.

### DIFF
--- a/stubs/Markdown/markdown/extensions/codehilite.pyi
+++ b/stubs/Markdown/markdown/extensions/codehilite.pyi
@@ -32,6 +32,7 @@ class CodeHilite:
         tab_length: int = ...,
         hl_lines: Optional[Any] = ...,
         use_pygments: bool = ...,
+        **options: Any,
     ) -> None: ...
     def hilite(self): ...
 

--- a/stubs/Markdown/markdown/extensions/codehilite.pyi
+++ b/stubs/Markdown/markdown/extensions/codehilite.pyi
@@ -22,6 +22,7 @@ class CodeHilite:
     def __init__(
         self,
         src: Optional[Any] = ...,
+        *,
         linenums: Optional[Any] = ...,
         guess_lang: bool = ...,
         css_class: str = ...,

--- a/stubs/Markdown/markdown/extensions/codehilite.pyi
+++ b/stubs/Markdown/markdown/extensions/codehilite.pyi
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any, Dict, Optional
 
 from markdown.extensions import Extension
 from markdown.treeprocessors import Treeprocessor
@@ -18,6 +18,7 @@ class CodeHilite:
     tab_length: Any
     hl_lines: Any
     use_pygments: Any
+    options: Dict[str, Any]
     def __init__(
         self,
         src: Optional[Any] = ...,
@@ -30,7 +31,6 @@ class CodeHilite:
         tab_length: int = ...,
         hl_lines: Optional[Any] = ...,
         use_pygments: bool = ...,
-        options: Any = ...,
     ) -> None: ...
     def hilite(self): ...
 

--- a/stubs/Markdown/markdown/extensions/codehilite.pyi
+++ b/stubs/Markdown/markdown/extensions/codehilite.pyi
@@ -30,6 +30,7 @@ class CodeHilite:
         tab_length: int = ...,
         hl_lines: Optional[Any] = ...,
         use_pygments: bool = ...,
+        options: Any = ...,
     ) -> None: ...
     def hilite(self): ...
 


### PR DESCRIPTION
I'm a regular contributor @Zulip, and I've added a commit that overrides the [`_parseHeader` function](https://github.com/Python-Markdown/markdown/blob/3ea29f9d9b7d201269444dccedc0383065532b7e/markdown/extensions/codehilite.py#L164), and while working, I found that this attribute is missing here. (Related PR: https://github.com/zulip/zulip/pull/18608)

This attribute is defined here: https://github.com/Python-Markdown/markdown/blob/3ea29f9d9b7d201269444dccedc0383065532b7e/markdown/extensions/codehilite.py#L113.