### PR TITLE
Update ModuleType.__file__ to be Optional

### DIFF
--- a/stdlib/types.pyi
+++ b/stdlib/types.pyi
@@ -170,7 +170,7 @@ class SimpleNamespace:
 
 class ModuleType:
     __name__: str
-    __file__: str
+    __file__: str | None
     __dict__: dict[str, Any]
     __loader__: _LoaderProtocol | None
     __package__: str | None


### PR DESCRIPTION
Per the Python documentation, `ModuleType.__file__` is `Optional`: 
> __file__ is optional. If set, this attribute’s value must be a string. The import system may opt to leave __file__ unset if it has no semantic meaning (e.g. a module loaded from a database).

Source: https://docs.python.org/3/reference/import.html#file__