### PR TITLE
Run mypy tests for stdlib and third-party separately

### DIFF
--- a/requirements-tests-py3.txt
+++ b/requirements-tests-py3.txt
@@ -1,8 +1,8 @@
-mypy==0.902
+mypy==0.910
 typed-ast==1.4.3
 black==21.6b0
 flake8==3.9.2
 flake8-bugbear==21.4.3
 flake8-pyi==20.10.0
-isort==5.8.0
+isort==5.9.2
 pytype==2021.06.17

--- a/tests/mypy_test.py
+++ b/tests/mypy_test.py
@@ -186,46 +186,43 @@ def run_mypy(args, configurations, major, minor, files):
         print("Cannot import mypy. Did you install it?")
         sys.exit(1)
 
-    with tempfile.NamedTemporaryFile("w+", delete=False) as temp:
+    with tempfile.NamedTemporaryFile("w+") as temp:
         temp.write("[mypy]\n")
-
         for dist_conf in configurations:
             temp.write("[mypy-%s]\n" % dist_conf.module_name)
             for k, v in dist_conf.values.items():
                 temp.write("{} = {}\n".format(k, v))
+        temp.flush()
 
-        config_file_name = temp.name
-    flags = [
-        "--python-version", "%d.%d" % (major, minor),
-        "--config-file", config_file_name,
-        "--strict-optional",
-        "--no-site-packages",
-        "--show-traceback",
-        "--no-implicit-optional",
-        "--disallow-any-generics",
-        "--disallow-subclassing-any",
-        "--warn-incomplete-stub",
-        # Setting custom typeshed dir prevents mypy from falling back to its bundled
-        # typeshed in case of stub deletions
-        "--custom-typeshed-dir", os.path.dirname(os.path.dirname(__file__)),
-    ]
-    if args.warn_unused_ignores:
-        flags.append("--warn-unused-ignores")
-    if args.platform:
-        flags.extend(["--platform", args.platform])
-    sys.argv = ["mypy"] + flags + files
-    if args.verbose:
-        print("running", " ".join(sys.argv))
-    else:
-        print("running mypy", " ".join(flags), "# with", len(files), "files")
-    try:
+        flags = [
+            "--python-version", "%d.%d" % (major, minor),
+            "--config-file", temp.name,
+            "--strict-optional",
+            "--no-site-packages",
+            "--show-traceback",
+            "--no-implicit-optional",
+            "--disallow-any-generics",
+            "--disallow-subclassing-any",
+            "--warn-incomplete-stub",
+            # Setting custom typeshed dir prevents mypy from falling back to its bundled
+            # typeshed in case of stub deletions
+            "--custom-typeshed-dir", os.path.dirname(os.path.dirname(__file__)),
+        ]
+        if args.warn_unused_ignores:
+            flags.append("--warn-unused-ignores")
+        if args.platform:
+            flags.extend(["--platform", args.platform])
+        sys.argv = ["mypy"] + flags + files
+        if args.verbose:
+            print("running", " ".join(sys.argv))
+        else:
+            print("running mypy", " ".join(flags), "# with", len(files), "files")
         if not args.dry_run:
-            mypy_main("", sys.stdout, sys.stderr)
-    except SystemExit as err:
-        return err.code
-    finally:
-        os.remove(config_file_name)
-    return 0
+            try:
+                mypy_main("", sys.stdout, sys.stderr)
+            except SystemExit as err:
+                return err.code
+        return 0
 
 def main():
     args = parser.parse_args()

--- a/tests/mypy_test.py
+++ b/tests/mypy_test.py
@@ -16,15 +16,14 @@ import argparse
 import os
 import re
 import sys
-import toml
 import tempfile
 from glob import glob
 from pathlib import Path
 from typing import Dict, NamedTuple
 
-parser = argparse.ArgumentParser(
-    description="Test runner for typeshed. Patterns are unanchored regexps on the full path."
-)
+import toml
+
+parser = argparse.ArgumentParser(description="Test runner for typeshed. Patterns are unanchored regexps on the full path.")
 parser.add_argument("-v", "--verbose", action="count", default=0, help="More output")
 parser.add_argument("-n", "--dry-run", action="store_true", help="Don't actually run mypy")
 parser.add_argument("-x", "--exclude", type=str, nargs="*", help="Exclude pattern")
@@ -123,10 +122,7 @@ def add_files(files, seen, root, name, args, exclude_list):
         if match(full, args, exclude_list):
             seen.add(mod)
             files.append(full)
-    elif (
-        os.path.isfile(os.path.join(full, "__init__.pyi")) or
-        os.path.isfile(os.path.join(full, "__init__.py"))
-    ):
+    elif os.path.isfile(os.path.join(full, "__init__.pyi")) or os.path.isfile(os.path.join(full, "__init__.py")):
         for r, ds, fs in os.walk(full):
             ds.sort()
             fs.sort()
@@ -142,6 +138,7 @@ def add_files(files, seen, root, name, args, exclude_list):
 class MypyDistConf(NamedTuple):
     module_name: str
     values: Dict
+
 
 # The configuration section in the metadata file looks like the following, with multiple module sections possible
 # [mypy-tests]
@@ -195,8 +192,10 @@ def run_mypy(args, configurations, major, minor, files, *, custom_typeshed=False
         temp.flush()
 
         flags = [
-            "--python-version", "%d.%d" % (major, minor),
-            "--config-file", temp.name,
+            "--python-version",
+            "%d.%d" % (major, minor),
+            "--config-file",
+            temp.name,
             "--strict-optional",
             "--no-site-packages",
             "--show-traceback",
@@ -208,10 +207,7 @@ def run_mypy(args, configurations, major, minor, files, *, custom_typeshed=False
         if custom_typeshed:
             # Setting custom typeshed dir prevents mypy from falling back to its bundled
             # typeshed in case of stub deletions
-            flags.extend([
-                "--custom-typeshed-dir",
-                os.path.dirname(os.path.dirname(__file__)),
-            ])
+            flags.extend(["--custom-typeshed-dir", os.path.dirname(os.path.dirname(__file__))])
         if args.warn_unused_ignores:
             flags.append("--warn-unused-ignores")
         if args.platform:
@@ -227,6 +223,7 @@ def run_mypy(args, configurations, major, minor, files, *, custom_typeshed=False
             except SystemExit as err:
                 return err.code
         return 0
+
 
 def main():
     args = parser.parse_args()


### PR DESCRIPTION
This is part of #5751. It runs the mypy tests for stdlib and third-party stubs separately and has the option of running third-party stubs with the distributed typeshed package. This option is currently not enabled, because we already ship third-party stubs using `_typeshed` features not shipped with latest mypy.

This is best reviewed commit by commit.