### PR TITLE
Return ``TypeGuard[Callable[..., object]]`` from ``builtins.callable``

### DIFF
--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -60,7 +60,7 @@ from typing import (
     ValuesView,
     overload,
 )
-from typing_extensions import Literal, SupportsIndex, final
+from typing_extensions import Literal, SupportsIndex, TypeGuard, final
 
 if sys.version_info >= (3, 9):
     from types import GenericAlias
@@ -974,7 +974,7 @@ def bin(__number: int | SupportsIndex) -> str: ...
 if sys.version_info >= (3, 7):
     def breakpoint(*args: Any, **kws: Any) -> None: ...
 
-def callable(__obj: object) -> bool: ...
+def callable(__obj: object) -> TypeGuard[Callable[..., object]]: ...
 def chr(__i: int) -> str: ...
 
 # We define this here instead of using os.PathLike to avoid import cycle issues.


### PR DESCRIPTION
I'm aware that mypy and others already special-case ``builtins.callable``, but it might be nice to formally state this property of the function in the stubs.