### PR TITLE
Update `ModuleType` to have `__path__` optionally

### DIFF
--- a/stdlib/types.pyi
+++ b/stdlib/types.pyi
@@ -14,6 +14,7 @@ from typing import (
     Iterator,
     KeysView,
     Mapping,
+    MutableSequence,
     Tuple,
     Type,
     TypeVar,


### PR DESCRIPTION
Hello typeshed crew!
Analog to #6186 I'd like to add `__path__` to `ModuleType`.

Custom packages [always have this attribute](https://docs.python.org/3/reference/import.html#path__) and currently getting `__path__` from these via `sys.modules` like for instance:
```
sys.modules['mymodule_pack'].__path__
```

results in typing complaints like
```
Cannot access member "__path__" for type "ModuleType"
  Member "__path__" is unknown
```

Since `__file__` is already implemented. `__path__` would also be good. Thanks.
ëRiC