### PR TITLE
Improves BeautifulSoup4 typing.

### DIFF
--- a/stubs/beautifulsoup4/bs4/element.pyi
+++ b/stubs/beautifulsoup4/bs4/element.pyi
@@ -319,7 +319,7 @@ class Tag(PageElement):
         text: _Strainable | None = ...,
         limit: int | None = ...,
         **kwargs: _Strainable,
-    ) -> ResultSet[Type[_PageElementT]]: ...
+    ) -> ResultSet[_PageElementT]: ...
     __call__ = find_all
     findAll = find_all
     findChildren = find_all

--- a/stubs/beautifulsoup4/bs4/element.pyi
+++ b/stubs/beautifulsoup4/bs4/element.pyi
@@ -319,7 +319,7 @@ class Tag(PageElement):
         text: _Strainable | None = ...,
         limit: int | None = ...,
         **kwargs: _Strainable,
-    ) -> ResultSet[[Type[_PageElementT]]: ...
+    ) -> ResultSet[Type[_PageElementT]]: ...
     __call__ = find_all
     findAll = find_all
     findChildren = find_all

--- a/stubs/beautifulsoup4/bs4/element.pyi
+++ b/stubs/beautifulsoup4/bs4/element.pyi
@@ -319,7 +319,7 @@ class Tag(PageElement):
         text: _Strainable | None = ...,
         limit: int | None = ...,
         **kwargs: _Strainable,
-    ) -> ResultSet[_PageElementT]: ...
+    ) -> ResultSet[Any]: ...
     __call__ = find_all
     findAll = find_all
     findChildren = find_all

--- a/stubs/beautifulsoup4/bs4/element.pyi
+++ b/stubs/beautifulsoup4/bs4/element.pyi
@@ -319,7 +319,7 @@ class Tag(PageElement):
         text: _Strainable | None = ...,
         limit: int | None = ...,
         **kwargs: _Strainable,
-    ) -> ResultSet[PageElement]: ...
+    ) -> ResultSet[[Type[_PageElementT]]: ...
     __call__ = find_all
     findAll = find_all
     findChildren = find_all


### PR DESCRIPTION
PageElement.find_all() can return both PageElement and any subclass of PageElement on the latest version of bs4 and ResultSet already accounts for this so find_all() should be typed with the same generic TypeVar.