### PR TITLE
Make `argparse._SubParsersAction` generic

### DIFF
--- a/stdlib/argparse.pyi
+++ b/stdlib/argparse.pyi
@@ -1,5 +1,20 @@
 import sys
-from typing import IO, Any, Callable, Generator, Generic, Iterable, NoReturn, Pattern, Protocol, Sequence, Tuple, Type, TypeVar, overload
+from typing import (
+    IO,
+    Any,
+    Callable,
+    Generator,
+    Generic,
+    Iterable,
+    NoReturn,
+    Pattern,
+    Protocol,
+    Sequence,
+    Tuple,
+    Type,
+    TypeVar,
+    overload,
+)
 
 _T = TypeVar("_T")
 _ActionT = TypeVar("_ActionT", bound=Action)


### PR DESCRIPTION
Subparser types are inferred as `ArgumentParser` even if they can be statically refined based on parameters of `add_subparsers` call (i.e. based on `parser_class` parameter, or type of `self` if not provided). Consider this simple example:

```python
from argparse import ArgumentParser

class MyParser(ArgumentParser):
    pass

p = MyParser()
sp = p.add_subparsers()
# sp = p.add_subparsers(parser_class=MyParser) # same thing
sp_test = sp.add_parser("test")
print(type(sp_test)) # <class '__main__.MyParser'>
reveal_type(sp_test) # argparse.ArgumentParser
```

This PR allows `sp_test` to be inferred as `MyParser` instead of `ArgumentParser`.

Note that I added a generic base class to `argparse._SubParsersAction` in type stubs to mimic its behavior but it's not really generic in the actual module. I'm not sure if this is allowed.