### PR TITLE
Update third-party package versions

### DIFF
--- a/stubs/atomicwrites/METADATA.toml
+++ b/stubs/atomicwrites/METADATA.toml
@@ -1,2 +1,2 @@
-version = "0.1"
+version = "1.4"
 python2 = true

--- a/stubs/backports_abc/METADATA.toml
+++ b/stubs/backports_abc/METADATA.toml
@@ -1,2 +1,2 @@
-version = "0.1"
+version = "0.5"
 python2 = true

--- a/stubs/boto/METADATA.toml
+++ b/stubs/boto/METADATA.toml
@@ -1,3 +1,3 @@
-version = "0.1"
+version = "2.49"
 python2 = true
 requires = ["types-six"]

--- a/stubs/characteristic/METADATA.toml
+++ b/stubs/characteristic/METADATA.toml
@@ -1,2 +1,2 @@
-version = "0.1"
+version = "14.3"
 python2 = true

--- a/stubs/chardet/METADATA.toml
+++ b/stubs/chardet/METADATA.toml
@@ -1,3 +1,3 @@
-version = "0.1"
+version = "4.0"
 python2 = true
 requires = []

--- a/stubs/first/METADATA.toml
+++ b/stubs/first/METADATA.toml
@@ -1,2 +1,2 @@
-version = "0.1"
+version = "2.0"
 python2 = true

--- a/stubs/paramiko/METADATA.toml
+++ b/stubs/paramiko/METADATA.toml
@@ -1,3 +1,3 @@
-version = "0.1"
+version = "2.7"
 python2 = true
 requires = ["types-cryptography"]

--- a/stubs/python-dateutil/METADATA.toml
+++ b/stubs/python-dateutil/METADATA.toml
@@ -1,3 +1,3 @@
-version = "0.1"
+version = "2.8"
 python2 = true
 requires = []

--- a/stubs/python-gflags/METADATA.toml
+++ b/stubs/python-gflags/METADATA.toml
@@ -1,2 +1,2 @@
-version = "0.1"
+version = "3.1"
 python2 = true

--- a/stubs/pyvmomi/METADATA.toml
+++ b/stubs/pyvmomi/METADATA.toml
@@ -1,3 +1,3 @@
-version = "0.1"
+version = "7.0"
 python2 = true
 requires = ["types-enum34"]

--- a/stubs/retry/METADATA.toml
+++ b/stubs/retry/METADATA.toml
@@ -1,2 +1,2 @@
-version = "0.1"
+version = "0.9"
 python2 = true

--- a/stubs/singledispatch/METADATA.toml
+++ b/stubs/singledispatch/METADATA.toml
@@ -1,2 +1,2 @@
-version = "0.1"
+version = "3.7"
 python2 = true

--- a/stubs/toml/METADATA.toml
+++ b/stubs/toml/METADATA.toml
@@ -1,2 +1,2 @@
-version = "0.1"
+version = "0.10"
 python2 = true


### PR DESCRIPTION
This updates the third-party package versions of all packages still marked with "0.1" and supporting Python 2 to the latest version available on pypi, with the following exceptions:

* `backports` has the wrong package name.
* `click-spinner` actually has version `0.1.10` on pypi.
* The latest version on pypi of the remaining packages only support Python 3 and are outdated in typeshed.
