### PR TITLE
Stop using pytype.pytd.typeshed.get_python_major_versions.

### DIFF
--- a/tests/pytype_test.py
+++ b/tests/pytype_test.py
@@ -132,15 +132,9 @@ def determine_files_to_test(*, typeshed_location: str, paths: Sequence[str]) -> 
     files = []
     for f in sorted(filenames):
         rel = _get_relative(f)
-        if rel in skipped:
+        if rel in skipped or "@python2" in f:
             continue
-        versions = ts.get_python_major_versions(rel)
-        if 3 in versions:
-            files.append(f)
-        elif versions:
-            print("Skipping Python 2-only path: {}".format(f))
-        else:
-            print("Unrecognized path: {}".format(f))
+        files.append(f)
     return files
 
 


### PR DESCRIPTION
We deleted this method as part of our Python 2 cleanup efforts.