### PR TITLE
Add undocumented attribute multiprocessing.process.BaseProcess._identity

### DIFF
--- a/stdlib/multiprocessing/process.pyi
+++ b/stdlib/multiprocessing/process.pyi
@@ -5,6 +5,7 @@ class BaseProcess:
     name: str
     daemon: bool
     authkey: bytes
+    _identity: Tuple[int, ...]  # undocumented
     def __init__(
         self,
         group: None = ...,


### PR DESCRIPTION
A user filed an issue against pytype about this attribute being missing:
https://github.com/google/pytype/issues/1010. I determined its type from
the source code:
https://github.com/python/cpython/blob/3.9/Lib/multiprocessing/process.py.