### PR TITLE
add missing type hints in tabulate

### DIFF
--- a/stubs/tabulate/METADATA.toml
+++ b/stubs/tabulate/METADATA.toml
@@ -1,2 +1,2 @@
-version = "0.1"
+version = "0.8"
 python2 = true

--- a/stubs/tabulate/tabulate.pyi
+++ b/stubs/tabulate/tabulate.pyi
@@ -1,7 +1,10 @@
 from typing import Any, Callable, Container, Dict, Iterable, List, Mapping, NamedTuple, Optional, Sequence, Union
 
+LATEX_ESCAPE_RULES: Dict[str, str]
+MIN_PADDING: int
 PRESERVE_WHITESPACE: bool
 WIDE_CHARS_MODE: bool
+multiline_formats: Dict[str, str]
 tabulate_formats: List[str]
 
 class Line(NamedTuple):


### PR DESCRIPTION
Just some missing attributes and I also adjusted the version to reflect the current released one.