### PR TITLE
Test third-party stubs in isolation

### DIFF
--- a/tests/mypy_test.py
+++ b/tests/mypy_test.py
@@ -277,7 +277,8 @@ def test_third_party_distribution(distribution: str, major: int, minor: int, arg
     add_third_party_files(distribution, major, files, seen, args, exclude_list, configurations, seen_dist_configs)
 
     if not files:
-        return 0, -1
+        print("--- no files found ---")
+        sys.exit(1)
 
     # TODO: remove custom_typeshed after mypy 0.920 is released
     code = run_mypy(args, configurations, major, minor, files, custom_typeshed=True)

--- a/tests/mypy_test.py
+++ b/tests/mypy_test.py
@@ -270,13 +270,9 @@ def test_third_party_distribution(
 ) -> tuple[int, int]:
     """Test the stubs of a third-party distribution.
 
-    Return a tuple, where the first element is the number of checked files,
-    and the second element indicated mypy's return code (if at least one file
-    was checked).
+    Return a tuple, where the first element indicates mypy's return code
+    and the second element is the number of checked files.
     """
-
-    if not is_supported(distribution, major):
-        return 0, -1
 
     print(f"testing {distribution} with Python {major}.{minor}...")
 
@@ -291,7 +287,7 @@ def test_third_party_distribution(
 
     # TODO: remove custom_typeshed after mypy 0.920 is released
     code = run_mypy(args, configurations, major, minor, files, custom_typeshed=True)
-    return len(files), code
+    return code, len(files)
 
 
 def main():
@@ -338,10 +334,12 @@ def main():
 
         # Test files of all third party distributions.
         for distribution in sorted(os.listdir("stubs")):
-            checked, this_code = test_third_party_distribution(distribution, major, minor, args, exclude_list)
-            if checked > 0:
-                code = max(code, this_code)
-                files_checked += checked
+            if not is_supported(distribution, major):
+                continue
+
+            this_code, checked = test_third_party_distribution(distribution, major, minor, args, exclude_list)
+            code = max(code, this_code)
+            files_checked += checked
 
     if code:
         print(f"--- exit status {code}, {files_checked} files checked ---")

--- a/tests/mypy_test.py
+++ b/tests/mypy_test.py
@@ -245,6 +245,7 @@ def add_third_party_files(
 ) -> None:
     if distribution in seen_dists:
         return
+    seen_dists.add(distribution)
 
     dependencies = read_dependencies(distribution)
     for dependency in dependencies:
@@ -262,7 +263,6 @@ def add_third_party_files(
             continue
         add_files(files, set(), root, name, args, exclude_list)
         add_configuration(configurations, distribution)
-    seen_dists.add(distribution)
 
 
 def test_third_party_distribution(

--- a/tests/mypy_test.py
+++ b/tests/mypy_test.py
@@ -234,7 +234,15 @@ def read_dependencies(distribution: str) -> list[str]:
     return dependencies
 
 
-def add_third_party_files(distribution: str, major: int, files: list[str], args, exclude_list: re.Pattern[str], configurations: list[MypyDistConf], seen_dists: set[str]) -> None:
+def add_third_party_files(
+    distribution: str,
+    major: int,
+    files: list[str],
+    args,
+    exclude_list: re.Pattern[str],
+    configurations: list[MypyDistConf],
+    seen_dists: set[str],
+) -> None:
     if distribution in seen_dists:
         return
 
@@ -257,7 +265,9 @@ def add_third_party_files(distribution: str, major: int, files: list[str], args,
     seen_dists.add(distribution)
 
 
-def test_third_party_distribution(distribution: str, major: int, minor: int, args, exclude_list: re.Pattern[str]) -> tuple[int, int]:
+def test_third_party_distribution(
+    distribution: str, major: int, minor: int, args, exclude_list: re.Pattern[str]
+) -> tuple[int, int]:
     """Test the stubs of a third-party distribution.
 
     Return a tuple, where the first element is the number of checked files,


### PR DESCRIPTION
This is a first step towards #5952. For each third-party distribution, a separate mypy call is started. This has a few advantages, but also a few drawbacks:

* Missing dependencies in `METADATA.toml` are now spotted, since only the dependencies listed there are being added to the list of files to test.
* It's possible to add a custom configuration for a distribution to `METADATA.toml`. Previously, all configurations were merged before mypy was run, therefore all configurations applied to all files. Now, only the configurations of a distribution and its dependencies are merged when testing a distribution.
* Adding a non-stub dependency will crash the tests. (But this wouldn't work anyway, at the moment. This is actually a first step towards allowing this.)
* Stubs are now tested multiple times if they are part of the dependency chain of another distribution.

In the future, each distribution should get its own venv, so that the dependencies can be installed from pypi. See #5952 for the rationale.

The code in `mypy_test.py` is quite janky and hard to read at this point. I wanted to keep refactorings out of this PR, but might send a separate cleanup PR later.