### PR TITLE
Added missing symbol in selenium stubs that was included in `__all__`…

### DIFF
--- a/stubs/selenium/selenium/webdriver/__init__.pyi
+++ b/stubs/selenium/selenium/webdriver/__init__.pyi
@@ -6,7 +6,6 @@ from .common.action_chains import ActionChains as ActionChains
 from .common.desired_capabilities import DesiredCapabilities as DesiredCapabilities
 from .common.proxy import Proxy as Proxy
 from .common.touch_actions import TouchActions as TouchActions
-from .edge.options import Options as EdgeOptions
 from .edge.webdriver import WebDriver as Edge
 from .firefox.firefox_profile import FirefoxProfile as FirefoxProfile
 from .firefox.options import Options as FirefoxOptions
@@ -30,7 +29,6 @@ __all__ = [
     "Ie",
     "IeOptions",
     "Edge",
-    "EdgeOptions",
     "Opera",
     "Safari",
     "BlackBerry",

--- a/stubs/selenium/selenium/webdriver/__init__.pyi
+++ b/stubs/selenium/selenium/webdriver/__init__.pyi
@@ -6,6 +6,7 @@ from .common.action_chains import ActionChains as ActionChains
 from .common.desired_capabilities import DesiredCapabilities as DesiredCapabilities
 from .common.proxy import Proxy as Proxy
 from .common.touch_actions import TouchActions as TouchActions
+from .edge.options import Options as EdgeOptions
 from .edge.webdriver import WebDriver as Edge
 from .firefox.firefox_profile import FirefoxProfile as FirefoxProfile
 from .firefox.options import Options as FirefoxOptions


### PR DESCRIPTION
… list but not otherwise provided. This was identified by a recently-added diagnostic check in pyright that validates the `__all__` list.