### PR TITLE
argparse#add_argument: make choices optional

### DIFF
--- a/stdlib/argparse.pyi
+++ b/stdlib/argparse.pyi
@@ -69,7 +69,7 @@ class _ActionsContainer:
         const: Any = ...,
         default: Any = ...,
         type: Union[Callable[[str], _T], Callable[[str], _T], FileType] = ...,
-        choices: Iterable[_T] = ...,
+        choices: Optional[Iterable[_T]] = ...,
         required: bool = ...,
         help: Optional[str] = ...,
         metavar: Optional[Union[str, Tuple[str, ...]]] = ...,


### PR DESCRIPTION
```py
import argparse
parser = argparse.ArgumentParser()
parser.add_argument('--a', choices=None)
parser.add_argument('--b', choices=[])
parser.add_argument('--c', choices=['1', '2'])
args = parser.parse_args()
```

Run:

```bash
> python3 test.py -h
usage: test.py [-h] [--a A] [--b {}] [--c {1,2}]

optional arguments:
  -h, --help  show this help message and exit
  --a A
  --b {}
  --c {1,2}
```