### PR TITLE
FIX: types for value attribute in dump and dumps

### DIFF
--- a/stdlib/plistlib.pyi
+++ b/stdlib/plistlib.pyi
@@ -31,7 +31,7 @@ else:
     ) -> Any: ...
 
 def dump(
-    value: Mapping[str, Any] | List[Any] | Tuple[Any, ...] | str | bool | float | bytes | bytearray | datetime,
+    value: Mapping[str, Any] | List[Any] | Tuple[Any, ...] | str | bool | float | bytes | datetime,
     fp: IO[bytes],
     *,
     fmt: PlistFormat = ...,
@@ -39,7 +39,7 @@ def dump(
     skipkeys: bool = ...,
 ) -> None: ...
 def dumps(
-    value: Mapping[str, Any] | List[Any] | Tuple[Any, ...] | str | bool | float | bytes | bytearray | datetime,
+    value: Mapping[str, Any] | List[Any] | Tuple[Any, ...] | str | bool | float | bytes | datetime,
     *,
     fmt: PlistFormat = ...,
     skipkeys: bool = ...,

--- a/stdlib/plistlib.pyi
+++ b/stdlib/plistlib.pyi
@@ -1,6 +1,7 @@
 import sys
+from datetime import datetime
 from enum import Enum
-from typing import IO, Any, Dict as _Dict, Mapping, MutableMapping, Type
+from typing import IO, Any, Dict as _Dict, List, Mapping, MutableMapping, Tuple, Type
 
 class PlistFormat(Enum):
     FMT_XML: int
@@ -30,9 +31,20 @@ else:
     ) -> Any: ...
 
 def dump(
-    value: Mapping[str, Any], fp: IO[bytes], *, fmt: PlistFormat = ..., sort_keys: bool = ..., skipkeys: bool = ...
+    value: Mapping[str, Any] | List[Any] | Tuple[Any, ...] | str | bool | float | bytes | bytearray | datetime,
+    fp: IO[bytes],
+    *,
+    fmt: PlistFormat = ...,
+    sort_keys: bool = ...,
+    skipkeys: bool = ...,
 ) -> None: ...
-def dumps(value: Mapping[str, Any], *, fmt: PlistFormat = ..., skipkeys: bool = ..., sort_keys: bool = ...) -> bytes: ...
+def dumps(
+    value: Mapping[str, Any] | List[Any] | Tuple[Any, ...] | str | bool | float | bytes | bytearray | datetime,
+    *,
+    fmt: PlistFormat = ...,
+    skipkeys: bool = ...,
+    sort_keys: bool = ...,
+) -> bytes: ...
 
 if sys.version_info < (3, 9):
     def readPlist(pathOrFile: str | IO[bytes]) -> Any: ...


### PR DESCRIPTION
issue: #6032

## Changes

- added new types to `plistlib` stub according to the following
[plistlib python docs](https://docs.python.org/3/library/plistlib.html#module-plistlib)
[accepted types in cpython implementation](https://github.com/python/cpython/blob/e046aabbe386fdf32bae6ffb7fae5ce479fd10c6/Lib/plistlib.py#L327)

## Checks
- [x] formatted with black and isort
- [x] all tests passes