### PR TITLE
Fix type of blocking_timeout argument to redis.lock.Lock

### DIFF
--- a/stubs/redis/redis/lock.pyi
+++ b/stubs/redis/redis/lock.pyi
@@ -13,7 +13,7 @@ class Lock:
         timeout: None | int | float = ...,
         sleep: float = ...,
         blocking: bool = ...,
-        blocking_timeout: None | int | float = ...,
+        blocking_timeout: float | None = ...,
         thread_local: bool = ...,
     ) -> None: ...
     def register_scripts(self) -> None: ...

--- a/stubs/redis/redis/lock.pyi
+++ b/stubs/redis/redis/lock.pyi
@@ -13,7 +13,7 @@ class Lock:
         timeout: None | int | float = ...,
         sleep: float = ...,
         blocking: bool = ...,
-        blocking_timeout: bool | None = ...,
+        blocking_timeout: None | int | float = ...,
         thread_local: bool = ...,
     ) -> None: ...
     def register_scripts(self) -> None: ...

--- a/stubs/redis/redis/lock.pyi
+++ b/stubs/redis/redis/lock.pyi
@@ -10,7 +10,7 @@ class Lock:
         self,
         redis: Redis[Any],
         name: str,
-        timeout: None | int | float = ...,
+        timeout: float | None = ...,
         sleep: float = ...,
         blocking: bool = ...,
         blocking_timeout: float | None = ...,


### PR DESCRIPTION
This fixes wrong type annotation on `blocking_timeout` argument to `redis.lock.Lock` object.