### PR TITLE
Support arbitrary values for extension values

### DIFF
--- a/stubs/protobuf/google/protobuf/internal/extension_dict.pyi
+++ b/stubs/protobuf/google/protobuf/internal/extension_dict.pyi
@@ -1,10 +1,10 @@
-from typing import Any, Generic, Iterator, TypeVar
+from typing import Any, Generic, Iterator, Text, TypeVar, Union
 
 from google.protobuf.descriptor import FieldDescriptor
 from google.protobuf.message import Message
 
 _ContainerMessageT = TypeVar("_ContainerMessageT", bound=Message)
-_ExtenderMessageT = TypeVar("_ExtenderMessageT", bound=Message)
+_ExtenderMessageT = TypeVar("_ExtenderMessageT", bound=Union[Message, bool, int, float, Text, bytes])
 
 class _ExtensionFieldDescriptor(FieldDescriptor, Generic[_ContainerMessageT, _ExtenderMessageT]): ...
 


### PR DESCRIPTION
Proto itself supports primitives, not just messages.
See https://github.com/dropbox/mypy-protobuf/issues/244 for an example
motivating this change.

Test Plan: I was able to use MYPYPATH to test an updated version of
mypy-protobuf with this change.