### PR TITLE
Harmonise return type of `builtins.__import__` and `importlib.import_module`

### DIFF
--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -1443,6 +1443,7 @@ class zip(Iterator[_T_co], Generic[_T_co]):
     def __iter__(self) -> Iterator[_T_co]: ...
     def __next__(self) -> _T_co: ...
 
+# Return type of `__import__` should be kept the same as return type of `importlib.import_module`
 def __import__(
     name: str,
     globals: Mapping[str, object] | None = ...,

--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -1449,7 +1449,7 @@ def __import__(
     locals: Mapping[str, object] | None = ...,
     fromlist: Sequence[str] = ...,
     level: int = ...,
-) -> Any: ...
+) -> types.ModuleType: ...
 
 # Actually the type of Ellipsis is <type 'ellipsis'>, but since it's
 # not exposed anywhere under that name, we make it private here.

--- a/stdlib/importlib/__init__.pyi
+++ b/stdlib/importlib/__init__.pyi
@@ -2,6 +2,7 @@ import types
 from importlib.abc import Loader
 from typing import Any, Mapping, Sequence
 
+# `__import__` and `import_module` return type should be kept the same as `builtins.__import__`
 def __import__(
     name: str,
     globals: Mapping[str, Any] | None = ...,

--- a/stdlib/types.pyi
+++ b/stdlib/types.pyi
@@ -178,6 +178,7 @@ class ModuleType:
     __path__: MutableSequence[str]
     __spec__: ModuleSpec | None
     def __init__(self, name: str, doc: str | None = ...) -> None: ...
+    def __getattr__(self, name: str) -> Any: ...
 
 @final
 class GeneratorType(Generator[_T_co, _T_contra, _V_co]):

--- a/stdlib/types.pyi
+++ b/stdlib/types.pyi
@@ -178,6 +178,9 @@ class ModuleType:
     __path__: MutableSequence[str]
     __spec__: ModuleSpec | None
     def __init__(self, name: str, doc: str | None = ...) -> None: ...
+    # __getattr__ doesn't exist at runtime,
+    # but having it here in typeshed makes dynamic imports
+    # using `builtins.__import__` or `importlib.import_module` less painful
     def __getattr__(self, name: str) -> Any: ...
 
 @final

--- a/tests/stubtest_allowlists/py3_common.txt
+++ b/tests/stubtest_allowlists/py3_common.txt
@@ -199,6 +199,7 @@ tkinter.font.Font.__getitem__  # Argument name differs (doesn't matter for __dun
 traceback.TracebackException.from_exception  # explicitly expanding arguments going into TracebackException __init__
 types.GetSetDescriptorType.__get__  # this function can accept no value for the type parameter.
 types.MemberDescriptorType.__get__  # this function can accept no value for the type parameter.
+types.ModuleType.__getattr__  # this doesn't exist at runtime
 types.SimpleNamespace.__init__  # class doesn't accept positional arguments but has default C signature
 typing.IO.__iter__  # Added because IO streams are iterable. See https://github.com/python/typeshed/commit/97bc450acd60c1bcdafef3ce8fbe3b95a9c0cac3
 typing.IO.__next__  # Added because IO streams are iterable. See https://github.com/python/typeshed/commit/97bc450acd60c1bcdafef3ce8fbe3b95a9c0cac3


### PR DESCRIPTION
This PR is an attempt at solving #6295 by adding `__getattr__` to `types.ModuleType` and changing the return type of `builtins.__import__` so that it now returns `types.ModuleType` rather than `Any`.