### PR TITLE
CONTRIBUTING: Use PEP 604 syntax

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -327,7 +327,7 @@ checker, and leave out unnecessary detail:
 
 Some further tips for good type hints:
 * use built-in generics (`list`, `dict`, `tuple`, `set`), instead
-  of importing them from `typing`, **except** in type aliases and for
+  of importing them from `typing`, **except** in type aliases, in base classes, and for
   arbitrary length tuples (`Tuple[int, ...]`);
 * use `X | Y` instead of `Union[X, Y]` and `X | None`, instead of
   `Optional[X]`, **except** when it is not possible due to mypy bugs (type aliases and base classes);

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -327,9 +327,10 @@ checker, and leave out unnecessary detail:
 
 Some further tips for good type hints:
 * use built-in generics (`list`, `dict`, `tuple`, `set`), instead
-  of importing them from `typing`, **except** for arbitrary length tuples
-  (`Tuple[int, ...]`) (see
-  [python/mypy#9980](https://github.com/python/mypy/issues/9980));
+  of importing them from `typing`, **except** in type aliases and for
+  arbitrary length tuples (`Tuple[int, ...]`);
+* use `X | Y` instead of `Union[X, Y]` and `X | None`, instead of
+  `Optional[X]`, **except** in type aliases;
 * in Python 3 stubs, import collections (`Mapping`, `Iterable`, etc.)
   from `collections.abc` instead of `typing`;
 * avoid invariant collection types (`list`, `dict`) in argument

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -330,7 +330,7 @@ Some further tips for good type hints:
   of importing them from `typing`, **except** in type aliases and for
   arbitrary length tuples (`Tuple[int, ...]`);
 * use `X | Y` instead of `Union[X, Y]` and `X | None`, instead of
-  `Optional[X]`, **except** in type aliases;
+  `Optional[X]`, **except** in type aliases and class bases;
 * in Python 3 stubs, import collections (`Mapping`, `Iterable`, etc.)
   from `collections.abc` instead of `typing`;
 * avoid invariant collection types (`list`, `dict`) in argument

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -330,7 +330,7 @@ Some further tips for good type hints:
   of importing them from `typing`, **except** in type aliases and for
   arbitrary length tuples (`Tuple[int, ...]`);
 * use `X | Y` instead of `Union[X, Y]` and `X | None`, instead of
-  `Optional[X]`, **except** in type aliases and class bases;
+  `Optional[X]`, **except** when it is not possible due to mypy bugs (type aliases and base classes);
 * in Python 3 stubs, import collections (`Mapping`, `Iterable`, etc.)
   from `collections.abc` instead of `typing`;
 * avoid invariant collection types (`list`, `dict`) in argument


### PR DESCRIPTION
Built-in generics not possible in type aliases