### PR TITLE
Remove LogRecord.message.

### DIFF
--- a/stdlib/logging/__init__.pyi
+++ b/stdlib/logging/__init__.pyi
@@ -326,7 +326,6 @@ class LogRecord:
     lineno: int
     module: str
     msecs: float
-    message: str
     msg: str
     name: str
     pathname: str


### PR DESCRIPTION
This attribute is created inside of the [`logging.Formatter.format`](https://github.com/python/cpython/blob/560a79f94e94de66a18f2a5e4194c2fe51e2adf1/Lib/logging/__init__.py#L681) and does not exist otherwise.  Referring to it inside of a `logging.Filter` will cause an `AttributeError`.