### PR TITLE
Properly export types from psutil._compat

### DIFF
--- a/stubs/psutil/psutil/_compat.pyi
+++ b/stubs/psutil/psutil/_compat.pyi
@@ -1,6 +1,8 @@
-FileNotFoundError = FileNotFoundError
-PermissionError = PermissionError
-ProcessLookupError = ProcessLookupError
-InterruptedError = InterruptedError
-ChildProcessError = ChildProcessError
-FileExistsError = FileExistsError
+from builtins import (
+    ChildProcessError as ChildProcessError,
+    FileExistsError as FileExistsError,
+    FileNotFoundError as FileNotFoundError,
+    InterruptedError as InterruptedError,
+    PermissionError as PermissionError,
+    ProcessLookupError as ProcessLookupError,
+)


### PR DESCRIPTION
For #6110.

These are circular definitions; export them directly from the builtins instead (like other modules).