### PR TITLE
Fix isort w.r.t. `_ast`/`_collections_abc`/`_tracemalloc`/`_warnings`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,8 @@ extra_standard_library = [
     "_markupbase",
     "_random",
     "_tkinter",
+    "_tracemalloc",
+    "_warnings",
     "_weakrefset",
     "genericpath",
     "opcode",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,8 @@ extra_standard_library = [
     "typing_extensions",
     "_typeshed",
     # Extra modules not recognized by isort
+    "_ast",
+    "_collections_abc",
     "_compression",
     "_csv",
     "_curses",

--- a/stdlib/@python2/ast.pyi
+++ b/stdlib/@python2/ast.pyi
@@ -4,10 +4,9 @@
 # from _ast below when loaded in an unorthodox way by the Dropbox
 # internal Bazel integration.
 import typing as _typing
-from typing import Any, Iterator
-
 from _ast import *
 from _ast import AST, Module
+from typing import Any, Iterator
 
 def parse(source: str | unicode, filename: str | unicode = ..., mode: str | unicode = ...) -> Module: ...
 def copy_location(new_node: AST, old_node: AST) -> AST: ...

--- a/stdlib/@python2/warnings.pyi
+++ b/stdlib/@python2/warnings.pyi
@@ -1,8 +1,7 @@
+from _warnings import warn as warn, warn_explicit as warn_explicit
 from types import ModuleType, TracebackType
 from typing import List, TextIO, Type, overload
 from typing_extensions import Literal
-
-from _warnings import warn as warn, warn_explicit as warn_explicit
 
 def showwarning(
     message: Warning | str, category: Type[Warning], filename: str, lineno: int, file: TextIO | None = ..., line: str | None = ...

--- a/stdlib/ast.pyi
+++ b/stdlib/ast.pyi
@@ -8,10 +8,9 @@
 # sys.
 import sys
 import typing as _typing
+from _ast import *  # type: ignore
 from typing import Any, Iterator, TypeVar, overload
 from typing_extensions import Literal
-
-from _ast import *  # type: ignore
 
 if sys.version_info >= (3, 8):
     class Num(Constant):

--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -1,5 +1,7 @@
 import sys
 import types
+from _ast import AST
+from _collections_abc import dict_items, dict_keys, dict_values
 from _typeshed import (
     OpenBinaryMode,
     OpenBinaryModeReading,
@@ -58,9 +60,6 @@ from typing import (
     overload,
 )
 from typing_extensions import Literal, SupportsIndex, TypeGuard, final
-
-from _ast import AST
-from _collections_abc import dict_items, dict_keys, dict_values
 
 if sys.version_info >= (3, 9):
     from types import GenericAlias

--- a/stdlib/collections/__init__.pyi
+++ b/stdlib/collections/__init__.pyi
@@ -1,9 +1,8 @@
 import sys
+from _collections_abc import dict_items, dict_keys, dict_values
 from _typeshed import Self
 from typing import Any, Dict, Generic, NoReturn, Tuple, Type, TypeVar, overload
 from typing_extensions import final
-
-from _collections_abc import dict_items, dict_keys, dict_values
 
 if sys.version_info >= (3, 10):
     from typing import Callable, Iterable, Iterator, Mapping, MutableMapping, MutableSequence, Reversible, Sequence

--- a/stdlib/tracemalloc.pyi
+++ b/stdlib/tracemalloc.pyi
@@ -1,7 +1,6 @@
 import sys
-from typing import Optional, Sequence, Tuple, Union, overload
-
 from _tracemalloc import *
+from typing import Optional, Sequence, Tuple, Union, overload
 
 def get_object_traceback(obj: object) -> Traceback | None: ...
 def take_snapshot() -> Snapshot: ...

--- a/stdlib/warnings.pyi
+++ b/stdlib/warnings.pyi
@@ -1,8 +1,7 @@
+from _warnings import warn as warn, warn_explicit as warn_explicit
 from types import ModuleType, TracebackType
 from typing import Any, Sequence, TextIO, Type, overload
 from typing_extensions import Literal
-
-from _warnings import warn as warn, warn_explicit as warn_explicit
 
 _ActionKind = Literal["default", "error", "ignore", "always", "module", "once"]
 


### PR DESCRIPTION
With the current configuration settings in pyproject.toml, isort has not been recognising these modules as standard-library modules. This PR adds them to the "extra_standard_library" list in the isort settings, and reformats the stdlib accordingly.