### PR TITLE
Add json.py_encode_basestring stubs

### DIFF
--- a/stdlib/json/encoder.pyi
+++ b/stdlib/json/encoder.pyi
@@ -1,5 +1,8 @@
 from typing import Any, Callable, Iterator, Optional, Tuple
 
+def py_encode_basestring(s: str) -> str: ...  # undocumented
+def py_encode_basestring_ascii(s: str) -> str: ...  # undocumented
+
 class JSONEncoder:
     item_separator: str
     key_separator: str


### PR DESCRIPTION
Both functions are undocumented, but not private.