### PR TITLE
Update protobuf generated stubs from mypy-protobuf 2.8

### DIFF
--- a/scripts/generate_proto_stubs.sh
+++ b/scripts/generate_proto_stubs.sh
@@ -10,7 +10,7 @@
 #
 # Update these two variables when rerunning script
 PROTOBUF_VERSION=3.17.3
-MYPY_PROTOBUF_VERSION=v2.6
+MYPY_PROTOBUF_VERSION=v2.8
 
 set -ex
 
@@ -73,3 +73,5 @@ protoc_install/bin/protoc --proto_path=$PYTHON_PROTOBUF_DIR/src --mypy_out=$REPO
 
 isort $REPO_ROOT/stubs/protobuf
 black $REPO_ROOT/stubs/protobuf
+
+sed -i="" "s/mypy-protobuf [^\"]*/mypy-protobuf ${MYPY_PROTOBUF_VERSION}/" $REPO_ROOT/stubs/protobuf/METADATA.toml

--- a/stubs/protobuf/@tests/stubtest_allowlist.txt
+++ b/stubs/protobuf/@tests/stubtest_allowlist.txt
@@ -9,6 +9,7 @@ google.protobuf.compiler.plugin_pb2.CodeGeneratorResponse.FEATURE_PROTO3_OPTIONA
 google.protobuf.compiler.plugin_pb2.CodeGeneratorResponse.Feature
 google.protobuf.compiler.plugin_pb2.CodeGeneratorResponse.File.__init__
 google.protobuf.compiler.plugin_pb2.CodeGeneratorResponse._Feature
+google.protobuf.compiler.plugin_pb2.CodeGeneratorResponse._FeatureEnumTypeWrapper
 google.protobuf.compiler.plugin_pb2.CodeGeneratorResponse.__init__
 google.protobuf.compiler.plugin_pb2.Version.__init__
 google.protobuf.descriptor.Descriptor.__new__
@@ -49,7 +50,9 @@ google.protobuf.descriptor_pb2.FieldDescriptorProto.TYPE_UINT32
 google.protobuf.descriptor_pb2.FieldDescriptorProto.TYPE_UINT64
 google.protobuf.descriptor_pb2.FieldDescriptorProto.Type
 google.protobuf.descriptor_pb2.FieldDescriptorProto._Label
+google.protobuf.descriptor_pb2.FieldDescriptorProto._LabelEnumTypeWrapper
 google.protobuf.descriptor_pb2.FieldDescriptorProto._Type
+google.protobuf.descriptor_pb2.FieldDescriptorProto._TypeEnumTypeWrapper
 google.protobuf.descriptor_pb2.FieldDescriptorProto.__init__
 google.protobuf.descriptor_pb2.FieldOptions.CORD
 google.protobuf.descriptor_pb2.FieldOptions.CType
@@ -60,7 +63,9 @@ google.protobuf.descriptor_pb2.FieldOptions.JS_STRING
 google.protobuf.descriptor_pb2.FieldOptions.STRING
 google.protobuf.descriptor_pb2.FieldOptions.STRING_PIECE
 google.protobuf.descriptor_pb2.FieldOptions._CType
+google.protobuf.descriptor_pb2.FieldOptions._CTypeEnumTypeWrapper
 google.protobuf.descriptor_pb2.FieldOptions._JSType
+google.protobuf.descriptor_pb2.FieldOptions._JSTypeEnumTypeWrapper
 google.protobuf.descriptor_pb2.FieldOptions.__init__
 google.protobuf.descriptor_pb2.FileDescriptorProto.__init__
 google.protobuf.descriptor_pb2.FileDescriptorSet.__init__
@@ -69,6 +74,7 @@ google.protobuf.descriptor_pb2.FileOptions.LITE_RUNTIME
 google.protobuf.descriptor_pb2.FileOptions.OptimizeMode
 google.protobuf.descriptor_pb2.FileOptions.SPEED
 google.protobuf.descriptor_pb2.FileOptions._OptimizeMode
+google.protobuf.descriptor_pb2.FileOptions._OptimizeModeEnumTypeWrapper
 google.protobuf.descriptor_pb2.FileOptions.__init__
 google.protobuf.descriptor_pb2.GeneratedCodeInfo.Annotation.__init__
 google.protobuf.descriptor_pb2.GeneratedCodeInfo.__init__
@@ -79,6 +85,7 @@ google.protobuf.descriptor_pb2.MethodOptions.IDEMPOTENT
 google.protobuf.descriptor_pb2.MethodOptions.IdempotencyLevel
 google.protobuf.descriptor_pb2.MethodOptions.NO_SIDE_EFFECTS
 google.protobuf.descriptor_pb2.MethodOptions._IdempotencyLevel
+google.protobuf.descriptor_pb2.MethodOptions._IdempotencyLevelEnumTypeWrapper
 google.protobuf.descriptor_pb2.MethodOptions.__init__
 google.protobuf.descriptor_pb2.OneofDescriptorProto.__init__
 google.protobuf.descriptor_pb2.OneofOptions.__init__
@@ -154,7 +161,9 @@ google.protobuf.type_pb2.Field.TYPE_UINT32
 google.protobuf.type_pb2.Field.TYPE_UINT64
 google.protobuf.type_pb2.Field.TYPE_UNKNOWN
 google.protobuf.type_pb2.Field._Cardinality
+google.protobuf.type_pb2.Field._CardinalityEnumTypeWrapper
 google.protobuf.type_pb2.Field._Kind
+google.protobuf.type_pb2.Field._KindEnumTypeWrapper
 google.protobuf.type_pb2.Field.__init__
 google.protobuf.type_pb2.Option.__init__
 google.protobuf.type_pb2.SYNTAX_PROTO2

--- a/stubs/protobuf/METADATA.toml
+++ b/stubs/protobuf/METADATA.toml
@@ -1,4 +1,4 @@
 version = "3.17"
 python2 = true
 requires = ["types-futures"]
-extra_description = "Generated with aid from mypy-protobuf 2.6"
+extra_description = "Generated with aid from mypy-protobuf v2.8"

--- a/stubs/protobuf/google/protobuf/any_pb2.pyi
+++ b/stubs/protobuf/google/protobuf/any_pb2.pyi
@@ -11,13 +11,122 @@ import typing_extensions
 
 DESCRIPTOR: google.protobuf.descriptor.FileDescriptor = ...
 
+# `Any` contains an arbitrary serialized protocol buffer message along with a
+# URL that describes the type of the serialized message.
+#
+# Protobuf library provides support to pack/unpack Any values in the form
+# of utility functions or additional generated methods of the Any type.
+#
+# Example 1: Pack and unpack a message in C++.
+#
+#     Foo foo = ...;
+#     Any any;
+#     any.PackFrom(foo);
+#     ...
+#     if (any.UnpackTo(&foo)) {
+#       ...
+#     }
+#
+# Example 2: Pack and unpack a message in Java.
+#
+#     Foo foo = ...;
+#     Any any = Any.pack(foo);
+#     ...
+#     if (any.is(Foo.class)) {
+#       foo = any.unpack(Foo.class);
+#     }
+#
+#  Example 3: Pack and unpack a message in Python.
+#
+#     foo = Foo(...)
+#     any = Any()
+#     any.Pack(foo)
+#     ...
+#     if any.Is(Foo.DESCRIPTOR):
+#       any.Unpack(foo)
+#       ...
+#
+#  Example 4: Pack and unpack a message in Go
+#
+#      foo := &pb.Foo{...}
+#      any, err := anypb.New(foo)
+#      if err != nil {
+#        ...
+#      }
+#      ...
+#      foo := &pb.Foo{}
+#      if err := any.UnmarshalTo(foo); err != nil {
+#        ...
+#      }
+#
+# The pack methods provided by protobuf library will by default use
+# 'type.googleapis.com/full.type.name' as the type URL and the unpack
+# methods only use the fully qualified type name after the last '/'
+# in the type URL, for example "foo.bar.com/x/y.z" will yield type
+# name "y.z".
+#
+#
+# JSON
+# ====
+# The JSON representation of an `Any` value uses the regular
+# representation of the deserialized, embedded message, with an
+# additional field `@type` which contains the type URL. Example:
+#
+#     package google.profile;
+#     message Person {
+#       string first_name = 1;
+#       string last_name = 2;
+#     }
+#
+#     {
+#       "@type": "type.googleapis.com/google.profile.Person",
+#       "firstName": <string>,
+#       "lastName": <string>
+#     }
+#
+# If the embedded message type is well-known and has a custom JSON
+# representation, that representation will be embedded adding a field
+# `value` which holds the custom JSON in addition to the `@type`
+# field. Example (for message [google.protobuf.Duration][]):
+#
+#     {
+#       "@type": "type.googleapis.com/google.protobuf.Duration",
+#       "value": "1.212s"
+#     }
 class Any(google.protobuf.message.Message, google.protobuf.internal.well_known_types.Any):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
     TYPE_URL_FIELD_NUMBER: builtins.int
     VALUE_FIELD_NUMBER: builtins.int
+    # A URL/resource name that uniquely identifies the type of the serialized
+    # protocol buffer message. This string must contain at least
+    # one "/" character. The last segment of the URL's path must represent
+    # the fully qualified name of the type (as in
+    # `path/google.protobuf.Duration`). The name should be in a canonical form
+    # (e.g., leading "." is not accepted).
+    #
+    # In practice, teams usually precompile into the binary all types that they
+    # expect it to use in the context of Any. However, for URLs which use the
+    # scheme `http`, `https`, or no scheme, one can optionally set up a type
+    # server that maps type URLs to message definitions as follows:
+    #
+    # * If no scheme is provided, `https` is assumed.
+    # * An HTTP GET on the URL must yield a [google.protobuf.Type][]
+    #   value in binary format, or produce an error.
+    # * Applications are allowed to cache lookup results based on the
+    #   URL, or have them precompiled into a binary to avoid any
+    #   lookup. Therefore, binary compatibility needs to be preserved
+    #   on changes to types. (Use versioned type names to manage
+    #   breaking changes.)
+    #
+    # Note: this functionality is not currently available in the official
+    # protobuf release, and it is not used for type URLs beginning with
+    # type.googleapis.com.
+    #
+    # Schemes other than `http`, `https` (or the empty scheme) might be
+    # used with implementation specific semantics.
     type_url: typing.Text = ...
+    # Must be a valid serialized protocol buffer of the above specified type.
     value: builtins.bytes = ...
