### PR TITLE
Remove leftover pyright tornado configuration

### DIFF
--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -16,7 +16,6 @@
         "stubs/pathlib2",
         "stubs/pymssql",
         "stubs/scribe",
-        "stubs/tornado"
     ],
     "typeCheckingMode": "basic",
     "strictListInference": true,

--- a/pyrightconfig.stricter.json
+++ b/pyrightconfig.stricter.json
@@ -17,7 +17,6 @@
         "stubs/pathlib2",
         "stubs/pymssql",
         "stubs/scribe",
-        "stubs/tornado",
         // Modules that are incomplete in some way.
         "stdlib/distutils/command",
         "stdlib/lib2to3/refactor.pyi",


### PR DESCRIPTION
tornado was removed in 5a7f25584ed720be571879b5aa416f5dde6fcf46.