### PR TITLE
Add some submodule versions to stdlib/VERSIONS.

### DIFF
--- a/stdlib/VERSIONS
+++ b/stdlib/VERSIONS
@@ -23,7 +23,7 @@ _ast: 2.7-
 _bisect: 2.7-
 _bootlocale: 3.6-3.9
 _codecs: 2.7-
-_collections_abc: 3.6-
+_collections_abc: 3.3-
 _compat_pickle: 3.6-
 _compression: 3.6-
 _csv: 2.7-
@@ -50,6 +50,7 @@ _threading_local: 3.6-
 _tkinter: 2.7-
 _tracemalloc: 3.6-
 _typeshed: 2.7-  # not present at runtime, only for type checking
+_typeshed.tkinter: 3.0-
 _warnings: 2.7-
 _weakref: 2.7-
 _weakrefset: 2.7-
@@ -83,6 +84,7 @@ code: 2.7-
 codecs: 2.7-
 codeop: 2.7-
 collections: 2.7-
+collections.abc: 3.3-
 colorsys: 2.7-
 compileall: 2.7-
 concurrent: 3.2-
@@ -136,6 +138,7 @@ imaplib: 2.7-
 imghdr: 2.7-
 imp: 2.7-
 importlib: 2.7-
+importlib.metadata: 3.8-
 importlib.resources: 3.7-
 inspect: 2.7-
 io: 2.7-


### PR DESCRIPTION
Adds some version ranges for submodules that are available in different
versions than their parent modules.

I noticed these while updating pytype's pinned typeshed commit. pytype
can't actually use this submodule version information yet, but from what
I understand, all type checkers at least handle this information
gracefully (by ignoring it), so it doesn't hurt to add it.

* collections.abc is available in Python 3.3 and later. _collections_abc
  is imported by the collections.abc stub, so its version range is also
  changed from 3.6- to 3.3-.
* _typeshed.tkinter needs to be 3.0-, since it imports tkinter, which is
  marked as 3.0-.
* importlib.metadata is available in 3.8 and later.