### PR TITLE
Bump versions of obsolete packages

### DIFF
--- a/stubs/Flask/METADATA.toml
+++ b/stubs/Flask/METADATA.toml
@@ -1,4 +1,4 @@
-version = "0.1"
+version = "1.1"
 python2 = true
 requires = ["types-Jinja2", "types-Werkzeug", "types-click"]
 obsolete_since = "2.0"

--- a/stubs/Jinja2/METADATA.toml
+++ b/stubs/Jinja2/METADATA.toml
@@ -1,4 +1,4 @@
-version = "0.1"
+version = "2.11"
 python2 = true
 requires = ["types-MarkupSafe"]
 obsolete_since = "3.0"

--- a/stubs/MarkupSafe/METADATA.toml
+++ b/stubs/MarkupSafe/METADATA.toml
@@ -1,3 +1,3 @@
-version = "0.1"
+version = "1.1"
 python2 = true
 obsolete_since = "2.0"

--- a/stubs/Werkzeug/METADATA.toml
+++ b/stubs/Werkzeug/METADATA.toml
@@ -1,4 +1,4 @@
-version = "0.1"
+version = "1.0"
 python2 = true
 requires = []
 obsolete_since = "2.0"

--- a/stubs/click/METADATA.toml
+++ b/stubs/click/METADATA.toml
@@ -1,3 +1,3 @@
-version = "0.1"
+version = "7.1"
 python2 = true
 obsolete_since = "8.0"

--- a/stubs/itsdangerous/METADATA.toml
+++ b/stubs/itsdangerous/METADATA.toml
@@ -1,3 +1,3 @@
-version = "0.1"
+version = "1.1"
 python2 = true
 obsolete_since = "2.0"

--- a/stubs/jwt/METADATA.toml
+++ b/stubs/jwt/METADATA.toml
@@ -1,3 +1,3 @@
-version = "0.1"
+version = "1.7"
 requires = ["types-cryptography"]
 obsolete_since = "2.0.0"


### PR DESCRIPTION
To latest version pre obsoletion. While the minor versions are not necessarily 100% correct (it's possible that some stubs haven't been updated to the latest version), this is a clearer marker that these stubs are not intended to be used with the latest version that includes stubs.