### PR TITLE
Add the rest of string.Template's class attributes

### DIFF
--- a/stdlib/string.pyi
+++ b/stdlib/string.pyi
@@ -1,5 +1,11 @@
-from re import Pattern, RegexFlag  # Importing from regex breaks the Markdown stubtest
+import sys
+from re import RegexFlag
 from typing import Any, Iterable, Mapping, Sequence, Tuple
+
+if sys.version_info >= (3, 8):
+    from re import Pattern
+else:
+    from typing import Pattern
 
 ascii_letters: str
 ascii_lowercase: str

--- a/stdlib/string.pyi
+++ b/stdlib/string.pyi
@@ -1,5 +1,5 @@
-# from re import RegexFlag  # Importing from regex breaks the Markdown stubtest
-from typing import Any, Iterable, Mapping, Pattern, Sequence, Tuple
+from re import Pattern, RegexFlag  # Importing from regex breaks the Markdown stubtest
+from typing import Any, Iterable, Mapping, Sequence, Tuple
 
 ascii_letters: str
 ascii_lowercase: str
@@ -18,7 +18,7 @@ class Template:
     delimiter: str
     idpattern: str
     braceidpattern: str | None
-    flags: Any  # RegexFlag
+    flags: RegexFlag
     pattern: Pattern[str]
     def __init__(self, template: str) -> None: ...
     def substitute(self, __mapping: Mapping[str, object] = ..., **kwds: object) -> str: ...

--- a/stdlib/string.pyi
+++ b/stdlib/string.pyi
@@ -1,4 +1,5 @@
-from typing import Any, Iterable, Mapping, Sequence, Tuple
+# from re import RegexFlag  # Importing from regex breaks the Markdown stubtest
+from typing import Any, Iterable, Mapping, Pattern, Sequence, Tuple
 
 ascii_letters: str
 ascii_lowercase: str
@@ -14,6 +15,11 @@ def capwords(s: str, sep: str | None = ...) -> str: ...
 
 class Template:
     template: str
+    delimiter: str
+    idpattern: str
+    braceidpattern: str | None
+    flags: Any  # RegexFlag
+    pattern: Pattern[str]
     def __init__(self, template: str) -> None: ...
     def substitute(self, __mapping: Mapping[str, object] = ..., **kwds: object) -> str: ...
     def safe_substitute(self, __mapping: Mapping[str, object] = ..., **kwds: object) -> str: ...


### PR DESCRIPTION
Adds the following attributes to `string.Template`.

```
$ stubtest --custom-typeshed-dir . string --concise
string.Template.braceidpattern is not present in stub
string.Template.delimiter is not present in stub
string.Template.flags is not present in stub
string.Template.idpattern is not present in stub
string.Template.pattern is not present in stub
```

Also just wanted to say thanks for the fantastic [Good ways to contribute](https://github.com/python/typeshed/issues/4641) issue.