### PR TITLE
stdlib logging: specify style type as literal choice

### DIFF
--- a/stdlib/logging/__init__.pyi
+++ b/stdlib/logging/__init__.pyi
@@ -14,7 +14,7 @@ _ExcInfoType = Union[None, bool, _SysExcInfoType, BaseException]
 _ArgsType = Union[Tuple[Any, ...], Mapping[str, Any]]
 _FilterType = Union[Filter, Callable[[LogRecord], int]]
 _Level = Union[int, str]
-_FormatStyle = Literal['%', '{', '$']
+_FormatStyle = Literal["%", "{", "$"]
 
 raiseExceptions: bool
 logThreads: bool

--- a/stdlib/logging/__init__.pyi
+++ b/stdlib/logging/__init__.pyi
@@ -7,12 +7,14 @@ from string import Template
 from time import struct_time
 from types import FrameType, TracebackType
 from typing import Any, ClassVar, Generic, Optional, Pattern, TextIO, Tuple, Type, TypeVar, Union, overload
+from typing_extensions import Literal
 
 _SysExcInfoType = Union[Tuple[Type[BaseException], BaseException, Optional[TracebackType]], Tuple[None, None, None]]
 _ExcInfoType = Union[None, bool, _SysExcInfoType, BaseException]
 _ArgsType = Union[Tuple[Any, ...], Mapping[str, Any]]
 _FilterType = Union[Filter, Callable[[LogRecord], int]]
 _Level = Union[int, str]
+_FormatStyle = Literal['%', '{', '$']
 
 raiseExceptions: bool
 logThreads: bool
@@ -301,10 +303,10 @@ class Formatter:
 
     if sys.version_info >= (3, 8):
         def __init__(
-            self, fmt: Optional[str] = ..., datefmt: Optional[str] = ..., style: str = ..., validate: bool = ...
+            self, fmt: Optional[str] = ..., datefmt: Optional[str] = ..., style: _FormatStyle = ..., validate: bool = ...
         ) -> None: ...
     else:
-        def __init__(self, fmt: Optional[str] = ..., datefmt: Optional[str] = ..., style: str = ...) -> None: ...
+        def __init__(self, fmt: Optional[str] = ..., datefmt: Optional[str] = ..., style: _FormatStyle = ...) -> None: ...
     def format(self, record: LogRecord) -> str: ...
     def formatTime(self, record: LogRecord, datefmt: Optional[str] = ...) -> str: ...
     def formatException(self, ei: _SysExcInfoType) -> str: ...
@@ -711,7 +713,7 @@ if sys.version_info >= (3, 9):
         filemode: str = ...,
         format: str = ...,
         datefmt: Optional[str] = ...,
-        style: str = ...,
+        style: _FormatStyle = ...,
         level: Optional[_Level] = ...,
         stream: Optional[SupportsWrite[str]] = ...,
         handlers: Optional[Iterable[Handler]] = ...,
@@ -727,7 +729,7 @@ elif sys.version_info >= (3, 8):
         filemode: str = ...,
         format: str = ...,
         datefmt: Optional[str] = ...,
-        style: str = ...,
+        style: _FormatStyle = ...,
         level: Optional[_Level] = ...,
         stream: Optional[SupportsWrite[str]] = ...,
         handlers: Optional[Iterable[Handler]] = ...,
@@ -741,7 +743,7 @@ else:
         filemode: str = ...,
         format: str = ...,
         datefmt: Optional[str] = ...,
-        style: str = ...,
+        style: _FormatStyle = ...,
         level: Optional[_Level] = ...,
         stream: Optional[SupportsWrite[str]] = ...,
         handlers: Optional[Iterable[Handler]] = ...,


### PR DESCRIPTION
documented for style parameter: https://docs.python.org/3/library/logging.html#logging.Formatter
