### PR TITLE
FIx Methods missing from importlib.machinery.ModuleSpec.loader()

### DIFF
--- a/stdlib/importlib/machinery.pyi
+++ b/stdlib/importlib/machinery.pyi
@@ -2,7 +2,6 @@ import importlib.abc
 import types
 from typing import Any, Callable, Sequence
 
-# TODO: the loaders seem a bit backwards, attribute is protocol but __init__ arg isn't?
 class ModuleSpec:
     def __init__(
         self,


### PR DESCRIPTION
Fix #6163 