### PR TITLE
Fix python-slugify replacements argument type

### DIFF
--- a/stubs/python-slugify/METADATA.toml
+++ b/stubs/python-slugify/METADATA.toml
@@ -1,2 +1,1 @@
-version = "0.1"
-python2 = true
+version = "5.0"

--- a/stubs/python-slugify/slugify/slugify.pyi
+++ b/stubs/python-slugify/slugify/slugify.pyi
@@ -15,5 +15,5 @@ def slugify(
     stopwords: Iterable[str] = ...,
     regex_pattern: str | None = ...,
     lowercase: bool = ...,
-    replacements: Iterable[str] = ...,
+    replacements: Iterable[Tuple[str, str]] = ...,
 ) -> str: ...

--- a/stubs/python-slugify/slugify/slugify.pyi
+++ b/stubs/python-slugify/slugify/slugify.pyi
@@ -1,4 +1,4 @@
-from typing import Iterable, Tuple
+from typing import Iterable
 
 def smart_truncate(
     string: str, max_length: int = ..., word_boundary: bool = ..., separator: str = ..., save_order: bool = ...
@@ -15,5 +15,5 @@ def slugify(
     stopwords: Iterable[str] = ...,
     regex_pattern: str | None = ...,
     lowercase: bool = ...,
-    replacements: Iterable[Tuple[str, str]] = ...,
+    replacements: Iterable[Iterable[str]] = ...,
 ) -> str: ...

--- a/stubs/python-slugify/slugify/slugify.pyi
+++ b/stubs/python-slugify/slugify/slugify.pyi
@@ -1,4 +1,4 @@
-from typing import Iterable
+from typing import Iterable, Tuple
 
 def smart_truncate(
     string: str, max_length: int = ..., word_boundary: bool = ..., separator: str = ..., save_order: bool = ...


### PR DESCRIPTION
According to the [documentation](https://github.com/un33k/python-slugify#options) (and [source code](https://github.com/un33k/python-slugify/blob/master/slugify/slugify.py#L100)) of python-slugify the type of the replacements parameter is not an iterable of strings, but an iterable of 2-tuple strings. This PR fixes the argument type.