### PR TITLE
Use TypedDicts for logging.config.dictConfig

### DIFF
--- a/stdlib/logging/config.pyi
+++ b/stdlib/logging/config.pyi
@@ -36,7 +36,7 @@ class _OptionalDictConfigArgs(TypedDict, total=False):
     # type checkers would warn about extra keys if this was a TypedDict
     handlers: dict[str, dict[str, Any]]
     loggers: dict[str, _LoggerConfiguration]
-    root: _RootLoggerConfiguration
+    root: _RootLoggerConfiguration | None
     incremental: bool
     disable_existing_loggers: bool
 


### PR DESCRIPTION
Closes #6131

Let's see the damage on mypy primer....