### PR TITLE
Test decoupling of typing aliases

### DIFF
--- a/stdlib/_collections_abc.pyi
+++ b/stdlib/_collections_abc.pyi
@@ -1,4 +1,9 @@
+from abc import abstractmethod
 from typing import (
+    Any,
+    Generic,
+    TypeVar,
+    overload,
     AbstractSet as Set,
     AsyncGenerator as AsyncGenerator,
     AsyncIterable as AsyncIterable,
@@ -21,7 +26,7 @@ from typing import (
     MutableSequence as MutableSequence,
     MutableSet as MutableSet,
     Reversible as Reversible,
-    Sequence as Sequence,
+    # Sequence as Sequence,
     Sized as Sized,
     ValuesView as ValuesView,
 )
@@ -53,3 +58,19 @@ __all__ = [
     "MutableSequence",
     "ByteString",
 ]
+
+_T_co = TypeVar("_T_co", covariant=True)  # Any type covariant containers.
+
+class Sequence(Collection[_T_co], Reversible[_T_co], Generic[_T_co]):
+    @overload
+    @abstractmethod
+    def __getitem__(self, i: int) -> _T_co: ...
+    @overload
+    @abstractmethod
+    def __getitem__(self, s: slice) -> Sequence[_T_co]: ...
+    # Mixin methods
+    def index(self, value: Any, start: int = ..., stop: int = ...) -> int: ...
+    def count(self, value: Any) -> int: ...
+    def __contains__(self, x: object) -> bool: ...
+    def __iter__(self) -> Iterator[_T_co]: ...
+    def __reversed__(self) -> Iterator[_T_co]: ...

--- a/stdlib/typing.pyi
+++ b/stdlib/typing.pyi
@@ -1,4 +1,5 @@
 import collections  # Needed by aliases like DefaultDict, see mypy issue 2986
+import collections.abc
 import sys
 from abc import ABCMeta, abstractmethod
 from types import BuiltinFunctionType, CodeType, FrameType, FunctionType, MethodType, ModuleType, TracebackType
@@ -304,19 +305,7 @@ class Collection(Iterable[_T_co], Container[_T_co], Protocol[_T_co]):
     @abstractmethod
     def __len__(self) -> int: ...
 
-class Sequence(Collection[_T_co], Reversible[_T_co], Generic[_T_co]):
-    @overload
-    @abstractmethod
-    def __getitem__(self, i: int) -> _T_co: ...
-    @overload
-    @abstractmethod
-    def __getitem__(self, s: slice) -> Sequence[_T_co]: ...
-    # Mixin methods
-    def index(self, value: Any, start: int = ..., stop: int = ...) -> int: ...
-    def count(self, value: Any) -> int: ...
-    def __contains__(self, x: object) -> bool: ...
-    def __iter__(self) -> Iterator[_T_co]: ...
-    def __reversed__(self) -> Iterator[_T_co]: ...
+Sequence = _Alias()
 
 class MutableSequence(Sequence[_T], Generic[_T]):
     @abstractmethod


### PR DESCRIPTION
Test decoupling of typing aliases from the `typing` module.
Related issue #6257