### PR TITLE
docutils - added missing stubs for __init__ methods

### DIFF
--- a/stubs/docutils/@tests/stubtest_allowlist.txt
+++ b/stubs/docutils/@tests/stubtest_allowlist.txt
@@ -2,7 +2,6 @@ docutils.TransformSpec.unknown_reference_resolvers
 docutils.frontend.ConfigParser.__getattr__
 docutils.frontend.ConfigParser.read
 docutils.frontend.OptionParser.__getattr__
-docutils.frontend.OptionParser.__init__
 docutils.io.FileOutput.__getattr__
 docutils.io.FileOutput.__init__
 docutils.io.Input.__getattr__

--- a/stubs/docutils/@tests/stubtest_allowlist.txt
+++ b/stubs/docutils/@tests/stubtest_allowlist.txt
@@ -8,5 +8,4 @@ docutils.io.FileOutput.__init__
 docutils.io.Input.__getattr__
 docutils.io.Input.__init__
 docutils.parsers.rst.Directive.__getattr__
-docutils.parsers.rst.Directive.__init__
 docutils.parsers.rst.nodes

--- a/stubs/docutils/METADATA.toml
+++ b/stubs/docutils/METADATA.toml
@@ -1,1 +1,1 @@
-version = "0.1"
+version = "0.17"

--- a/stubs/docutils/docutils/frontend.pyi
+++ b/stubs/docutils/docutils/frontend.pyi
@@ -1,7 +1,7 @@
 import optparse
+from collections.abc import Iterable, Mapping
 from configparser import RawConfigParser
 from typing import Any, ClassVar, Tuple, Type
-from collections.abc import Iterable, Mapping
 
 from docutils import SettingsSpec
 from docutils.parsers import Parser

--- a/stubs/docutils/docutils/frontend.pyi
+++ b/stubs/docutils/docutils/frontend.pyi
@@ -1,8 +1,9 @@
 import optparse
 from configparser import RawConfigParser
-from typing import Any, ClassVar, Tuple
+from typing import Any, ClassVar, Dict, Tuple, Type
 
 from docutils import SettingsSpec
+from docutils.parsers import Parser
 from docutils.utils import DependencyList
 
 __docformat__: str
@@ -60,6 +61,14 @@ class OptionParser(optparse.OptionParser, SettingsSpec):
     default_error_encoding_error_handler: ClassVar[str]
     config_section: ClassVar[str]
     version_template: ClassVar[str]
+    def __init__(
+        self,
+        components: Tuple[Type[Parser]] = ...,
+        defaults: Dict[str, object] = ...,
+        read_config_files: bool = ...,
+        *args,
+        **kwargs,
+    ) -> None: ...
     def __getattr__(self, name: str) -> Any: ...  # incomplete
 
 class ConfigParser(RawConfigParser):

