### PR TITLE
use TextIOWrapper for sys.__stdin__, sys.__stdout__, sys.__stderr__

### DIFF
--- a/stdlib/sys.pyi
+++ b/stdlib/sys.pyi
@@ -1,5 +1,6 @@
 import sys
 from builtins import object as _object
+from io import TextIOWrapper
 from importlib.abc import Loader, PathEntryFinder
 from importlib.machinery import ModuleSpec
 from types import FrameType, ModuleType, TracebackType
@@ -74,14 +75,14 @@ if sys.version_info >= (3, 8):
     pycache_prefix: Optional[str]
 ps1: str
 ps2: str
-stdin: TextIO
-stdout: TextIO
-stderr: TextIO
+stdin: TextIOWrapper
+stdout: TextIOWrapper
+stderr: TextIOWrapper
 if sys.version_info >= (3, 10):
     stdlib_module_names: FrozenSet[str]
-__stdin__: TextIO
-__stdout__: TextIO
-__stderr__: TextIO
+__stdin__: TextIOWrapper
+__stdout__: TextIOWrapper
+__stderr__: TextIOWrapper
 tracebacklimit: int
 version: str
 api_version: int

--- a/stdlib/sys.pyi
+++ b/stdlib/sys.pyi
@@ -15,7 +15,6 @@ from typing import (
     Optional,
     Protocol,
     Sequence,
-    TextIO,
     Tuple,
     Type,
     TypeVar,

--- a/stdlib/sys.pyi
+++ b/stdlib/sys.pyi
@@ -15,6 +15,7 @@ from typing import (
     Optional,
     Protocol,
     Sequence,
+    TextIO,
     Tuple,
     Type,
     TypeVar,
@@ -74,9 +75,9 @@ if sys.version_info >= (3, 8):
     pycache_prefix: Optional[str]
 ps1: str
 ps2: str
-stdin: TextIOWrapper
-stdout: TextIOWrapper
-stderr: TextIOWrapper
+stdin: TextIO
+stdout: TextIO
+stderr: TextIO
 if sys.version_info >= (3, 10):
     stdlib_module_names: FrozenSet[str]
 __stdin__: TextIOWrapper

--- a/stdlib/sys.pyi
+++ b/stdlib/sys.pyi
@@ -1,8 +1,8 @@
 import sys
 from builtins import object as _object
-from io import TextIOWrapper
 from importlib.abc import Loader, PathEntryFinder
 from importlib.machinery import ModuleSpec
+from io import TextIOWrapper
 from types import FrameType, ModuleType, TracebackType
 from typing import (
     Any,


### PR DESCRIPTION
Hey I ran across this since my [sys.stdout.reconfigure](https://docs.python.org/3/library/io.html#io.TextIOWrapper.reconfigure) call wasn't recognized.
If this is incorrect and I'm misunderstanding/missing something, please let me know :)
![image](https://user-images.githubusercontent.com/17343631/121749627-fa899780-cad8-11eb-8f2a-45cff8fa63ca.png)
```py
>>> import sys
>>> [type(getattr(sys, x)) for x in ['stdin', 'stdout', 'stderr', '__stdin__', '__stdout__', '__stderr__']]
[<class '_io.TextIOWrapper'>, <class '_io.TextIOWrapper'>, <class '_io.TextIOWrapper'>, <class '_io.TextIOWrapper'>, <class '_io.TextIOWrapper'>, <class '_io.TextIOWrapper'>]
```
