### PR TITLE
check_new_syntax.py: improve dicts in error message

### DIFF
--- a/tests/check_new_syntax.py
+++ b/tests/check_new_syntax.py
@@ -10,7 +10,7 @@ def check_new_syntax(tree: ast.AST, path: Path) -> list[str]:
     errors = []
 
     def unparse_without_tuple_parens(node: ast.AST) -> str:
-        if isinstance(node, ast.Tuple):
+        if isinstance(node, ast.Tuple) and node.elts:
             return ast.unparse(node)[1:-1]
         return ast.unparse(node)
 


### PR DESCRIPTION
It previously showed `dict[(str, int)]`, but now shows `dict[str, int]`.

Because `Dict` subscripts are always pairs of two types, we could just do `[1:-1]` unconditionally, but I'm going to reuse the same logic for tuples which can be like `Tuple[X]` or `Tuple[X, Y]`.