### PR TITLE
Make AsyncMock stubs available for python 3.6+

### DIFF
--- a/stubs/mock/METADATA.toml
+++ b/stubs/mock/METADATA.toml
@@ -1,2 +1,1 @@
-version = "0.1"
-python2 = true
+version = "4.0"

--- a/stubs/mock/mock.pyi
+++ b/stubs/mock/mock.pyi
@@ -164,63 +164,35 @@ class _patch(Generic[_T]):
     autospec: Any
     kwargs: Mapping[str, Any]
     additional_patchers: Any
-    if sys.version_info >= (3, 8):
-        @overload
-        def __init__(
-            self: _patch[MagicMock | AsyncMock],
-            getter: Callable[[], Any],
-            attribute: str,
-            *,
-            spec: Any | None,
-            create: bool,
-            spec_set: Any | None,
-            autospec: Any | None,
-            new_callable: Any | None,
-            kwargs: Mapping[str, Any],
-        ) -> None: ...
-        # This overload also covers the case, where new==DEFAULT. In this case, self is _patch[Any].
-        # Ideally we'd be able to add an overload for it so that self is _patch[MagicMock],
-        # but that's impossible with the current type system.
-        @overload
-        def __init__(
-            self: _patch[_T],
-            getter: Callable[[], Any],
-            attribute: str,
-            new: _T,
-            spec: Any | None,
-            create: bool,
-            spec_set: Any | None,
-            autospec: Any | None,
-            new_callable: Any | None,
-            kwargs: Mapping[str, Any],
-        ) -> None: ...
-    else:
-        @overload
-        def __init__(
-            self: _patch[MagicMock],
-            getter: Callable[[], Any],
-            attribute: str,
-            *,
-            spec: Any | None,
-            create: bool,
-            spec_set: Any | None,
-            autospec: Any | None,
-            new_callable: Any | None,
-            kwargs: Mapping[str, Any],
-        ) -> None: ...
-        @overload
-        def __init__(
-            self: _patch[_T],
-            getter: Callable[[], Any],
-            attribute: str,
-            new: _T,
-            spec: Any | None,
-            create: bool,
-            spec_set: Any | None,
-            autospec: Any | None,
-            new_callable: Any | None,
-            kwargs: Mapping[str, Any],
-        ) -> None: ...
+    @overload
+    def __init__(
+        self: _patch[MagicMock | AsyncMock],
+        getter: Callable[[], Any],
+        attribute: str,
+        *,
+        spec: Any | None,
+        create: bool,
+        spec_set: Any | None,
+        autospec: Any | None,
+        new_callable: Any | None,
+        kwargs: Mapping[str, Any],
+    ) -> None: ...
+    # This overload also covers the case, where new==DEFAULT. In this case, self is _patch[Any].
+    # Ideally we'd be able to add an overload for it so that self is _patch[MagicMock],
+    # but that's impossible with the current type system.
+    @overload
+    def __init__(
+        self: _patch[_T],
+        getter: Callable[[], Any],
+        attribute: str,
+        new: _T,
+        spec: Any | None,
+        create: bool,
+        spec_set: Any | None,
+        autospec: Any | None,
+        new_callable: Any | None,
+        kwargs: Mapping[str, Any],
+    ) -> None: ...
     def copy(self) -> _patch[_T]: ...
     def __call__(self, func: Callable[..., _R]) -> Callable[..., _R]: ...
     def decorate_class(self, klass: _TT) -> _TT: ...
@@ -249,113 +221,59 @@ class _patch_dict:
 class _patcher:
     TEST_PREFIX: str
     dict: Type[_patch_dict]
