### PR TITLE
lru_cache preserves signature of wrapped function

### DIFF
--- a/requirements-tests-py3.txt
+++ b/requirements-tests-py3.txt
@@ -1,5 +1,5 @@
 mypy==0.910
-pytype==2021.10.25
+pytype==2021.11.2
 typed-ast==1.4.3
 black==21.9b0
 flake8==4.0.1

--- a/stdlib/functools.pyi
+++ b/stdlib/functools.pyi
@@ -2,6 +2,7 @@ import sys
 import types
 from _typeshed import SupportsItems, SupportsLessThan
 from typing import Any, Callable, Generic, Hashable, Iterable, NamedTuple, Sequence, Set, Sized, Tuple, Type, TypeVar, overload
+from typing_extensions import ParamSpec
 
 if sys.version_info >= (3, 9):
     from types import GenericAlias
@@ -10,6 +11,7 @@ _AnyCallable = Callable[..., Any]
 
 _T = TypeVar("_T")
 _S = TypeVar("_S")
+_P = ParamSpec("_P")
 
 @overload
 def reduce(function: Callable[[_T, _S], _T], sequence: Iterable[_S], initial: _T) -> _T: ...
@@ -22,20 +24,20 @@ class _CacheInfo(NamedTuple):
     maxsize: int
     currsize: int
 
-class _lru_cache_wrapper(Generic[_T]):
-    __wrapped__: Callable[..., _T]
-    def __call__(self, *args: Hashable, **kwargs: Hashable) -> _T: ...
+class _lru_cache_wrapper(Generic[_P, _T]):
+    __wrapped__: Callable[_P, _T]
+    def __call__(self, *args: _P.args, **kwargs: _P.kwargs) -> _T: ...
     def cache_info(self) -> _CacheInfo: ...
     def cache_clear(self) -> None: ...
 
 if sys.version_info >= (3, 8):
     @overload
-    def lru_cache(maxsize: int | None = ..., typed: bool = ...) -> Callable[[Callable[..., _T]], _lru_cache_wrapper[_T]]: ...
+    def lru_cache(maxsize: int | None = ..., typed: bool = ...) -> Callable[[Callable[_P, _T]], _lru_cache_wrapper[_P, _T]]: ...
     @overload
-    def lru_cache(maxsize: Callable[..., _T], typed: bool = ...) -> _lru_cache_wrapper[_T]: ...
+    def lru_cache(maxsize: Callable[_P, _T], typed: bool = ...) -> _lru_cache_wrapper[_P, _T]: ...
 
 else:
-    def lru_cache(maxsize: int | None = ..., typed: bool = ...) -> Callable[[Callable[..., _T]], _lru_cache_wrapper[_T]]: ...
+    def lru_cache(maxsize: int | None = ..., typed: bool = ...) -> Callable[[Callable[_P, _T]], _lru_cache_wrapper[_P, _T]]: ...
 
 WRAPPER_ASSIGNMENTS: Sequence[str]
 WRAPPER_UPDATES: Sequence[str]
@@ -115,7 +117,7 @@ if sys.version_info >= (3, 8):
             def __class_getitem__(cls, item: Any) -> GenericAlias: ...
 
 if sys.version_info >= (3, 9):
-    def cache(__user_function: Callable[..., _T]) -> _lru_cache_wrapper[_T]: ...
+    def cache(__user_function: Callable[_P, _T]) -> _lru_cache_wrapper[_P, _T]: ...
 
 def _make_key(
     args: Tuple[Hashable, ...],

--- a/stdlib/functools.pyi
+++ b/stdlib/functools.pyi
@@ -24,20 +24,20 @@ class _CacheInfo(NamedTuple):
     maxsize: int
     currsize: int
 
-class _lru_cache_wrapper(Generic[_P, _T]):
-    __wrapped__: Callable[_P, _T]
-    def __call__(self, *args: _P.args, **kwargs: _P.kwargs) -> _T: ...
+class _lru_cache_wrapper(Generic[_P, _T]):  # type: ignore
+    __wrapped__: Callable[_P, _T]  # type: ignore
+    def __call__(self, *args: _P.args, **kwargs: _P.kwargs) -> _T: ...  # type: ignore
     def cache_info(self) -> _CacheInfo: ...
     def cache_clear(self) -> None: ...
 
 if sys.version_info >= (3, 8):
     @overload
-    def lru_cache(maxsize: int | None = ..., typed: bool = ...) -> Callable[[Callable[_P, _T]], _lru_cache_wrapper[_P, _T]]: ...
+    def lru_cache(maxsize: int | None = ..., typed: bool = ...) -> Callable[[Callable[_P, _T]], _lru_cache_wrapper[_P, _T]]: ...  # type: ignore
     @overload
-    def lru_cache(maxsize: Callable[_P, _T], typed: bool = ...) -> _lru_cache_wrapper[_P, _T]: ...
+    def lru_cache(maxsize: Callable[_P, _T], typed: bool = ...) -> _lru_cache_wrapper[_P, _T]: ...  # type: ignore
 
 else:
-    def lru_cache(maxsize: int | None = ..., typed: bool = ...) -> Callable[[Callable[_P, _T]], _lru_cache_wrapper[_P, _T]]: ...
+    def lru_cache(maxsize: int | None = ..., typed: bool = ...) -> Callable[[Callable[_P, _T]], _lru_cache_wrapper[_P, _T]]: ...  # type: ignore
 
 WRAPPER_ASSIGNMENTS: Sequence[str]
 WRAPPER_UPDATES: Sequence[str]
@@ -117,7 +117,7 @@ if sys.version_info >= (3, 8):
             def __class_getitem__(cls, item: Any) -> GenericAlias: ...
 
 if sys.version_info >= (3, 9):
-    def cache(__user_function: Callable[_P, _T]) -> _lru_cache_wrapper[_P, _T]: ...
+    def cache(__user_function: Callable[_P, _T]) -> _lru_cache_wrapper[_P, _T]: ...  # type: ignore
 
 def _make_key(
     args: Tuple[Hashable, ...],


### PR DESCRIPTION
This PR uses `ParamSpec` to make `lru_cache` preserve the signature of the wrapped function.

Unfortunately this removes the constraint that `*args` and `**kwargs` must be `Hashable` at least until the meaning of the `bound` parameter in `ParamSpec` is decided, but I feel that preserving the function signature is a worthy trade-off.