--- a/stubs/docutils/docutils/frontend.pyi
+++ b/stubs/docutils/docutils/frontend.pyi
@@ -65,7 +65,7 @@ class OptionParser(optparse.OptionParser, SettingsSpec):
     def __init__(
         self,
         components: Iterable[Type[Parser]] = ...,
-        defaults: Mapping[str, Any] = ...,
+        defaults: Mapping[str, Any] | None = ...,
         read_config_files: bool | None = ...,
         *args,
         **kwargs,

--- a/stubs/docutils/docutils/frontend.pyi
+++ b/stubs/docutils/docutils/frontend.pyi
@@ -65,7 +65,7 @@ class OptionParser(optparse.OptionParser, SettingsSpec):
     def __init__(
         self,
         components: Iterable[Type[Parser]] = ...,
-        defaults: Mapping[str, object] = ...,
+        defaults: Mapping[str, Any] = ...,
         read_config_files: bool | None = ...,
         *args,
         **kwargs,

--- a/stubs/docutils/docutils/frontend.pyi
+++ b/stubs/docutils/docutils/frontend.pyi
@@ -1,6 +1,7 @@
 import optparse
 from configparser import RawConfigParser
-from typing import Any, ClassVar, Dict, Tuple, Type
+from typing import Any, ClassVar, Tuple, Type
+from collections.abc import Iterable, Mapping
 
 from docutils import SettingsSpec
 from docutils.parsers import Parser
@@ -63,9 +64,9 @@ class OptionParser(optparse.OptionParser, SettingsSpec):
     version_template: ClassVar[str]
     def __init__(
         self,
-        components: Tuple[Type[Parser]] = ...,
-        defaults: Dict[str, object] = ...,
-        read_config_files: bool = ...,
+        components: Iterable[Type[Parser]] = ...,
+        defaults: Mapping[str, object] = ...,
+        read_config_files: bool | None = ...,
         *args,
         **kwargs,
     ) -> None: ...

--- a/stubs/docutils/docutils/parsers/rst/__init__.pyi
+++ b/stubs/docutils/docutils/parsers/rst/__init__.pyi
@@ -1,7 +1,8 @@
-from typing import Any, ClassVar, Dict, List, Tuple
+from typing import Any, ClassVar, Tuple
 from typing_extensions import Literal
 
 from docutils import parsers
+from docutils.parsers.rst import states
 
 class Parser(parsers.Parser):
     config_section_dependencies: ClassVar[Tuple[str, ...]]
@@ -19,14 +20,14 @@ class Directive:
     def __init__(
         self,
         name: str,
-        arguments: List[object],
-        options: Dict[str, object],
-        content: List[str],
+        arguments: list[Any],
+        options: dict[str, Any],
+        content: list[str],
         lineno: int,
         content_offset: int,
         block_text: str,
-        state: parsers.rst.states.RSTState,
-        state_machine: parsers.rst.states.RSTStateMachine,
+        state: states.RSTState,
+        state_machine: states.RSTStateMachine,
     ) -> None: ...
     def __getattr__(self, name: str) -> Any: ...  # incomplete
 

--- a/stubs/docutils/docutils/parsers/rst/__init__.pyi
+++ b/stubs/docutils/docutils/parsers/rst/__init__.pyi
@@ -2,7 +2,6 @@ from typing import Any, ClassVar, Dict, List, Tuple
 from typing_extensions import Literal
 
 from docutils import parsers
-from docutils.parsers.rst.states import RSTState, RSTStateMachine
 
 class Parser(parsers.Parser):
     config_section_dependencies: ClassVar[Tuple[str, ...]]
@@ -26,8 +25,8 @@ class Directive:
         lineno: int,
         content_offset: int,
         block_text: str,
-        state: RSTState,
-        state_machine: RSTStateMachine,
+        state: parsers.rst.states.RSTState,
+        state_machine: parsers.rst.states.RSTStateMachine,
     ) -> None: ...
     def __getattr__(self, name: str) -> Any: ...  # incomplete
 

--- a/stubs/docutils/docutils/parsers/rst/__init__.pyi
+++ b/stubs/docutils/docutils/parsers/rst/__init__.pyi
@@ -1,7 +1,8 @@
-from typing import Any, ClassVar, Tuple
+from typing import Any, ClassVar, Dict, List, Tuple
 from typing_extensions import Literal
 
 from docutils import parsers
+from docutils.parsers.rst.states import RSTState, RSTStateMachine
 
 class Parser(parsers.Parser):
     config_section_dependencies: ClassVar[Tuple[str, ...]]
@@ -16,6 +17,18 @@ class DirectiveError(Exception):
     def __init__(self, level: Any, message: str) -> None: ...
 
 class Directive:
+    def __init__(
+        self,
+        name: str,
+        arguments: List[object],
+        options: Dict[str, object],
+        content: List[str],
+        lineno: int,
+        content_offset: int,
+        block_text: str,
+        state: RSTState,
+        state_machine: RSTStateMachine,
+    ) -> None: ...
     def __getattr__(self, name: str) -> Any: ...  # incomplete
 
 def convert_directive_function(directive_fn): ...


### PR DESCRIPTION
The `OptionParser` and `Directive` classes had no `__init__` method stubs which was causing mypy to claim my valid arguments were not expected.

For the `Directive` class I used the documentation from https://docutils.sourceforge.io/0.4/docs/howto/rst-directives.html as my guide.

For the `OptionParser` class I referred to the [original source code: ](https://sourceforge.net/p/docutils/code/HEAD/tree/trunk/docutils/docutils/frontend.py#l591) and some [implementation examples from Sphinx](https://github.com/sphinx-doc/sphinx/blob/9e1b4a8f1678e26670d34765e74edf3a3be3c62c/tests/test_search.py#L38).
It's worth calling out the `components` parameter as it expects a _class_ rather than an object to be passed in (see the Sphinx example for confirmation).

I have read the [contribution guidelines](https://github.com/python/typeshed/blob/ff63953188eca97ea7591f83a33c23cac863c161/CONTRIBUTING.md) and I think everything here is up to code, if not I'll fix it ASAP!
