### PR TITLE
Flag LogRecord.args as optional

### DIFF
--- a/stdlib/logging/__init__.pyi
+++ b/stdlib/logging/__init__.pyi
@@ -326,7 +326,9 @@ class Filter:
     def filter(self, record: LogRecord) -> bool: ...
 
 class LogRecord:
-    args: _ArgsType
+    # args can be set to None by logging.handlers.QueueHandler
+    # (see https://bugs.python.org/issue44473)
+    args: Optional[_ArgsType]
     asctime: str
     created: float
     exc_info: Optional[_SysExcInfoType]


### PR DESCRIPTION
logging.handlers.QueueHandler sets the arguments of a log record to None. See https://bugs.python.org/issue44473.

Resolved #5713