### PR TITLE
Rework stubtest tests

### DIFF
--- a/.github/workflows/stubtest.yml
+++ b/.github/workflows/stubtest.yml
@@ -1,0 +1,52 @@
+name: Run stubtest on all stubs
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+permissions:
+  contents: read
+
+env:
+  PIP_DISABLE_PIP_VERSION_CHECK: 1
+
+jobs:
+  stubtest-stdlib:
+    name: Check stdlib with stubtest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
+        # Python 3.9.7 is required due to changes to ForwardRef.
+        python-version: ["3.6", "3.7", "3.8", "3.9.7", "3.10"]
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Update pip
+        run: python -m pip install -U pip
+      - name: Install dependencies
+        run: pip install $(grep tomli== requirements-tests-py3.txt) $(grep mypy== requirements-tests-py3.txt)
+      - name: Run stubtest
+        run: python tests/stubtest_stdlib.py --ignore-unused-allowlist
+
+  stubtest-third-party:
+    name: Check third party stubs with stubtest
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        shard-index: [0, 1, 2, 3]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Install dependencies
+        run: pip install $(grep tomli== requirements-tests-py3.txt)
+      - name: Run stubtest
+        run: python tests/stubtest_third_party.py --num-shards 4 --shard-index ${{ matrix.shard-index }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -142,7 +142,7 @@ jobs:
         run: pip install $(grep tomli== requirements-tests-py3.txt)
       - name: Run stubtest
         run: |
-          STUBS=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | egrep ^stubs/ | cut -d "/" -f 2)
+          STUBS=$(git diff --name-only ${{ github.event.pull_request.base.sha }} HEAD | egrep ^stubs/ | cut -d "/" -f 2)
           if test -n "$STUBS"; then
               python tests/stubtest_third_party.py $STUBS
           fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -132,10 +132,7 @@ jobs:
   stubtest-third-party:
     name: Check third party stubs with stubtest
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        shard-index: [0, 1, 2, 3]
-      fail-fast: false
+    if: github.ref != 'refs/heads/master'
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -144,4 +141,8 @@ jobs:
       - name: Install dependencies
         run: pip install $(grep tomli== requirements-tests-py3.txt)
       - name: Run stubtest
-        run: python tests/stubtest_third_party.py --num-shards 4 --shard-index ${{ matrix.shard-index }}
+        run: |
+          STUBS=$(git diff --name-only master | egrep ^stubs/ | cut -d "/" -f 2)
+          if test -n "$STUBS"; then
+              python tests/stubtest_third_party.py $STUBS
+          fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -146,5 +146,8 @@ jobs:
         run: |
           STUBS=$(git diff --name-only origin/${{ github.base_ref }} HEAD | egrep ^stubs/ | cut -d "/" -f 2)
           if test -n "$STUBS"; then
-              python tests/stubtest_third_party.py $STUBS
+            echo "Testing $STUBS..."
+            python tests/stubtest_third_party.py $STUBS
+          else
+            echo "Nothing to test"
           fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -142,7 +142,7 @@ jobs:
         run: pip install $(grep tomli== requirements-tests-py3.txt)
       - name: Run stubtest
         run: |
-          STUBS=$(git diff --name-only ${{ github.base_ref }} {{ github.head_ref }} | egrep ^stubs/ | cut -d "/" -f 2)
+          STUBS=$(git diff --name-only ${{ github.base_ref }} ${{ github.head_ref }} | egrep ^stubs/ | cut -d "/" -f 2)
           if test -n "$STUBS"; then
               python tests/stubtest_third_party.py $STUBS
           fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -136,7 +136,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          fetch-depth: 100
+          fetch-depth: 0
       - uses: actions/setup-python@v2
         with:
           python-version: 3.9

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -144,7 +144,7 @@ jobs:
         run: pip install $(grep tomli== requirements-tests-py3.txt)
       - name: Run stubtest
         run: |
-          STUBS=$(git diff --name-only origin/${{ github.base_ref }} ${{ github.head_ref }} | egrep ^stubs/ | cut -d "/" -f 2)
+          STUBS=$(git diff --name-only origin/${{ github.base_ref }} origin/${{ github.head_ref }} | egrep ^stubs/ | cut -d "/" -f 2)
           if test -n "$STUBS"; then
               python tests/stubtest_third_party.py $STUBS
           fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -135,6 +135,8 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 100
       - uses: actions/setup-python@v2
         with:
           python-version: 3.9

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -144,7 +144,7 @@ jobs:
         run: pip install $(grep tomli== requirements-tests-py3.txt)
       - name: Run stubtest
         run: |
-          STUBS=$(git diff --name-only origin/${{ github.base_ref }} origin/${{ github.head_ref }} | egrep ^stubs/ | cut -d "/" -f 2)
+          STUBS=$(git diff --name-only origin/${{ github.base_ref }} HEAD | egrep ^stubs/ | cut -d "/" -f 2)
           if test -n "$STUBS"; then
               python tests/stubtest_third_party.py $STUBS
           fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -144,7 +144,7 @@ jobs:
         run: pip install $(grep tomli== requirements-tests-py3.txt)
       - name: Run stubtest
         run: |
-          STUBS=$(git diff --name-only ${{ github.base_ref }} ${{ github.head_ref }} | egrep ^stubs/ | cut -d "/" -f 2)
+          STUBS=$(git diff --name-only origin/${{ github.base_ref }} ${{ github.head_ref }} | egrep ^stubs/ | cut -d "/" -f 2)
           if test -n "$STUBS"; then
               python tests/stubtest_third_party.py $STUBS
           fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -142,7 +142,7 @@ jobs:
         run: pip install $(grep tomli== requirements-tests-py3.txt)
       - name: Run stubtest
         run: |
-          STUBS=$(git diff --name-only master | egrep ^stubs/ | cut -d "/" -f 2)
+          STUBS=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | egrep ^stubs/ | cut -d "/" -f 2)
           if test -n "$STUBS"; then
               python tests/stubtest_third_party.py $STUBS
           fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -132,7 +132,7 @@ jobs:
   stubtest-third-party:
     name: Check third party stubs with stubtest
     runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/master'
+    if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -142,7 +142,7 @@ jobs:
         run: pip install $(grep tomli== requirements-tests-py3.txt)
       - name: Run stubtest
         run: |
-          STUBS=$(git diff --name-only ${{ github.event.pull_request.base.sha }} HEAD | egrep ^stubs/ | cut -d "/" -f 2)
+          STUBS=$(git diff --name-only ${{ github.base_ref }} {{ github.head_ref }} | egrep ^stubs/ | cut -d "/" -f 2)
           if test -n "$STUBS"; then
               python tests/stubtest_third_party.py $STUBS
           fi

--- a/stubs/Pillow/METADATA.toml
+++ b/stubs/Pillow/METADATA.toml
@@ -1,1 +1,1 @@
-version = "8.3.*"
+version = "8.3.*" 

--- a/stubs/Pillow/METADATA.toml
+++ b/stubs/Pillow/METADATA.toml
@@ -1,1 +1,1 @@
-version = "8.3.*" 
+version = "8.3.*"


### PR DESCRIPTION
On PRs, stubtest now only runs for stdlib and the third-party stubs that changed. In addition, once a day, stubtest is run against stdlib and all third-party stubs to find potential problems with new upstream releases.