### PR TITLE
python2/tempfile: dir argument can be None

### DIFF
--- a/stdlib/@python2/tempfile.pyi
+++ b/stdlib/@python2/tempfile.pyi
@@ -55,14 +55,14 @@ def TemporaryFile(
     bufsize: int = ...,
     suffix: Union[bytes, unicode] = ...,
     prefix: Union[bytes, unicode] = ...,
-    dir: Union[bytes, unicode] = ...,
+    dir: Optional[Union[bytes, unicode]] = ...,
 ) -> _TemporaryFileWrapper: ...
 def NamedTemporaryFile(
     mode: Union[bytes, unicode] = ...,
     bufsize: int = ...,
     suffix: Union[bytes, unicode] = ...,
     prefix: Union[bytes, unicode] = ...,
-    dir: Union[bytes, unicode] = ...,
+    dir: Optional[Union[bytes, unicode]] = ...,
     delete: bool = ...,
 ) -> _TemporaryFileWrapper: ...
 def SpooledTemporaryFile(
@@ -71,7 +71,7 @@ def SpooledTemporaryFile(
     buffering: int = ...,
     suffix: Union[bytes, unicode] = ...,
     prefix: Union[bytes, unicode] = ...,
-    dir: Union[bytes, unicode] = ...,
+    dir: Optional[Union[bytes, unicode]] = ...,
 ) -> _TemporaryFileWrapper: ...
 
 class TemporaryDirectory:


### PR DESCRIPTION
Reference: https://docs.python.org/2.7/library/tempfile.html#tempfile.TemporaryFile (similar for the others).

As for `TemporaryDirectory`, I don't think it actually exists on Python 2 (at least I get an import error), so didn't touch it.