### PR TITLE
Update remaining versions for third-party stubs

### DIFF
--- a/stubs/DateTimeRange/METADATA.toml
+++ b/stubs/DateTimeRange/METADATA.toml
@@ -1,3 +1,2 @@
-version = "0.1"
-python2 = true
+version = "1.2"
 requires = ["types-python-dateutil"]

--- a/stubs/JACK-Client/METADATA.toml
+++ b/stubs/JACK-Client/METADATA.toml
@@ -1,1 +1,1 @@
-version = "0.1"
+version = "0.5"

--- a/stubs/aiofiles/METADATA.toml
+++ b/stubs/aiofiles/METADATA.toml
@@ -1,2 +1,2 @@
-version = "0.1"
+version = "0.7"
 requires = []

--- a/stubs/contextvars/METADATA.toml
+++ b/stubs/contextvars/METADATA.toml
@@ -1,1 +1,1 @@
-version = "0.1"
+version = "2.4"

--- a/stubs/dataclasses/METADATA.toml
+++ b/stubs/dataclasses/METADATA.toml
@@ -1,1 +1,1 @@
-version = "0.1"
+version = "0.8"

--- a/stubs/decorator/METADATA.toml
+++ b/stubs/decorator/METADATA.toml
@@ -1,2 +1,1 @@
-version = "0.1"
-python2 = true
+version = "5.1"

--- a/stubs/frozendict/METADATA.toml
+++ b/stubs/frozendict/METADATA.toml
@@ -1,1 +1,1 @@
-version = "0.1"
+version = "2.0"

--- a/stubs/pyRFC3339/METADATA.toml
+++ b/stubs/pyRFC3339/METADATA.toml
@@ -1,1 +1,1 @@
-version = "0.1"
+version = "1.1"

--- a/stubs/pycurl/METADATA.toml
+++ b/stubs/pycurl/METADATA.toml
@@ -1,2 +1,1 @@
-version = "0.1"
-python2 = true
+version = "7.44"

--- a/stubs/tzlocal/METADATA.toml
+++ b/stubs/tzlocal/METADATA.toml
@@ -1,3 +1,2 @@
-version = "0.1"
-python2 = true
+version = "3.0"
 requires = ["types-pytz"]

--- a/stubs/ujson/METADATA.toml
+++ b/stubs/ujson/METADATA.toml
@@ -1,2 +1,1 @@
-version = "0.1"
-python2 = true
+version = "4.2"

--- a/stubs/waitress/METADATA.toml
+++ b/stubs/waitress/METADATA.toml
@@ -1,2 +1,2 @@
-version = "0.1"
+version = "2.0"
 requires = []


### PR DESCRIPTION
Also remove the python2 markers of packages that don't list Python 2 as supported in the latest version.

This depends on #6093, which should be merged into this branch before merging to verify CI.