### PR TITLE
Add missing class to Markdown

### DIFF
--- a/stubs/Markdown/markdown/blockprocessors.pyi
+++ b/stubs/Markdown/markdown/blockprocessors.pyi
@@ -62,4 +62,8 @@ class HRProcessor(BlockProcessor):
     match: Match[str]
 
 class EmptyBlockProcessor(BlockProcessor): ...
+
+class ReferenceProcessor(BlockProcessor):
+    RE: Pattern[str]
+
 class ParagraphProcessor(BlockProcessor): ...


### PR DESCRIPTION
markdown.blockprocessors.ReferenceProcessor was missing from this stub.

https://github.com/Python-Markdown/markdown/blob/master/markdown/blockprocessors.py#L559