### PR TITLE
`StackSummary.extract()` takes an `Iterable`

### DIFF
--- a/stdlib/traceback.pyi
+++ b/stdlib/traceback.pyi
@@ -146,7 +146,7 @@ class StackSummary(List[FrameSummary]):
     @classmethod
     def extract(
         cls,
-        frame_gen: Generator[Tuple[FrameType, int], None, None],
+        frame_gen: Iterable[Tuple[FrameType, int]],
         *,
         limit: int | None = ...,
         lookup_lines: bool = ...,


### PR DESCRIPTION
Currently, `StackSummary.extract(walk_stack(frame))` is a typecheck error, because the annotation calls for a generator but `walk_stack()` returns an iterable.  Since we never `.send()`, I've updated the type hint on `extract()`.