### PR TITLE
Fix type of stroke_width parameter in Pillow's ImageDraw.*text* functions

### DIFF
--- a/stubs/Pillow/PIL/ImageDraw.pyi
+++ b/stubs/Pillow/PIL/ImageDraw.pyi
@@ -66,7 +66,7 @@ class ImageDraw:
         direction: Literal["rtl", "ltr", "ttb"] | None = ...,
         features: Sequence[str] | None = ...,
         language: str | None = ...,
-        stroke_width: float = ...,
+        stroke_width: int = ...,
         stroke_fill: _Ink | None = ...,
         embedded_color: bool = ...,
         *args,
@@ -84,7 +84,7 @@ class ImageDraw:
         direction: Literal["rtl", "ltr", "ttb"] | None = ...,
         features: Any | None = ...,
         language: str | None = ...,
-        stroke_width: float = ...,
+        stroke_width: int = ...,
         stroke_fill: _Ink | None = ...,
         embedded_color: bool = ...,
     ) -> None: ...
@@ -96,7 +96,7 @@ class ImageDraw:
         direction: Literal["rtl", "ltr", "ttb"] | None = ...,
         features: Sequence[str] | None = ...,
         language: str | None = ...,
-        stroke_width: float = ...,
+        stroke_width: int = ...,
     ) -> tuple[int, int]: ...
     def multiline_textsize(
         self,
@@ -106,7 +106,7 @@ class ImageDraw:
         direction: Literal["rtl", "ltr", "ttb"] | None = ...,
         features: Sequence[str] | None = ...,
         language: str | None = ...,
-        stroke_width: float = ...,
+        stroke_width: int = ...,
     ) -> tuple[int, int]: ...
     def textlength(
         self,
@@ -128,7 +128,7 @@ class ImageDraw:
         direction: Literal["rtl", "ltr", "ttb"] | None = ...,
         features: Any | None = ...,
         language: str | None = ...,
-        stroke_width: float = ...,
+        stroke_width: int = ...,
         embedded_color: bool = ...,
     ) -> tuple[int, int, int, int]: ...
     def multiline_textbbox(
@@ -142,7 +142,7 @@ class ImageDraw:
         direction: Literal["rtl", "ltr", "ttb"] | None = ...,
         features: Any | None = ...,
         language: str | None = ...,
-        stroke_width: float = ...,
+        stroke_width: int = ...,
         embedded_color: bool = ...,
     ) -> tuple[int, int, int, int]: ...
 


### PR DESCRIPTION
TypeError Exception is raised if stroke_width is supplied as float.
Why: https://github.com/python-pillow/Pillow/blob/2bc754e1021081615e821acc1cd5d928e31d6d1d/src/_imagingft.c#L769

Happy to have my first contribution here! :smile: 
