### PR TITLE
Add importlib.metadata.packages_distributions() for Python 3.10

### DIFF
--- a/stdlib/importlib/metadata.pyi
+++ b/stdlib/importlib/metadata.pyi
@@ -2,11 +2,15 @@ import abc
 import pathlib
 import sys
 from _typeshed import StrPath
+from collections.abc import Mapping
 from email.message import Message
 from importlib.abc import MetaPathFinder
 from os import PathLike
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, NamedTuple, Optional, Tuple, overload
+
+if sys.version_info >= (3, 10):
+    def packages_distributions() -> Mapping[str, List[str]]: ...
 
 if sys.version_info >= (3, 8):
     class PackageNotFoundError(ModuleNotFoundError): ...


### PR DESCRIPTION
`packages_distributions()` is a new addition to `importlib.metadata` in Python 3.10.

I basically copied [function signature with annotation][1] from the source code

- [What's new in Python 3.10 - importlib.metadata][2]
- [importlib-metadata v3.7.0 changelog][3]
- The corresponding `importlib-metadata` [commit 466cd3c][4]

[1]: https://github.com/python/importlib_metadata/blob/5fb702911718a58f617bc774d846e6e4084da5d2/importlib_metadata/__init__.py#L1011
[2]: https://docs.python.org/3.10/whatsnew/3.10.html#importlib-metadata
[3]: https://importlib-metadata.readthedocs.io/en/latest/history.html#v3-7-0
[4]: https://github.com/python/importlib_metadata/commit/466cd3c8e6036cbd16584629fa0e54d6c0d6b027