-    if sys.version_info >= (3, 8):
-        @overload
-        def __call__(  # type: ignore
-            self,
-            target: Any,
-            *,
-            spec: Any | None = ...,
-            create: bool = ...,
-            spec_set: Any | None = ...,
-            autospec: Any | None = ...,
-            new_callable: Any | None = ...,
-            **kwargs: Any,
-        ) -> _patch[MagicMock | AsyncMock]: ...
-        # This overload also covers the case, where new==DEFAULT. In this case, the return type is _patch[Any].
-        # Ideally we'd be able to add an overload for it so that the return type is _patch[MagicMock],
-        # but that's impossible with the current type system.
-        @overload
-        def __call__(
-            self,
-            target: Any,
-            new: _T,
-            spec: Any | None = ...,
-            create: bool = ...,
-            spec_set: Any | None = ...,
-            autospec: Any | None = ...,
-            new_callable: Any | None = ...,
-            **kwargs: Any,
-        ) -> _patch[_T]: ...
-    else:
-        @overload
-        def __call__(  # type: ignore
-            self,
-            target: Any,
-            *,
-            spec: Any | None = ...,
-            create: bool = ...,
-            spec_set: Any | None = ...,
-            autospec: Any | None = ...,
-            new_callable: Any | None = ...,
-            **kwargs: Any,
-        ) -> _patch[MagicMock]: ...
-        @overload
-        def __call__(
-            self,
-            target: Any,
-            new: _T,
-            spec: Any | None = ...,
-            create: bool = ...,
-            spec_set: Any | None = ...,
-            autospec: Any | None = ...,
-            new_callable: Any | None = ...,
-            **kwargs: Any,
-        ) -> _patch[_T]: ...
-    if sys.version_info >= (3, 8):
-        @overload
-        def object(  # type: ignore
-            self,
-            target: Any,
-            attribute: Text,
-            *,
-            spec: Any | None = ...,
-            create: bool = ...,
-            spec_set: Any | None = ...,
-            autospec: Any | None = ...,
-            new_callable: Any | None = ...,
-            **kwargs: Any,
-        ) -> _patch[MagicMock | AsyncMock]: ...
-        @overload
-        def object(
-            self,
-            target: Any,
-            attribute: Text,
-            new: _T = ...,
-            spec: Any | None = ...,
-            create: bool = ...,
-            spec_set: Any | None = ...,
-            autospec: Any | None = ...,
-            new_callable: Any | None = ...,
-            **kwargs: Any,
-        ) -> _patch[_T]: ...
-    else:
-        @overload
-        def object(  # type: ignore
-            self,
-            target: Any,
-            attribute: Text,
-            *,
-            spec: Any | None = ...,
-            create: bool = ...,
-            spec_set: Any | None = ...,
-            autospec: Any | None = ...,
-            new_callable: Any | None = ...,
-            **kwargs: Any,
-        ) -> _patch[MagicMock]: ...
-        @overload
-        def object(
-            self,
-            target: Any,
-            attribute: Text,
-            new: _T = ...,
-            spec: Any | None = ...,
-            create: bool = ...,
-            spec_set: Any | None = ...,
-            autospec: Any | None = ...,
-            new_callable: Any | None = ...,
-            **kwargs: Any,
-        ) -> _patch[_T]: ...
+    @overload
+    def __call__(  # type: ignore
+        self,
+        target: Any,
+        *,
+        spec: Any | None = ...,
+        create: bool = ...,
+        spec_set: Any | None = ...,
+        autospec: Any | None = ...,
+        new_callable: Any | None = ...,
+        **kwargs: Any,
+    ) -> _patch[MagicMock | AsyncMock]: ...
+    # This overload also covers the case, where new==DEFAULT. In this case, the return type is _patch[Any].
+    # Ideally we'd be able to add an overload for it so that the return type is _patch[MagicMock],
+    # but that's impossible with the current type system.
+    @overload
+    def __call__(
+        self,
+        target: Any,
+        new: _T,
+        spec: Any | None = ...,
+        create: bool = ...,
+        spec_set: Any | None = ...,
+        autospec: Any | None = ...,
+        new_callable: Any | None = ...,
+        **kwargs: Any,
+    ) -> _patch[_T]: ...
+    @overload
+    def object(  # type: ignore
+        self,
+        target: Any,
+        attribute: Text,
+        *,
+        spec: Any | None = ...,
+        create: bool = ...,
+        spec_set: Any | None = ...,
+        autospec: Any | None = ...,
+        new_callable: Any | None = ...,
+        **kwargs: Any,
+    ) -> _patch[MagicMock | AsyncMock]: ...
+    @overload
+    def object(
+        self,
+        target: Any,
+        attribute: Text,
+        new: _T = ...,
+        spec: Any | None = ...,
+        create: bool = ...,
+        spec_set: Any | None = ...,
+        autospec: Any | None = ...,
+        new_callable: Any | None = ...,
+        **kwargs: Any,
+    ) -> _patch[_T]: ...
     def multiple(
         self,
         target: Any,
@@ -379,24 +297,25 @@ class NonCallableMagicMock(MagicMixin, NonCallableMock):
 class MagicMock(MagicMixin, Mock):
     def mock_add_spec(self, spec: Any, spec_set: bool = ...) -> None: ...
 
-if sys.version_info >= (3, 8):
-    class AsyncMockMixin(Base):
-        def __init__(self, *args: Any, **kwargs: Any) -> None: ...
-        async def _execute_mock_call(self, *args: Any, **kwargs: Any) -> Any: ...
-        def assert_awaited(self) -> None: ...
-        def assert_awaited_once(self) -> None: ...
-        def assert_awaited_with(self, *args: Any, **kwargs: Any) -> None: ...
-        def assert_awaited_once_with(self, *args: Any, **kwargs: Any) -> None: ...
-        def assert_any_await(self, *args: Any, **kwargs: Any) -> None: ...
-        def assert_has_awaits(self, calls: _CallList, any_order: bool = ...) -> None: ...
-        def assert_not_awaited(self) -> None: ...
-        def reset_mock(self, *args: Any, **kwargs: Any) -> None: ...
-        await_count: int
-        await_args: _Call | None
-        await_args_list: _CallList
-    class AsyncMagicMixin(MagicMixin):
-        def __init__(self, *args: Any, **kw: Any) -> None: ...
-    class AsyncMock(AsyncMockMixin, AsyncMagicMixin, Mock): ...
+class AsyncMockMixin(Base):
+    def __init__(self, *args: Any, **kwargs: Any) -> None: ...
+    async def _execute_mock_call(self, *args: Any, **kwargs: Any) -> Any: ...
+    def assert_awaited(self) -> None: ...
+    def assert_awaited_once(self) -> None: ...
+    def assert_awaited_with(self, *args: Any, **kwargs: Any) -> None: ...
+    def assert_awaited_once_with(self, *args: Any, **kwargs: Any) -> None: ...
+    def assert_any_await(self, *args: Any, **kwargs: Any) -> None: ...
+    def assert_has_awaits(self, calls: _CallList, any_order: bool = ...) -> None: ...
+    def assert_not_awaited(self) -> None: ...
+    def reset_mock(self, *args: Any, **kwargs: Any) -> None: ...
+    await_count: int
+    await_args: _Call | None
+    await_args_list: _CallList
+
+class AsyncMagicMixin(MagicMixin):
+    def __init__(self, *args: Any, **kw: Any) -> None: ...
+
+class AsyncMock(AsyncMockMixin, AsyncMagicMixin, Mock): ...
 
 class MagicProxy:
     name: Any


### PR DESCRIPTION
- AsyncMock is available in 3.6+ with the third party mock package
- The 3.8+ restriction only exists in stdlib unittest.mock