### PR TITLE
Use Literal for MatchSingleton

### DIFF
--- a/stdlib/_ast.pyi
+++ b/stdlib/_ast.pyi
@@ -1,6 +1,7 @@
 import sys
 import typing
 from typing import Any, ClassVar, Optional
+from typing_extensions import Literal
 
 PyCF_ONLY_AST: int
 if sys.version_info >= (3, 8):
@@ -390,7 +391,7 @@ if sys.version_info >= (3, 10):
     class MatchValue(pattern):
         value: expr
     class MatchSingleton(pattern):
-        value: Optional[bool]
+        value: Literal[True, False, None]
     class MatchSequence(pattern):
         patterns: typing.List[pattern]
     class MatchStar(pattern):


### PR DESCRIPTION
`MatchSingleton` can only ever be `True`, `False`, or `None`.
The current `Optional[bool]` is inaccurate for that as it also allows implicit booleans: `1 != 2`.

https://docs.python.org/3.10/library/ast.html#ast.MatchSingleton