### PR TITLE
Improves `PIL.ImageDraw`

### DIFF
--- a/stubs/Pillow/PIL/ImageDraw.pyi
+++ b/stubs/Pillow/PIL/ImageDraw.pyi
@@ -5,7 +5,7 @@ from typing_extensions import Literal
 from .Image import Image
 from .ImageFont import _Font
 
-_Ink = Union[str, int, Tuple[int, int, int]]
+_Ink = Union[str, int, Tuple[int, int, int], Tuple[int, int, int, int]]
 _XY = Sequence[Union[float, Tuple[float, float]]]
 _Outline = Any
 


### PR DESCRIPTION
`_Ink` source: https://github.com/python-pillow/Pillow/blob/50302231edbfa19389d0d606f656c8c6ec17e4fa/src/PIL/ImageColor.py#L119-L128
Closes https://github.com/python/typeshed/issues/6147