### PR TITLE
Make `dict` KeyType bound to `Hashable`

### DIFF
--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -33,6 +33,7 @@ from typing import (
     Callable,
     FrozenSet,
     Generic,
+    Hashable,
     ItemsView,
     Iterable,
     Iterator,
@@ -71,9 +72,9 @@ class _SupportsTrunc(Protocol):
 _T = TypeVar("_T")
 _T_co = TypeVar("_T_co", covariant=True)
 _T_contra = TypeVar("_T_contra", contravariant=True)
-_KT = TypeVar("_KT")
+_KT = TypeVar("_KT", bound=Hashable)
 _VT = TypeVar("_VT")
-_KT_co = TypeVar("_KT_co", covariant=True)  # Key type covariant containers.
+_KT_co = TypeVar("_KT_co", bound=Hashable, covariant=True)  # Key type covariant containers.
 _VT_co = TypeVar("_VT_co", covariant=True)  # Value type covariant containers.
 _S = TypeVar("_S")
 _T1 = TypeVar("_T1")


### PR DESCRIPTION
I wonder what happens when we set `dict`s key type parameter to be bound to `Hashable`.

I think there's an issue where mypy thinks `type[object]` is not `Hashable`, so this will depend on that.

https://github.com/python/mypy/issues/11470
https://github.com/python/mypy/issues/11469