-
     def __init__(self,
         *,
         type_url : typing.Text = ...,

--- a/stubs/protobuf/google/protobuf/api_pb2.pyi
+++ b/stubs/protobuf/google/protobuf/api_pb2.pyi
@@ -13,6 +13,15 @@ import typing_extensions
 
 DESCRIPTOR: google.protobuf.descriptor.FileDescriptor = ...
 
+# Api is a light-weight descriptor for an API Interface.
+#
+# Interfaces are also described as "protocol buffer services" in some contexts,
+# such as by the "service" keyword in a .proto file, but they are different
+# from API Services, which represent a concrete implementation of an interface
+# as opposed to simply a description of methods and bindings. They are also
+# sometimes simply referred to as "APIs" in other contexts, such as the name of
+# this message itself. See https://cloud.google.com/apis/design/glossary for
+# detailed terminology.
 class Api(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
     NAME_FIELD_NUMBER: builtins.int
@@ -22,22 +31,44 @@ class Api(google.protobuf.message.Message):
     SOURCE_CONTEXT_FIELD_NUMBER: builtins.int
     MIXINS_FIELD_NUMBER: builtins.int
     SYNTAX_FIELD_NUMBER: builtins.int
+    # The fully qualified name of this interface, including package name
+    # followed by the interface's simple name.
     name: typing.Text = ...
-    version: typing.Text = ...
-    syntax: google.protobuf.type_pb2.Syntax.V = ...
-
+    # The methods of this interface, in unspecified order.
     @property
     def methods(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[global___Method]: ...
-
+    # Any metadata attached to the interface.
     @property
     def options(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[google.protobuf.type_pb2.Option]: ...
-
+    # A version string for this interface. If specified, must have the form
+    # `major-version.minor-version`, as in `1.10`. If the minor version is
+    # omitted, it defaults to zero. If the entire version field is empty, the
+    # major version is derived from the package name, as outlined below. If the
+    # field is not empty, the version in the package name will be verified to be
+    # consistent with what is provided here.
+    #
+    # The versioning schema uses [semantic
+    # versioning](http://semver.org) where the major version number
+    # indicates a breaking change and the minor version an additive,
+    # non-breaking change. Both version numbers are signals to users
+    # what to expect from different versions, and should be carefully
+    # chosen based on the product plan.
+    #
+    # The major version is also reflected in the package name of the
+    # interface, which must end in `v<major-version>`, as in
+    # `google.feature.v1`. For major versions 0 and 1, the suffix can
+    # be omitted. Zero major versions must only be used for
+    # experimental, non-GA interfaces.
+    version: typing.Text = ...
+    # Source context for the protocol buffer service represented by this
+    # message.
     @property
     def source_context(self) -> google.protobuf.source_context_pb2.SourceContext: ...
-
+    # Included interfaces. See [Mixin][].
     @property
     def mixins(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[global___Mixin]: ...
-
+    # The source syntax of the service.
+    syntax: google.protobuf.type_pb2.Syntax.V = ...
     def __init__(self,
         *,
         name : typing.Text = ...,
@@ -52,6 +83,7 @@ class Api(google.protobuf.message.Message):
     def ClearField(self, field_name: typing_extensions.Literal[u"methods",b"methods",u"mixins",b"mixins",u"name",b"name",u"options",b"options",u"source_context",b"source_context",u"syntax",b"syntax",u"version",b"version"]) -> None: ...
 global___Api = Api
 
+# Method represents a method of an API interface.
 class Method(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
     NAME_FIELD_NUMBER: builtins.int
@@ -61,16 +93,21 @@ class Method(google.protobuf.message.Message):
     RESPONSE_STREAMING_FIELD_NUMBER: builtins.int
     OPTIONS_FIELD_NUMBER: builtins.int
     SYNTAX_FIELD_NUMBER: builtins.int
+    # The simple name of this method.
     name: typing.Text = ...
+    # A URL of the input message type.
     request_type_url: typing.Text = ...
+    # If true, the request is streamed.
     request_streaming: builtins.bool = ...
+    # The URL of the output message type.
     response_type_url: typing.Text = ...
+    # If true, the response is streamed.
     response_streaming: builtins.bool = ...
-    syntax: google.protobuf.type_pb2.Syntax.V = ...
-
+    # Any metadata attached to the method.
     @property
     def options(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[google.protobuf.type_pb2.Option]: ...
-
+    # The source syntax of this method.
+    syntax: google.protobuf.type_pb2.Syntax.V = ...
     def __init__(self,
         *,
         name : typing.Text = ...,
@@ -84,13 +121,93 @@ class Method(google.protobuf.message.Message):
     def ClearField(self, field_name: typing_extensions.Literal[u"name",b"name",u"options",b"options",u"request_streaming",b"request_streaming",u"request_type_url",b"request_type_url",u"response_streaming",b"response_streaming",u"response_type_url",b"response_type_url",u"syntax",b"syntax"]) -> None: ...
 global___Method = Method
 
+# Declares an API Interface to be included in this interface. The including
+# interface must redeclare all the methods from the included interface, but
+# documentation and options are inherited as follows:
+#
+# - If after comment and whitespace stripping, the documentation
+#   string of the redeclared method is empty, it will be inherited
+#   from the original method.
+#
+# - Each annotation belonging to the service config (http,
+#   visibility) which is not set in the redeclared method will be
+#   inherited.
+#
+# - If an http annotation is inherited, the path pattern will be
+#   modified as follows. Any version prefix will be replaced by the
+#   version of the including interface plus the [root][] path if
+#   specified.
+#
+# Example of a simple mixin:
+#
+#     package google.acl.v1;
+#     service AccessControl {
+#       // Get the underlying ACL object.
+#       rpc GetAcl(GetAclRequest) returns (Acl) {
+#         option (google.api.http).get = "/v1/{resource=**}:getAcl";
+#       }
+#     }
+#
+#     package google.storage.v2;
+#     service Storage {
+#       rpc GetAcl(GetAclRequest) returns (Acl);
+#
+#       // Get a data record.
+#       rpc GetData(GetDataRequest) returns (Data) {
+#         option (google.api.http).get = "/v2/{resource=**}";
+#       }
+#     }
+#
+# Example of a mixin configuration:
+#
+#     apis:
+#     - name: google.storage.v2.Storage
+#       mixins:
+#       - name: google.acl.v1.AccessControl
+#
+# The mixin construct implies that all methods in `AccessControl` are
+# also declared with same name and request/response types in
+# `Storage`. A documentation generator or annotation processor will
+# see the effective `Storage.GetAcl` method after inheriting
+# documentation and annotations as follows:
+#
+#     service Storage {
+#       // Get the underlying ACL object.
+#       rpc GetAcl(GetAclRequest) returns (Acl) {
+#         option (google.api.http).get = "/v2/{resource=**}:getAcl";
+#       }
+#       ...
+#     }
+#
+# Note how the version in the path pattern changed from `v1` to `v2`.
+#
+# If the `root` field in the mixin is specified, it should be a
+# relative path under which inherited HTTP paths are placed. Example:
+#
+#     apis:
+#     - name: google.storage.v2.Storage
+#       mixins:
+#       - name: google.acl.v1.AccessControl
+#         root: acls
+#
+# This implies the following inherited HTTP annotation:
+#
+#     service Storage {
+#       // Get the underlying ACL object.
+#       rpc GetAcl(GetAclRequest) returns (Acl) {
+#         option (google.api.http).get = "/v2/acls/{resource=**}:getAcl";
+#       }
+#       ...
+#     }
 class Mixin(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
     NAME_FIELD_NUMBER: builtins.int
     ROOT_FIELD_NUMBER: builtins.int
+    # The fully qualified name of the interface which is included.
     name: typing.Text = ...
+    # If non-empty specifies a path under which inherited HTTP paths
+    # are rooted.
     root: typing.Text = ...
-
     def __init__(self,
         *,
         name : typing.Text = ...,

--- a/stubs/protobuf/google/protobuf/compiler/plugin_pb2.pyi
+++ b/stubs/protobuf/google/protobuf/compiler/plugin_pb2.pyi
@@ -13,6 +13,7 @@ import typing_extensions
 
 DESCRIPTOR: google.protobuf.descriptor.FileDescriptor = ...
 
+# The version number of protocol compiler.
 class Version(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
     MAJOR_FIELD_NUMBER: builtins.int
@@ -22,8 +23,9 @@ class Version(google.protobuf.message.Message):
     major: builtins.int = ...
     minor: builtins.int = ...
     patch: builtins.int = ...
+    # A suffix for alpha, beta or rc release, e.g., "alpha-1", "rc2". It should
+    # be empty for mainline stable releases.
     suffix: typing.Text = ...
-
     def __init__(self,
         *,
         major : typing.Optional[builtins.int] = ...,
@@ -35,23 +37,39 @@ class Version(google.protobuf.message.Message):
     def ClearField(self, field_name: typing_extensions.Literal[u"major",b"major",u"minor",b"minor",u"patch",b"patch",u"suffix",b"suffix"]) -> None: ...
 global___Version = Version
 
+# An encoded CodeGeneratorRequest is written to the plugin's stdin.
 class CodeGeneratorRequest(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
     FILE_TO_GENERATE_FIELD_NUMBER: builtins.int
     PARAMETER_FIELD_NUMBER: builtins.int
     PROTO_FILE_FIELD_NUMBER: builtins.int
     COMPILER_VERSION_FIELD_NUMBER: builtins.int
-
+    # The .proto files that were explicitly listed on the command-line.  The
+    # code generator should generate code only for these files.  Each file's
+    # descriptor will be included in proto_file, below.
     @property
     def file_to_generate(self) -> google.protobuf.internal.containers.RepeatedScalarFieldContainer[typing.Text]: ...
+    # The generator parameter passed on the command-line.
     parameter: typing.Text = ...
-
+    # FileDescriptorProtos for all files in files_to_generate and everything
+    # they import.  The files will appear in topological order, so each file
+    # appears before any file that imports it.
+    #
+    # protoc guarantees that all proto_files will be written after
+    # the fields above, even though this is not technically guaranteed by the
+    # protobuf wire format.  This theoretically could allow a plugin to stream
+    # in the FileDescriptorProtos and handle them one by one rather than read
+    # the entire set into memory at once.  However, as of this writing, this
+    # is not similarly optimized on protoc's end -- it will store all fields in
+    # memory at once before sending them to the plugin.
+    #
+    # Type names of fields and extensions in the FileDescriptorProto are always
+    # fully qualified.
     @property
     def proto_file(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[google.protobuf.descriptor_pb2.FileDescriptorProto]: ...
-
+    # The version number of protocol compiler.
     @property
     def compiler_version(self) -> global___Version: ...
-
     def __init__(self,
         *,
         file_to_generate : typing.Optional[typing.Iterable[typing.Text]] = ...,
@@ -63,32 +81,86 @@ class CodeGeneratorRequest(google.protobuf.message.Message):
     def ClearField(self, field_name: typing_extensions.Literal[u"compiler_version",b"compiler_version",u"file_to_generate",b"file_to_generate",u"parameter",b"parameter",u"proto_file",b"proto_file"]) -> None: ...
 global___CodeGeneratorRequest = CodeGeneratorRequest
 
+# The plugin writes an encoded CodeGeneratorResponse to stdout.
 class CodeGeneratorResponse(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
-    class Feature(metaclass=_Feature):
+    # Sync with code_generator.h.
+    class Feature(_Feature, metaclass=_FeatureEnumTypeWrapper):
+        pass
+    class _Feature:
         V = typing.NewType('V', builtins.int)
-
-    FEATURE_NONE = CodeGeneratorResponse.Feature.V(0)
-    FEATURE_PROTO3_OPTIONAL = CodeGeneratorResponse.Feature.V(1)
-
-    class _Feature(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[Feature.V], builtins.type):  # type: ignore
+    class _FeatureEnumTypeWrapper(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[_Feature.V], builtins.type):
         DESCRIPTOR: google.protobuf.descriptor.EnumDescriptor = ...
         FEATURE_NONE = CodeGeneratorResponse.Feature.V(0)
         FEATURE_PROTO3_OPTIONAL = CodeGeneratorResponse.Feature.V(1)
 
+    FEATURE_NONE = CodeGeneratorResponse.Feature.V(0)
+    FEATURE_PROTO3_OPTIONAL = CodeGeneratorResponse.Feature.V(1)
+
+    # Represents a single generated file.
     class File(google.protobuf.message.Message):
         DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
         NAME_FIELD_NUMBER: builtins.int
         INSERTION_POINT_FIELD_NUMBER: builtins.int
         CONTENT_FIELD_NUMBER: builtins.int
         GENERATED_CODE_INFO_FIELD_NUMBER: builtins.int
+        # The file name, relative to the output directory.  The name must not
+        # contain "." or ".." components and must be relative, not be absolute (so,
+        # the file cannot lie outside the output directory).  "/" must be used as
+        # the path separator, not "\".
+        #
+        # If the name is omitted, the content will be appended to the previous
+        # file.  This allows the generator to break large files into small chunks,
+        # and allows the generated text to be streamed back to protoc so that large
+        # files need not reside completely in memory at one time.  Note that as of
+        # this writing protoc does not optimize for this -- it will read the entire
+        # CodeGeneratorResponse before writing files to disk.
         name: typing.Text = ...
+        # If non-empty, indicates that the named file should already exist, and the
+        # content here is to be inserted into that file at a defined insertion
+        # point.  This feature allows a code generator to extend the output
+        # produced by another code generator.  The original generator may provide
+        # insertion points by placing special annotations in the file that look
+        # like:
+        #   @@protoc_insertion_point(NAME)
+        # The annotation can have arbitrary text before and after it on the line,
+        # which allows it to be placed in a comment.  NAME should be replaced with
+        # an identifier naming the point -- this is what other generators will use
+        # as the insertion_point.  Code inserted at this point will be placed
+        # immediately above the line containing the insertion point (thus multiple
+        # insertions to the same point will come out in the order they were added).
+        # The double-@ is intended to make it unlikely that the generated code
+        # could contain things that look like insertion points by accident.
+        #
+        # For example, the C++ code generator places the following line in the
+        # .pb.h files that it generates:
+        #   // @@protoc_insertion_point(namespace_scope)
+        # This line appears within the scope of the file's package namespace, but
+        # outside of any particular class.  Another plugin can then specify the
+        # insertion_point "namespace_scope" to generate additional classes or
+        # other declarations that should be placed in this scope.
+        #
+        # Note that if the line containing the insertion point begins with
+        # whitespace, the same whitespace will be added to every line of the
+        # inserted text.  This is useful for languages like Python, where
+        # indentation matters.  In these languages, the insertion point comment
+        # should be indented the same amount as any inserted code will need to be
+        # in order to work correctly in that context.
+        #
+        # The code generator that generates the initial file and the one which
+        # inserts into it must both run as part of a single invocation of protoc.
+        # Code generators are executed in the order in which they appear on the
+        # command line.
+        #
+        # If |insertion_point| is present, |name| must also be present.
         insertion_point: typing.Text = ...
+        # The file contents.
         content: typing.Text = ...
-
+        # Information describing the file content being inserted. If an insertion
+        # point is used, this information will be appropriately offset and inserted
+        # into the code generation metadata for the generated files.
         @property
         def generated_code_info(self) -> google.protobuf.descriptor_pb2.GeneratedCodeInfo: ...
-
         def __init__(self,
             *,
             name : typing.Optional[typing.Text] = ...,
@@ -102,12 +174,20 @@ class CodeGeneratorResponse(google.protobuf.message.Message):
     ERROR_FIELD_NUMBER: builtins.int
     SUPPORTED_FEATURES_FIELD_NUMBER: builtins.int
     FILE_FIELD_NUMBER: builtins.int
+    # Error message.  If non-empty, code generation failed.  The plugin process
+    # should exit with status code zero even if it reports an error in this way.
+    #
+    # This should be used to indicate errors in .proto files which prevent the
+    # code generator from generating correct code.  Errors which indicate a
+    # problem in protoc itself -- such as the input CodeGeneratorRequest being
+    # unparseable -- should be reported by writing a message to stderr and
+    # exiting with a non-zero status code.
     error: typing.Text = ...
+    # A bitmask of supported features that the code generator supports.
+    # This is a bitwise "or" of values from the Feature enum.
     supported_features: builtins.int = ...
-
     @property
     def file(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[global___CodeGeneratorResponse.File]: ...
-
     def __init__(self,
         *,
         error : typing.Optional[typing.Text] = ...,

--- a/stubs/protobuf/google/protobuf/descriptor_pb2.pyi
+++ b/stubs/protobuf/google/protobuf/descriptor_pb2.pyi
@@ -12,13 +12,13 @@ import typing_extensions
 
 DESCRIPTOR: google.protobuf.descriptor.FileDescriptor = ...
 
+# The protocol compiler can output a FileDescriptorSet containing the .proto
+# files it parses.
 class FileDescriptorSet(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
     FILE_FIELD_NUMBER: builtins.int
-
     @property
     def file(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[global___FileDescriptorProto]: ...
-
     def __init__(self,
         *,
         file : typing.Optional[typing.Iterable[global___FileDescriptorProto]] = ...,
@@ -26,6 +26,7 @@ class FileDescriptorSet(google.protobuf.message.Message):
     def ClearField(self, field_name: typing_extensions.Literal[u"file",b"file"]) -> None: ...
 global___FileDescriptorSet = FileDescriptorSet
 
+# Describes a complete .proto file.
 class FileDescriptorProto(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
     NAME_FIELD_NUMBER: builtins.int
@@ -40,37 +41,40 @@ class FileDescriptorProto(google.protobuf.message.Message):
     OPTIONS_FIELD_NUMBER: builtins.int
     SOURCE_CODE_INFO_FIELD_NUMBER: builtins.int
     SYNTAX_FIELD_NUMBER: builtins.int
+    # file name, relative to root of source tree
     name: typing.Text = ...
+    # e.g. "foo", "foo.bar", etc.
     package: typing.Text = ...
-
+    # Names of files imported by this file.
     @property
     def dependency(self) -> google.protobuf.internal.containers.RepeatedScalarFieldContainer[typing.Text]: ...
-
+    # Indexes of the public imported files in the dependency list above.
     @property
     def public_dependency(self) -> google.protobuf.internal.containers.RepeatedScalarFieldContainer[builtins.int]: ...
-
+    # Indexes of the weak imported files in the dependency list.
+    # For Google-internal migration only. Do not use.
     @property
     def weak_dependency(self) -> google.protobuf.internal.containers.RepeatedScalarFieldContainer[builtins.int]: ...
-    syntax: typing.Text = ...
-
+    # All top-level definitions in this file.
     @property
     def message_type(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[global___DescriptorProto]: ...
-
     @property
     def enum_type(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[global___EnumDescriptorProto]: ...
-
     @property
     def service(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[global___ServiceDescriptorProto]: ...
-
     @property
     def extension(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[global___FieldDescriptorProto]: ...
-
     @property
     def options(self) -> global___FileOptions: ...
-
+    # This field contains optional information about the original source code.
+    # You may safely remove this entire field without harming runtime
+    # functionality of the descriptors -- the information is needed only by
+    # development tools.
     @property
     def source_code_info(self) -> global___SourceCodeInfo: ...
-
+    # The syntax of the proto file.
+    # The supported values are "proto2" and "proto3".
+    syntax: typing.Text = ...
     def __init__(self,
         *,
         name : typing.Optional[typing.Text] = ...,
@@ -90,6 +94,7 @@ class FileDescriptorProto(google.protobuf.message.Message):
     def ClearField(self, field_name: typing_extensions.Literal[u"dependency",b"dependency",u"enum_type",b"enum_type",u"extension",b"extension",u"message_type",b"message_type",u"name",b"name",u"options",b"options",u"package",b"package",u"public_dependency",b"public_dependency",u"service",b"service",u"source_code_info",b"source_code_info",u"syntax",b"syntax",u"weak_dependency",b"weak_dependency"]) -> None: ...
 global___FileDescriptorProto = FileDescriptorProto
 
+# Describes a message type.
 class DescriptorProto(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
     class ExtensionRange(google.protobuf.message.Message):
@@ -97,12 +102,12 @@ class DescriptorProto(google.protobuf.message.Message):
         START_FIELD_NUMBER: builtins.int
         END_FIELD_NUMBER: builtins.int
         OPTIONS_FIELD_NUMBER: builtins.int
+        # Inclusive.
         start: builtins.int = ...
+        # Exclusive.
         end: builtins.int = ...
-
         @property
         def options(self) -> global___ExtensionRangeOptions: ...
-
         def __init__(self,
             *,
             start : typing.Optional[builtins.int] = ...,
@@ -112,13 +117,17 @@ class DescriptorProto(google.protobuf.message.Message):
         def HasField(self, field_name: typing_extensions.Literal[u"end",b"end",u"options",b"options",u"start",b"start"]) -> builtins.bool: ...
         def ClearField(self, field_name: typing_extensions.Literal[u"end",b"end",u"options",b"options",u"start",b"start"]) -> None: ...
 
+    # Range of reserved tag numbers. Reserved tag numbers may not be used by
+    # fields or extension ranges in the same message. Reserved ranges may
+    # not overlap.
     class ReservedRange(google.protobuf.message.Message):
         DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
         START_FIELD_NUMBER: builtins.int
         END_FIELD_NUMBER: builtins.int
+        # Inclusive.
         start: builtins.int = ...
+        # Exclusive.
         end: builtins.int = ...
-
         def __init__(self,
             *,
             start : typing.Optional[builtins.int] = ...,
@@ -138,34 +147,26 @@ class DescriptorProto(google.protobuf.message.Message):
     RESERVED_RANGE_FIELD_NUMBER: builtins.int
     RESERVED_NAME_FIELD_NUMBER: builtins.int
     name: typing.Text = ...
-
-    @property
-    def reserved_name(self) -> google.protobuf.internal.containers.RepeatedScalarFieldContainer[typing.Text]: ...
-
     @property
     def field(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[global___FieldDescriptorProto]: ...
-
     @property
     def extension(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[global___FieldDescriptorProto]: ...
-
     @property
     def nested_type(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[global___DescriptorProto]: ...
-
     @property
     def enum_type(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[global___EnumDescriptorProto]: ...
-
     @property
     def extension_range(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[global___DescriptorProto.ExtensionRange]: ...
-
     @property
     def oneof_decl(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[global___OneofDescriptorProto]: ...
-
     @property
     def options(self) -> global___MessageOptions: ...
-
     @property
     def reserved_range(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[global___DescriptorProto.ReservedRange]: ...
-
+    # Reserved field names, which may not be used by fields in the same message.
+    # A given name may only be reserved once.
+    @property
+    def reserved_name(self) -> google.protobuf.internal.containers.RepeatedScalarFieldContainer[typing.Text]: ...
     def __init__(self,
         *,
         name : typing.Optional[typing.Text] = ...,
@@ -186,10 +187,9 @@ global___DescriptorProto = DescriptorProto
 class ExtensionRangeOptions(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
     UNINTERPRETED_OPTION_FIELD_NUMBER: builtins.int
-
+    # The parser stores options it doesn't recognize here. See above.
     @property
     def uninterpreted_option(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[global___UninterpretedOption]: ...
-
     def __init__(self,
         *,
         uninterpreted_option : typing.Optional[typing.Iterable[global___UninterpretedOption]] = ...,
@@ -197,63 +197,96 @@ class ExtensionRangeOptions(google.protobuf.message.Message):
     def ClearField(self, field_name: typing_extensions.Literal[u"uninterpreted_option",b"uninterpreted_option"]) -> None: ...
 global___ExtensionRangeOptions = ExtensionRangeOptions
 
+# Describes a field within a message.
 class FieldDescriptorProto(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
-    class Type(metaclass=_Type):
+    class Type(_Type, metaclass=_TypeEnumTypeWrapper):
+        pass
+    class _Type:
         V = typing.NewType('V', builtins.int)
-
-    TYPE_DOUBLE = FieldDescriptorProto.Type.V(1)
-    TYPE_FLOAT = FieldDescriptorProto.Type.V(2)
-    TYPE_INT64 = FieldDescriptorProto.Type.V(3)
-    TYPE_UINT64 = FieldDescriptorProto.Type.V(4)
-    TYPE_INT32 = FieldDescriptorProto.Type.V(5)
-    TYPE_FIXED64 = FieldDescriptorProto.Type.V(6)
-    TYPE_FIXED32 = FieldDescriptorProto.Type.V(7)
-    TYPE_BOOL = FieldDescriptorProto.Type.V(8)
-    TYPE_STRING = FieldDescriptorProto.Type.V(9)
-    TYPE_GROUP = FieldDescriptorProto.Type.V(10)
-    TYPE_MESSAGE = FieldDescriptorProto.Type.V(11)
-    TYPE_BYTES = FieldDescriptorProto.Type.V(12)
-    TYPE_UINT32 = FieldDescriptorProto.Type.V(13)
-    TYPE_ENUM = FieldDescriptorProto.Type.V(14)
-    TYPE_SFIXED32 = FieldDescriptorProto.Type.V(15)
-    TYPE_SFIXED64 = FieldDescriptorProto.Type.V(16)
-    TYPE_SINT32 = FieldDescriptorProto.Type.V(17)
-    TYPE_SINT64 = FieldDescriptorProto.Type.V(18)
-
-    class _Type(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[Type.V], builtins.type):  # type: ignore
+    class _TypeEnumTypeWrapper(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[_Type.V], builtins.type):
         DESCRIPTOR: google.protobuf.descriptor.EnumDescriptor = ...
+        # 0 is reserved for errors.
+        # Order is weird for historical reasons.
         TYPE_DOUBLE = FieldDescriptorProto.Type.V(1)
         TYPE_FLOAT = FieldDescriptorProto.Type.V(2)
+        # Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT64 if
+        # negative values are likely.
         TYPE_INT64 = FieldDescriptorProto.Type.V(3)
         TYPE_UINT64 = FieldDescriptorProto.Type.V(4)
+        # Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT32 if
+        # negative values are likely.
         TYPE_INT32 = FieldDescriptorProto.Type.V(5)
         TYPE_FIXED64 = FieldDescriptorProto.Type.V(6)
         TYPE_FIXED32 = FieldDescriptorProto.Type.V(7)
         TYPE_BOOL = FieldDescriptorProto.Type.V(8)
         TYPE_STRING = FieldDescriptorProto.Type.V(9)
+        # Tag-delimited aggregate.
+        # Group type is deprecated and not supported in proto3. However, Proto3
+        # implementations should still be able to parse the group wire format and
+        # treat group fields as unknown fields.
         TYPE_GROUP = FieldDescriptorProto.Type.V(10)
+        # Length-delimited aggregate.
         TYPE_MESSAGE = FieldDescriptorProto.Type.V(11)
+        # New in version 2.
         TYPE_BYTES = FieldDescriptorProto.Type.V(12)
         TYPE_UINT32 = FieldDescriptorProto.Type.V(13)
         TYPE_ENUM = FieldDescriptorProto.Type.V(14)
         TYPE_SFIXED32 = FieldDescriptorProto.Type.V(15)
         TYPE_SFIXED64 = FieldDescriptorProto.Type.V(16)
+        # Uses ZigZag encoding.
         TYPE_SINT32 = FieldDescriptorProto.Type.V(17)
+        # Uses ZigZag encoding.
         TYPE_SINT64 = FieldDescriptorProto.Type.V(18)
 
-    class Label(metaclass=_Label):
+    # 0 is reserved for errors.
+    # Order is weird for historical reasons.
+    TYPE_DOUBLE = FieldDescriptorProto.Type.V(1)
+    TYPE_FLOAT = FieldDescriptorProto.Type.V(2)
+    # Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT64 if
+    # negative values are likely.
+    TYPE_INT64 = FieldDescriptorProto.Type.V(3)
+    TYPE_UINT64 = FieldDescriptorProto.Type.V(4)
+    # Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT32 if
+    # negative values are likely.
+    TYPE_INT32 = FieldDescriptorProto.Type.V(5)
+    TYPE_FIXED64 = FieldDescriptorProto.Type.V(6)
+    TYPE_FIXED32 = FieldDescriptorProto.Type.V(7)
+    TYPE_BOOL = FieldDescriptorProto.Type.V(8)
+    TYPE_STRING = FieldDescriptorProto.Type.V(9)
+    # Tag-delimited aggregate.
+    # Group type is deprecated and not supported in proto3. However, Proto3
+    # implementations should still be able to parse the group wire format and
+    # treat group fields as unknown fields.
+    TYPE_GROUP = FieldDescriptorProto.Type.V(10)
+    # Length-delimited aggregate.
+    TYPE_MESSAGE = FieldDescriptorProto.Type.V(11)
+    # New in version 2.
+    TYPE_BYTES = FieldDescriptorProto.Type.V(12)
+    TYPE_UINT32 = FieldDescriptorProto.Type.V(13)
+    TYPE_ENUM = FieldDescriptorProto.Type.V(14)
+    TYPE_SFIXED32 = FieldDescriptorProto.Type.V(15)
+    TYPE_SFIXED64 = FieldDescriptorProto.Type.V(16)
+    # Uses ZigZag encoding.
+    TYPE_SINT32 = FieldDescriptorProto.Type.V(17)
+    # Uses ZigZag encoding.
+    TYPE_SINT64 = FieldDescriptorProto.Type.V(18)
+
+    class Label(_Label, metaclass=_LabelEnumTypeWrapper):
+        pass
+    class _Label:
         V = typing.NewType('V', builtins.int)
-
-    LABEL_OPTIONAL = FieldDescriptorProto.Label.V(1)
-    LABEL_REQUIRED = FieldDescriptorProto.Label.V(2)
-    LABEL_REPEATED = FieldDescriptorProto.Label.V(3)
-
-    class _Label(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[Label.V], builtins.type):  # type: ignore
+    class _LabelEnumTypeWrapper(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[_Label.V], builtins.type):
         DESCRIPTOR: google.protobuf.descriptor.EnumDescriptor = ...
+        # 0 is reserved for errors
         LABEL_OPTIONAL = FieldDescriptorProto.Label.V(1)
         LABEL_REQUIRED = FieldDescriptorProto.Label.V(2)
         LABEL_REPEATED = FieldDescriptorProto.Label.V(3)
+
+    # 0 is reserved for errors
+    LABEL_OPTIONAL = FieldDescriptorProto.Label.V(1)
+    LABEL_REQUIRED = FieldDescriptorProto.Label.V(2)
+    LABEL_REPEATED = FieldDescriptorProto.Label.V(3)
 
     NAME_FIELD_NUMBER: builtins.int
     NUMBER_FIELD_NUMBER: builtins.int
@@ -269,17 +302,56 @@ class FieldDescriptorProto(google.protobuf.message.Message):
     name: typing.Text = ...
     number: builtins.int = ...
     label: global___FieldDescriptorProto.Label.V = ...
+    # If type_name is set, this need not be set.  If both this and type_name
+    # are set, this must be one of TYPE_ENUM, TYPE_MESSAGE or TYPE_GROUP.
     type: global___FieldDescriptorProto.Type.V = ...
+    # For message and enum types, this is the name of the type.  If the name
+    # starts with a '.', it is fully-qualified.  Otherwise, C++-like scoping
+    # rules are used to find the type (i.e. first the nested types within this
+    # message are searched, then within the parent, on up to the root
+    # namespace).
     type_name: typing.Text = ...
+    # For extensions, this is the name of the type being extended.  It is
+    # resolved in the same manner as type_name.
     extendee: typing.Text = ...
+    # For numeric types, contains the original text representation of the value.
+    # For booleans, "true" or "false".
+    # For strings, contains the default text contents (not escaped in any way).
+    # For bytes, contains the C escaped value.  All bytes >= 128 are escaped.
+    # TODO(kenton):  Base-64 encode?
     default_value: typing.Text = ...
+    # If set, gives the index of a oneof in the containing type's oneof_decl
+    # list.  This field is a member of that oneof.
     oneof_index: builtins.int = ...
+    # JSON name of this field. The value is set by protocol compiler. If the
+    # user has set a "json_name" option on this field, that option's value
+    # will be used. Otherwise, it's deduced from the field's name by converting
+    # it to camelCase.
     json_name: typing.Text = ...
-    proto3_optional: builtins.bool = ...
-
     @property
     def options(self) -> global___FieldOptions: ...
-
+    # If true, this is a proto3 "optional". When a proto3 field is optional, it
+    # tracks presence regardless of field type.
+    #
+    # When proto3_optional is true, this field must be belong to a oneof to
+    # signal to old proto3 clients that presence is tracked for this field. This
+    # oneof is known as a "synthetic" oneof, and this field must be its sole
+    # member (each proto3 optional field gets its own synthetic oneof). Synthetic
+    # oneofs exist in the descriptor only, and do not generate any API. Synthetic
+    # oneofs must be ordered after all "real" oneofs.
+    #
+    # For message fields, proto3_optional doesn't create any semantic change,
+    # since non-repeated message fields always track presence. However it still
+    # indicates the semantic detail of whether the user wrote "optional" or not.
+    # This can be useful for round-tripping the .proto file. For consistency we
+    # give message fields a synthetic oneof also, even though it is not required
+    # to track presence. This is especially important because the parser can't
+    # tell if a field is a message or an enum, so it must always create a
+    # synthetic oneof.
+    #
+    # Proto2 optional fields do not set this flag, because they already indicate
+    # optional with `LABEL_OPTIONAL`.
+    proto3_optional: builtins.bool = ...
     def __init__(self,
         *,
         name : typing.Optional[typing.Text] = ...,
@@ -298,15 +370,14 @@ class FieldDescriptorProto(google.protobuf.message.Message):
     def ClearField(self, field_name: typing_extensions.Literal[u"default_value",b"default_value",u"extendee",b"extendee",u"json_name",b"json_name",u"label",b"label",u"name",b"name",u"number",b"number",u"oneof_index",b"oneof_index",u"options",b"options",u"proto3_optional",b"proto3_optional",u"type",b"type",u"type_name",b"type_name"]) -> None: ...
 global___FieldDescriptorProto = FieldDescriptorProto
 
+# Describes a oneof.
 class OneofDescriptorProto(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
     NAME_FIELD_NUMBER: builtins.int
     OPTIONS_FIELD_NUMBER: builtins.int
     name: typing.Text = ...
-
     @property
     def options(self) -> global___OneofOptions: ...
-
     def __init__(self,
         *,
         name : typing.Optional[typing.Text] = ...,
@@ -316,15 +387,23 @@ class OneofDescriptorProto(google.protobuf.message.Message):
     def ClearField(self, field_name: typing_extensions.Literal[u"name",b"name",u"options",b"options"]) -> None: ...
 global___OneofDescriptorProto = OneofDescriptorProto
 
+# Describes an enum type.
 class EnumDescriptorProto(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
+    # Range of reserved numeric values. Reserved values may not be used by
+    # entries in the same enum. Reserved ranges may not overlap.
+    #
+    # Note that this is distinct from DescriptorProto.ReservedRange in that it
+    # is inclusive such that it can appropriately represent the entire int32
+    # domain.
     class EnumReservedRange(google.protobuf.message.Message):
         DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
         START_FIELD_NUMBER: builtins.int
         END_FIELD_NUMBER: builtins.int
+        # Inclusive.
         start: builtins.int = ...
+        # Inclusive.
         end: builtins.int = ...
-
         def __init__(self,
             *,
             start : typing.Optional[builtins.int] = ...,
@@ -339,19 +418,19 @@ class EnumDescriptorProto(google.protobuf.message.Message):
     RESERVED_RANGE_FIELD_NUMBER: builtins.int
     RESERVED_NAME_FIELD_NUMBER: builtins.int
     name: typing.Text = ...
-
-    @property
-    def reserved_name(self) -> google.protobuf.internal.containers.RepeatedScalarFieldContainer[typing.Text]: ...
-
     @property
     def value(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[global___EnumValueDescriptorProto]: ...
-
     @property
     def options(self) -> global___EnumOptions: ...
-
+    # Range of reserved numeric values. Reserved numeric values may not be used
+    # by enum values in the same enum declaration. Reserved ranges may not
+    # overlap.
     @property
     def reserved_range(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[global___EnumDescriptorProto.EnumReservedRange]: ...
-
+    # Reserved enum value names, which may not be reused. A given name may only
+    # be reserved once.
+    @property
+    def reserved_name(self) -> google.protobuf.internal.containers.RepeatedScalarFieldContainer[typing.Text]: ...
     def __init__(self,
         *,
         name : typing.Optional[typing.Text] = ...,
@@ -364,6 +443,7 @@ class EnumDescriptorProto(google.protobuf.message.Message):
     def ClearField(self, field_name: typing_extensions.Literal[u"name",b"name",u"options",b"options",u"reserved_name",b"reserved_name",u"reserved_range",b"reserved_range",u"value",b"value"]) -> None: ...
 global___EnumDescriptorProto = EnumDescriptorProto
 
+# Describes a value within an enum.
 class EnumValueDescriptorProto(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
     NAME_FIELD_NUMBER: builtins.int
@@ -371,10 +451,8 @@ class EnumValueDescriptorProto(google.protobuf.message.Message):
     OPTIONS_FIELD_NUMBER: builtins.int
     name: typing.Text = ...
     number: builtins.int = ...
-
     @property
     def options(self) -> global___EnumValueOptions: ...
-
     def __init__(self,
         *,
         name : typing.Optional[typing.Text] = ...,
@@ -385,19 +463,17 @@ class EnumValueDescriptorProto(google.protobuf.message.Message):
     def ClearField(self, field_name: typing_extensions.Literal[u"name",b"name",u"number",b"number",u"options",b"options"]) -> None: ...
 global___EnumValueDescriptorProto = EnumValueDescriptorProto
 
+# Describes a service.
 class ServiceDescriptorProto(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
     NAME_FIELD_NUMBER: builtins.int
     METHOD_FIELD_NUMBER: builtins.int
     OPTIONS_FIELD_NUMBER: builtins.int
     name: typing.Text = ...
-
     @property
     def method(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[global___MethodDescriptorProto]: ...
-
     @property
     def options(self) -> global___ServiceOptions: ...
-
     def __init__(self,
         *,
         name : typing.Optional[typing.Text] = ...,
@@ -408,6 +484,7 @@ class ServiceDescriptorProto(google.protobuf.message.Message):
     def ClearField(self, field_name: typing_extensions.Literal[u"method",b"method",u"name",b"name",u"options",b"options"]) -> None: ...
 global___ServiceDescriptorProto = ServiceDescriptorProto
 
+# Describes a method of a service.
 class MethodDescriptorProto(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
     NAME_FIELD_NUMBER: builtins.int
@@ -417,14 +494,16 @@ class MethodDescriptorProto(google.protobuf.message.Message):
     CLIENT_STREAMING_FIELD_NUMBER: builtins.int
     SERVER_STREAMING_FIELD_NUMBER: builtins.int
     name: typing.Text = ...
+    # Input and output type names.  These are resolved in the same way as
+    # FieldDescriptorProto.type_name, but must refer to a message type.
     input_type: typing.Text = ...
     output_type: typing.Text = ...
-    client_streaming: builtins.bool = ...
-    server_streaming: builtins.bool = ...
-
     @property
     def options(self) -> global___MethodOptions: ...
-
+    # Identifies if client streams multiple client messages
+    client_streaming: builtins.bool = ...
+    # Identifies if server streams multiple server messages
+    server_streaming: builtins.bool = ...
     def __init__(self,
         *,
         name : typing.Optional[typing.Text] = ...,
@@ -438,20 +517,62 @@ class MethodDescriptorProto(google.protobuf.message.Message):
     def ClearField(self, field_name: typing_extensions.Literal[u"client_streaming",b"client_streaming",u"input_type",b"input_type",u"name",b"name",u"options",b"options",u"output_type",b"output_type",u"server_streaming",b"server_streaming"]) -> None: ...
 global___MethodDescriptorProto = MethodDescriptorProto
 
+# ===================================================================
+# Options
+
+# Each of the definitions above may have "options" attached.  These are
+# just annotations which may cause code to be generated slightly differently
+# or may contain hints for code that manipulates protocol messages.
+#
+# Clients may define custom options as extensions of the *Options messages.
+# These extensions may not yet be known at parsing time, so the parser cannot
+# store the values in them.  Instead it stores them in a field in the *Options
+# message called uninterpreted_option. This field must have the same name
+# across all *Options messages. We then use this field to populate the
+# extensions when we build a descriptor, at which point all protos have been
+# parsed and so all extensions are known.
+#
+# Extension numbers for custom options may be chosen as follows:
+# * For options which will only be used within a single application or
+#   organization, or for experimental options, use field numbers 50000
+#   through 99999.  It is up to you to ensure that you do not use the
+#   same number for multiple options.
+# * For options which will be published and used publicly by multiple
+#   independent entities, e-mail protobuf-global-extension-registry@google.com
+#   to reserve extension numbers. Simply provide your project name (e.g.
+#   Objective-C plugin) and your project website (if available) -- there's no
+#   need to explain how you intend to use them. Usually you only need one
+#   extension number. You can declare multiple options with only one extension
+#   number by putting them in a sub-message. See the Custom Options section of
+#   the docs for examples:
+#   https://developers.google.com/protocol-buffers/docs/proto#options
+#   If this turns out to be popular, a web service will be set up
+#   to automatically assign option numbers.
+
 class FileOptions(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
-    class OptimizeMode(metaclass=_OptimizeMode):
+    # Generated classes can be optimized for speed or code size.
+    class OptimizeMode(_OptimizeMode, metaclass=_OptimizeModeEnumTypeWrapper):
+        pass
+    class _OptimizeMode:
         V = typing.NewType('V', builtins.int)
-
-    SPEED = FileOptions.OptimizeMode.V(1)
-    CODE_SIZE = FileOptions.OptimizeMode.V(2)
-    LITE_RUNTIME = FileOptions.OptimizeMode.V(3)
-
-    class _OptimizeMode(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[OptimizeMode.V], builtins.type):  # type: ignore
+    class _OptimizeModeEnumTypeWrapper(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[_OptimizeMode.V], builtins.type):
         DESCRIPTOR: google.protobuf.descriptor.EnumDescriptor = ...
+        # Generate complete code for parsing, serialization,
         SPEED = FileOptions.OptimizeMode.V(1)
+        # etc.
+        # Use ReflectionOps to implement these methods.
         CODE_SIZE = FileOptions.OptimizeMode.V(2)
+        # Generate code using MessageLite and the lite runtime.
         LITE_RUNTIME = FileOptions.OptimizeMode.V(3)
+
+    # Generate complete code for parsing, serialization,
+    SPEED = FileOptions.OptimizeMode.V(1)
+    # etc.
+    # Use ReflectionOps to implement these methods.
+    CODE_SIZE = FileOptions.OptimizeMode.V(2)
+    # Generate code using MessageLite and the lite runtime.
+    LITE_RUNTIME = FileOptions.OptimizeMode.V(3)
 
     JAVA_PACKAGE_FIELD_NUMBER: builtins.int
     JAVA_OUTER_CLASSNAME_FIELD_NUMBER: builtins.int
@@ -474,30 +595,91 @@ class FileOptions(google.protobuf.message.Message):
     PHP_METADATA_NAMESPACE_FIELD_NUMBER: builtins.int
     RUBY_PACKAGE_FIELD_NUMBER: builtins.int
     UNINTERPRETED_OPTION_FIELD_NUMBER: builtins.int
+    # Sets the Java package where classes generated from this .proto will be
+    # placed.  By default, the proto package is used, but this is often
+    # inappropriate because proto packages do not normally start with backwards
+    # domain names.
     java_package: typing.Text = ...
+    # Controls the name of the wrapper Java class generated for the .proto file.
+    # That class will always contain the .proto file's getDescriptor() method as
+    # well as any top-level extensions defined in the .proto file.
+    # If java_multiple_files is disabled, then all the other classes from the
+    # .proto file will be nested inside the single wrapper outer class.
     java_outer_classname: typing.Text = ...
+    # If enabled, then the Java code generator will generate a separate .java
+    # file for each top-level message, enum, and service defined in the .proto
+    # file.  Thus, these types will *not* be nested inside the wrapper class
+    # named by java_outer_classname.  However, the wrapper class will still be
+    # generated to contain the file's getDescriptor() method as well as any
+    # top-level extensions defined in the file.
     java_multiple_files: builtins.bool = ...
+    # This option does nothing.
     java_generate_equals_and_hash: builtins.bool = ...
+    # If set true, then the Java2 code generator will generate code that
+    # throws an exception whenever an attempt is made to assign a non-UTF-8
+    # byte sequence to a string field.
+    # Message reflection will do the same.
+    # However, an extension field still accepts non-UTF-8 byte sequences.
+    # This option has no effect on when used with the lite runtime.
     java_string_check_utf8: builtins.bool = ...
     optimize_for: global___FileOptions.OptimizeMode.V = ...
+    # Sets the Go package where structs generated from this .proto will be
+    # placed. If omitted, the Go package will be derived from the following:
+    #   - The basename of the package import path, if provided.
+    #   - Otherwise, the package statement in the .proto file, if present.
+    #   - Otherwise, the basename of the .proto file, without extension.
     go_package: typing.Text = ...
+    # Should generic services be generated in each language?  "Generic" services
+    # are not specific to any particular RPC system.  They are generated by the
+    # main code generators in each language (without additional plugins).
+    # Generic services were the only kind of service generation supported by
+    # early versions of google.protobuf.
+    #
+    # Generic services are now considered deprecated in favor of using plugins
+    # that generate code specific to your particular RPC system.  Therefore,
+    # these default to false.  Old code which depends on generic services should
+    # explicitly set them to true.
     cc_generic_services: builtins.bool = ...
     java_generic_services: builtins.bool = ...
     py_generic_services: builtins.bool = ...
     php_generic_services: builtins.bool = ...
+    # Is this file deprecated?
+    # Depending on the target platform, this can emit Deprecated annotations
+    # for everything in the file, or it will be completely ignored; in the very
+    # least, this is a formalization for deprecating files.
     deprecated: builtins.bool = ...
+    # Enables the use of arenas for the proto messages in this file. This applies
+    # only to generated classes for C++.
     cc_enable_arenas: builtins.bool = ...
+    # Sets the objective c class prefix which is prepended to all objective c
+    # generated classes from this .proto. There is no default.
     objc_class_prefix: typing.Text = ...
+    # Namespace for generated classes; defaults to the package.
     csharp_namespace: typing.Text = ...
+    # By default Swift generators will take the proto package and CamelCase it
+    # replacing '.' with underscore and use that to prefix the types/symbols
+    # defined. When this options is provided, they will use this value instead
+    # to prefix the types/symbols defined.
     swift_prefix: typing.Text = ...
+    # Sets the php class prefix which is prepended to all php generated classes
+    # from this .proto. Default is empty.
     php_class_prefix: typing.Text = ...
+    # Use this option to change the namespace of php generated classes. Default
+    # is empty. When this option is empty, the package name will be used for
+    # determining the namespace.
     php_namespace: typing.Text = ...
+    # Use this option to change the namespace of php generated metadata classes.
+    # Default is empty. When this option is empty, the proto file name will be
+    # used for determining the namespace.
     php_metadata_namespace: typing.Text = ...
+    # Use this option to change the package of ruby generated classes. Default
+    # is empty. When this option is not set, the package name will be used for
+    # determining the ruby package.
     ruby_package: typing.Text = ...
-
+    # The parser stores options it doesn't recognize here.
+    # See the documentation for the "Options" section above.
     @property
     def uninterpreted_option(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[global___UninterpretedOption]: ...
-
     def __init__(self,
         *,
         java_package : typing.Optional[typing.Text] = ...,
@@ -533,14 +715,59 @@ class MessageOptions(google.protobuf.message.Message):
     DEPRECATED_FIELD_NUMBER: builtins.int
     MAP_ENTRY_FIELD_NUMBER: builtins.int
     UNINTERPRETED_OPTION_FIELD_NUMBER: builtins.int
+    # Set true to use the old proto1 MessageSet wire format for extensions.
+    # This is provided for backwards-compatibility with the MessageSet wire
+    # format.  You should not use this for any other reason:  It's less
+    # efficient, has fewer features, and is more complicated.
+    #
+    # The message must be defined exactly as follows:
+    #   message Foo {
+    #     option message_set_wire_format = true;
+    #     extensions 4 to max;
+    #   }
+    # Note that the message cannot have any defined fields; MessageSets only
+    # have extensions.
+    #
+    # All extensions of your type must be singular messages; e.g. they cannot
+    # be int32s, enums, or repeated messages.
+    #
+    # Because this is an option, the above two restrictions are not enforced by
+    # the protocol compiler.
     message_set_wire_format: builtins.bool = ...
+    # Disables the generation of the standard "descriptor()" accessor, which can
+    # conflict with a field of the same name.  This is meant to make migration
+    # from proto1 easier; new code should avoid fields named "descriptor".
     no_standard_descriptor_accessor: builtins.bool = ...
+    # Is this message deprecated?
+    # Depending on the target platform, this can emit Deprecated annotations
+    # for the message, or it will be completely ignored; in the very least,
+    # this is a formalization for deprecating messages.
     deprecated: builtins.bool = ...
+    # Whether the message is an automatically generated map entry type for the
+    # maps field.
+    #
+    # For maps fields:
+    #     map<KeyType, ValueType> map_field = 1;
+    # The parsed descriptor looks like:
+    #     message MapFieldEntry {
+    #         option map_entry = true;
+    #         optional KeyType key = 1;
+    #         optional ValueType value = 2;
+    #     }
+    #     repeated MapFieldEntry map_field = 1;
+    #
+    # Implementations may choose not to generate the map_entry=true message, but
+    # use a native map in the target language to hold the keys and values.
+    # The reflection APIs in such implementations still need to work as
+    # if the field is a repeated message field.
+    #
+    # NOTE: Do not set the option in .proto files. Always use the maps syntax
+    # instead. The option should only be implicitly set by the proto compiler
+    # parser.
     map_entry: builtins.bool = ...
-
+    # The parser stores options it doesn't recognize here. See above.
     @property
     def uninterpreted_option(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[global___UninterpretedOption]: ...
-
     def __init__(self,
         *,
         message_set_wire_format : typing.Optional[builtins.bool] = ...,
@@ -555,31 +782,41 @@ global___MessageOptions = MessageOptions
 
 class FieldOptions(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
-    class CType(metaclass=_CType):
+    class CType(_CType, metaclass=_CTypeEnumTypeWrapper):
+        pass
+    class _CType:
         V = typing.NewType('V', builtins.int)
-
-    STRING = FieldOptions.CType.V(0)
-    CORD = FieldOptions.CType.V(1)
-    STRING_PIECE = FieldOptions.CType.V(2)
-
-    class _CType(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[CType.V], builtins.type):  # type: ignore
+    class _CTypeEnumTypeWrapper(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[_CType.V], builtins.type):
         DESCRIPTOR: google.protobuf.descriptor.EnumDescriptor = ...
+        # Default mode.
         STRING = FieldOptions.CType.V(0)
         CORD = FieldOptions.CType.V(1)
         STRING_PIECE = FieldOptions.CType.V(2)
 
-    class JSType(metaclass=_JSType):
+    # Default mode.
+    STRING = FieldOptions.CType.V(0)
+    CORD = FieldOptions.CType.V(1)
+    STRING_PIECE = FieldOptions.CType.V(2)
+
+    class JSType(_JSType, metaclass=_JSTypeEnumTypeWrapper):
+        pass
+    class _JSType:
         V = typing.NewType('V', builtins.int)
-
-    JS_NORMAL = FieldOptions.JSType.V(0)
-    JS_STRING = FieldOptions.JSType.V(1)
-    JS_NUMBER = FieldOptions.JSType.V(2)
-
-    class _JSType(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[JSType.V], builtins.type):  # type: ignore
+    class _JSTypeEnumTypeWrapper(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[_JSType.V], builtins.type):
         DESCRIPTOR: google.protobuf.descriptor.EnumDescriptor = ...
+        # Use the default type.
         JS_NORMAL = FieldOptions.JSType.V(0)
+        # Use JavaScript strings.
         JS_STRING = FieldOptions.JSType.V(1)
+        # Use JavaScript numbers.
         JS_NUMBER = FieldOptions.JSType.V(2)
+
+    # Use the default type.
+    JS_NORMAL = FieldOptions.JSType.V(0)
+    # Use JavaScript strings.
+    JS_STRING = FieldOptions.JSType.V(1)
+    # Use JavaScript numbers.
+    JS_NUMBER = FieldOptions.JSType.V(2)
 
     CTYPE_FIELD_NUMBER: builtins.int
     PACKED_FIELD_NUMBER: builtins.int
@@ -588,16 +825,68 @@ class FieldOptions(google.protobuf.message.Message):
     DEPRECATED_FIELD_NUMBER: builtins.int
     WEAK_FIELD_NUMBER: builtins.int
     UNINTERPRETED_OPTION_FIELD_NUMBER: builtins.int
+    # The ctype option instructs the C++ code generator to use a different
+    # representation of the field than it normally would.  See the specific
+    # options below.  This option is not yet implemented in the open source
+    # release -- sorry, we'll try to include it in a future version!
     ctype: global___FieldOptions.CType.V = ...
+    # The packed option can be enabled for repeated primitive fields to enable
+    # a more efficient representation on the wire. Rather than repeatedly
+    # writing the tag and type for each element, the entire array is encoded as
+    # a single length-delimited blob. In proto3, only explicit setting it to
+    # false will avoid using packed encoding.
     packed: builtins.bool = ...
+    # The jstype option determines the JavaScript type used for values of the
+    # field.  The option is permitted only for 64 bit integral and fixed types
+    # (int64, uint64, sint64, fixed64, sfixed64).  A field with jstype JS_STRING
+    # is represented as JavaScript string, which avoids loss of precision that
+    # can happen when a large value is converted to a floating point JavaScript.
+    # Specifying JS_NUMBER for the jstype causes the generated JavaScript code to
+    # use the JavaScript "number" type.  The behavior of the default option
+    # JS_NORMAL is implementation dependent.
+    #
+    # This option is an enum to permit additional types to be added, e.g.
+    # goog.math.Integer.
     jstype: global___FieldOptions.JSType.V = ...
+    # Should this field be parsed lazily?  Lazy applies only to message-type
+    # fields.  It means that when the outer message is initially parsed, the
+    # inner message's contents will not be parsed but instead stored in encoded
+    # form.  The inner message will actually be parsed when it is first accessed.
+    #
+    # This is only a hint.  Implementations are free to choose whether to use
+    # eager or lazy parsing regardless of the value of this option.  However,
+    # setting this option true suggests that the protocol author believes that
+    # using lazy parsing on this field is worth the additional bookkeeping
+    # overhead typically needed to implement it.
+    #
+    # This option does not affect the public interface of any generated code;
+    # all method signatures remain the same.  Furthermore, thread-safety of the
+    # interface is not affected by this option; const methods remain safe to
+    # call from multiple threads concurrently, while non-const methods continue
+    # to require exclusive access.
+    #
+    #
+    # Note that implementations may choose not to check required fields within
+    # a lazy sub-message.  That is, calling IsInitialized() on the outer message
+    # may return true even if the inner message has missing required fields.
+    # This is necessary because otherwise the inner message would have to be
+    # parsed in order to perform the check, defeating the purpose of lazy
+    # parsing.  An implementation which chooses not to check required fields
+    # must be consistent about it.  That is, for any particular sub-message, the
+    # implementation must either *always* check its required fields, or *never*
+    # check its required fields, regardless of whether or not the message has
+    # been parsed.
     lazy: builtins.bool = ...
+    # Is this field deprecated?
+    # Depending on the target platform, this can emit Deprecated annotations
+    # for accessors, or it will be completely ignored; in the very least, this
+    # is a formalization for deprecating fields.
     deprecated: builtins.bool = ...
+    # For Google-internal migration only. Do not use.
     weak: builtins.bool = ...
-
+    # The parser stores options it doesn't recognize here. See above.
     @property
     def uninterpreted_option(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[global___UninterpretedOption]: ...
-
     def __init__(self,
         *,
         ctype : typing.Optional[global___FieldOptions.CType.V] = ...,
@@ -615,10 +904,9 @@ global___FieldOptions = FieldOptions
 class OneofOptions(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
     UNINTERPRETED_OPTION_FIELD_NUMBER: builtins.int
-
+    # The parser stores options it doesn't recognize here. See above.
     @property
     def uninterpreted_option(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[global___UninterpretedOption]: ...
-
     def __init__(self,
         *,
         uninterpreted_option : typing.Optional[typing.Iterable[global___UninterpretedOption]] = ...,
@@ -631,12 +919,17 @@ class EnumOptions(google.protobuf.message.Message):
     ALLOW_ALIAS_FIELD_NUMBER: builtins.int
     DEPRECATED_FIELD_NUMBER: builtins.int
     UNINTERPRETED_OPTION_FIELD_NUMBER: builtins.int
+    # Set this option to true to allow mapping different tag names to the same
+    # value.
     allow_alias: builtins.bool = ...
+    # Is this enum deprecated?
+    # Depending on the target platform, this can emit Deprecated annotations
+    # for the enum, or it will be completely ignored; in the very least, this
+    # is a formalization for deprecating enums.
     deprecated: builtins.bool = ...
-
+    # The parser stores options it doesn't recognize here. See above.
     @property
     def uninterpreted_option(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[global___UninterpretedOption]: ...
-
     def __init__(self,
         *,
         allow_alias : typing.Optional[builtins.bool] = ...,
@@ -651,11 +944,14 @@ class EnumValueOptions(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
     DEPRECATED_FIELD_NUMBER: builtins.int
     UNINTERPRETED_OPTION_FIELD_NUMBER: builtins.int
+    # Is this enum value deprecated?
+    # Depending on the target platform, this can emit Deprecated annotations
+    # for the enum value, or it will be completely ignored; in the very least,
+    # this is a formalization for deprecating enum values.
     deprecated: builtins.bool = ...
-
+    # The parser stores options it doesn't recognize here. See above.
     @property
     def uninterpreted_option(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[global___UninterpretedOption]: ...
-
     def __init__(self,
         *,
         deprecated : typing.Optional[builtins.bool] = ...,
@@ -669,11 +965,19 @@ class ServiceOptions(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
     DEPRECATED_FIELD_NUMBER: builtins.int
     UNINTERPRETED_OPTION_FIELD_NUMBER: builtins.int
-    deprecated: builtins.bool = ...
+    # Note:  Field numbers 1 through 32 are reserved for Google's internal RPC
+    #   framework.  We apologize for hoarding these numbers to ourselves, but
+    #   we were already using them long before we decided to release Protocol
+    #   Buffers.
 
+    # Is this service deprecated?
+    # Depending on the target platform, this can emit Deprecated annotations
+    # for the service, or it will be completely ignored; in the very least,
+    # this is a formalization for deprecating services.
+    deprecated: builtins.bool = ...
+    # The parser stores options it doesn't recognize here. See above.
     @property
     def uninterpreted_option(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[global___UninterpretedOption]: ...
-
     def __init__(self,
         *,
         deprecated : typing.Optional[builtins.bool] = ...,
@@ -685,28 +989,44 @@ global___ServiceOptions = ServiceOptions
 
 class MethodOptions(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
-    class IdempotencyLevel(metaclass=_IdempotencyLevel):
+    # Is this method side-effect-free (or safe in HTTP parlance), or idempotent,
+    # or neither? HTTP based RPC implementation may choose GET verb for safe
+    # methods, and PUT verb for idempotent methods instead of the default POST.
+    class IdempotencyLevel(_IdempotencyLevel, metaclass=_IdempotencyLevelEnumTypeWrapper):
+        pass
+    class _IdempotencyLevel:
         V = typing.NewType('V', builtins.int)
-
-    IDEMPOTENCY_UNKNOWN = MethodOptions.IdempotencyLevel.V(0)
-    NO_SIDE_EFFECTS = MethodOptions.IdempotencyLevel.V(1)
-    IDEMPOTENT = MethodOptions.IdempotencyLevel.V(2)
-
-    class _IdempotencyLevel(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[IdempotencyLevel.V], builtins.type):  # type: ignore
+    class _IdempotencyLevelEnumTypeWrapper(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[_IdempotencyLevel.V], builtins.type):
         DESCRIPTOR: google.protobuf.descriptor.EnumDescriptor = ...
         IDEMPOTENCY_UNKNOWN = MethodOptions.IdempotencyLevel.V(0)
+        # implies idempotent
         NO_SIDE_EFFECTS = MethodOptions.IdempotencyLevel.V(1)
+        # idempotent, but may have side effects
         IDEMPOTENT = MethodOptions.IdempotencyLevel.V(2)
+
+    IDEMPOTENCY_UNKNOWN = MethodOptions.IdempotencyLevel.V(0)
+    # implies idempotent
+    NO_SIDE_EFFECTS = MethodOptions.IdempotencyLevel.V(1)
+    # idempotent, but may have side effects
+    IDEMPOTENT = MethodOptions.IdempotencyLevel.V(2)
 
     DEPRECATED_FIELD_NUMBER: builtins.int
     IDEMPOTENCY_LEVEL_FIELD_NUMBER: builtins.int
     UNINTERPRETED_OPTION_FIELD_NUMBER: builtins.int
+    # Note:  Field numbers 1 through 32 are reserved for Google's internal RPC
+    #   framework.  We apologize for hoarding these numbers to ourselves, but
+    #   we were already using them long before we decided to release Protocol
+    #   Buffers.
+
+    # Is this method deprecated?
+    # Depending on the target platform, this can emit Deprecated annotations
+    # for the method, or it will be completely ignored; in the very least,
+    # this is a formalization for deprecating methods.
     deprecated: builtins.bool = ...
     idempotency_level: global___MethodOptions.IdempotencyLevel.V = ...
-
+    # The parser stores options it doesn't recognize here. See above.
     @property
     def uninterpreted_option(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[global___UninterpretedOption]: ...
-
     def __init__(self,
         *,
         deprecated : typing.Optional[builtins.bool] = ...,
@@ -717,15 +1037,25 @@ class MethodOptions(google.protobuf.message.Message):
     def ClearField(self, field_name: typing_extensions.Literal[u"deprecated",b"deprecated",u"idempotency_level",b"idempotency_level",u"uninterpreted_option",b"uninterpreted_option"]) -> None: ...
 global___MethodOptions = MethodOptions
 
+# A message representing a option the parser does not recognize. This only
+# appears in options protos created by the compiler::Parser class.
+# DescriptorPool resolves these when building Descriptor objects. Therefore,
+# options protos in descriptor objects (e.g. returned by Descriptor::options(),
+# or produced by Descriptor::CopyTo()) will never have UninterpretedOptions
+# in them.
 class UninterpretedOption(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
+    # The name of the uninterpreted option.  Each string represents a segment in
+    # a dot-separated name.  is_extension is true iff a segment represents an
+    # extension (denoted with parentheses in options specs in .proto files).
+    # E.g.,{ ["foo", false], ["bar.baz", true], ["qux", false] } represents
+    # "foo.(bar.baz).qux".
     class NamePart(google.protobuf.message.Message):
         DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
         NAME_PART_FIELD_NUMBER: builtins.int
         IS_EXTENSION_FIELD_NUMBER: builtins.int
         name_part: typing.Text = ...
         is_extension: builtins.bool = ...
-
         def __init__(self,
             *,
             name_part : typing.Optional[typing.Text] = ...,
@@ -741,16 +1071,16 @@ class UninterpretedOption(google.protobuf.message.Message):
     DOUBLE_VALUE_FIELD_NUMBER: builtins.int
     STRING_VALUE_FIELD_NUMBER: builtins.int
     AGGREGATE_VALUE_FIELD_NUMBER: builtins.int
+    @property
+    def name(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[global___UninterpretedOption.NamePart]: ...
+    # The value of the uninterpreted option, in whatever type the tokenizer
+    # identified it as during parsing. Exactly one of these should be set.
     identifier_value: typing.Text = ...
     positive_int_value: builtins.int = ...
     negative_int_value: builtins.int = ...
     double_value: builtins.float = ...
     string_value: builtins.bytes = ...
     aggregate_value: typing.Text = ...
-
-    @property
-    def name(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[global___UninterpretedOption.NamePart]: ...
-
     def __init__(self,
         *,
         name : typing.Optional[typing.Iterable[global___UninterpretedOption.NamePart]] = ...,
@@ -765,6 +1095,11 @@ class UninterpretedOption(google.protobuf.message.Message):
     def ClearField(self, field_name: typing_extensions.Literal[u"aggregate_value",b"aggregate_value",u"double_value",b"double_value",u"identifier_value",b"identifier_value",u"name",b"name",u"negative_int_value",b"negative_int_value",u"positive_int_value",b"positive_int_value",u"string_value",b"string_value"]) -> None: ...
 global___UninterpretedOption = UninterpretedOption
 
+# ===================================================================
+# Optional source code info
+
+# Encapsulates information about the original source file from which a
+# FileDescriptorProto was generated.
 class SourceCodeInfo(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
     class Location(google.protobuf.message.Message):
@@ -774,18 +1109,89 @@ class SourceCodeInfo(google.protobuf.message.Message):
         LEADING_COMMENTS_FIELD_NUMBER: builtins.int
         TRAILING_COMMENTS_FIELD_NUMBER: builtins.int
         LEADING_DETACHED_COMMENTS_FIELD_NUMBER: builtins.int
-
+        # Identifies which part of the FileDescriptorProto was defined at this
+        # location.
+        #
+        # Each element is a field number or an index.  They form a path from
+        # the root FileDescriptorProto to the place where the definition.  For
+        # example, this path:
+        #   [ 4, 3, 2, 7, 1 ]
+        # refers to:
+        #   file.message_type(3)  // 4, 3
+        #       .field(7)         // 2, 7
+        #       .name()           // 1
+        # This is because FileDescriptorProto.message_type has field number 4:
+        #   repeated DescriptorProto message_type = 4;
+        # and DescriptorProto.field has field number 2:
+        #   repeated FieldDescriptorProto field = 2;
+        # and FieldDescriptorProto.name has field number 1:
+        #   optional string name = 1;
+        #
+        # Thus, the above path gives the location of a field name.  If we removed
+        # the last element:
+        #   [ 4, 3, 2, 7 ]
+        # this path refers to the whole field declaration (from the beginning
+        # of the label to the terminating semicolon).
         @property
         def path(self) -> google.protobuf.internal.containers.RepeatedScalarFieldContainer[builtins.int]: ...
-
+        # Always has exactly three or four elements: start line, start column,
+        # end line (optional, otherwise assumed same as start line), end column.
+        # These are packed into a single field for efficiency.  Note that line
+        # and column numbers are zero-based -- typically you will want to add
+        # 1 to each before displaying to a user.
         @property
         def span(self) -> google.protobuf.internal.containers.RepeatedScalarFieldContainer[builtins.int]: ...
+        # If this SourceCodeInfo represents a complete declaration, these are any
+        # comments appearing before and after the declaration which appear to be
+        # attached to the declaration.
+        #
+        # A series of line comments appearing on consecutive lines, with no other
+        # tokens appearing on those lines, will be treated as a single comment.
+        #
+        # leading_detached_comments will keep paragraphs of comments that appear
+        # before (but not connected to) the current element. Each paragraph,
+        # separated by empty lines, will be one comment element in the repeated
+        # field.
+        #
+        # Only the comment content is provided; comment markers (e.g. //) are
+        # stripped out.  For block comments, leading whitespace and an asterisk
+        # will be stripped from the beginning of each line other than the first.
+        # Newlines are included in the output.
+        #
+        # Examples:
+        #
+        #   optional int32 foo = 1;  // Comment attached to foo.
+        #   // Comment attached to bar.
+        #   optional int32 bar = 2;
+        #
+        #   optional string baz = 3;
+        #   // Comment attached to baz.
+        #   // Another line attached to baz.
+        #
+        #   // Comment attached to qux.
+        #   //
+        #   // Another line attached to qux.
+        #   optional double qux = 4;
+        #
+        #   // Detached comment for corge. This is not leading or trailing comments
+        #   // to qux or corge because there are blank lines separating it from
+        #   // both.
+        #
+        #   // Detached comment for corge paragraph 2.
+        #
+        #   optional string corge = 5;
+        #   /* Block comment attached
+        #    * to corge.  Leading asterisks
+        #    * will be removed. */
+        #   /* Block comment attached to
+        #    * grault. */
+        #   optional int32 grault = 6;
+        #
+        #   // ignored detached comments.
         leading_comments: typing.Text = ...
         trailing_comments: typing.Text = ...
-
         @property
         def leading_detached_comments(self) -> google.protobuf.internal.containers.RepeatedScalarFieldContainer[typing.Text]: ...
-
         def __init__(self,
             *,
             path : typing.Optional[typing.Iterable[builtins.int]] = ...,
@@ -798,10 +1204,51 @@ class SourceCodeInfo(google.protobuf.message.Message):
         def ClearField(self, field_name: typing_extensions.Literal[u"leading_comments",b"leading_comments",u"leading_detached_comments",b"leading_detached_comments",u"path",b"path",u"span",b"span",u"trailing_comments",b"trailing_comments"]) -> None: ...
 
     LOCATION_FIELD_NUMBER: builtins.int
-
+    # A Location identifies a piece of source code in a .proto file which
+    # corresponds to a particular definition.  This information is intended
+    # to be useful to IDEs, code indexers, documentation generators, and similar
+    # tools.
+    #
+    # For example, say we have a file like:
+    #   message Foo {
+    #     optional string foo = 1;
+    #   }
+    # Let's look at just the field definition:
+    #   optional string foo = 1;
+    #   ^       ^^     ^^  ^  ^^^
+    #   a       bc     de  f  ghi
+    # We have the following locations:
+    #   span   path               represents
+    #   [a,i)  [ 4, 0, 2, 0 ]     The whole field definition.
+    #   [a,b)  [ 4, 0, 2, 0, 4 ]  The label (optional).
+    #   [c,d)  [ 4, 0, 2, 0, 5 ]  The type (string).
+    #   [e,f)  [ 4, 0, 2, 0, 1 ]  The name (foo).
+    #   [g,h)  [ 4, 0, 2, 0, 3 ]  The number (1).
+    #
+    # Notes:
+    # - A location may refer to a repeated field itself (i.e. not to any
+    #   particular index within it).  This is used whenever a set of elements are
+    #   logically enclosed in a single code segment.  For example, an entire
+    #   extend block (possibly containing multiple extension definitions) will
+    #   have an outer location whose path refers to the "extensions" repeated
+    #   field without an index.
+    # - Multiple locations may have the same path.  This happens when a single
+    #   logical declaration is spread out across multiple places.  The most
+    #   obvious example is the "extend" block again -- there may be multiple
+    #   extend blocks in the same scope, each of which will have the same path.
+    # - A location's span is not always a subset of its parent's span.  For
+    #   example, the "extendee" of an extension declaration appears at the
+    #   beginning of the "extend" block and is shared by all extensions within
+    #   the block.
+    # - Just because a location's span is a subset of some other location's span
+    #   does not mean that it is a descendant.  For example, a "group" defines
+    #   both a type and a field in a single declaration.  Thus, the locations
+    #   corresponding to the type and field and their components will overlap.
+    # - Code which tries to interpret locations should probably be designed to
+    #   ignore those that it doesn't understand, as more types of locations could
+    #   be recorded in the future.
     @property
     def location(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[global___SourceCodeInfo.Location]: ...
-
     def __init__(self,
         *,
         location : typing.Optional[typing.Iterable[global___SourceCodeInfo.Location]] = ...,
@@ -809,6 +1256,9 @@ class SourceCodeInfo(google.protobuf.message.Message):
     def ClearField(self, field_name: typing_extensions.Literal[u"location",b"location"]) -> None: ...
 global___SourceCodeInfo = SourceCodeInfo
 
+# Describes the relationship between generated code and its original source
+# file. A GeneratedCodeInfo message is associated with only one generated
+# source file, but may contain references to different source .proto files.
 class GeneratedCodeInfo(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
     class Annotation(google.protobuf.message.Message):
@@ -817,13 +1267,19 @@ class GeneratedCodeInfo(google.protobuf.message.Message):
         SOURCE_FILE_FIELD_NUMBER: builtins.int
         BEGIN_FIELD_NUMBER: builtins.int
         END_FIELD_NUMBER: builtins.int
-
+        # Identifies the element in the original source .proto file. This field
+        # is formatted the same as SourceCodeInfo.Location.path.
         @property
         def path(self) -> google.protobuf.internal.containers.RepeatedScalarFieldContainer[builtins.int]: ...
+        # Identifies the filesystem path to the original source .proto.
         source_file: typing.Text = ...
+        # Identifies the starting offset in bytes in the generated code
+        # that relates to the identified object.
         begin: builtins.int = ...
+        # Identifies the ending offset in bytes in the generated code that
+        # relates to the identified offset. The end offset should be one past
+        # the last relevant byte (so the length of the text = end - begin).
         end: builtins.int = ...
-
         def __init__(self,
             *,
             path : typing.Optional[typing.Iterable[builtins.int]] = ...,
@@ -835,10 +1291,10 @@ class GeneratedCodeInfo(google.protobuf.message.Message):
         def ClearField(self, field_name: typing_extensions.Literal[u"begin",b"begin",u"end",b"end",u"path",b"path",u"source_file",b"source_file"]) -> None: ...
 
     ANNOTATION_FIELD_NUMBER: builtins.int
-
+    # An Annotation connects some span of text in generated code to an element
+    # of its generating .proto file.
     @property
     def annotation(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[global___GeneratedCodeInfo.Annotation]: ...
-
     def __init__(self,
         *,
         annotation : typing.Optional[typing.Iterable[global___GeneratedCodeInfo.Annotation]] = ...,

--- a/stubs/protobuf/google/protobuf/duration_pb2.pyi
+++ b/stubs/protobuf/google/protobuf/duration_pb2.pyi
@@ -10,13 +10,79 @@ import typing_extensions
 
 DESCRIPTOR: google.protobuf.descriptor.FileDescriptor = ...
 
+# A Duration represents a signed, fixed-length span of time represented
+# as a count of seconds and fractions of seconds at nanosecond
+# resolution. It is independent of any calendar and concepts like "day"
+# or "month". It is related to Timestamp in that the difference between
+# two Timestamp values is a Duration and it can be added or subtracted
+# from a Timestamp. Range is approximately +-10,000 years.
+#
+# # Examples
+#
+# Example 1: Compute Duration from two Timestamps in pseudo code.
+#
+#     Timestamp start = ...;
+#     Timestamp end = ...;
+#     Duration duration = ...;
+#
+#     duration.seconds = end.seconds - start.seconds;
+#     duration.nanos = end.nanos - start.nanos;
+#
+#     if (duration.seconds < 0 && duration.nanos > 0) {
+#       duration.seconds += 1;
+#       duration.nanos -= 1000000000;
+#     } else if (duration.seconds > 0 && duration.nanos < 0) {
+#       duration.seconds -= 1;
+#       duration.nanos += 1000000000;
+#     }
+#
+# Example 2: Compute Timestamp from Timestamp + Duration in pseudo code.
+#
+#     Timestamp start = ...;
+#     Duration duration = ...;
+#     Timestamp end = ...;
+#
+#     end.seconds = start.seconds + duration.seconds;
+#     end.nanos = start.nanos + duration.nanos;
+#
+#     if (end.nanos < 0) {
+#       end.seconds -= 1;
+#       end.nanos += 1000000000;
+#     } else if (end.nanos >= 1000000000) {
+#       end.seconds += 1;
+#       end.nanos -= 1000000000;
+#     }
+#
+# Example 3: Compute Duration from datetime.timedelta in Python.
+#
+#     td = datetime.timedelta(days=3, minutes=10)
+#     duration = Duration()
+#     duration.FromTimedelta(td)
+#
+# # JSON Mapping
+#
+# In JSON format, the Duration type is encoded as a string rather than an
+# object, where the string ends in the suffix "s" (indicating seconds) and
+# is preceded by the number of seconds, with nanoseconds expressed as
+# fractional seconds. For example, 3 seconds with 0 nanoseconds should be
+# encoded in JSON format as "3s", while 3 seconds and 1 nanosecond should
+# be expressed in JSON format as "3.000000001s", and 3 seconds and 1
+# microsecond should be expressed in JSON format as "3.000001s".
 class Duration(google.protobuf.message.Message, google.protobuf.internal.well_known_types.Duration):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
     SECONDS_FIELD_NUMBER: builtins.int
     NANOS_FIELD_NUMBER: builtins.int
+    # Signed seconds of the span of time. Must be from -315,576,000,000
+    # to +315,576,000,000 inclusive. Note: these bounds are computed from:
+    # 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
     seconds: builtins.int = ...
+    # Signed fractions of a second at nanosecond resolution of the span
+    # of time. Durations less than one second are represented with a 0
+    # `seconds` field and a positive or negative `nanos` field. For durations
+    # of one second or more, a non-zero value for the `nanos` field must be
+    # of the same sign as the `seconds` field. Must be from -999,999,999
+    # to +999,999,999 inclusive.
     nanos: builtins.int = ...
-
     def __init__(self,
         *,
         seconds : builtins.int = ...,

--- a/stubs/protobuf/google/protobuf/empty_pb2.pyi
+++ b/stubs/protobuf/google/protobuf/empty_pb2.pyi
@@ -7,9 +7,17 @@ import google.protobuf.message
 
 DESCRIPTOR: google.protobuf.descriptor.FileDescriptor = ...
 
+# A generic empty message that you can re-use to avoid defining duplicated
+# empty messages in your APIs. A typical example is to use it as the request
+# or the response type of an API method. For instance:
+#
+#     service Foo {
+#       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
+#     }
+#
+# The JSON representation for `Empty` is empty JSON object `{}`.
 class Empty(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
-
     def __init__(self,
         ) -> None: ...
 global___Empty = Empty

--- a/stubs/protobuf/google/protobuf/field_mask_pb2.pyi
+++ b/stubs/protobuf/google/protobuf/field_mask_pb2.pyi
@@ -12,13 +12,211 @@ import typing_extensions
 
 DESCRIPTOR: google.protobuf.descriptor.FileDescriptor = ...
 
+# `FieldMask` represents a set of symbolic field paths, for example:
+#
+#     paths: "f.a"
+#     paths: "f.b.d"
+#
+# Here `f` represents a field in some root message, `a` and `b`
+# fields in the message found in `f`, and `d` a field found in the
+# message in `f.b`.
+#
+# Field masks are used to specify a subset of fields that should be
+# returned by a get operation or modified by an update operation.
+# Field masks also have a custom JSON encoding (see below).
+#
+# # Field Masks in Projections
+#
+# When used in the context of a projection, a response message or
+# sub-message is filtered by the API to only contain those fields as
+# specified in the mask. For example, if the mask in the previous
+# example is applied to a response message as follows:
+#
+#     f {
+#       a : 22
+#       b {
+#         d : 1
+#         x : 2
+#       }
+#       y : 13
+#     }
+#     z: 8
+#
+# The result will not contain specific values for fields x,y and z
+# (their value will be set to the default, and omitted in proto text
+# output):
+#
+#
+#     f {
+#       a : 22
+#       b {
+#         d : 1
+#       }
+#     }
+#
+# A repeated field is not allowed except at the last position of a
+# paths string.
+#
+# If a FieldMask object is not present in a get operation, the
+# operation applies to all fields (as if a FieldMask of all fields
+# had been specified).
+#
+# Note that a field mask does not necessarily apply to the
+# top-level response message. In case of a REST get operation, the
+# field mask applies directly to the response, but in case of a REST
+# list operation, the mask instead applies to each individual message
+# in the returned resource list. In case of a REST custom method,
+# other definitions may be used. Where the mask applies will be
+# clearly documented together with its declaration in the API.  In
+# any case, the effect on the returned resource/resources is required
+# behavior for APIs.
+#
+# # Field Masks in Update Operations
+#
+# A field mask in update operations specifies which fields of the
+# targeted resource are going to be updated. The API is required
+# to only change the values of the fields as specified in the mask
+# and leave the others untouched. If a resource is passed in to
+# describe the updated values, the API ignores the values of all
+# fields not covered by the mask.
+#
+# If a repeated field is specified for an update operation, new values will
+# be appended to the existing repeated field in the target resource. Note that
+# a repeated field is only allowed in the last position of a `paths` string.
+#
+# If a sub-message is specified in the last position of the field mask for an
+# update operation, then new value will be merged into the existing sub-message
+# in the target resource.
+#
+# For example, given the target message:
+#
+#     f {
+#       b {
+#         d: 1
+#         x: 2
+#       }
+#       c: [1]
+#     }
+#
+# And an update message:
+#
+#     f {
+#       b {
+#         d: 10
+#       }
+#       c: [2]
+#     }
+#
+# then if the field mask is:
+#
+#  paths: ["f.b", "f.c"]
+#
+# then the result will be:
+#
+#     f {
+#       b {
+#         d: 10
+#         x: 2
+#       }
+#       c: [1, 2]
+#     }
+#
+# An implementation may provide options to override this default behavior for
+# repeated and message fields.
+#
+# In order to reset a field's value to the default, the field must
+# be in the mask and set to the default value in the provided resource.
+# Hence, in order to reset all fields of a resource, provide a default
+# instance of the resource and set all fields in the mask, or do
+# not provide a mask as described below.
+#
+# If a field mask is not present on update, the operation applies to
+# all fields (as if a field mask of all fields has been specified).
+# Note that in the presence of schema evolution, this may mean that
+# fields the client does not know and has therefore not filled into
+# the request will be reset to their default. If this is unwanted
+# behavior, a specific service may require a client to always specify
+# a field mask, producing an error if not.
+#
+# As with get operations, the location of the resource which
+# describes the updated values in the request message depends on the
+# operation kind. In any case, the effect of the field mask is
+# required to be honored by the API.
+#
+# ## Considerations for HTTP REST
+#
+# The HTTP kind of an update operation which uses a field mask must
+# be set to PATCH instead of PUT in order to satisfy HTTP semantics
+# (PUT must only be used for full updates).
+#
+# # JSON Encoding of Field Masks
+#
+# In JSON, a field mask is encoded as a single string where paths are
+# separated by a comma. Fields name in each path are converted
+# to/from lower-camel naming conventions.
+#
+# As an example, consider the following message declarations:
+#
+#     message Profile {
+#       User user = 1;
+#       Photo photo = 2;
+#     }
+#     message User {
+#       string display_name = 1;
+#       string address = 2;
+#     }
+#
+# In proto a field mask for `Profile` may look as such:
+#
+#     mask {
+#       paths: "user.display_name"
+#       paths: "photo"
+#     }
+#
+# In JSON, the same mask is represented as below:
+#
+#     {
+#       mask: "user.displayName,photo"
+#     }
+#
+# # Field Masks and Oneof Fields
+#
+# Field masks treat fields in oneofs just as regular fields. Consider the
+# following message:
+#
+#     message SampleMessage {
+#       oneof test_oneof {
+#         string name = 4;
+#         SubMessage sub_message = 9;
+#       }
+#     }
+#
+# The field mask can be:
+#
+#     mask {
+#       paths: "name"
+#     }
+#
+# Or:
+#
+#     mask {
+#       paths: "sub_message"
+#     }
+#
+# Note that oneof type names ("test_oneof" in this case) cannot be used in
+# paths.
+#
+# ## Field Mask Verification
+#
+# The implementation of any API method which has a FieldMask type field in the
+# request should verify the included field paths, and return an
+# `INVALID_ARGUMENT` error if any path is unmappable.
 class FieldMask(google.protobuf.message.Message, google.protobuf.internal.well_known_types.FieldMask):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
     PATHS_FIELD_NUMBER: builtins.int
-
+    # The set of field mask paths.
     @property
     def paths(self) -> google.protobuf.internal.containers.RepeatedScalarFieldContainer[typing.Text]: ...
-
     def __init__(self,
         *,
         paths : typing.Optional[typing.Iterable[typing.Text]] = ...,

--- a/stubs/protobuf/google/protobuf/source_context_pb2.pyi
+++ b/stubs/protobuf/google/protobuf/source_context_pb2.pyi
@@ -10,11 +10,14 @@ import typing_extensions
 
 DESCRIPTOR: google.protobuf.descriptor.FileDescriptor = ...
 
+# `SourceContext` represents information about the source of a
+# protobuf element, like the file in which it is defined.
 class SourceContext(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
     FILE_NAME_FIELD_NUMBER: builtins.int
+    # The path-qualified name of the .proto file that contained the associated
+    # protobuf element.  For example: `"google/protobuf/source_context.proto"`.
     file_name: typing.Text = ...
-
     def __init__(self,
         *,
         file_name : typing.Text = ...,

--- a/stubs/protobuf/google/protobuf/struct_pb2.pyi
+++ b/stubs/protobuf/google/protobuf/struct_pb2.pyi
@@ -13,17 +13,32 @@ import typing_extensions
 
 DESCRIPTOR: google.protobuf.descriptor.FileDescriptor = ...
 
-class NullValue(metaclass=_NullValue):
+# `NullValue` is a singleton enumeration to represent the null value for the
+# `Value` type union.
+#
+#  The JSON representation for `NullValue` is JSON `null`.
+class NullValue(_NullValue, metaclass=_NullValueEnumTypeWrapper):
+    pass
+class _NullValue:
     V = typing.NewType('V', builtins.int)
-
-global___NullValue = NullValue
-
-NULL_VALUE = NullValue.V(0)
-
-class _NullValue(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[NullValue.V], builtins.type):  # type: ignore
+class _NullValueEnumTypeWrapper(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[_NullValue.V], builtins.type):
     DESCRIPTOR: google.protobuf.descriptor.EnumDescriptor = ...
+    # Null value.
     NULL_VALUE = NullValue.V(0)
 
+# Null value.
+NULL_VALUE = NullValue.V(0)
+global___NullValue = NullValue
+
+
+# `Struct` represents a structured data value, consisting of fields
+# which map to dynamically typed values. In some languages, `Struct`
+# might be supported by a native representation. For example, in
+# scripting languages like JS a struct is represented as an
+# object. The details of that representation are described together
+# with the proto support for the language.
+#
+# The JSON representation for `Struct` is JSON object.
 class Struct(google.protobuf.message.Message, google.protobuf.internal.well_known_types.Struct):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
     class FieldsEntry(google.protobuf.message.Message):
@@ -31,10 +46,8 @@ class Struct(google.protobuf.message.Message, google.protobuf.internal.well_know
         KEY_FIELD_NUMBER: builtins.int
         VALUE_FIELD_NUMBER: builtins.int
         key: typing.Text = ...
-
         @property
         def value(self) -> global___Value: ...
-
         def __init__(self,
             *,
             key : typing.Text = ...,
@@ -44,10 +57,9 @@ class Struct(google.protobuf.message.Message, google.protobuf.internal.well_know
         def ClearField(self, field_name: typing_extensions.Literal[u"key",b"key",u"value",b"value"]) -> None: ...
 
     FIELDS_FIELD_NUMBER: builtins.int
-
+    # Unordered map of dynamically typed values.
     @property
     def fields(self) -> google.protobuf.internal.containers.MessageMap[typing.Text, global___Value]: ...
-
     def __init__(self,
         *,
         fields : typing.Optional[typing.Mapping[typing.Text, global___Value]] = ...,
@@ -55,6 +67,12 @@ class Struct(google.protobuf.message.Message, google.protobuf.internal.well_know
     def ClearField(self, field_name: typing_extensions.Literal[u"fields",b"fields"]) -> None: ...
 global___Struct = Struct
 
+# `Value` represents a dynamically typed value which can be either
+# null, a number, a string, a boolean, a recursive struct value, or a
+# list of values. A producer of value is expected to set one of that
+# variants, absence of any variant indicates an error.
+#
+# The JSON representation for `Value` is JSON value.
 class Value(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
     NULL_VALUE_FIELD_NUMBER: builtins.int
@@ -63,17 +81,20 @@ class Value(google.protobuf.message.Message):
     BOOL_VALUE_FIELD_NUMBER: builtins.int
     STRUCT_VALUE_FIELD_NUMBER: builtins.int
     LIST_VALUE_FIELD_NUMBER: builtins.int
+    # Represents a null value.
     null_value: global___NullValue.V = ...
+    # Represents a double value.
     number_value: builtins.float = ...
+    # Represents a string value.
     string_value: typing.Text = ...
+    # Represents a boolean value.
     bool_value: builtins.bool = ...
-
+    # Represents a structured value.
     @property
     def struct_value(self) -> global___Struct: ...
-
+    # Represents a repeated `Value`.
     @property
     def list_value(self) -> global___ListValue: ...
-
     def __init__(self,
         *,
         null_value : global___NullValue.V = ...,
@@ -88,13 +109,15 @@ class Value(google.protobuf.message.Message):
     def WhichOneof(self, oneof_group: typing_extensions.Literal[u"kind",b"kind"]) -> typing.Optional[typing_extensions.Literal["null_value","number_value","string_value","bool_value","struct_value","list_value"]]: ...
 global___Value = Value
 
+# `ListValue` is a wrapper around a repeated field of values.
+#
+# The JSON representation for `ListValue` is JSON array.
 class ListValue(google.protobuf.message.Message, google.protobuf.internal.well_known_types.ListValue):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
     VALUES_FIELD_NUMBER: builtins.int
-
+    # Repeated field of dynamically typed values.
     @property
     def values(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[global___Value]: ...
-
     def __init__(self,
         *,
         values : typing.Optional[typing.Iterable[global___Value]] = ...,

--- a/stubs/protobuf/google/protobuf/timestamp_pb2.pyi
+++ b/stubs/protobuf/google/protobuf/timestamp_pb2.pyi
@@ -10,13 +10,110 @@ import typing_extensions
 
 DESCRIPTOR: google.protobuf.descriptor.FileDescriptor = ...
 
+# A Timestamp represents a point in time independent of any time zone or local
+# calendar, encoded as a count of seconds and fractions of seconds at
+# nanosecond resolution. The count is relative to an epoch at UTC midnight on
+# January 1, 1970, in the proleptic Gregorian calendar which extends the
+# Gregorian calendar backwards to year one.
+#
+# All minutes are 60 seconds long. Leap seconds are "smeared" so that no leap
+# second table is needed for interpretation, using a [24-hour linear
+# smear](https://developers.google.com/time/smear).
+#
+# The range is from 0001-01-01T00:00:00Z to 9999-12-31T23:59:59.999999999Z. By
+# restricting to that range, we ensure that we can convert to and from [RFC
+# 3339](https://www.ietf.org/rfc/rfc3339.txt) date strings.
+#
+# # Examples
+#
+# Example 1: Compute Timestamp from POSIX `time()`.
+#
+#     Timestamp timestamp;
+#     timestamp.set_seconds(time(NULL));
+#     timestamp.set_nanos(0);
+#
+# Example 2: Compute Timestamp from POSIX `gettimeofday()`.
+#
+#     struct timeval tv;
+#     gettimeofday(&tv, NULL);
+#
+#     Timestamp timestamp;
+#     timestamp.set_seconds(tv.tv_sec);
+#     timestamp.set_nanos(tv.tv_usec * 1000);
+#
+# Example 3: Compute Timestamp from Win32 `GetSystemTimeAsFileTime()`.
+#
+#     FILETIME ft;
+#     GetSystemTimeAsFileTime(&ft);
+#     UINT64 ticks = (((UINT64)ft.dwHighDateTime) << 32) | ft.dwLowDateTime;
+#
+#     // A Windows tick is 100 nanoseconds. Windows epoch 1601-01-01T00:00:00Z
+#     // is 11644473600 seconds before Unix epoch 1970-01-01T00:00:00Z.
+#     Timestamp timestamp;
+#     timestamp.set_seconds((INT64) ((ticks / 10000000) - 11644473600LL));
+#     timestamp.set_nanos((INT32) ((ticks % 10000000) * 100));
+#
+# Example 4: Compute Timestamp from Java `System.currentTimeMillis()`.
+#
+#     long millis = System.currentTimeMillis();
+#
+#     Timestamp timestamp = Timestamp.newBuilder().setSeconds(millis / 1000)
+#         .setNanos((int) ((millis % 1000) * 1000000)).build();
+#
+#
+# Example 5: Compute Timestamp from Java `Instant.now()`.
+#
+#     Instant now = Instant.now();
+#
+#     Timestamp timestamp =
+#         Timestamp.newBuilder().setSeconds(now.getEpochSecond())
+#             .setNanos(now.getNano()).build();
+#
+#
+# Example 6: Compute Timestamp from current time in Python.
+#
+#     timestamp = Timestamp()
+#     timestamp.GetCurrentTime()
+#
+# # JSON Mapping
+#
+# In JSON format, the Timestamp type is encoded as a string in the
+# [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format. That is, the
+# format is "{year}-{month}-{day}T{hour}:{min}:{sec}[.{frac_sec}]Z"
+# where {year} is always expressed using four digits while {month}, {day},
+# {hour}, {min}, and {sec} are zero-padded to two digits each. The fractional
+# seconds, which can go up to 9 digits (i.e. up to 1 nanosecond resolution),
+# are optional. The "Z" suffix indicates the timezone ("UTC"); the timezone
+# is required. A proto3 JSON serializer should always use UTC (as indicated by
+# "Z") when printing the Timestamp type and a proto3 JSON parser should be
+# able to accept both UTC and other timezones (as indicated by an offset).
+#
+# For example, "2017-01-15T01:30:15.01Z" encodes 15.01 seconds past
+# 01:30 UTC on January 15, 2017.
+#
+# In JavaScript, one can convert a Date object to this format using the
+# standard
+# [toISOString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString)
+# method. In Python, a standard `datetime.datetime` object can be converted
+# to this format using
+# [`strftime`](https://docs.python.org/2/library/time.html#time.strftime) with
+# the time format spec '%Y-%m-%dT%H:%M:%S.%fZ'. Likewise, in Java, one can use
+# the Joda Time's [`ISODateTimeFormat.dateTime()`](
+# http://www.joda.org/joda-time/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime%2D%2D
+# ) to obtain a formatter capable of generating timestamps in this format.
 class Timestamp(google.protobuf.message.Message, google.protobuf.internal.well_known_types.Timestamp):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
     SECONDS_FIELD_NUMBER: builtins.int
     NANOS_FIELD_NUMBER: builtins.int
+    # Represents seconds of UTC time since Unix epoch
+    # 1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
+    # 9999-12-31T23:59:59Z inclusive.
     seconds: builtins.int = ...
+    # Non-negative fractions of a second at nanosecond resolution. Negative
+    # second values with fractions must still have non-negative nanos values
+    # that count forward in time. Must be from 0 to 999,999,999
+    # inclusive.
     nanos: builtins.int = ...
-
     def __init__(self,
         *,
         seconds : builtins.int = ...,

--- a/stubs/protobuf/google/protobuf/type_pb2.pyi
+++ b/stubs/protobuf/google/protobuf/type_pb2.pyi
@@ -14,19 +14,26 @@ import typing_extensions
 
 DESCRIPTOR: google.protobuf.descriptor.FileDescriptor = ...
 
-class Syntax(metaclass=_Syntax):
+# The syntax in which a protocol buffer element is defined.
+class Syntax(_Syntax, metaclass=_SyntaxEnumTypeWrapper):
+    pass
+class _Syntax:
     V = typing.NewType('V', builtins.int)
-
-global___Syntax = Syntax
-
-SYNTAX_PROTO2 = Syntax.V(0)
-SYNTAX_PROTO3 = Syntax.V(1)
-
-class _Syntax(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[Syntax.V], builtins.type):  # type: ignore
+class _SyntaxEnumTypeWrapper(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[_Syntax.V], builtins.type):
     DESCRIPTOR: google.protobuf.descriptor.EnumDescriptor = ...
+    # Syntax `proto2`.
     SYNTAX_PROTO2 = Syntax.V(0)
+    # Syntax `proto3`.
     SYNTAX_PROTO3 = Syntax.V(1)
 
+# Syntax `proto2`.
+SYNTAX_PROTO2 = Syntax.V(0)
+# Syntax `proto3`.
+SYNTAX_PROTO3 = Syntax.V(1)
+global___Syntax = Syntax
+
+
+# A protocol buffer message type.
 class Type(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
     NAME_FIELD_NUMBER: builtins.int
@@ -35,21 +42,22 @@ class Type(google.protobuf.message.Message):
     OPTIONS_FIELD_NUMBER: builtins.int
     SOURCE_CONTEXT_FIELD_NUMBER: builtins.int
     SYNTAX_FIELD_NUMBER: builtins.int
+    # The fully qualified message name.
     name: typing.Text = ...
-
-    @property
-    def oneofs(self) -> google.protobuf.internal.containers.RepeatedScalarFieldContainer[typing.Text]: ...
-    syntax: global___Syntax.V = ...
-
+    # The list of fields.
     @property
     def fields(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[global___Field]: ...
-
+    # The list of types appearing in `oneof` definitions in this type.
+    @property
+    def oneofs(self) -> google.protobuf.internal.containers.RepeatedScalarFieldContainer[typing.Text]: ...
+    # The protocol buffer options.
     @property
     def options(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[global___Option]: ...
-
+    # The source context.
     @property
     def source_context(self) -> google.protobuf.source_context_pb2.SourceContext: ...
-
+    # The source syntax.
+    syntax: global___Syntax.V = ...
     def __init__(self,
         *,
         name : typing.Text = ...,
@@ -63,67 +71,118 @@ class Type(google.protobuf.message.Message):
     def ClearField(self, field_name: typing_extensions.Literal[u"fields",b"fields",u"name",b"name",u"oneofs",b"oneofs",u"options",b"options",u"source_context",b"source_context",u"syntax",b"syntax"]) -> None: ...
 global___Type = Type
 
+# A single field of a message type.
 class Field(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
-    class Kind(metaclass=_Kind):
+    # Basic field types.
+    class Kind(_Kind, metaclass=_KindEnumTypeWrapper):
+        pass
+    class _Kind:
         V = typing.NewType('V', builtins.int)
-
-    TYPE_UNKNOWN = Field.Kind.V(0)
-    TYPE_DOUBLE = Field.Kind.V(1)
-    TYPE_FLOAT = Field.Kind.V(2)
-    TYPE_INT64 = Field.Kind.V(3)
-    TYPE_UINT64 = Field.Kind.V(4)
-    TYPE_INT32 = Field.Kind.V(5)
-    TYPE_FIXED64 = Field.Kind.V(6)
-    TYPE_FIXED32 = Field.Kind.V(7)
-    TYPE_BOOL = Field.Kind.V(8)
-    TYPE_STRING = Field.Kind.V(9)
-    TYPE_GROUP = Field.Kind.V(10)
-    TYPE_MESSAGE = Field.Kind.V(11)
-    TYPE_BYTES = Field.Kind.V(12)
-    TYPE_UINT32 = Field.Kind.V(13)
-    TYPE_ENUM = Field.Kind.V(14)
-    TYPE_SFIXED32 = Field.Kind.V(15)
-    TYPE_SFIXED64 = Field.Kind.V(16)
-    TYPE_SINT32 = Field.Kind.V(17)
-    TYPE_SINT64 = Field.Kind.V(18)
-
-    class _Kind(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[Kind.V], builtins.type):  # type: ignore
+    class _KindEnumTypeWrapper(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[_Kind.V], builtins.type):
         DESCRIPTOR: google.protobuf.descriptor.EnumDescriptor = ...
+        # Field type unknown.
         TYPE_UNKNOWN = Field.Kind.V(0)
+        # Field type double.
         TYPE_DOUBLE = Field.Kind.V(1)
+        # Field type float.
         TYPE_FLOAT = Field.Kind.V(2)
+        # Field type int64.
         TYPE_INT64 = Field.Kind.V(3)
+        # Field type uint64.
         TYPE_UINT64 = Field.Kind.V(4)
+        # Field type int32.
         TYPE_INT32 = Field.Kind.V(5)
+        # Field type fixed64.
         TYPE_FIXED64 = Field.Kind.V(6)
+        # Field type fixed32.
         TYPE_FIXED32 = Field.Kind.V(7)
+        # Field type bool.
         TYPE_BOOL = Field.Kind.V(8)
+        # Field type string.
         TYPE_STRING = Field.Kind.V(9)
+        # Field type group. Proto2 syntax only, and deprecated.
         TYPE_GROUP = Field.Kind.V(10)
+        # Field type message.
         TYPE_MESSAGE = Field.Kind.V(11)
+        # Field type bytes.
         TYPE_BYTES = Field.Kind.V(12)
+        # Field type uint32.
         TYPE_UINT32 = Field.Kind.V(13)
+        # Field type enum.
         TYPE_ENUM = Field.Kind.V(14)
+        # Field type sfixed32.
         TYPE_SFIXED32 = Field.Kind.V(15)
+        # Field type sfixed64.
         TYPE_SFIXED64 = Field.Kind.V(16)
+        # Field type sint32.
         TYPE_SINT32 = Field.Kind.V(17)
+        # Field type sint64.
         TYPE_SINT64 = Field.Kind.V(18)
 
-    class Cardinality(metaclass=_Cardinality):
+    # Field type unknown.
+    TYPE_UNKNOWN = Field.Kind.V(0)
+    # Field type double.
+    TYPE_DOUBLE = Field.Kind.V(1)
+    # Field type float.
+    TYPE_FLOAT = Field.Kind.V(2)
+    # Field type int64.
+    TYPE_INT64 = Field.Kind.V(3)
+    # Field type uint64.
+    TYPE_UINT64 = Field.Kind.V(4)
+    # Field type int32.
+    TYPE_INT32 = Field.Kind.V(5)
+    # Field type fixed64.
+    TYPE_FIXED64 = Field.Kind.V(6)
+    # Field type fixed32.
+    TYPE_FIXED32 = Field.Kind.V(7)
+    # Field type bool.
+    TYPE_BOOL = Field.Kind.V(8)
+    # Field type string.
+    TYPE_STRING = Field.Kind.V(9)
+    # Field type group. Proto2 syntax only, and deprecated.
+    TYPE_GROUP = Field.Kind.V(10)
+    # Field type message.
+    TYPE_MESSAGE = Field.Kind.V(11)
+    # Field type bytes.
+    TYPE_BYTES = Field.Kind.V(12)
+    # Field type uint32.
+    TYPE_UINT32 = Field.Kind.V(13)
+    # Field type enum.
+    TYPE_ENUM = Field.Kind.V(14)
+    # Field type sfixed32.
+    TYPE_SFIXED32 = Field.Kind.V(15)
+    # Field type sfixed64.
+    TYPE_SFIXED64 = Field.Kind.V(16)
+    # Field type sint32.
+    TYPE_SINT32 = Field.Kind.V(17)
+    # Field type sint64.
+    TYPE_SINT64 = Field.Kind.V(18)
+
+    # Whether a field is optional, required, or repeated.
+    class Cardinality(_Cardinality, metaclass=_CardinalityEnumTypeWrapper):
+        pass
+    class _Cardinality:
         V = typing.NewType('V', builtins.int)
-
-    CARDINALITY_UNKNOWN = Field.Cardinality.V(0)
-    CARDINALITY_OPTIONAL = Field.Cardinality.V(1)
-    CARDINALITY_REQUIRED = Field.Cardinality.V(2)
-    CARDINALITY_REPEATED = Field.Cardinality.V(3)
-
-    class _Cardinality(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[Cardinality.V], builtins.type):  # type: ignore
+    class _CardinalityEnumTypeWrapper(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[_Cardinality.V], builtins.type):
         DESCRIPTOR: google.protobuf.descriptor.EnumDescriptor = ...
+        # For fields with unknown cardinality.
         CARDINALITY_UNKNOWN = Field.Cardinality.V(0)
+        # For optional fields.
         CARDINALITY_OPTIONAL = Field.Cardinality.V(1)
+        # For required fields. Proto2 syntax only.
         CARDINALITY_REQUIRED = Field.Cardinality.V(2)
+        # For repeated fields.
         CARDINALITY_REPEATED = Field.Cardinality.V(3)
+
+    # For fields with unknown cardinality.
+    CARDINALITY_UNKNOWN = Field.Cardinality.V(0)
+    # For optional fields.
+    CARDINALITY_OPTIONAL = Field.Cardinality.V(1)
+    # For required fields. Proto2 syntax only.
+    CARDINALITY_REQUIRED = Field.Cardinality.V(2)
+    # For repeated fields.
+    CARDINALITY_REPEATED = Field.Cardinality.V(3)
 
     KIND_FIELD_NUMBER: builtins.int
     CARDINALITY_FIELD_NUMBER: builtins.int
@@ -135,19 +194,29 @@ class Field(google.protobuf.message.Message):
     OPTIONS_FIELD_NUMBER: builtins.int
     JSON_NAME_FIELD_NUMBER: builtins.int
     DEFAULT_VALUE_FIELD_NUMBER: builtins.int
+    # The field type.
     kind: global___Field.Kind.V = ...
+    # The field cardinality.
     cardinality: global___Field.Cardinality.V = ...
+    # The field number.
     number: builtins.int = ...
+    # The field name.
     name: typing.Text = ...
+    # The field type URL, without the scheme, for message or enumeration
+    # types. Example: `"type.googleapis.com/google.protobuf.Timestamp"`.
     type_url: typing.Text = ...
+    # The index of the field type in `Type.oneofs`, for message or enumeration
+    # types. The first type has index 1; zero means the type is not in the list.
     oneof_index: builtins.int = ...
+    # Whether to use alternative packed wire representation.
     packed: builtins.bool = ...
-    json_name: typing.Text = ...
-    default_value: typing.Text = ...
-
+    # The protocol buffer options.
     @property
     def options(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[global___Option]: ...
-
+    # The field JSON name.
+    json_name: typing.Text = ...
+    # The string value of the default value of this field. Proto2 syntax only.
+    default_value: typing.Text = ...
     def __init__(self,
         *,
         kind : global___Field.Kind.V = ...,
@@ -164,6 +233,7 @@ class Field(google.protobuf.message.Message):
     def ClearField(self, field_name: typing_extensions.Literal[u"cardinality",b"cardinality",u"default_value",b"default_value",u"json_name",b"json_name",u"kind",b"kind",u"name",b"name",u"number",b"number",u"oneof_index",b"oneof_index",u"options",b"options",u"packed",b"packed",u"type_url",b"type_url"]) -> None: ...
 global___Field = Field
 
+# Enum type definition.
 class Enum(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
     NAME_FIELD_NUMBER: builtins.int
@@ -171,18 +241,19 @@ class Enum(google.protobuf.message.Message):
     OPTIONS_FIELD_NUMBER: builtins.int
     SOURCE_CONTEXT_FIELD_NUMBER: builtins.int
     SYNTAX_FIELD_NUMBER: builtins.int
+    # Enum type name.
     name: typing.Text = ...
-    syntax: global___Syntax.V = ...
-
+    # Enum value definitions.
     @property
     def enumvalue(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[global___EnumValue]: ...
-
+    # Protocol buffer options.
     @property
     def options(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[global___Option]: ...
-
+    # The source context.
     @property
     def source_context(self) -> google.protobuf.source_context_pb2.SourceContext: ...
-
+    # The source syntax.
+    syntax: global___Syntax.V = ...
     def __init__(self,
         *,
         name : typing.Text = ...,
@@ -195,17 +266,19 @@ class Enum(google.protobuf.message.Message):
     def ClearField(self, field_name: typing_extensions.Literal[u"enumvalue",b"enumvalue",u"name",b"name",u"options",b"options",u"source_context",b"source_context",u"syntax",b"syntax"]) -> None: ...
 global___Enum = Enum
 
+# Enum value definition.
 class EnumValue(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
     NAME_FIELD_NUMBER: builtins.int
     NUMBER_FIELD_NUMBER: builtins.int
     OPTIONS_FIELD_NUMBER: builtins.int
+    # Enum value name.
     name: typing.Text = ...
+    # Enum value number.
     number: builtins.int = ...
-
+    # Protocol buffer options.
     @property
     def options(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[global___Option]: ...
-
     def __init__(self,
         *,
         name : typing.Text = ...,
@@ -215,15 +288,23 @@ class EnumValue(google.protobuf.message.Message):
     def ClearField(self, field_name: typing_extensions.Literal[u"name",b"name",u"number",b"number",u"options",b"options"]) -> None: ...
 global___EnumValue = EnumValue
 
+# A protocol buffer option, which can be attached to a message, field,
+# enumeration, etc.
 class Option(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
     NAME_FIELD_NUMBER: builtins.int
     VALUE_FIELD_NUMBER: builtins.int
+    # The option's name. For protobuf built-in options (options defined in
+    # descriptor.proto), this is the short name. For example, `"map_entry"`.
+    # For custom options, it should be the fully-qualified name. For example,
+    # `"google.api.http"`.
     name: typing.Text = ...
-
+    # The option's value packed in an Any message. If the value is a primitive,
+    # the corresponding wrapper type defined in google/protobuf/wrappers.proto
+    # should be used. If the value is an enum, it should be stored as an int32
+    # value using the google.protobuf.Int32Value type.
     @property
     def value(self) -> google.protobuf.any_pb2.Any: ...
-
     def __init__(self,
         *,
         name : typing.Text = ...,

--- a/stubs/protobuf/google/protobuf/wrappers_pb2.pyi
+++ b/stubs/protobuf/google/protobuf/wrappers_pb2.pyi
@@ -10,11 +10,14 @@ import typing_extensions
 
 DESCRIPTOR: google.protobuf.descriptor.FileDescriptor = ...
 
+# Wrapper message for `double`.
+#
+# The JSON representation for `DoubleValue` is JSON number.
 class DoubleValue(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
     VALUE_FIELD_NUMBER: builtins.int
+    # The double value.
     value: builtins.float = ...
-
     def __init__(self,
         *,
         value : builtins.float = ...,
@@ -22,11 +25,14 @@ class DoubleValue(google.protobuf.message.Message):
     def ClearField(self, field_name: typing_extensions.Literal[u"value",b"value"]) -> None: ...
 global___DoubleValue = DoubleValue
 
+# Wrapper message for `float`.
+#
+# The JSON representation for `FloatValue` is JSON number.
 class FloatValue(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
     VALUE_FIELD_NUMBER: builtins.int
+    # The float value.
     value: builtins.float = ...
-
     def __init__(self,
         *,
         value : builtins.float = ...,
@@ -34,11 +40,14 @@ class FloatValue(google.protobuf.message.Message):
     def ClearField(self, field_name: typing_extensions.Literal[u"value",b"value"]) -> None: ...
 global___FloatValue = FloatValue
 
+# Wrapper message for `int64`.
+#
+# The JSON representation for `Int64Value` is JSON string.
 class Int64Value(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
     VALUE_FIELD_NUMBER: builtins.int
+    # The int64 value.
     value: builtins.int = ...
-
     def __init__(self,
         *,
         value : builtins.int = ...,
@@ -46,11 +55,14 @@ class Int64Value(google.protobuf.message.Message):
     def ClearField(self, field_name: typing_extensions.Literal[u"value",b"value"]) -> None: ...
 global___Int64Value = Int64Value
 
+# Wrapper message for `uint64`.
+#
+# The JSON representation for `UInt64Value` is JSON string.
 class UInt64Value(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
     VALUE_FIELD_NUMBER: builtins.int
+    # The uint64 value.
     value: builtins.int = ...
-
     def __init__(self,
         *,
         value : builtins.int = ...,
@@ -58,11 +70,14 @@ class UInt64Value(google.protobuf.message.Message):
     def ClearField(self, field_name: typing_extensions.Literal[u"value",b"value"]) -> None: ...
 global___UInt64Value = UInt64Value
 
+# Wrapper message for `int32`.
+#
+# The JSON representation for `Int32Value` is JSON number.
 class Int32Value(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
     VALUE_FIELD_NUMBER: builtins.int
+    # The int32 value.
     value: builtins.int = ...
-
     def __init__(self,
         *,
         value : builtins.int = ...,
@@ -70,11 +85,14 @@ class Int32Value(google.protobuf.message.Message):
     def ClearField(self, field_name: typing_extensions.Literal[u"value",b"value"]) -> None: ...
 global___Int32Value = Int32Value
 
+# Wrapper message for `uint32`.
+#
+# The JSON representation for `UInt32Value` is JSON number.
 class UInt32Value(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
     VALUE_FIELD_NUMBER: builtins.int
+    # The uint32 value.
     value: builtins.int = ...
-
     def __init__(self,
         *,
         value : builtins.int = ...,
@@ -82,11 +100,14 @@ class UInt32Value(google.protobuf.message.Message):
     def ClearField(self, field_name: typing_extensions.Literal[u"value",b"value"]) -> None: ...
 global___UInt32Value = UInt32Value
 
+# Wrapper message for `bool`.
+#
+# The JSON representation for `BoolValue` is JSON `true` and `false`.
 class BoolValue(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
     VALUE_FIELD_NUMBER: builtins.int
+    # The bool value.
     value: builtins.bool = ...
-
     def __init__(self,
         *,
         value : builtins.bool = ...,
@@ -94,11 +115,14 @@ class BoolValue(google.protobuf.message.Message):
     def ClearField(self, field_name: typing_extensions.Literal[u"value",b"value"]) -> None: ...
 global___BoolValue = BoolValue
 
+# Wrapper message for `string`.
+#
+# The JSON representation for `StringValue` is JSON string.
 class StringValue(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
     VALUE_FIELD_NUMBER: builtins.int
+    # The string value.
     value: typing.Text = ...
-
     def __init__(self,
         *,
         value : typing.Text = ...,
@@ -106,11 +130,14 @@ class StringValue(google.protobuf.message.Message):
     def ClearField(self, field_name: typing_extensions.Literal[u"value",b"value"]) -> None: ...
 global___StringValue = StringValue
 
+# Wrapper message for `bytes`.
+#
+# The JSON representation for `BytesValue` is JSON string.
 class BytesValue(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
     VALUE_FIELD_NUMBER: builtins.int
+    # The bytes value.
     value: builtins.bytes = ...
-
     def __init__(self,
         *,
         value : builtins.bytes = ...,


### PR DESCRIPTION
Includes features from 2.7 and 2.8
https://github.com/dropbox/mypy-protobuf/blob/master/CHANGELOG.md

Notably
- propagate comments
- Field ordering in original order
- remove type-ignore used on enums