### PR TITLE
Fix small issues in ftplib

### DIFF
--- a/stdlib/ftplib.pyi
+++ b/stdlib/ftplib.pyi
@@ -33,7 +33,10 @@ class FTP:
     lastresp: str
     file: TextIO | None
     encoding: str
-    trust_server_pasv_ipv4_address: bool
+
+    # The following variable is intentionally left undocumented.
+    # See https://bugs.python.org/issue43285 for relevant discussion
+    # trust_server_pasv_ipv4_address: bool
     def __enter__(self: Self) -> Self: ...
     def __exit__(
         self, exc_type: Type[BaseException] | None, exc_val: BaseException | None, exc_tb: TracebackType | None


### PR DESCRIPTION
Fix the following issues:

```
$ stubtest --custom-typeshed-dir . ftplib --concise
ftplib.FTP.__init__ is inconsistent, stub does not have argument "encoding"
ftplib.FTP.trust_server_pasv_ipv4_address is not present in stub
ftplib.FTP_TLS.__init__ is inconsistent, stub does not have argument "encoding"
```

Note that the `trust_server_pasv_ipv4_address` variable is undocumented, and [appears to be related to a security issue](https://github.com/python/cpython/blob/3.10/Lib/ftplib.py#L106-L107). A relevant quote from the author of the PR that added this variable:

> I don't actually want to document the attribute that people can set for the old behavior beyond the notes in NEWS or What's New.  It is something I anticipate nobody in the world ever actually setting so I'd rather not imply that anyone even should by giving it more prominent doc space.

So let me know if I should remove the type hint for that variable (as this would likely increase its visibility).