### PR TITLE
Signal handler callables take `int`, not `Signals`

### DIFF
--- a/stdlib/signal.pyi
+++ b/stdlib/signal.pyi
@@ -80,7 +80,7 @@ if sys.platform != "win32":
     SIG_SETMASK = Sigmasks.SIG_SETMASK
 
 _SIGNUM = Union[int, Signals]
-_HANDLER = Union[Callable[[Signals, FrameType], Any], int, Handlers, None]
+_HANDLER = Union[Callable[[int, Optional[FrameType]], Any], int, Handlers, None]
 
 SIGABRT: Signals
 if sys.platform != "win32":


### PR DESCRIPTION
Closes #5621.

In the `Callable` variant of `signal._HANDLER`, change `Signals` to `int` and `FrameType` to `Optional[FrameType]`.