### PR TITLE
Bump pytype version to 2021.08.11.

### DIFF
--- a/requirements-tests-py3.txt
+++ b/requirements-tests-py3.txt
@@ -5,4 +5,4 @@ flake8==3.9.2
 flake8-bugbear==21.4.3
 flake8-pyi==20.10.0
 isort==5.9.2
-pytype==2021.08.03
+pytype==2021.08.11


### PR DESCRIPTION
This version contains a fix for a pytype bug that is blocking
https://github.com/python/typeshed/pull/5896.