### PR TITLE
Add version and obsolete since field

### DIFF
--- a/stubs/geoip2/@tests/stubtest_allowlist.txt
+++ b/stubs/geoip2/@tests/stubtest_allowlist.txt
@@ -1,6 +1,5 @@
 geoip2.database.Reader.__exit__
 geoip2.database.Reader.__init__
-geoip2.errors.HTTPError.__init__
 geoip2.models.SimpleModel.__init__
 geoip2.records.City.__init__
 geoip2.records.Continent.__init__

--- a/stubs/geoip2/METADATA.toml
+++ b/stubs/geoip2/METADATA.toml
@@ -1,3 +1,4 @@
-version = "0.1"
+version = "3.0"
+obsolete_since = "4.0.2"
 python2 = true
 requires = ["types-maxminddb"]


### PR DESCRIPTION
I chose version 3.0 instead of 4.0, since this 4.0 dropped Python 2
support and the stubs are marked as still supporting Python 2.