### PR TITLE
Improve support for running tests on Windows

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,8 +36,8 @@ check your code before committing, you can copy the file `pre-commit` to
 ### Linux/Mac OS
 
 On Linux and Mac OS, you will be able to run the full test suite on Python 3.8
-or 3.9. The mypy tests cannot be run on Python <3.7, and the pytype tests
-[cannot be run on Python 3.10](https://github.com/google/pytype/issues/1022).
+or 3.9. Running the tests on <=3.7 is not supported, and the pytype tests
+[cannot currently be run on Python 3.10](https://github.com/google/pytype/issues/1022).
 
 To install the necessary requirements, run the following commands from a
 terminal window:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,11 +25,23 @@ it takes a bit longer. For more details, read below.
 ## Preparing the environment
 
 To reformat the code, check for common problems, and
-run the tests, you need to prepare a
-[virtual environment](https://docs.python.org/3/tutorial/venv.html)
-with the necessary libraries installed using Python 3.8 or newer.
+run the tests, it can be useful to prepare a
+[virtual environment](https://docs.python.org/3/tutorial/venv.html) and install
+certain libraries typeshed uses to check stub files.
 
-To do this, run:
+Follow platform-specific instructions below. Following that, to automatically
+check your code before committing, you can copy the file `pre-commit` to
+`.git/hooks/pre-commit`.
+
+### Linux/Mac OS
+
+On Linux and Mac OS, you will be able to run the full test suite on Python 3.8
+or 3.9. The mypy tests cannot be run on Python <3.7, and the pytype tests
+[cannot be run on Python 3.10](https://github.com/google/pytype/issues/1022).
+
+To install the necessary requirements, run the following commands from a
+terminal window:
+
 ```
 $ python3 -m venv .venv3
 $ source .venv3/bin/activate
@@ -37,8 +49,30 @@ $ source .venv3/bin/activate
 (.venv3)$ pip install -r requirements-tests-py3.txt
 ```
 
-To automatically check your code before committing, copy the file
-`pre-commit` to `.git/hooks/pre-commit`.
+### Windows
+
+If you are using a Windows operating system, you will not be able to run the
+full test suite. One option is to install
+[Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/faq),
+which will allow you to run the full suite of tests. If you choose to install
+WSL, follow the Linux/Mac OS instructions above.
+
+If you do not wish to install WSL, you will not be able to run the pytype
+tests, as pytype
+[does not currently support running on Windows](https://github.com/google/pytype#requirements).
+However, the upside of this is that you will be able to run all
+Windows-compatible tests on Python 3.9, 3.8 or 3.10, as it is only the pytype
+tests that cannot currently be run on 3.10.
+
+To install all non-pytype requirements on Windows without WSL, run the
+following commands from a Windows terminal:
+
+```
+> python3 -m venv .venv3
+> ".venv3/Scripts/activate"
+(.venv3) > python -m pip install -U pip
+(.venv3) > python -m pip install -r requirements-tests-py3.txt
+```
 
 ## Where to make changes
 

--- a/requirements-tests-py3.txt
+++ b/requirements-tests-py3.txt
@@ -1,5 +1,5 @@
 mypy==0.910
-pytype==2021.11.2
+pytype==2021.11.2; platform_system != "Windows"
 black==21.9b0
 flake8==4.0.1
 flake8-bugbear==21.9.2

--- a/tests/README.md
+++ b/tests/README.md
@@ -13,7 +13,7 @@ objects at runtime.
 objects at runtime.
 
 To run the tests, follow the [setup instructions](../CONTRIBUTING.md#preparing-the-environment)
-in the `CONTRIBUTING.md` document. In particular, we recommend running with Python 3.8 or newer.
+in the `CONTRIBUTING.md` document. In particular, we recommend running with Python 3.8 or 3.9.
 
 ## mypy\_test.py
 
@@ -35,8 +35,11 @@ You can restrict mypy tests to a single version by passing `-p2` or `-p3.9`:
 
 ## pytype\_test.py
 
-This test requires Python 2.7 and Python 3.6. Pytype will
-find these automatically if they're in `PATH`.
+This test requires Python 2.7 and Python 3.6. Pytype will find these
+automatically if they're in `PATH`. Note: this test cannot be run on Windows
+systems unless you are using Windows Subsystem for Linux. Pytype also does not
+yet fully support Python 3.10.
+
 Run using:
 ```
 (.venv3)$ python3 tests/pytype_test.py


### PR DESCRIPTION
This PR:

- Modifies `CONTRIBUTING.md` and `tests/README.md` to add instructions for running tests on Windows, and clarify that pytype tests cannot be run on Python 3.10.
- Modifies  `requirements-tests-py3.txt` so that running `pip install -r requirements-tests-py3.txt` does not fail on Windows.
- Closes #6282 