### PR TITLE
Supported repeated field containers for extensions

### DIFF
--- a/stubs/protobuf/google/protobuf/internal/extension_dict.pyi
+++ b/stubs/protobuf/google/protobuf/internal/extension_dict.pyi
@@ -1,10 +1,14 @@
 from typing import Any, Generic, Iterator, Text, TypeVar, Union
 
 from google.protobuf.descriptor import FieldDescriptor
+from google.protobuf.internal.containers import RepeatedCompositeFieldContainer, RepeatedScalarFieldContainer
 from google.protobuf.message import Message
 
 _ContainerMessageT = TypeVar("_ContainerMessageT", bound=Message)
-_ExtenderMessageT = TypeVar("_ExtenderMessageT", bound=Union[Message, bool, int, float, Text, bytes])
+_ExtenderMessageT = TypeVar(
+    "_ExtenderMessageT",
+    bound=Union[Message, RepeatedScalarFieldContainer[Any], RepeatedCompositeFieldContainer[Any], bool, int, float, Text, bytes],
+)
 
 class _ExtensionFieldDescriptor(FieldDescriptor, Generic[_ContainerMessageT, _ExtenderMessageT]): ...
 


### PR DESCRIPTION
See https://github.com/dropbox/mypy-protobuf/issues/244 for the
inspiration for this. Repeated extensions are allowed by protobuf,
and they generate to extension values with repeated fields.

Notably map fields (ScalarMap and MessageMap) are NOT allowed to be
extension values - producing errors as such - so those are omitted.

testproto/test_extensions3.proto:19:6: Map fields are not allowed to be extensions.