### PR TITLE
Remove unnecessary pyrightconfig excludes

### DIFF
--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -5,11 +5,7 @@
         "stubs"
     ],
     "exclude": [
-        // Python 2 only modules.
-        "**/@python2",
-        "stubs/enum34",
-        "stubs/futures",
-        "stubs/ipaddress"
+        "**/@python2"
     ],
     "typeCheckingMode": "basic",
     "strictListInference": true,

--- a/pyrightconfig.stricter.json
+++ b/pyrightconfig.stricter.json
@@ -37,6 +37,7 @@
         "stubs/mysqlclient",
         "stubs/oauthlib",
         "stubs/Pillow",
+        "stubs/paramiko",
         "stubs/prettytable",
         "stubs/protobuf",
         "stubs/google-cloud-ndb",

--- a/pyrightconfig.stricter.json
+++ b/pyrightconfig.stricter.json
@@ -6,19 +6,13 @@
         "stubs"
     ],
     "exclude": [
-        // Python 2 only modules.
         "**/@python2",
-        "stubs/enum34",
-        "stubs/futures",
-        "stubs/ipaddress",
-        // Modules that are incomplete in some way.
         "stdlib/distutils/command",
         "stdlib/lib2to3/refactor.pyi",
         "stdlib/sqlite3/dbapi2.pyi",
         "stdlib/tkinter",
         "stdlib/xml/dom",
         "stdlib/xml/sax",
-        "stubs/appdirs",
         "stubs/aws-xray-sdk",
         "stubs/babel",
         "stubs/backports.ssl_match_hostname",
@@ -43,7 +37,6 @@
         "stubs/mysqlclient",
         "stubs/oauthlib",
         "stubs/Pillow",
-        "stubs/paramiko",
         "stubs/prettytable",
         "stubs/protobuf",
         "stubs/google-cloud-ndb",
@@ -62,10 +55,8 @@
         "stubs/simplejson",
         "stubs/slumber",
         "stubs/stripe",
-        "stubs/toposort",
         "stubs/ttkthemes",
         "stubs/vobject",
-        "stubs/waitress",
         "stubs/Werkzeug"
     ],
     "typeCheckingMode": "basic",


### PR DESCRIPTION
Done with quick and dirty script, with manual cleanup afterwards:

```bash
#!/bin/bash
set -e

git checkout pyrightconfig.json
grep '        ".*/.*",' pyrightconfig.json | while read -r line; do
    cp pyrightconfig.json old.json
    python3 -c 'import sys; s=open("pyrightconfig.json").read(); open("pyrightconfig.json","w").write(s.replace(sys.argv[1],""))' "$line"
    if npx -p pyright@1.1.184 pyright -p pyrightconfig.json &>/dev/null; then
        echo "ok without:  $line"
        rm old.json
    else
        echo "need:        $line"
        mv old.json pyrightconfig.json
    fi
done
```