### PR TITLE
Add missing exceptions to requests __init__.pyi

### DIFF
--- a/stubs/requests/requests/__init__.pyi
+++ b/stubs/requests/requests/__init__.pyi
@@ -13,6 +13,8 @@ from .api import (
 )
 from .exceptions import (
     ConnectionError as ConnectionError,
+    ConnectTimeout as ConnectTimeout,
+    FileModeWarning as FileModeWarning,
     HTTPError as HTTPError,
     ReadTimeout as ReadTimeout,
     RequestException as RequestException,


### PR DESCRIPTION
These two are missing from this file even though they are present in the requests package's `__init__.py`.

There is one other missing exception, `JSONDecodeError`, but I wasn't sure how best to handle that so I've omitted it.
It would require something in `compat.pyi` which inherits differently in certain conditions.