### PR TITLE
Improve fpdf.image_parsing

### DIFF
--- a/stubs/fpdf2/fpdf/image_parsing.pyi
+++ b/stubs/fpdf2/fpdf/image_parsing.pyi
@@ -1,6 +1,11 @@
 from typing import Any
+from typing_extensions import Literal
 
-SUPPORTED_IMAGE_FILTERS: Any
+_ImageFilter = Literal["AUTO", "FlateDecode", "DCTDecode", "JPXDecode"]
+
+SUPPORTED_IMAGE_FILTERS: tuple[_ImageFilter, ...]
 
 def load_image(filename): ...
-def get_img_info(img, image_filter: str = ...): ...
+
+# Returned dict could be typed as a TypedDict.
+def get_img_info(img, image_filter: _ImageFilter = ..., dims: Any | None = ...) -> dict[str, Any]: ...


### PR DESCRIPTION
* Annotate more attributes, arguments, and return types.
* Add "dims" argument to get_img_info(), added in 2.4.6.