### PR TITLE
dateparser.search.search_dates: allow arbitrary-length tuples for languages argument

### DIFF
--- a/stubs/dateparser/dateparser/search/__init__.pyi
+++ b/stubs/dateparser/dateparser/search/__init__.pyi
@@ -1,6 +1,7 @@
 import sys
+from collections.abc import Mapping, Set
 from datetime import datetime
-from typing import Any, Mapping, Set, Tuple, overload
+from typing import Any, Tuple, overload
 
 if sys.version_info >= (3, 8):
     from typing import Literal


### PR DESCRIPTION
Discovered in #6161

The implementation has `if isinstance(languages, (list, tuple, Set)):` where `Set` is imported from `collections.abc`. It is a bit weird how it allows arbitrary sets (such as `some_dict.keys()`), but not arbitrary sequences (such as deques).