### PR TITLE
mypy_test: Skip files starting with '.'

### DIFF
--- a/tests/mypy_test.py
+++ b/tests/mypy_test.py
@@ -320,7 +320,7 @@ def main():
             supported_versions = parse_versions(os.path.join("stdlib", "VERSIONS"))
             root = "stdlib"
             for name in os.listdir(root):
-                if name == "@python2" or name == "VERSIONS":
+                if name == "@python2" or name == "VERSIONS" or name.startswith("."):
                     continue
                 mod, _ = os.path.splitext(name)
                 if supported_versions[mod][0] <= (major, minor) <= supported_versions[mod][1]:


### PR DESCRIPTION
For example, vim temp files.