### PR TITLE
Remove our custom code of conduct link

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,5 +1,0 @@
-Everyone participating in the typeshed community, and in particular in
-our issue tracker, pull requests, and Gitter channel, is expected to treat
-other people with respect and more generally to follow the guidelines
-articulated in the [Python Community Code of
-Conduct](https://www.python.org/psf/codeofconduct/).


### PR DESCRIPTION
By removing this, the code of conduct from the Python organization
(https://github.com/python/.github/blob/master/CODE_OF_CONDUCT.md)
should be picked up.