### PR TITLE
Fix stdlib logging SysLogHandler missing attribute

### DIFF
--- a/stdlib/@python2/logging/handlers.pyi
+++ b/stdlib/@python2/logging/handlers.pyi
@@ -84,6 +84,7 @@ class SysLogHandler(Handler):
     LOG_LOCAL5: int
     LOG_LOCAL6: int
     LOG_LOCAL7: int
+    address: Tuple[str, int] | str  # undocumented
     unixsocket: bool  # undocumented
     socktype: SocketKind  # undocumented
     facility: int  # undocumented

--- a/stdlib/logging/handlers.pyi
+++ b/stdlib/logging/handlers.pyi
@@ -167,6 +167,7 @@ class SysLogHandler(Handler):
     LOG_LOCAL5: int
     LOG_LOCAL6: int
     LOG_LOCAL7: int
+    address: tuple[str, int] | str  # undocumented
     unixsocket: bool  # undocumented
     socktype: SocketKind  # undocumented
     ident: str  # undocumented


### PR DESCRIPTION
As per CPython logging handlers source:
https://github.com/python/cpython/blob/main/Lib/logging/handlers.py#L835

The `SysLogHandler` has attribute `address` that is not included in the typeshed.

This pull request fixes that.