### PR TITLE
Bring `_collections_abc` closer to runtime definition

### DIFF
--- a/stdlib/_collections_abc.pyi
+++ b/stdlib/_collections_abc.pyi
@@ -1,8 +1,5 @@
 import sys
-from types import EllipsisType as EllipsisType  # undocumented
-from types import FunctionType as FunctionType  # undocumented
-from types import GenericAlias as GenericAlias  # undocumented
-from types import MappingProxyType
+from types import FunctionType as FunctionType, GenericAlias as GenericAlias, MappingProxyType as mappingproxy  # undocumented
 from typing import (
     AbstractSet as Set,
     AsyncGenerator as AsyncGenerator,
@@ -68,19 +65,19 @@ _VT_co = TypeVar("_VT_co", covariant=True)  # Value type covariant containers.
 @final
 class dict_keys(KeysView[_KT_co], Generic[_KT_co, _VT_co]):  # undocumented
     if sys.version_info >= (3, 10):
-        mapping: MappingProxyType[_KT_co, _VT_co]
+        mapping: mappingproxy[_KT_co, _VT_co]
 
 @final
 class dict_values(ValuesView[_VT_co], Generic[_KT_co, _VT_co]):  # undocumented
     if sys.version_info >= (3, 10):
-        mapping: MappingProxyType[_KT_co, _VT_co]
+        mapping: mappingproxy[_KT_co, _VT_co]
 
 @final
 class dict_items(ItemsView[_KT_co, _VT_co], Generic[_KT_co, _VT_co]):  # undocumented
     if sys.version_info >= (3, 10):
-        mapping: MappingProxyType[_KT_co, _VT_co]
+        mapping: mappingproxy[_KT_co, _VT_co]
 
-mappingproxy = MappingProxyType  # undocumented
+EllipsisType = ellipsis  # undocumented # noqa F811 from builtins
 generator = Generator  # undocumented
 coroutine = Coroutine  # undocumented
 async_generator = AsyncGenerator  # undocumented

--- a/stdlib/_collections_abc.pyi
+++ b/stdlib/_collections_abc.pyi
@@ -1,3 +1,8 @@
+import sys
+from types import EllipsisType as EllipsisType  # undocumented
+from types import FunctionType as FunctionType  # undocumented
+from types import GenericAlias as GenericAlias  # undocumented
+from types import MappingProxyType
 from typing import (
     AbstractSet as Set,
     AsyncGenerator as AsyncGenerator,
@@ -10,6 +15,7 @@ from typing import (
     Container as Container,
     Coroutine as Coroutine,
     Generator as Generator,
+    Generic,
     Hashable as Hashable,
     ItemsView as ItemsView,
     Iterable as Iterable,
@@ -23,8 +29,10 @@ from typing import (
     Reversible as Reversible,
     Sequence as Sequence,
     Sized as Sized,
+    TypeVar,
     ValuesView as ValuesView,
 )
+from typing_extensions import final
 
 __all__ = [
     "Awaitable",
@@ -53,3 +61,26 @@ __all__ = [
     "MutableSequence",
     "ByteString",
 ]
+
+_KT_co = TypeVar("_KT_co", covariant=True)  # Key type covariant containers.
+_VT_co = TypeVar("_VT_co", covariant=True)  # Value type covariant containers.
+
+@final
+class dict_keys(KeysView[_KT_co], Generic[_KT_co, _VT_co]):  # undocumented
+    if sys.version_info >= (3, 10):
+        mapping: MappingProxyType[_KT_co, _VT_co]
+
+@final
+class dict_values(ValuesView[_VT_co], Generic[_KT_co, _VT_co]):  # undocumented
+    if sys.version_info >= (3, 10):
+        mapping: MappingProxyType[_KT_co, _VT_co]
+
+@final
+class dict_items(ItemsView[_KT_co, _VT_co], Generic[_KT_co, _VT_co]):  # undocumented
+    if sys.version_info >= (3, 10):
+        mapping: MappingProxyType[_KT_co, _VT_co]
+
+mappingproxy = MappingProxyType  # undocumented
+generator = Generator  # undocumented
+coroutine = Coroutine  # undocumented
+async_generator = AsyncGenerator  # undocumented

--- a/stdlib/_collections_abc.pyi
+++ b/stdlib/_collections_abc.pyi
@@ -2,6 +2,7 @@ import sys
 from types import FunctionType as FunctionType, MappingProxyType as mappingproxy  # undocumented
 from typing import (
     AbstractSet as Set,
+    Any,
     AsyncGenerator as AsyncGenerator,
     AsyncIterable as AsyncIterable,
     AsyncIterator as AsyncIterator,
@@ -26,6 +27,7 @@ from typing import (
     Reversible as Reversible,
     Sequence as Sequence,
     Sized as Sized,
+    Type,
     TypeVar,
     ValuesView as ValuesView,
 )
@@ -81,6 +83,6 @@ class dict_items(ItemsView[_KT_co, _VT_co], Generic[_KT_co, _VT_co]):  # undocum
         mapping: mappingproxy[_KT_co, _VT_co]
 
 EllipsisType = ellipsis  # undocumented # noqa F811 from builtins
-generator = Generator  # undocumented
-coroutine = Coroutine  # undocumented
-async_generator = AsyncGenerator  # undocumented
+generator: Type[Generator[Any, Any, Any]] = ...  # undocumented
+coroutine: Type[Coroutine[Any, Any, Any]] = ...  # undocumented
+async_generator: Type[AsyncGenerator[Any, Any]] = ...  # undocumented

--- a/stdlib/_collections_abc.pyi
+++ b/stdlib/_collections_abc.pyi
@@ -1,5 +1,5 @@
 import sys
-from types import FunctionType as FunctionType, GenericAlias as GenericAlias, MappingProxyType as mappingproxy  # undocumented
+from types import FunctionType as FunctionType, MappingProxyType as mappingproxy  # undocumented
 from typing import (
     AbstractSet as Set,
     AsyncGenerator as AsyncGenerator,
@@ -30,6 +30,9 @@ from typing import (
     ValuesView as ValuesView,
 )
 from typing_extensions import final
+
+if sys.version_info >= (3, 9):
+    from types import GenericAlias as GenericAlias  # undocumented
 
 __all__ = [
     "Awaitable",

--- a/stdlib/_collections_abc.pyi
+++ b/stdlib/_collections_abc.pyi
@@ -1,8 +1,7 @@
 import sys
-from types import FunctionType as FunctionType, MappingProxyType as mappingproxy  # undocumented
+from types import MappingProxyType
 from typing import (
     AbstractSet as Set,
-    Any,
     AsyncGenerator as AsyncGenerator,
     AsyncIterable as AsyncIterable,
     AsyncIterator as AsyncIterator,
@@ -27,14 +26,10 @@ from typing import (
     Reversible as Reversible,
     Sequence as Sequence,
     Sized as Sized,
-    Type,
     TypeVar,
     ValuesView as ValuesView,
 )
 from typing_extensions import final
-
-if sys.version_info >= (3, 9):
-    from types import GenericAlias as GenericAlias  # undocumented
 
 __all__ = [
     "Awaitable",
@@ -70,19 +65,14 @@ _VT_co = TypeVar("_VT_co", covariant=True)  # Value type covariant containers.
 @final
 class dict_keys(KeysView[_KT_co], Generic[_KT_co, _VT_co]):  # undocumented
     if sys.version_info >= (3, 10):
-        mapping: mappingproxy[_KT_co, _VT_co]
+        mapping: MappingProxyType[_KT_co, _VT_co]
 
 @final
 class dict_values(ValuesView[_VT_co], Generic[_KT_co, _VT_co]):  # undocumented
     if sys.version_info >= (3, 10):
-        mapping: mappingproxy[_KT_co, _VT_co]
+        mapping: MappingProxyType[_KT_co, _VT_co]
 
 @final
 class dict_items(ItemsView[_KT_co, _VT_co], Generic[_KT_co, _VT_co]):  # undocumented
     if sys.version_info >= (3, 10):
-        mapping: mappingproxy[_KT_co, _VT_co]
-
-EllipsisType = ellipsis  # undocumented # noqa F811 from builtins
-generator: Type[Generator[Any, Any, Any]] = ...  # undocumented
-coroutine: Type[Coroutine[Any, Any, Any]] = ...  # undocumented
-async_generator: Type[AsyncGenerator[Any, Any]] = ...  # undocumented
+        mapping: MappingProxyType[_KT_co, _VT_co]

--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -72,8 +72,6 @@ _T_co = TypeVar("_T_co", covariant=True)
 _T_contra = TypeVar("_T_contra", contravariant=True)
 _KT = TypeVar("_KT")
 _VT = TypeVar("_VT")
-_KT_co = TypeVar("_KT_co", covariant=True)  # Key type covariant containers.
-_VT_co = TypeVar("_VT_co", covariant=True)  # Value type covariant containers.
 _S = TypeVar("_S")
 _T1 = TypeVar("_T1")
 _T2 = TypeVar("_T2")

--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -20,7 +20,7 @@ from _typeshed import (
     SupportsWrite,
 )
 from io import BufferedRandom, BufferedReader, BufferedWriter, FileIO, TextIOWrapper
-from types import CodeType, MappingProxyType, TracebackType
+from types import CodeType, TracebackType
 from typing import (
     IO,
     AbstractSet,
@@ -62,6 +62,7 @@ from typing import (
 from typing_extensions import Literal, SupportsIndex, TypeGuard, final
 
 from _ast import AST
+from _collections_abc import dict_items, dict_keys, dict_values
 
 if sys.version_info >= (3, 9):
     from types import GenericAlias
@@ -809,18 +810,6 @@ class list(MutableSequence[_T], Generic[_T]):
     if sys.version_info >= (3, 9):
         def __class_getitem__(cls, __item: Any) -> GenericAlias: ...
 
-class _dict_keys(KeysView[_KT_co], Generic[_KT_co, _VT_co]):
-    if sys.version_info >= (3, 10):
-        mapping: MappingProxyType[_KT_co, _VT_co]
-
-class _dict_values(ValuesView[_VT_co], Generic[_KT_co, _VT_co]):
-    if sys.version_info >= (3, 10):
-        mapping: MappingProxyType[_KT_co, _VT_co]
-
-class _dict_items(ItemsView[_KT_co, _VT_co], Generic[_KT_co, _VT_co]):
-    if sys.version_info >= (3, 10):
-        mapping: MappingProxyType[_KT_co, _VT_co]
-
 class dict(MutableMapping[_KT, _VT], Generic[_KT, _VT]):
     @overload
     def __init__(self: dict[_KT, _VT]) -> None: ...
@@ -845,9 +834,9 @@ class dict(MutableMapping[_KT, _VT], Generic[_KT, _VT]):
     def update(self, __m: Iterable[tuple[_KT, _VT]], **kwargs: _VT) -> None: ...
     @overload
     def update(self, **kwargs: _VT) -> None: ...
-    def keys(self) -> _dict_keys[_KT, _VT]: ...
-    def values(self) -> _dict_values[_KT, _VT]: ...
-    def items(self) -> _dict_items[_KT, _VT]: ...
+    def keys(self) -> dict_keys[_KT, _VT]: ...
+    def values(self) -> dict_values[_KT, _VT]: ...
+    def items(self) -> dict_items[_KT, _VT]: ...
     @classmethod
     @overload
     def fromkeys(cls, __iterable: Iterable[_T], __value: None = ...) -> dict[_T, Any | None]: ...

--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -32,10 +32,8 @@ from typing import (
     Callable,
     FrozenSet,
     Generic,
-    ItemsView,
     Iterable,
     Iterator,
-    KeysView,
     Mapping,
     MutableMapping,
     MutableSequence,
@@ -56,7 +54,6 @@ from typing import (
     Type,
     TypeVar,
     Union,
-    ValuesView,
     overload,
 )
 from typing_extensions import Literal, SupportsIndex, TypeGuard, final

--- a/stdlib/collections/__init__.pyi
+++ b/stdlib/collections/__init__.pyi
@@ -1,8 +1,9 @@
 import sys
 from _typeshed import Self
-from builtins import _dict_items, _dict_keys, _dict_values
 from typing import Any, Dict, Generic, NoReturn, Tuple, Type, TypeVar, overload
 from typing_extensions import final
+
+from _collections_abc import dict_items, dict_keys, dict_values
 
 if sys.version_info >= (3, 10):
     from typing import Callable, Iterable, Iterator, Mapping, MutableMapping, MutableSequence, Reversible, Sequence
@@ -242,15 +243,15 @@ class Counter(Dict[_T, int], Generic[_T]):
     def __ior__(self, other: Counter[_T]) -> Counter[_T]: ...  # type: ignore
 
 @final
-class _OrderedDictKeysView(_dict_keys[_KT_co, _VT_co], Reversible[_KT_co]):
+class _OrderedDictKeysView(dict_keys[_KT_co, _VT_co], Reversible[_KT_co]):  # type: ignore[misc]
     def __reversed__(self) -> Iterator[_KT_co]: ...
 
 @final
-class _OrderedDictItemsView(_dict_items[_KT_co, _VT_co], Reversible[Tuple[_KT_co, _VT_co]]):
+class _OrderedDictItemsView(dict_items[_KT_co, _VT_co], Reversible[Tuple[_KT_co, _VT_co]]):  # type: ignore[misc]
     def __reversed__(self) -> Iterator[tuple[_KT_co, _VT_co]]: ...
 
 @final
-class _OrderedDictValuesView(_dict_values[_KT_co, _VT_co], Reversible[_VT_co], Generic[_KT_co, _VT_co]):
+class _OrderedDictValuesView(dict_values[_KT_co, _VT_co], Reversible[_VT_co], Generic[_KT_co, _VT_co]):  # type: ignore[misc]
     def __reversed__(self) -> Iterator[_VT_co]: ...
 
 class OrderedDict(Dict[_KT, _VT], Reversible[_KT], Generic[_KT, _VT]):


### PR DESCRIPTION
Currently, the following code succeeds at runtime, but [fails mypy](https://mypy-play.net/?mypy=latest&python=3.10&flags=show-error-codes&gist=4671377be6f6e4fa6601f13e41cdfbb4):

```python
from _collections_abc import dict_keys
```

This PR proposes several changes to bring the `_collections_abc` stub closer to its runtime definition. The significant change is moving the definitions of `dict_keys`, `dict_values` and `dict_items` from `builtins` to `_collections_abc`.

I have also added `@final` to these classes, as they cannot be subclassed at runtime, and added `# type: ignore` comments to `_OrderedDictKeysView`/`_OrderedDictValuesView`/`_OrderedDictItemsView`. (These are indeed subclasses of `dict_keys`/`dict_values`/`dict_items`, even though the three classes cannot be subclassed _at runtime_; see #6299.)