### PR TITLE
pyyaml: delete CDangerLoader and CDangerDumper

### DIFF
--- a/stubs/PyYAML/@tests/stubtest_allowlist.txt
+++ b/stubs/PyYAML/@tests/stubtest_allowlist.txt
@@ -1,12 +1,8 @@
 yaml.CBaseDumper.__init__
-yaml.CDangerDumper
-yaml.CDangerLoader
 yaml.CDumper.__init__
 yaml.CEmitter
 yaml.CParser
 yaml.YAMLObjectMetaclass.__init__
 yaml.constructor.FullConstructor.set_python_instance_state
 yaml.cyaml.CBaseDumper.__init__
-yaml.cyaml.CDangerDumper
-yaml.cyaml.CDangerLoader
 yaml.cyaml.CDumper.__init__

--- a/stubs/PyYAML/yaml/cyaml.pyi
+++ b/stubs/PyYAML/yaml/cyaml.pyi
@@ -39,7 +39,6 @@ class CFullLoader(CParser, FullConstructor, Resolver):
 class CUnsafeLoader(CParser, UnsafeConstructor, Resolver):
     def __init__(self, stream: str | bytes | _Readable) -> None: ...
 
-class CDangerLoader(CParser, Constructor, Resolver): ...  # undocumented
 
 class CEmitter(object):
     def __init__(
@@ -79,4 +78,3 @@ class CDumper(CEmitter, SafeRepresenter, Resolver): ...
 
 CSafeDumper = CDumper
 
-class CDangerDumper(CEmitter, Serializer, Representer, Resolver): ...  # undocumented


### PR DESCRIPTION
These were removed between PyYAML 4.1 and 4.2. Discussed in #5988.