### PR TITLE
Broaden the signature of subprocess.list2cmdline.

### DIFF
--- a/stdlib/subprocess.pyi
+++ b/stdlib/subprocess.pyi
@@ -1,7 +1,22 @@
 import sys
 from _typeshed import Self, StrOrBytesPath
 from types import TracebackType
-from typing import IO, Any, AnyStr, Callable, Generic, Mapping, Optional, Sequence, Tuple, Type, TypeVar, Union, overload
+from typing import (
+    IO,
+    Any,
+    AnyStr,
+    Callable,
+    Generic,
+    Iterable,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+    overload,
+)
 from typing_extensions import Literal
 
 if sys.version_info >= (3, 9):
@@ -1016,7 +1031,7 @@ class Popen(Generic[AnyStr]):
 # The result really is always a str.
 def getstatusoutput(cmd: _TXT) -> Tuple[int, str]: ...
 def getoutput(cmd: _TXT) -> str: ...
-def list2cmdline(seq: Sequence[str]) -> str: ...  # undocumented
+def list2cmdline(seq: Iterable[str]) -> str: ...  # undocumented
 
 if sys.platform == "win32":
     class STARTUPINFO:


### PR DESCRIPTION
Although the parameter is called 'seq', the implementation shows that it
can be anything that can be passed to map(), which takes iterables:
https://github.com/python/cpython/blob/0f42b726c87f72d522893f927b4cb592b8875641/Lib/subprocess.py#L565.