### PR TITLE
Adds `AM_STR` and `PM_STR` to `locale.py`

### DIFF
--- a/stdlib/locale.pyi
+++ b/stdlib/locale.pyi
@@ -11,6 +11,8 @@ D_T_FMT: int
 D_FMT: int
 T_FMT: int
 T_FMT_AMPM: int
+AM_STR: int
+PM_STR: int
 
 DAY_1: int
 DAY_2: int


### PR DESCRIPTION
Source: https://github.com/python/cpython/blob/bb3e0c240bc60fe08d332ff5955d54197f79751c/Modules/_localemodule.c#L555-L556

Related https://github.com/python/mypy/issues/11183