### PR TITLE
text_type should be a type alias, not a variable

### DIFF
--- a/stubs/six/six/__init__.pyi
+++ b/stubs/six/six/__init__.pyi
@@ -25,8 +25,8 @@ PY34: Literal[True]
 string_types: tuple[Type[str]]
 integer_types: tuple[Type[int]]
 class_types: tuple[Type[Type[Any]]]
-text_type: Type[str]
-binary_type: Type[bytes]
+text_type = str
+binary_type = bytes
 
 MAXSIZE: int
 


### PR DESCRIPTION
# Test Case, `code.py`
```python
import six
def hello(name: six.text_type) -> None:
    print(f"Hello {name}!")
hello("Johan")
```

# Before this change
```
(env) /t/dom $ mypy code.py
code.py:2: error: Variable "six.text_type" is not valid as a type
code.py:2: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases
Found 1 error in 1 file (checked 1 source file)
(env) /t/dom [1] $ fd six
```

# With this change in place
```
(env) /t/dom $ mypy code.py
Success: no issues found in 1 source file
(env) /t/dom $ 
```

# Context
```
(env) /t/dom $ mypy --version
mypy 0.910
(env) /t/dom $ python --version
Python 3.9.6
(env) /t/dom $ pip freeze|grep six
six==1.16.0
types-six==1.16.0
(env) /t/dom $ 
```

# Notes
There may be other cases like this in the same file, I'm fixing this particular one because I got burned by it.