### PR TITLE
More specific types in `dateparser/date.pyi::DateDataParser`

### DIFF
--- a/stubs/dateparser/dateparser/date.pyi
+++ b/stubs/dateparser/dateparser/date.pyi
@@ -1,3 +1,4 @@
+import collections
 import sys
 from _typeshed import Self as Self
 from datetime import datetime
@@ -91,7 +92,7 @@ class DateDataParser:
     languages: list[str] | None
     locales: list[str] | tuple[str] | set[str] | None
     region: str
-    previous_locales: dict[Locale, None]
+    previous_locales: collections.OrderedDict[Locale, None]
     def __init__(
         self,
         languages: list[str] | tuple[str] | set[str] | None = ...,

--- a/stubs/dateparser/dateparser/date.pyi
+++ b/stubs/dateparser/dateparser/date.pyi
@@ -1,7 +1,7 @@
 import sys
 from _typeshed import Self as Self
 from datetime import datetime
-from typing import Any, ClassVar, Iterable, Iterator, Type, overload
+from typing import ClassVar, Iterable, Iterator, Type, overload
 
 from dateparser import _Settings
 from dateparser.conf import Settings

--- a/stubs/dateparser/dateparser/date.pyi
+++ b/stubs/dateparser/dateparser/date.pyi
@@ -88,10 +88,10 @@ class DateDataParser:
     locale_loader: ClassVar[LocaleDataLoader | None]
     try_previous_locales: bool
     use_given_order: bool
-    languages: Any
-    locales: Any
-    region: Any
-    previous_locales: Any
+    languages: list[str] | None
+    locales: list[str] | tuple[str] | set[str] | None
+    region: str
+    previous_locales: dict[Locale, None]
     def __init__(
         self,
         languages: list[str] | tuple[str] | set[str] | None = ...,


### PR DESCRIPTION
Considering `dict[Locale, None]`: looks like it is a hack of some kind: https://github.com/scrapinghub/dateparser/issues/457