### PR TITLE
Allow requests to have bool in params arg

### DIFF
--- a/stubs/requests/requests/sessions.pyi
+++ b/stubs/requests/requests/sessions.pyi
@@ -49,8 +49,8 @@ _Hook = Callable[[Response], Any]
 _Hooks = MutableMapping[Text, List[_Hook]]
 _HooksInput = MutableMapping[Text, Union[Iterable[_Hook], _Hook]]
 
-_ParamsMappingKeyType = Union[Text, bytes, int, float]
-_ParamsMappingValueType = Union[Text, bytes, int, float, Iterable[Union[Text, bytes, int, float]], None]
+_ParamsMappingKeyType = Union[Text, bytes, int, float, bool]
+_ParamsMappingValueType = Union[Text, bytes, int, float, bool, Iterable[Union[Text, bytes, int, float, bool]], None]
 _Params = Union[
     SupportsItems[_ParamsMappingKeyType, _ParamsMappingValueType],
     Tuple[_ParamsMappingKeyType, _ParamsMappingValueType],


### PR DESCRIPTION
 - Booleans are valid keys/values for params

Example of this working with booleans:
```python
requests.request('get', 'http://localhost:4444/123', params={'a': True, True: 'b'})
```


```
$ nc -l -p 4444
GET /123?a=True&True=b HTTP/1.1
Host: localhost:4444
User-Agent: python-requests/2.25.1
Accept-Encoding: gzip, deflate
Accept: */*
Connection: keep-alive
```

Thanks!
