### PR TITLE
Clean up mypy flags

### DIFF
--- a/tests/mypy_test.py
+++ b/tests/mypy_test.py
@@ -202,12 +202,10 @@ def get_mypy_flags(args, major: int, minor: int, temp_name: str, *, custom_types
             "%d.%d" % (major, minor),
             "--config-file",
             temp_name,
-            "--strict-optional",
             "--no-site-packages",
             "--show-traceback",
             "--no-implicit-optional",
             "--disallow-any-generics",
-            "--disallow-subclassing-any",
             "--warn-incomplete-stub",
             "--no-error-summary",
         ]


### PR DESCRIPTION
* Remove --strict-optional: This has been the default since mypy 0.600.
* Remove --disallow-subclassing-any: When we subclass Any in typeshed,
  we do so deliberately. This just causes us to add unncessary ignores.