### PR TITLE
Resolve builtins/importlib inconsistencies

### DIFF
--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -1443,6 +1443,7 @@ class zip(Iterator[_T_co], Generic[_T_co]):
     def __iter__(self) -> Iterator[_T_co]: ...
     def __next__(self) -> _T_co: ...
 
+# Signature of `builtins.__import__` should be kept identical to `importlib.__import__`
 # Return type of `__import__` should be kept the same as return type of `importlib.import_module`
 def __import__(
     name: str,

--- a/stdlib/importlib/__init__.pyi
+++ b/stdlib/importlib/__init__.pyi
@@ -1,16 +1,18 @@
-import types
 from importlib.abc import Loader
-from typing import Any, Mapping, Sequence
+from types import ModuleType
+from typing import Mapping, Sequence
 
-# `__import__` and `import_module` return type should be kept the same as `builtins.__import__`
+# Signature of `builtins.__import__` should be kept identical to `importlib.__import__`
 def __import__(
     name: str,
-    globals: Mapping[str, Any] | None = ...,
-    locals: Mapping[str, Any] | None = ...,
+    globals: Mapping[str, object] | None = ...,
+    locals: Mapping[str, object] | None = ...,
     fromlist: Sequence[str] = ...,
     level: int = ...,
-) -> types.ModuleType: ...
-def import_module(name: str, package: str | None = ...) -> types.ModuleType: ...
+) -> ModuleType: ...
+
+# `importlib.import_module` return type should be kept the same as `builtins.__import__`
+def import_module(name: str, package: str | None = ...) -> ModuleType: ...
 def find_loader(name: str, path: str | None = ...) -> Loader | None: ...
 def invalidate_caches() -> None: ...
-def reload(module: types.ModuleType) -> types.ModuleType: ...
+def reload(module: ModuleType) -> ModuleType: ...


### PR DESCRIPTION
This corrects an oversight from #6292, in which I changed the annotation for the `globals` and `locals` arguments of `builtins.__import__`, but not for `importlib.__import__`, which should have the same signature as `builtins.__import__`.