### PR TITLE
redis: include local property on Lock class

### DIFF
--- a/stubs/redis/redis/lock.pyi
+++ b/stubs/redis/redis/lock.pyi
@@ -1,11 +1,17 @@
 from types import TracebackType
-from typing import Any, Text, Type, Union
+from typing import Any, Optional, Text, Type, Union
+from typing_extensions import Protocol
 
 from redis.client import Redis
 
 _TokenValue = Union[bytes, Text]
 
+
+class _Local(Protocol):
+    token: Optional[_TokenValue]
+
 class Lock:
+    local: _Local
     def __init__(
         self,
         redis: Redis[Any],

--- a/stubs/redis/redis/lock.pyi
+++ b/stubs/redis/redis/lock.pyi
@@ -1,5 +1,5 @@
 from types import TracebackType
-from typing import Any, Optional, Text, Type, Union
+from typing import Any, Text, Type, Union
 from typing_extensions import Protocol
 
 from redis.client import Redis

--- a/stubs/redis/redis/lock.pyi
+++ b/stubs/redis/redis/lock.pyi
@@ -6,9 +6,8 @@ from redis.client import Redis
 
 _TokenValue = Union[bytes, Text]
 
-
 class _Local(Protocol):
-    token: Optional[_TokenValue]
+    token: _TokenValue | None
 
 class Lock:
     local: _Local


### PR DESCRIPTION
The Lock class as a property local that has a token property that sometimes
needs be accessed / set.

```python
lock = redis.lock(key)
lock.local.token = token
lock.extend(10)
```

Technically the type of `local` is `SimpleNamespace | threading.local`
but I think this setup is a bit stricter but satisfies the API.