### PR TITLE
Mark cryptography as obsolete

### DIFF
--- a/stubs/cryptography/METADATA.toml
+++ b/stubs/cryptography/METADATA.toml
@@ -1,3 +1,4 @@
-version = "0.1"
+version = "3.3"
 python2 = true
 requires = ["types-enum34", "types-ipaddress"]
+obsolete_since = "3.4.4"


### PR DESCRIPTION
Bump version to 3.3 (last version before Python 2 removal)