### PR TITLE
Update `urllib3.util.retry.Retry.__init__()` to match the latest version released on PyPI

### DIFF
--- a/stubs/requests/@tests/stubtest_allowlist.txt
+++ b/stubs/requests/@tests/stubtest_allowlist.txt
@@ -44,7 +44,6 @@ requests.packages.urllib3.response.HTTPResponse.__init__
 requests.packages.urllib3.response.PY3
 requests.packages.urllib3.util.connection.poll
 requests.packages.urllib3.util.connection.select
-requests.packages.urllib3.util.retry.Retry.__init__
 requests.packages.urllib3.util.retry.Retry.is_forced_retry
 requests.packages.urllib3.util.retry.Retry.sleep
 requests.packages.urllib3.util.ssl_.create_default_context

--- a/stubs/requests/requests/packages/urllib3/util/retry.pyi
+++ b/stubs/requests/requests/packages/urllib3/util/retry.pyi
@@ -27,11 +27,17 @@ class Retry:
         connect=...,
         read=...,
         redirect=...,
-        method_whitelist=...,
+        status=...,
+        other=...,
+        allowed_methods=...,
         status_forcelist=...,
         backoff_factor=...,
         raise_on_redirect=...,
-        _observed_errors=...,
+        raise_on_status=...,
+        history=...,
+        respect_retry_after_header=...,
+        remove_headers_on_redirect=...,
+        method_whitelist=...,
     ) -> None: ...
     def new(self, **kw): ...
     @classmethod


### PR DESCRIPTION
For reference, here is the corresponding source code in urllib3 repo:

https://github.com/urllib3/urllib3/blob/13603ecb4be3bbcd7bd2fd1d650ac659f85a959d/src/urllib3/util/retry.py#L225-L243