### PR TITLE
Support name, content-type and headers in file upload

### DIFF
--- a/stubs/requests/requests/sessions.pyi
+++ b/stubs/requests/requests/sessions.pyi
@@ -87,12 +87,11 @@ class Session(SessionRedirectMixin):
         data: _Data = ...,
         headers: _TextMapping | None = ...,
         cookies: None | RequestsCookieJar | _TextMapping = ...,
-        files: Union[
-            MutableMapping[Text, Union[IO[Any]]],
-            MutableMapping[Text, Tuple[Text, IO[Any]]],
-            MutableMapping[Text, Tuple[Text, IO[Any], Text]],
-            MutableMapping[Text, Tuple[Text, IO[Any], Text, _TextMapping]],
-        ] | None = ...,
+        files: MutableMapping[Text, Union[IO[Any]]]
+        | MutableMapping[Text, Tuple[Text, IO[Any]]]
+        | MutableMapping[Text, Tuple[Text, IO[Any], Text]]
+        | MutableMapping[Text, Tuple[Text, IO[Any], Text, _TextMapping]]
+        | None = ...,
         auth: None | Tuple[Text, Text] | _auth.AuthBase | Callable[[PreparedRequest], PreparedRequest] = ...,
         timeout: None | float | Tuple[float, float] | Tuple[float, None] = ...,
         allow_redirects: bool | None = ...,

--- a/stubs/requests/requests/sessions.pyi
+++ b/stubs/requests/requests/sessions.pyi
@@ -87,7 +87,12 @@ class Session(SessionRedirectMixin):
         data: _Data = ...,
         headers: _TextMapping | None = ...,
         cookies: None | RequestsCookieJar | _TextMapping = ...,
-        files: MutableMapping[Text, Union[IO[Any], Tuple[Text, IO[Any]], Tuple[Text, IO[Any], Text], Tuple[Text, IO[Any], Text, _TextMapping]]] | None = ...,
+        files: Union[
+            MutableMapping[Text, Union[IO[Any]]],
+            MutableMapping[Text, Tuple[Text, IO[Any]]],
+            MutableMapping[Text, Tuple[Text, IO[Any], Text]],
+            MutableMapping[Text, Tuple[Text, IO[Any], Text, _TextMapping]],
+        ] | None = ...,
         auth: None | Tuple[Text, Text] | _auth.AuthBase | Callable[[PreparedRequest], PreparedRequest] = ...,
         timeout: None | float | Tuple[float, float] | Tuple[float, None] = ...,
         allow_redirects: bool | None = ...,

--- a/stubs/requests/requests/sessions.pyi
+++ b/stubs/requests/requests/sessions.pyi
@@ -57,13 +57,14 @@ _Params = Union[
     Iterable[Tuple[_ParamsMappingKeyType, _ParamsMappingValueType]],
     Union[Text, bytes],
 ]
+_TextMapping = MutableMapping[Text, Text]
 _SessionT = TypeVar("_SessionT", bound=Session)
 
 class Session(SessionRedirectMixin):
     __attrs__: Any
     headers: CaseInsensitiveDict[Text]
     auth: None | Tuple[Text, Text] | _auth.AuthBase | Callable[[PreparedRequest], PreparedRequest]
-    proxies: MutableMapping[Text, Text]
+    proxies: _TextMapping
     hooks: _Hooks
     params: _Params
     stream: bool
@@ -84,13 +85,13 @@ class Session(SessionRedirectMixin):
         url: str | bytes | Text,
         params: _Params | None = ...,
         data: _Data = ...,
-        headers: MutableMapping[Text, Text] | None = ...,
-        cookies: None | RequestsCookieJar | MutableMapping[Text, Text] = ...,
-        files: MutableMapping[Text, IO[Any]] | None = ...,
+        headers: _TextMapping | None = ...,
+        cookies: None | RequestsCookieJar | _TextMapping = ...,
+        files: MutableMapping[Text, Union[IO[Any], Tuple[Text, IO[Any]], Tuple[Text, IO[Any], Text], Tuple[Text, IO[Any], Text, _TextMapping]]] | None = ...,
         auth: None | Tuple[Text, Text] | _auth.AuthBase | Callable[[PreparedRequest], PreparedRequest] = ...,
         timeout: None | float | Tuple[float, float] | Tuple[float, None] = ...,
         allow_redirects: bool | None = ...,
-        proxies: MutableMapping[Text, Text] | None = ...,
+        proxies: _TextMapping | None = ...,
         hooks: _HooksInput | None = ...,
         stream: bool | None = ...,
         verify: None | bool | Text = ...,

--- a/stubs/requests/requests/sessions.pyi
+++ b/stubs/requests/requests/sessions.pyi
@@ -87,7 +87,7 @@ class Session(SessionRedirectMixin):
         data: _Data = ...,
         headers: _TextMapping | None = ...,
         cookies: None | RequestsCookieJar | _TextMapping = ...,
-        files: MutableMapping[Text, Union[IO[Any]]]
+        files: MutableMapping[Text, IO[Any]]
         | MutableMapping[Text, Tuple[Text, IO[Any]]]
         | MutableMapping[Text, Tuple[Text, IO[Any], Text]]
         | MutableMapping[Text, Tuple[Text, IO[Any], Text, _TextMapping]]


### PR DESCRIPTION
`requests` supports not only passing binary file-like objects for multi-part file uploads but also additionally passing a name,  content-type and headers. This adds type hints for those options.

See https://docs.python-requests.org/en/master/user/quickstart/#post-a-multipart-encoded-file.