### PR TITLE
ttkthemes: allow constructing ThemedStyle with no arguments

### DIFF
--- a/stubs/ttkthemes/ttkthemes/themed_style.pyi
+++ b/stubs/ttkthemes/ttkthemes/themed_style.pyi
@@ -5,7 +5,7 @@ from ._widget import ThemedWidget
 
 class ThemedStyle(ttk.Style, ThemedWidget):
     def __init__(
-        self, master: tkinter.Misc | None, *, theme: str | None = ..., gif_override: bool | None = ..., **kwargs
+        self, master: tkinter.Misc | None = ..., *, theme: str | None = ..., gif_override: bool | None = ..., **kwargs
     ) -> None: ...
     # theme_use() can't return None (differs from ttk.Style)
     def theme_use(self, theme_name: str | None = ...) -> str: ...  # type: ignore


### PR DESCRIPTION
It works at runtime. The arguments get passed to `ttk.Style` which uses tkinter's default root window as the master widget when it is not given.