### PR TITLE
attr.attrs can take a list of `converters`

### DIFF
--- a/stubs/attrs/attr/__init__.pyi
+++ b/stubs/attrs/attr/__init__.pyi
@@ -49,7 +49,7 @@ class Attribute(Generic[_T]):
     order: bool
     hash: Optional[bool]
     init: bool
-    converter: Optional[_ConverterType[_T]]
+    converter: None | _ConverterType[_T] | List[_ConverterType[_T]] | Tuple[_ConverterType[_T], ...]
     metadata: Dict[Any, Any]
     type: Optional[Type[_T]]
     kw_only: bool
@@ -105,7 +105,7 @@ def attrib(
     init: bool = ...,
     metadata: Optional[Mapping[Any, Any]] = ...,
     type: Optional[Type[_T]] = ...,
-    converter: Optional[_ConverterType[_T]] = ...,
+    converter: None | _ConverterType[_T] | List[_ConverterType[_T]] | Tuple[_ConverterType[_T], ...] = ...,
     factory: Optional[Callable[[], _T]] = ...,
     kw_only: bool = ...,
     eq: Optional[bool] = ...,
@@ -123,7 +123,7 @@ def attrib(
     init: bool = ...,
     metadata: Optional[Mapping[Any, Any]] = ...,
     type: Optional[Type[_T]] = ...,
-    converter: Optional[_ConverterType[_T]] = ...,
+    converter: None | _ConverterType[_T] | List[_ConverterType[_T]] | Tuple[_ConverterType[_T], ...] = ...,
     factory: Optional[Callable[[], _T]] = ...,
     kw_only: bool = ...,
     eq: Optional[bool] = ...,
@@ -141,7 +141,7 @@ def attrib(
     init: bool = ...,
     metadata: Optional[Mapping[Any, Any]] = ...,
     type: object = ...,
-    converter: Optional[_ConverterType[_T]] = ...,
+    converter: None | _ConverterType[_T] | List[_ConverterType[_T]] | Tuple[_ConverterType[_T], ...] = ...,
     factory: Optional[Callable[[], _T]] = ...,
     kw_only: bool = ...,
     eq: Optional[bool] = ...,


### PR DESCRIPTION
attrs v20.1.0 added support for taking a list of converter objects
https://www.attrs.org/en/stable/changelog.html#id45 (PR 618)