### PR TITLE
Further BeautifulSoup4 improvements.

### DIFF
--- a/stubs/beautifulsoup4/bs4/element.pyi
+++ b/stubs/beautifulsoup4/bs4/element.pyi
@@ -348,6 +348,6 @@ class SoupStrainer:
     searchTag = search_tag
     def search(self, markup: PageElement | Iterable[PageElement]): ...
 
-class ResultSet(Generic[_PageElementT], List[_PageElementT]):
+class ResultSet(List[_PageElementT], Generic[_PageElementT]):
     source: SoupStrainer
     def __init__(self, source: SoupStrainer, result: Iterable[_PageElementT] = ...) -> None: ...


### PR DESCRIPTION
Per the [PSF](https://www.python.org/download/releases/2.3/mro/), class inheritance is evaluated left-to-right and Generic being first causes the ResultSet class to be marked as not being Iterable because, by definition, Generic lacks a __iter__ method. The solution is to put the List type first, which is more logical given ResultSet [explicitly](https://bazaar.launchpad.net/~leonardr/beautifulsoup/bs4/view/head:/bs4/element.py#L2247) inherits from list anyway. 