### PR TITLE
Add codeobject.co_positions() for Python 3.11

### DIFF
--- a/stdlib/types.pyi
+++ b/stdlib/types.pyi
@@ -144,6 +144,8 @@ class CodeType:
             co_name: str = ...,
             co_lnotab: bytes = ...,
         ) -> CodeType: ...
+    if sys.version_info >= (3, 11):
+        def co_positions(self) -> Iterable[tuple[int | None, int | None, int | None, int | None]]: ...
 
 @final
 class MappingProxyType(Mapping[_KT, _VT_co], Generic[_KT, _VT_co]):


### PR DESCRIPTION
Hi!

I hope it is OK to start adding stuff from Python 3.11. I am ready to update the code in case of any changes to the API in the following alpha/beta versions.

`co_positions()` is the new `codeobject` method introduced in PEP 657 to retrieve source code positions of bytecode instructions. See

- [Data Model - codeobject.co_positions()](https://docs.python.org/3.11/reference/datamodel.html#codeobject.co_positions)
- [PEP 657 - Include Fine Grained Error Locations in Tracebacks](https://www.python.org/dev/peps/pep-0657/)
- [What’s New In Python 3.11 - Enhanced error locations in tracebacks](https://docs.python.org/3.11/whatsnew/3.11.html#enhanced-error-locations-in-tracebacks)

Thank you 🙇‍♂️