### PR TITLE
Fix annotation in selenium.webdriver.remove.webdriver

### DIFF
--- a/stubs/selenium/selenium/webdriver/remote/webdriver.pyi
+++ b/stubs/selenium/selenium/webdriver/remote/webdriver.pyi
@@ -24,7 +24,7 @@ class WebDriver:
     error_handler: Any
     def __init__(
         self,
-        command_executor: str = ...,
+        command_executor: str | RemoteConnection = ...,
         desired_capabilities: Any | None = ...,
         browser_profile: Any | None = ...,
         proxy: Any | None = ...,


### PR DESCRIPTION
Docstring description of the argument includes this text:

> Either a string representing URL of the remote server or
> a custom remote_connection.RemoteConnection object.