### PR TITLE
freezegun: Add missing argument

### DIFF
--- a/stubs/freezegun/@tests/stubtest_allowlist.txt
+++ b/stubs/freezegun/@tests/stubtest_allowlist.txt
@@ -1,3 +1,0 @@
-freezegun.api._freeze_time.__init__
-freezegun.api.freeze_time
-freezegun.freeze_time

--- a/stubs/freezegun/freezegun/api.pyi
+++ b/stubs/freezegun/freezegun/api.pyi
@@ -31,6 +31,7 @@ class _freeze_time:
         ignore: Sequence[str],
         tick: bool,
         as_arg: bool,
+        as_kwarg: str,
         auto_tick_seconds: float,
     ) -> None: ...
     @overload
@@ -53,5 +54,6 @@ def freeze_time(
     ignore: Sequence[str] | None = ...,
     tick: bool | None = ...,
     as_arg: bool | None = ...,
+    as_kwarg: str | None = ...,
     auto_tick_seconds: float | None = ...,
 ) -> _freeze_time: ...


### PR DESCRIPTION
Stubs for freezegun were missing the `as_kwarg` argument, which [was added](https://github.com/spulec/freezegun/commit/c48b04fba5d8a829f3c5d2b05aa602231dc3254a) in freezegun version 1.0.0.