### PR TITLE
change prints in scripts/create_baseline_stubs.py

### DIFF
--- a/scripts/create_baseline_stubs.py
+++ b/scripts/create_baseline_stubs.py
@@ -161,12 +161,10 @@ def main() -> None:
 
     print("\nDone!\n\nSuggested next steps:")
     print(f" 1. Manually review the generated stubs in {stub_dir}")
-    print(" 2. Run stubtest to test the generated stubs against runtime definitions")
-    print(f' 3. Run "flake8 {stub_dir}" to check code style')
-    print(f' 4. Run "mypy {stub_dir}" to check for errors')
-    print(f' 5. Run "black {stub_dir}" (if you\'ve made code changes)')
-    print(" 6. Create branch in the typeshed repo and commit the stubs (and other changes)")
-    print(" 7. Create typeshed PR")
+    print(f' 2. Run "MYPYPATH={stub_dir} python3 -m mypy.stubtest {package}" to check the stubs against runtime')
+    print(f' 3. Run "mypy {stub_dir}" to check for errors')
+    print(f' 4. Run "black {stub_dir}" and "isort {stub_dir}" (if you\'ve made code changes)')
+    print(" 5. Commit the stubs on a new branch and create a typeshed PR")
 
 
 if __name__ == "__main__":

--- a/scripts/create_baseline_stubs.py
+++ b/scripts/create_baseline_stubs.py
@@ -164,7 +164,7 @@ def main() -> None:
     print(f' 2. Run "MYPYPATH={stub_dir} python3 -m mypy.stubtest {package}" to check the stubs against runtime')
     print(f' 3. Run "mypy {stub_dir}" to check for errors')
     print(f' 4. Run "black {stub_dir}" and "isort {stub_dir}" (if you\'ve made code changes)')
-    print(" 5. Commit the stubs on a new branch and create a typeshed PR")
+    print(" 5. Commit the changes on a new branch and create a typeshed PR")
 
 
 if __name__ == "__main__":

--- a/scripts/create_baseline_stubs.py
+++ b/scripts/create_baseline_stubs.py
@@ -164,7 +164,8 @@ def main() -> None:
     print(f' 2. Run "MYPYPATH={stub_dir} python3 -m mypy.stubtest {package}" to check the stubs against runtime')
     print(f' 3. Run "mypy {stub_dir}" to check for errors')
     print(f' 4. Run "black {stub_dir}" and "isort {stub_dir}" (if you\'ve made code changes)')
-    print(" 5. Commit the changes on a new branch and create a typeshed PR")
+    print(f' 5. Run "flake8 {stub_dir}" to check for e.g. unused imports')
+    print(" 6. Commit the changes on a new branch and create a typeshed PR")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I have now used the script a few times. It's awesome, but I have always found the message it prints when done to be quite misleading. I changed it like this:

- Show the command for running stubtest. When using the script, I didn't know how to stubtest locally, so I just created the PR and waited for CI errors.
- Combine PR creation into a single step to shorten the list. We don't want the list to be too intimidating. Our contribution process is simple, and we shouldn't make it look more complicated than it really is.
- Run `flake8` after `black` and `isort`, so that it won't complain about style. It will still complain about unused imports, for example. We could use pyright for that, but then you would need to have node installed just to create new stubs (and again, it is nicer to run it locally than wait for the CI to run).