### PR TITLE
Add `RawJSON` to `simplejson` stubs

### DIFF
--- a/stubs/simplejson/@tests/stubtest_allowlist.txt
+++ b/stubs/simplejson/@tests/stubtest_allowlist.txt
@@ -5,6 +5,8 @@ simplejson.JSONDecoder.raw_decode
 simplejson.JSONEncoder.__init__
 simplejson.JSONEncoder.iterencode
 simplejson.JSONEncoderForHTML.iterencode
+simplejson.RawJSON.__init__
+simplejson.RawJSON.encoded_json
 simplejson.decoder.JSONDecoder.__init__
 simplejson.decoder.JSONDecoder.decode
 simplejson.decoder.JSONDecoder.raw_decode
@@ -15,4 +17,6 @@ simplejson.encoder.JSONEncoder.iterencode
 simplejson.encoder.JSONEncoderForHTML.iterencode
 simplejson.load
 simplejson.loads
+simplejson.raw_json.RawJSON.__init__
+simplejson.raw_json.RawJSON.encoded_json
 simplejson.scanner.JSONDecodeError.__init__

--- a/stubs/simplejson/@tests/stubtest_allowlist.txt
+++ b/stubs/simplejson/@tests/stubtest_allowlist.txt
@@ -5,8 +5,6 @@ simplejson.JSONDecoder.raw_decode
 simplejson.JSONEncoder.__init__
 simplejson.JSONEncoder.iterencode
 simplejson.JSONEncoderForHTML.iterencode
-simplejson.RawJSON.__init__
-simplejson.RawJSON.encoded_json
 simplejson.decoder.JSONDecoder.__init__
 simplejson.decoder.JSONDecoder.decode
 simplejson.decoder.JSONDecoder.raw_decode
@@ -17,6 +15,4 @@ simplejson.encoder.JSONEncoder.iterencode
 simplejson.encoder.JSONEncoderForHTML.iterencode
 simplejson.load
 simplejson.loads
-simplejson.raw_json.RawJSON.__init__
-simplejson.raw_json.RawJSON.encoded_json
 simplejson.scanner.JSONDecodeError.__init__

--- a/stubs/simplejson/METADATA.toml
+++ b/stubs/simplejson/METADATA.toml
@@ -1,2 +1,2 @@
-version = "0.1"
+version = "3.17"
 python2 = true

--- a/stubs/simplejson/simplejson/__init__.pyi
+++ b/stubs/simplejson/simplejson/__init__.pyi
@@ -2,6 +2,7 @@ from typing import IO, Any, Text, Union
 
 from simplejson.decoder import JSONDecoder as JSONDecoder
 from simplejson.encoder import JSONEncoder as JSONEncoder, JSONEncoderForHTML as JSONEncoderForHTML
+from simplejson.raw_json import RawJSON as RawJSON
 from simplejson.scanner import JSONDecodeError as JSONDecodeError
 
 _LoadsString = Union[Text, bytes, bytearray]

--- a/stubs/simplejson/simplejson/raw_json.pyi
+++ b/stubs/simplejson/simplejson/raw_json.pyi
@@ -1,0 +1,4 @@
+class RawJSON(object):
+    encoded_json: str
+
+    def __init__(self, encoded_json: str) -> None: ...

--- a/stubs/simplejson/simplejson/raw_json.pyi
+++ b/stubs/simplejson/simplejson/raw_json.pyi
@@ -1,4 +1,3 @@
 class RawJSON(object):
     encoded_json: str
-
     def __init__(self, encoded_json: str) -> None: ...


### PR DESCRIPTION
Available as `simplejson.RawJSON` since 3.10.0, available also as `simplejson.raw_json.RawJSON` since 3.12.0.

I checked if there are any other features that might be missing in these stubs and the only other new feature I found is `int_as_string_bitcount` encoded option (https://github.com/simplejson/simplejson/blob/16f362cacd53abee3e60b14d18536cf32e4219f0/CHANGES.txt#L242), but these stubs currently just use `Any` for `**kwargs` so I skipped it.