### PR TITLE
Remove covariance in mock.patch.multiple

### DIFF
--- a/stdlib/unittest/mock.pyi
+++ b/stdlib/unittest/mock.pyi
@@ -320,8 +320,8 @@ class _patcher:
         spec_set: Any | None = ...,
         autospec: Any | None = ...,
         new_callable: Any | None = ...,
-        **kwargs: _T,
-    ) -> _patch[_T]: ...
+        **kwargs: Any,
+    ) -> _patch[Any]: ...
     def stopall(self) -> None: ...
 
 patch: _patcher


### PR DESCRIPTION
The _T annotation for **kwargs would seem to imply that each of the kwarg values would be of the same type. However the interface conveys no such constraint: Any key can be mocked with any value, including DEFAULT.

A simple case that is improperly handled is `mock.patch.multiple(settings, A=1, B='foo')` since `1` and `'foo'` aren't consistent types.