### PR TITLE
Remove leftover openssl-python in pyright configuration

### DIFF
--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -12,7 +12,6 @@
         "stubs/futures",
         "stubs/ipaddress",
         "stubs/kazoo",
-        "stubs/openssl-python",
         "stubs/pathlib2",
         "stubs/pymssql",
         "stubs/scribe",

--- a/pyrightconfig.stricter.json
+++ b/pyrightconfig.stricter.json
@@ -13,7 +13,6 @@
         "stubs/futures",
         "stubs/ipaddress",
         "stubs/kazoo",
-        "stubs/openssl-python",
         "stubs/pathlib2",
         "stubs/pymssql",
         "stubs/scribe",


### PR DESCRIPTION
The package was renamed in a98fceca2f6e6b9af84f467288a9e52d8c459417.