### PR TITLE
add missing type hints in termcolor

### DIFF
--- a/stubs/termcolor/METADATA.toml
+++ b/stubs/termcolor/METADATA.toml
@@ -1,2 +1,2 @@
-version = "0.1"
+version = "1.1"
 python2 = true

--- a/stubs/termcolor/termcolor.pyi
+++ b/stubs/termcolor/termcolor.pyi
@@ -1,5 +1,10 @@
 from typing import Any, Iterable, Optional, Text
 
+ATTRIBUTES: dict[str, int]
+COLORS: dict[str, int]
+HIGHLIGHTS: dict[str, int]
+RESET: str
+
 def colored(
     text: Text, color: Optional[Text] = ..., on_color: Optional[Text] = ..., attrs: Optional[Iterable[Text]] = ...
 ) -> Text: ...


### PR DESCRIPTION
I also raised the version to the latest release version.