### PR TITLE
Fix import sorting in create_baseline_stubs script

### DIFF
--- a/scripts/create_baseline_stubs.py
+++ b/scripts/create_baseline_stubs.py
@@ -7,6 +7,7 @@ Run with -h for more help.
 """
 
 import argparse
+import glob
 import os
 import re
 import shutil
@@ -67,7 +68,9 @@ def run_black(stub_dir: str) -> None:
 
 def run_isort(stub_dir: str) -> None:
     print(f"Running isort: isort --recursive {stub_dir}")
-    subprocess.run(["isort", "--recursive", stub_dir])
+    paths = glob.glob(os.path.join(stub_dir, "**", "*.pyi"), recursive=True)
+    if paths:
+        subprocess.run(["isort"] + paths)
 
 
 def create_metadata(stub_dir: str, version: str) -> None:
@@ -150,8 +153,8 @@ def main() -> None:
     # Stubs were generated under out/. Copy them to stubs/.
     copy_stubs("out", package, stub_dir)
 
-    run_black(stub_dir)
     run_isort(stub_dir)
+    run_black(stub_dir)
 
     create_metadata(stub_dir, version)
 

--- a/scripts/create_baseline_stubs.py
+++ b/scripts/create_baseline_stubs.py
@@ -7,7 +7,6 @@ Run with -h for more help.
 """
 
 import argparse
-import glob
 import os
 import re
 import shutil
@@ -67,10 +66,8 @@ def run_black(stub_dir: str) -> None:
 
 
 def run_isort(stub_dir: str) -> None:
-    print(f"Running isort: isort --recursive {stub_dir}")
-    paths = glob.glob(os.path.join(stub_dir, "**", "*.pyi"), recursive=True)
-    if paths:
-        subprocess.run(["isort"] + paths)
+    print(f"Running isort: isort {stub_dir}")
+    subprocess.run(["python3", "-m", "isort", stub_dir])
 
 
 def create_metadata(stub_dir: str, version: str) -> None:


### PR DESCRIPTION
The isort `--recursive` option doesn't recognize `.pyi` files, so find all
`.pyi` files explicitly.

Run isort before black since changes made by isort don't follow stub
conventions.