### PR TITLE
Use string literals for typing `warnings` actions

### DIFF
--- a/stdlib/warnings.pyi
+++ b/stdlib/warnings.pyi
@@ -4,6 +4,8 @@ from typing_extensions import Literal
 
 from _warnings import warn as warn, warn_explicit as warn_explicit
 
+_ActionKind = Literal["default", "error", "ignore", "always", "module", "once"]
+
 filters: Sequence[tuple[str, str | None, Type[Warning], str | None, int]]  # undocumented, do not mutate
 
 def showwarning(
@@ -11,19 +13,14 @@ def showwarning(
 ) -> None: ...
 def formatwarning(message: Warning | str, category: Type[Warning], filename: str, lineno: int, line: str | None = ...) -> str: ...
 def filterwarnings(
-    action: Literal["default", "error", "ignore", "always", "module", "once"],
+    action: _ActionKind,
     message: str = ...,
     category: Type[Warning] = ...,
     module: str = ...,
     lineno: int = ...,
     append: bool = ...,
 ) -> None: ...
-def simplefilter(
-    action: Literal["default", "error", "ignore", "always", "module", "once"],
-    category: Type[Warning] = ...,
-    lineno: int = ...,
-    append: bool = ...,
-) -> None: ...
+def simplefilter(action: _ActionKind, category: Type[Warning] = ..., lineno: int = ..., append: bool = ...) -> None: ...
 def resetwarnings() -> None: ...
 
 class _OptionError(Exception): ...


### PR DESCRIPTION
The `actions` parameter, present in a number of `warnings` functions, only accepts a [select few strings](https://docs.python.org/3/library/warnings.html#warning-filter), 
strings that we can express with literals.