### PR TITLE
Add CAN_RAW_JOIN_FILTERS constant to socket stub

### DIFF
--- a/stdlib/_socket.pyi
+++ b/stdlib/_socket.pyi
@@ -325,6 +325,7 @@ if sys.platform == "linux" and sys.version_info >= (3, 7):
 
 if sys.platform == "linux" and sys.version_info >= (3, 9):
     CAN_J1939: int
+    CAN_RAW_JOIN_FILTERS: int
 
     J1939_MAX_UNICAST_ADDR: int
     J1939_IDLE_ADDR: int

--- a/stdlib/socket.pyi
+++ b/stdlib/socket.pyi
@@ -341,6 +341,7 @@ if sys.platform == "linux" and sys.version_info >= (3, 8):
 if sys.platform == "linux" and sys.version_info >= (3, 9):
     from _socket import (
         CAN_J1939 as CAN_J1939,
+        CAN_RAW_JOIN_FILTERS as CAN_RAW_JOIN_FILTERS,
         J1939_EE_INFO_NONE as J1939_EE_INFO_NONE,
         J1939_EE_INFO_TX_ABORT as J1939_EE_INFO_TX_ABORT,
         J1939_FILTER_MAX as J1939_FILTER_MAX,


### PR DESCRIPTION
This constant has been added in python 3.9: https://docs.python.org/3.9/library/socket.html#socket.CAN_RAW_JOIN_FILTERS