### PR TITLE
fix types of enum _member_names, etc.

### DIFF
--- a/stdlib/enum.pyi
+++ b/stdlib/enum.pyi
@@ -19,15 +19,15 @@ class EnumMeta(ABCMeta):
     @_builtins_property
     def __members__(self: Type[_T]) -> Mapping[str, _T]: ...
     def __len__(self) -> int: ...
+    _member_names_: list[str]  # undocumented
+    _member_map_: dict[str, Enum]  # undocumented
+    _value2member_map_: dict[Any, Enum]  # undocumented
 
 class Enum(metaclass=EnumMeta):
     name: str
     value: Any
     _name_: str
     _value_: Any
-    _member_names_: list[str]  # undocumented
-    _member_map_: dict[str, Enum]  # undocumented
-    _value2member_map_: dict[int, Enum]  # undocumented
     if sys.version_info >= (3, 7):
         _ignore_: str | list[str]
     _order_: str


### PR DESCRIPTION
```python
import enum

class C(enum.Enum):
    D = 1

reveal_type(C._member_names_)
```

**before**:

```console
$ mypy t.py
t.py:6: note: Revealed type is "Literal[t.C._member_names_]?"
```

**after**:

```console
$ mypy t.py --custom-typeshed .
t.py:6: note: Revealed type is "builtins.list[builtins.str]"
```