### PR TITLE
Support the documented protocol for sys.ps1 and sys.ps2

### DIFF
--- a/stdlib/sys.pyi
+++ b/stdlib/sys.pyi
@@ -70,8 +70,8 @@ if sys.version_info >= (3, 9):
 prefix: str
 if sys.version_info >= (3, 8):
     pycache_prefix: str | None
-ps1: str
-ps2: str
+ps1: object
+ps2: object
 stdin: TextIO
 stdout: TextIO
 stderr: TextIO


### PR DESCRIPTION
Fix for the type declaration of standard lib sys.ps1 and sys.ps2
discussed in #6121. Closes #6121.