### PR TITLE
fix cache param in mp.pool.ApplyResult.__init__

### DIFF
--- a/stdlib/multiprocessing/pool.pyi
+++ b/stdlib/multiprocessing/pool.pyi
@@ -1,6 +1,6 @@
 import sys
 from _typeshed import Self
-from typing import Any, Callable, ContextManager, Generic, Iterable, Iterator, List, Mapping, TypeVar
+from typing import Any, Callable, ContextManager, Dict, Generic, Iterable, Iterator, List, Mapping, TypeVar
 
 if sys.version_info >= (3, 9):
     from types import GenericAlias
@@ -12,7 +12,7 @@ _T = TypeVar("_T")
 class ApplyResult(Generic[_T]):
     def __init__(
         self,
-        pool: Pool,
+        cache: Dict[int, ApplyResult[Any]],
         callback: Callable[[_T], None] | None = ...,
         error_callback: Callable[[BaseException], None] | None = ...,
     ) -> None: ...


### PR DESCRIPTION
`multiprocessing.pool.ApplyResult.__init__` takes as its first param
a dictionary mapping from a generated integer task ID to ApplyResults
(usually, the parent `Pool`’s `_cache` member), not the `Pool` itself.