### PR TITLE
add ParamSpec to unittest.signals

### DIFF
--- a/stdlib/unittest/signals.pyi
+++ b/stdlib/unittest/signals.pyi
@@ -1,7 +1,9 @@
 import unittest.result
-from typing import Any, Callable, TypeVar, overload
+from typing import Callable, TypeVar, overload
+from typing_extensions import ParamSpec
 
-_F = TypeVar("_F", bound=Callable[..., Any])
+_P = ParamSpec("_P")
+_T = TypeVar("_T")
 
 def installHandler() -> None: ...
 def registerResult(result: unittest.result.TestResult) -> None: ...
@@ -9,4 +11,4 @@ def removeResult(result: unittest.result.TestResult) -> bool: ...
 @overload
 def removeHandler(method: None = ...) -> None: ...
 @overload
-def removeHandler(method: _F) -> _F: ...
+def removeHandler(method: Callable[_P, _T]) -> Callable[_P, _T]: ...  # type: ignore


### PR DESCRIPTION
After working on the other `ParamSpec` PR I think this should be a `TypeVar` rather than `Any` as type hint.