### PR TITLE
bump various dependencies

### DIFF
--- a/.github/workflows/mypy_primer.yml
+++ b/.github/workflows/mypy_primer.yml
@@ -44,7 +44,7 @@ jobs:
           # fail action if exit code isn't zero or one
           (
             mypy_primer \
-            --new c605579af8 --old c605579af8 \
+            --new 61c346230cf4960c976 --old 61c346230cf4960c976 \
             --custom-typeshed-repo typeshed_to_test \
             --new-typeshed $GITHUB_SHA --old-typeshed upstream_master \
             --num-shards 2 --shard-index ${{ matrix.shard-index }} \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,7 +84,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: jakebailey/pyright-action@v1
         with:
-          version: 1.1.142  # Must match pyright_test.py.
+          version: 1.1.144  # Must match pyright_test.py.
           python-platform: ${{ matrix.python-platform }}
           python-version: ${{ matrix.python-version }}
           no-comments: ${{ matrix.python-version != '3.9' || matrix.python-platform != 'Linux' }}  # Having each job create the same comment is too noisy.

--- a/requirements-tests-py3.txt
+++ b/requirements-tests-py3.txt
@@ -2,9 +2,9 @@
 # typeshed is released on PyPI.
 git+https://github.com/python/mypy.git@master
 typed-ast>=1.0.4
-black==21.4b1
+black==21.5b1
 flake8==3.8.4
 flake8-bugbear==20.1.4
 flake8-pyi==20.10.0
 isort==5.5.3
-pytype>=2021.5.11
+pytype>=2021.5.25

--- a/tests/pyright_test.py
+++ b/tests/pyright_test.py
@@ -5,7 +5,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-_PYRIGHT_VERSION = "1.1.142"  # Must match tests.yml.
+_PYRIGHT_VERSION = "1.1.144"  # Must match tests.yml.
 _WELL_KNOWN_FILE = Path("tests", "pyright_test.py")
 
 


### PR DESCRIPTION
- New pytype should pull in google/pytype#925 (support for `|` Union)
- New mypy should pull in python/mypy#10496 (improved TypeGuard support)
- Black and pyright didn't make changes relevant to typeshed as far as I'm aware, but better to keep them up to date