### PR TITLE
Updated pyright version to 1.1.160. Older versions contained a bug th…

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,7 +77,7 @@ jobs:
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
       fail-fast: false
     env:
-      PYRIGHT_VERSION: 1.1.152  # Must match pyright_test.py.
+      PYRIGHT_VERSION: 1.1.160 # Must match pyright_test.py.
     steps:
       - uses: actions/checkout@v2
       - uses: jakebailey/pyright-action@v1

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -51,7 +51,6 @@
     "reportUndefinedVariable": "error",
     "reportUnboundVariable": "error",
     "reportInvalidStubStatement": "error",
-    "reportUnsupportedDunderAll": "error",
     "reportInvalidTypeVarUse": "error",
     "reportPropertyTypeMismatch": "error",
     "reportSelfClsParameterName": "error",
@@ -59,5 +58,8 @@
     // of the "factions.Fraction.__pow__" method and "tasks.gather" function.
     // Mypy's overlapping overload logic misses these issues (see mypy
     // issue #10143 and #10157).
-    "reportOverlappingOverload": "none"
+    "reportOverlappingOverload": "none",
+    // Several stubs refer to symbols in __all__ that are conditionally
+    // declared based on platform or version checks.
+    "reportUnsupportedDunderAll": "none",
 }

--- a/pyrightconfig.stricter.json
+++ b/pyrightconfig.stricter.json
@@ -103,7 +103,6 @@
     "reportUndefinedVariable": "error",
     "reportUnboundVariable": "error",
     "reportInvalidStubStatement": "error",
-    "reportUnsupportedDunderAll": "error",
     "reportInvalidTypeVarUse": "error",
     "reportPropertyTypeMismatch": "error",
     "reportSelfClsParameterName": "error",
@@ -111,5 +110,8 @@
     // of the "factions.Fraction.__pow__" method and "tasks.gather" function.
     // Mypy's overlapping overload logic misses these issues (see mypy
     // issue #10143 and #10157).
-    "reportOverlappingOverload": "none"
+    "reportOverlappingOverload": "none",
+    // Several stubs refer to symbols in __all__ that are conditionally
+    // declared based on platform or version checks.
+    "reportUnsupportedDunderAll": "none",
 }

--- a/tests/pyright_test.py
+++ b/tests/pyright_test.py
@@ -5,7 +5,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-_PYRIGHT_VERSION = "1.1.152"  # Must match tests.yml.
+_PYRIGHT_VERSION = "1.1.160"  # Must match tests.yml.
 _WELL_KNOWN_FILE = Path("tests", "pyright_test.py")
 
 


### PR DESCRIPTION
…at prevented multiple third-party stub packages from having the same top-level module name.