### PR TITLE
improve urlencode(...) annotation for quote_via

### DIFF
--- a/stdlib/urllib/parse.pyi
+++ b/stdlib/urllib/parse.pyi
@@ -116,10 +116,10 @@ def urldefrag(url: bytes | None) -> DefragResultBytes: ...
 def urlencode(
     query: Mapping[Any, Any] | Mapping[Any, Sequence[Any]] | Sequence[tuple[Any, Any]] | Sequence[tuple[Any, Sequence[Any]]],
     doseq: bool = ...,
-    safe: AnyStr = ...,
+    safe: _Str = ...,
     encoding: str = ...,
     errors: str = ...,
-    quote_via: Callable[[str, AnyStr, str, str], str] = ...,
+    quote_via: Callable[[AnyStr, _Str, str, str], str] = ...,
 ) -> str: ...
 def urljoin(base: AnyStr, url: AnyStr | None, allow_fragments: bool = ...) -> AnyStr: ...
 @overload


### PR DESCRIPTION
resolves #6009

I opted to change `safe` to `_Str` (which is `str | bytes`) since that more closely matches the default parameter.   for `quote_via` I changed the first parameter to `AnyStr` to match the overloaded `quote_*` functions