### PR TITLE
add types to tkinter.filedialog.ask*

### DIFF
--- a/stdlib/tkinter/filedialog.pyi
+++ b/stdlib/tkinter/filedialog.pyi
@@ -1,4 +1,5 @@
-from tkinter import Button, Entry, Frame, Listbox, Scrollbar, Toplevel, commondialog
+from _typeshed import StrOrBytesPath
+from tkinter import Button, Entry, Frame, Listbox, Misc, Scrollbar, StringVar, Toplevel, commondialog
 from typing import Any, ClassVar, Dict, Optional, Tuple
 
 dialogstates: Dict[Any, Tuple[Any, Any]]
@@ -57,11 +58,76 @@ class SaveAs(_Dialog):
 class Directory(commondialog.Dialog):
     command: ClassVar[str] = ...
 
-def askopenfilename(**options): ...
-def asksaveasfilename(**options): ...
-def askopenfilenames(**options): ...
-def askopenfile(mode: str = ..., **options): ...
-def askopenfiles(mode: str = ..., **options): ...
-def asksaveasfile(mode: str = ..., **options): ...
-def askdirectory(**options): ...
+# TODO: command kwarg available on macos
+def asksaveasfilename(
+    *,
+    confirmoverwrite: bool | None = ...,
+    defaultextension: str | None = ...,
+    filetypes: Iterable[Tuple[str, str] | Tuple[str, _TkinterSequence[str]]] | None = ...,
+    initialdir: StrOrBytesPath | None = ...,
+    initialfile: StrOrBytesPath | None = ...,
+    parent: Misc | None = ...,
+    title: str | None = ...,
+    typevariable: StringVar | str | None = ...,
+) -> str: ...  # can be empty string
+def askopenfilename(
+    *,
+    defaultextension: str | None = ...,
+    filetypes: Iterable[Tuple[str, str] | Tuple[str, _TkinterSequence[str]]] | None = ...,
+    initialdir: StrOrBytesPath | None = ...,
+    initialfile: StrOrBytesPath | None = ...,
+    parent: Misc | None = ...,
+    title: str | None = ...,
+    typevariable: StringVar | str | None = ...,
+) -> str: ...  # can be empty string
+def askopenfilenames(
+    *,
+    defaultextension: str | None = ...,
+    filetypes: Iterable[Tuple[str, str] | Tuple[str, _TkinterSequence[str]]] | None = ...,
+    initialdir: StrOrBytesPath | None = ...,
+    initialfile: StrOrBytesPath | None = ...,
+    parent: Misc | None = ...,
+    title: str | None = ...,
+    typevariable: StringVar | str | None = ...,
+) -> Literal[""] | Tuple[str, ...]: ...
+def askdirectory(
+    *, initialdir: StrOrBytesPath | None = ..., mustexist: bool | None = ..., parent: Misc | None = ..., title: str | None = ...
+) -> str: ...  # can be empty string
+
+# TODO: If someone actually uses these, overload to have the actual return type of open(..., mode)
+def asksaveasfile(
+    mode: str = ...,
+    *,
+    confirmoverwrite: bool | None = ...,
+    defaultextension: str | None = ...,
+    filetypes: Iterable[Tuple[str, str] | Tuple[str, _TkinterSequence[str]]] | None = ...,
+    initialdir: StrOrBytesPath | None = ...,
+    initialfile: StrOrBytesPath | None = ...,
+    parent: Misc | None = ...,
+    title: str | None = ...,
+    typevariable: StringVar | str | None = ...,
+) -> IO[Any] | None: ...
+def askopenfile(
+    mode: str = ...,
+    *,
+    defaultextension: str | None = ...,
+    filetypes: Iterable[Tuple[str, str] | Tuple[str, _TkinterSequence[str]]] | None = ...,
+    initialdir: StrOrBytesPath | None = ...,
+    initialfile: StrOrBytesPath | None = ...,
+    parent: Misc | None = ...,
+    title: str | None = ...,
+    typevariable: StringVar | str | None = ...,
+) -> IO[Any] | None: ...
+def askopenfiles(
+    mode: str = ...,
+    *,
+    defaultextension: str | None = ...,
+    filetypes: Iterable[Tuple[str, str] | Tuple[str, _TkinterSequence[str]]] | None = ...,
+    initialdir: StrOrBytesPath | None = ...,
+    initialfile: StrOrBytesPath | None = ...,
+    parent: Misc | None = ...,
+    title: str | None = ...,
+    typevariable: StringVar | str | None = ...,
+) -> Tuple[IO[Any], ...]: ...  # can be empty tuple
+
 def test() -> None: ...

--- a/stdlib/tkinter/filedialog.pyi
+++ b/stdlib/tkinter/filedialog.pyi
@@ -1,6 +1,7 @@
 from _typeshed import StrOrBytesPath
-from tkinter import Button, Entry, Frame, Listbox, Misc, Scrollbar, StringVar, Toplevel, commondialog
-from typing import Any, ClassVar, Dict, Optional, Tuple
+from tkinter import Button, Entry, Frame, Listbox, Misc, Scrollbar, StringVar, Toplevel, _TkinterSequence, commondialog
+from typing import Any, ClassVar, Dict, Iterable, Optional, Tuple
+from typing_extensions import Literal
 
 dialogstates: Dict[Any, Tuple[Any, Any]]
 

--- a/stdlib/tkinter/filedialog.pyi
+++ b/stdlib/tkinter/filedialog.pyi
@@ -1,6 +1,6 @@
 from _typeshed import StrOrBytesPath
 from tkinter import Button, Entry, Frame, Listbox, Misc, Scrollbar, StringVar, Toplevel, _TkinterSequence, commondialog
-from typing import Any, ClassVar, Dict, Iterable, Optional, Tuple
+from typing import IO, Any, ClassVar, Dict, Iterable, Optional, Tuple
 from typing_extensions import Literal
 
 dialogstates: Dict[Any, Tuple[Any, Any]]
@@ -130,5 +130,4 @@ def askopenfiles(
     title: str | None = ...,
     typevariable: StringVar | str | None = ...,
 ) -> Tuple[IO[Any], ...]: ...  # can be empty tuple
-
 def test() -> None: ...


### PR DESCRIPTION
Fixes #5571 

The options are documented in `tk_getOpenFile` and `tk_getSaveFile` manual page (they are both in the same manual page), but to figure out which options actually apply, it turns out to be easiest to give an invalid option:

```
>>> import tkinter.filedialog
>>> tkinter.filedialog.askopenfilename(lol="wat")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.7/tkinter/filedialog.py", line 375, in askopenfilename
    return Open(**options).show()
  File "/usr/lib/python3.7/tkinter/commondialog.py", line 43, in show
    s = w.tk.call(self.command, *w._options(self.options))
_tkinter.TclError: bad option "-lol": must be -defaultextension, -filetypes, -initialdir, -initialfile, -multiple, -parent, -title, or -typevariable
```