### PR TITLE
Update `random.choices` to include other types supported by `weights`

### DIFF
--- a/stdlib/random.pyi
+++ b/stdlib/random.pyi
@@ -1,6 +1,7 @@
 import _random
 import sys
 from collections.abc import Callable, Iterable, MutableSequence, Sequence, Set
+from fractions import Fraction
 from typing import Any, NoReturn, Optional, Tuple, TypeVar, Union
 
 _T = TypeVar("_T")
@@ -19,9 +20,9 @@ class Random(_random.Random):
     def choices(
         self,
         population: Sequence[_T],
-        weights: Optional[Sequence[float]] = ...,
+        weights: Optional[Sequence[Union[int, float, Fraction]]] = ...,
         *,
-        cum_weights: Optional[Sequence[float]] = ...,
+        cum_weights: Optional[Sequence[Union[int, float, Fraction]]] = ...,
         k: int = ...,
     ) -> list[_T]: ...
     def shuffle(self, x: MutableSequence[Any], random: Optional[Callable[[], float]] = ...) -> None: ...

--- a/stdlib/random.pyi
+++ b/stdlib/random.pyi
@@ -20,9 +20,9 @@ class Random(_random.Random):
     def choices(
         self,
         population: Sequence[_T],
-        weights: Optional[Sequence[Union[int, float, Fraction]]] = ...,
+        weights: Optional[Sequence[Union[float, Fraction]]] = ...,
         *,
-        cum_weights: Optional[Sequence[Union[int, float, Fraction]]] = ...,
+        cum_weights: Optional[Sequence[Union[float, Fraction]]] = ...,
         k: int = ...,
     ) -> list[_T]: ...
     def shuffle(self, x: MutableSequence[Any], random: Optional[Callable[[], float]] = ...) -> None: ...


### PR DESCRIPTION
Per [documentation of `random.choices()`](https://docs.python.org/3/library/random.html#random.choices):
> The *weights* or *cum_weights* can use any numeric type that interoperates with the `float` values returned by `random()` (that includes integers, floats, and fractions but excludes decimals)

I've also ensured that the type `Sequence[Union[...]]` is correct rather than `Union[Sequence[...], ...]`.