### PR TITLE
CI: use one runner per mypy version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,12 +61,13 @@ jobs:
     strategy:
       matrix:
         platform: ["linux", "win32", "darwin"]
+        python-version: ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10"]
       fail-fast: false
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
       - run: pip install $(grep mypy== requirements-tests-py3.txt)
-      - run: ./tests/mypy_test.py --platform=${{ matrix.platform }}
+      - run: ./tests/mypy_test.py --platform=${{ matrix.platform }} --python-version=${{ matrix.python-version }}
 
   pyright:
     name: Run pyright against the stubs

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,9 @@ on:
 permissions:
   contents: read
 
+env:
+  PIP_DISABLE_PIP_VERSION_CHECK: 1
+
 jobs:
   file-consistency:
     name: Check file consistency


### PR DESCRIPTION
This makes it easier to see, in which version(s) an error occured.