### PR TITLE
Upgrade bleach version to 4 and drop Python 2

### DIFF
--- a/stubs/bleach/METADATA.toml
+++ b/stubs/bleach/METADATA.toml
@@ -1,2 +1,1 @@
-version = "3.3"
-python2 = true
+version = "4.0"

--- a/stubs/bleach/bleach/__init__.pyi
+++ b/stubs/bleach/bleach/__init__.pyi
@@ -1,4 +1,5 @@
-from typing import Any, Container, Iterable
+from collections.abc import Container, Iterable
+from typing import Any
 
 from bleach.linkifier import DEFAULT_CALLBACKS as DEFAULT_CALLBACKS, Linker as Linker, _Callback
 from bleach.sanitizer import (

--- a/stubs/bleach/bleach/__init__.pyi
+++ b/stubs/bleach/bleach/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Any, Container, Iterable, Text
+from typing import Any, Container, Iterable
 
 from bleach.linkifier import DEFAULT_CALLBACKS as DEFAULT_CALLBACKS, Linker as Linker, _Callback
 from bleach.sanitizer import (
@@ -12,19 +12,19 @@ from bleach.sanitizer import (
 
 __all__ = ["clean", "linkify"]
 
-__releasedate__: Text
-__version__: Text
+__releasedate__: str
+__version__: str
 VERSION: Any  # packaging.version.Version
 
 def clean(
-    text: Text,
-    tags: Container[Text] = ...,
+    text: str,
+    tags: Container[str] = ...,
     attributes: _Attributes = ...,
-    styles: Container[Text] = ...,
-    protocols: Container[Text] = ...,
+    styles: Container[str] = ...,
+    protocols: Container[str] = ...,
     strip: bool = ...,
     strip_comments: bool = ...,
-) -> Text: ...
+) -> str: ...
 def linkify(
-    text: Text, callbacks: Iterable[_Callback] = ..., skip_tags: Container[Text] | None = ..., parse_email: bool = ...
-) -> Text: ...
+    text: str, callbacks: Iterable[_Callback] = ..., skip_tags: Container[str] | None = ..., parse_email: bool = ...
+) -> str: ...

--- a/stubs/bleach/bleach/callbacks.pyi
+++ b/stubs/bleach/bleach/callbacks.pyi
@@ -1,6 +1,6 @@
-from typing import Any, MutableMapping, Text
+from typing import Any, MutableMapping
 
-_Attrs = MutableMapping[Any, Text]
+_Attrs = MutableMapping[Any, str]
 
 def nofollow(attrs: _Attrs, new: bool = ...) -> _Attrs: ...
 def target_blank(attrs: _Attrs, new: bool = ...) -> _Attrs: ...

--- a/stubs/bleach/bleach/callbacks.pyi
+++ b/stubs/bleach/bleach/callbacks.pyi
@@ -1,4 +1,5 @@
-from typing import Any, MutableMapping
+from collections.abc import MutableMapping
+from typing import Any
 
 _Attrs = MutableMapping[Any, str]
 

--- a/stubs/bleach/bleach/html5lib_shim.pyi
+++ b/stubs/bleach/bleach/html5lib_shim.pyi
@@ -1,4 +1,5 @@
-from typing import Any, Generator, Iterable
+from collections.abc import Generator, Iterable
+from typing import Any
 
 class HTMLParser(object):  # actually html5lib.HTMLParser
     def __getattr__(self, __name: str) -> Any: ...  # incomplete

--- a/stubs/bleach/bleach/html5lib_shim.pyi
+++ b/stubs/bleach/bleach/html5lib_shim.pyi
@@ -1,26 +1,26 @@
-from typing import Any, Generator, Iterable, Text
+from typing import Any, Generator, Iterable
 
 class HTMLParser(object):  # actually html5lib.HTMLParser
-    def __getattr__(self, __name: Text) -> Any: ...  # incomplete
+    def __getattr__(self, __name: str) -> Any: ...  # incomplete
 
 class Filter(object):  # actually html5lib.filters.base.Filter
-    def __getattr__(self, __name: Text) -> Any: ...  # incomplete
+    def __getattr__(self, __name: str) -> Any: ...  # incomplete
 
 class SanitizerFilter(object):  # actually html5lib.filters.sanitizer.Filter
-    def __getattr__(self, __name: Text) -> Any: ...  # incomplete
+    def __getattr__(self, __name: str) -> Any: ...  # incomplete
 
 class HTMLSerializer(object):  # actually html5lib.serializer.HTMLSerializer
-    def __getattr__(self, __name: Text) -> Any: ...  # incomplete
+    def __getattr__(self, __name: str) -> Any: ...  # incomplete
 
 class BleachHTMLParser(HTMLParser):
-    tags: list[Text] | None
+    tags: list[str] | None
     strip: bool
     consume_entities: bool
-    def __init__(self, tags: Iterable[Text] | None, strip: bool, consume_entities: bool, **kwargs) -> None: ...
+    def __init__(self, tags: Iterable[str] | None, strip: bool, consume_entities: bool, **kwargs) -> None: ...
 
 class BleachHTMLSerializer(HTMLSerializer):
     escape_rcdata: bool
-    def escape_base_amp(self, stoken: Text) -> Generator[Text, None, None]: ...
-    def serialize(self, treewalker, encoding: Text | None = ...) -> Generator[Text, None, None]: ...
+    def escape_base_amp(self, stoken: str) -> Generator[str, None, None]: ...
+    def serialize(self, treewalker, encoding: str | None = ...) -> Generator[str, None, None]: ...
 
-def __getattr__(__name: Text) -> Any: ...  # incomplete
+def __getattr__(__name: str) -> Any: ...  # incomplete

--- a/stubs/bleach/bleach/linkifier.pyi
+++ b/stubs/bleach/bleach/linkifier.pyi
@@ -1,4 +1,5 @@
-from typing import Any, Container, Iterable, MutableMapping, Pattern, Protocol
+from collections.abc import Container, Iterable, MutableMapping
+from typing import Any, Pattern, Protocol
 
 from .html5lib_shim import Filter
 

--- a/stubs/bleach/bleach/linkifier.pyi
+++ b/stubs/bleach/bleach/linkifier.pyi
@@ -1,44 +1,44 @@
-from typing import Any, Container, Iterable, MutableMapping, Pattern, Protocol, Text
+from typing import Any, Container, Iterable, MutableMapping, Pattern, Protocol
 
 from .html5lib_shim import Filter
 
-_Attrs = MutableMapping[Any, Text]
+_Attrs = MutableMapping[Any, str]
 
 class _Callback(Protocol):
     def __call__(self, attrs: _Attrs, new: bool = ...) -> _Attrs: ...
 
 DEFAULT_CALLBACKS: list[_Callback]
 
-TLDS: list[Text]
+TLDS: list[str]
 
-def build_url_re(tlds: Iterable[Text] = ..., protocols: Iterable[Text] = ...) -> Pattern[Text]: ...
+def build_url_re(tlds: Iterable[str] = ..., protocols: Iterable[str] = ...) -> Pattern[str]: ...
 
-URL_RE: Pattern[Text]
-PROTO_RE: Pattern[Text]
+URL_RE: Pattern[str]
+PROTO_RE: Pattern[str]
 
-def build_email_re(tlds: Iterable[Text] = ...) -> Pattern[Text]: ...
+def build_email_re(tlds: Iterable[str] = ...) -> Pattern[str]: ...
 
-EMAIL_RE: Pattern[Text]
+EMAIL_RE: Pattern[str]
 
 class Linker(object):
     def __init__(
         self,
         callbacks: Iterable[_Callback] = ...,
-        skip_tags: Container[Text] | None = ...,
+        skip_tags: Container[str] | None = ...,
         parse_email: bool = ...,
-        url_re: Pattern[Text] = ...,
-        email_re: Pattern[Text] = ...,
-        recognized_tags: Container[Text] | None = ...,
+        url_re: Pattern[str] = ...,
+        email_re: Pattern[str] = ...,
+        recognized_tags: Container[str] | None = ...,
     ) -> None: ...
-    def linkify(self, text: Text) -> Text: ...
+    def linkify(self, text: str) -> str: ...
 
 class LinkifyFilter(Filter):
     callbacks: Any
-    skip_tags: Container[Text]
+    skip_tags: Container[str]
     parse_email: bool
     url_re: Any
     email_re: Any
     def __init__(
-        self, source, callbacks=..., skip_tags: Container[Text] | None = ..., parse_email: bool = ..., url_re=..., email_re=...
+        self, source, callbacks=..., skip_tags: Container[str] | None = ..., parse_email: bool = ..., url_re=..., email_re=...
     ) -> None: ...
-    def __getattr__(self, item: Text) -> Any: ...  # incomplete
+    def __getattr__(self, item: str) -> Any: ...  # incomplete

--- a/stubs/bleach/bleach/sanitizer.pyi
+++ b/stubs/bleach/bleach/sanitizer.pyi
@@ -1,24 +1,24 @@
-from typing import Any, Callable, Container, Dict, Iterable, List, Pattern, Text, Union
+from typing import Any, Callable, Container, Dict, Iterable, List, Pattern, Union
 
 from .html5lib_shim import BleachHTMLParser, BleachHTMLSerializer, SanitizerFilter
 
-ALLOWED_TAGS: list[Text]
-ALLOWED_ATTRIBUTES: dict[Text, list[Text]]
-ALLOWED_STYLES: list[Text]
-ALLOWED_PROTOCOLS: list[Text]
+ALLOWED_TAGS: list[str]
+ALLOWED_ATTRIBUTES: dict[str, list[str]]
+ALLOWED_STYLES: list[str]
+ALLOWED_PROTOCOLS: list[str]
 
-INVISIBLE_CHARACTERS: Text
-INVISIBLE_CHARACTERS_RE: Pattern[Text]
-INVISIBLE_REPLACEMENT_CHAR: Text
+INVISIBLE_CHARACTERS: str
+INVISIBLE_CHARACTERS_RE: Pattern[str]
+INVISIBLE_REPLACEMENT_CHAR: str
 
 # A html5lib Filter class
 _Filter = Any
 
 class Cleaner(object):
-    tags: Container[Text]
+    tags: Container[str]
     attributes: _Attributes
-    styles: Container[Text]
-    protocols: Container[Text]
+    styles: Container[str]
+    protocols: Container[str]
     strip: bool
     strip_comments: bool
     filters: Iterable[_Filter]
@@ -27,19 +27,19 @@ class Cleaner(object):
     serializer: BleachHTMLSerializer
     def __init__(
         self,
-        tags: Container[Text] = ...,
+        tags: Container[str] = ...,
         attributes: _Attributes = ...,
-        styles: Container[Text] = ...,
-        protocols: Container[Text] = ...,
+        styles: Container[str] = ...,
+        protocols: Container[str] = ...,
         strip: bool = ...,
         strip_comments: bool = ...,
         filters: Iterable[_Filter] | None = ...,
     ) -> None: ...
-    def clean(self, text: Text) -> Text: ...
+    def clean(self, text: str) -> str: ...
 
-_AttributeFilter = Callable[[Text, Text, Text], bool]
-_AttributeDict = Union[Dict[Text, Union[List[Text], _AttributeFilter]], Dict[Text, List[Text]], Dict[Text, _AttributeFilter]]
-_Attributes = Union[_AttributeFilter, _AttributeDict, List[Text]]
+_AttributeFilter = Callable[[str, str, str], bool]
+_AttributeDict = Union[Dict[str, Union[List[str], _AttributeFilter]], Dict[str, List[str]], Dict[str, _AttributeFilter]]
+_Attributes = Union[_AttributeFilter, _AttributeDict, List[str]]
 
 def attribute_filter_factory(attributes: _Attributes) -> _AttributeFilter: ...
 

--- a/stubs/bleach/bleach/sanitizer.pyi
+++ b/stubs/bleach/bleach/sanitizer.pyi
@@ -1,4 +1,5 @@
-from typing import Any, Callable, Container, Dict, Iterable, List, Pattern, Union
+from collections.abc import Callable, Container, Iterable
+from typing import Any, Dict, List, Pattern, Union
 
 from .html5lib_shim import BleachHTMLParser, BleachHTMLSerializer, SanitizerFilter
 

--- a/stubs/bleach/bleach/utils.pyi
+++ b/stubs/bleach/bleach/utils.pyi
@@ -1,7 +1,7 @@
 from collections import OrderedDict
-from typing import Any, Mapping, Text, overload
+from typing import Any, Mapping, overload
 
 @overload
 def alphabetize_attributes(attrs: None) -> None: ...
 @overload
-def alphabetize_attributes(attrs: Mapping[Any, Text]) -> OrderedDict[Any, Text]: ...
+def alphabetize_attributes(attrs: Mapping[Any, str]) -> OrderedDict[Any, str]: ...

--- a/stubs/bleach/bleach/utils.pyi
+++ b/stubs/bleach/bleach/utils.pyi
@@ -1,5 +1,6 @@
 from collections import OrderedDict
-from typing import Any, Mapping, overload
+from collections.abc import Mapping
+from typing import Any, overload
 
 @overload
 def alphabetize_attributes(attrs: None) -> None: ...

--- a/stubs/bleach/bleach/utils.pyi
+++ b/stubs/bleach/bleach/utils.pyi
@@ -1,7 +1,6 @@
 from collections import OrderedDict
 from typing import Any, Mapping, Text, overload
 
-def force_unicode(text: Text) -> Text: ...
 @overload
 def alphabetize_attributes(attrs: None) -> None: ...
 @overload


### PR DESCRIPTION
bleach 4 has no API changes, but dropped support for old Python
versions.