### PR TITLE
fix: arbitrary keyword arguments are not accepted in logging functions

### DIFF
--- a/stdlib/logging/__init__.pyi
+++ b/stdlib/logging/__init__.pyi
@@ -69,7 +69,6 @@ class Logger(Filterer):
             stack_info: bool = ...,
             stacklevel: int = ...,
             extra: Optional[dict[str, Any]] = ...,
-            **kwargs: Any,
         ) -> None: ...
         def info(
             self,
@@ -79,7 +78,6 @@ class Logger(Filterer):
             stack_info: bool = ...,
             stacklevel: int = ...,
             extra: Optional[dict[str, Any]] = ...,
-            **kwargs: Any,
         ) -> None: ...
         def warning(
             self,
@@ -89,7 +87,6 @@ class Logger(Filterer):
             stack_info: bool = ...,
             stacklevel: int = ...,
             extra: Optional[dict[str, Any]] = ...,
-            **kwargs: Any,
         ) -> None: ...
         def warn(
             self,
@@ -99,7 +96,6 @@ class Logger(Filterer):
             stack_info: bool = ...,
             stacklevel: int = ...,
             extra: Optional[dict[str, Any]] = ...,
-            **kwargs: Any,
         ) -> None: ...
         def error(
             self,
@@ -109,7 +105,6 @@ class Logger(Filterer):
             stack_info: bool = ...,
             stacklevel: int = ...,
             extra: Optional[dict[str, Any]] = ...,
-            **kwargs: Any,
         ) -> None: ...
         def exception(
             self,
@@ -119,7 +114,6 @@ class Logger(Filterer):
             stack_info: bool = ...,
             stacklevel: int = ...,
             extra: Optional[dict[str, Any]] = ...,
-            **kwargs: Any,
         ) -> None: ...
         def critical(
             self,
@@ -129,7 +123,6 @@ class Logger(Filterer):
             stack_info: bool = ...,
             stacklevel: int = ...,
             extra: Optional[dict[str, Any]] = ...,
-            **kwargs: Any,
         ) -> None: ...
         def log(
             self,
@@ -140,7 +133,6 @@ class Logger(Filterer):
             stack_info: bool = ...,
             stacklevel: int = ...,
             extra: Optional[dict[str, Any]] = ...,
-            **kwargs: Any,
         ) -> None: ...
         def _log(
             self,
@@ -160,7 +152,6 @@ class Logger(Filterer):
             exc_info: _ExcInfoType = ...,
             stack_info: bool = ...,
             extra: Optional[dict[str, Any]] = ...,
-            **kwargs: Any,
         ) -> None: ...
         def info(
             self,
@@ -169,7 +160,6 @@ class Logger(Filterer):
             exc_info: _ExcInfoType = ...,
             stack_info: bool = ...,
             extra: Optional[dict[str, Any]] = ...,
-            **kwargs: Any,
         ) -> None: ...
         def warning(
             self,
@@ -178,7 +168,6 @@ class Logger(Filterer):
             exc_info: _ExcInfoType = ...,
             stack_info: bool = ...,
             extra: Optional[dict[str, Any]] = ...,
-            **kwargs: Any,
         ) -> None: ...
         def warn(
             self,
@@ -187,7 +176,6 @@ class Logger(Filterer):
             exc_info: _ExcInfoType = ...,
             stack_info: bool = ...,
             extra: Optional[dict[str, Any]] = ...,
-            **kwargs: Any,
         ) -> None: ...
         def error(
             self,
@@ -196,7 +184,6 @@ class Logger(Filterer):
             exc_info: _ExcInfoType = ...,
             stack_info: bool = ...,
             extra: Optional[dict[str, Any]] = ...,
-            **kwargs: Any,
         ) -> None: ...
         def critical(
             self,
@@ -205,7 +192,6 @@ class Logger(Filterer):
             exc_info: _ExcInfoType = ...,
             stack_info: bool = ...,
             extra: Optional[dict[str, Any]] = ...,
-            **kwargs: Any,
         ) -> None: ...
         def log(
             self,
@@ -215,7 +201,6 @@ class Logger(Filterer):
             exc_info: _ExcInfoType = ...,
             stack_info: bool = ...,
             extra: Optional[dict[str, Any]] = ...,
-            **kwargs: Any,
         ) -> None: ...
         def exception(
             self,
@@ -224,7 +209,6 @@ class Logger(Filterer):
             exc_info: _ExcInfoType = ...,
             stack_info: bool = ...,
             extra: Optional[dict[str, Any]] = ...,
-            **kwargs: Any,
         ) -> None: ...
         def _log(
             self,


### PR DESCRIPTION
This bug was discovered in https://github.com/pypa/build/pull/339; we shipped build 0.6.0 with a usage of `log(logging.INFO, message, stacklevel=2)`, which is not supported in Python 3.6 and 3.7, but incorrectly reported as passing in MyPy, since there is a `**kwargs` here. This is incorrect; these functions all simply accept `*args` and `**kwargs`, but just pass them on to `_log`, which does not support `**kwargs` - see https://github.com/python/cpython/blob/af441df3ff0eab7bce782011cf702a8a9005da1f/Lib/logging/__init__.py#L1565, for example.

If, like me, you wondered about named placeholders for the formatting string, those are done with dicts, just like with `%`.

```pycon
>>> logging.warning("%(foo)s", foo="bar")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/Cellar/python@3.9/3.9.6/Frameworks/Python.framework/Versions/3.9/lib/python3.9/logging/__init__.py", line 2082, in warning
    root.warning(msg, *args, **kwargs)
  File "/usr/local/Cellar/python@3.9/3.9.6/Frameworks/Python.framework/Versions/3.9/lib/python3.9/logging/__init__.py", line 1458, in warning
    self._log(WARNING, msg, args, **kwargs)
TypeError: _log() got an unexpected keyword argument 'foo'
>>> logging.warning("%(foo)s", {"foo":"bar"})
WARNING:root:bar
```
