### PR TITLE
Use `contextlib` classes inside `contextlib`

### DIFF
--- a/stdlib/contextlib.pyi
+++ b/stdlib/contextlib.pyi
@@ -4,7 +4,6 @@ from types import TracebackType
 from typing import (
     IO,
     Any,
-    AsyncContextManager,
     AsyncIterator,
     Awaitable,
     Callable,
@@ -20,6 +19,7 @@ from typing_extensions import ParamSpec, Protocol
 
 AbstractContextManager = ContextManager
 if sys.version_info >= (3, 7):
+    from typing import AsyncContextManager
     AbstractAsyncContextManager = AsyncContextManager
 
 _T = TypeVar("_T")
@@ -29,53 +29,53 @@ _F = TypeVar("_F", bound=Callable[..., Any])
 _P = ParamSpec("_P")
 
 _ExitFunc = Callable[[Optional[Type[BaseException]], Optional[BaseException], Optional[TracebackType]], bool]
-_CM_EF = TypeVar("_CM_EF", ContextManager[Any], _ExitFunc)
+_CM_EF = TypeVar("_CM_EF", AbstractContextManager[Any], _ExitFunc)
 
-class _GeneratorContextManager(ContextManager[_T_co]):
+class _GeneratorContextManager(AbstractContextManager[_T_co]):
     def __call__(self, func: _F) -> _F: ...
 
 # type ignore to deal with incomplete ParamSpec support in mypy
 def contextmanager(func: Callable[_P, Iterator[_T]]) -> Callable[_P, _GeneratorContextManager[_T]]: ...  # type: ignore
 
 if sys.version_info >= (3, 7):
-    def asynccontextmanager(func: Callable[_P, AsyncIterator[_T]]) -> Callable[_P, AsyncContextManager[_T]]: ...  # type: ignore
+    def asynccontextmanager(func: Callable[_P, AsyncIterator[_T]]) -> Callable[_P, AbstractAsyncContextManager[_T]]: ...  # type: ignore
 
 class _SupportsClose(Protocol):
     def close(self) -> object: ...
 
 _SupportsCloseT = TypeVar("_SupportsCloseT", bound=_SupportsClose)
 
-class closing(ContextManager[_SupportsCloseT]):
+class closing(AbstractContextManager[_SupportsCloseT]):
     def __init__(self, thing: _SupportsCloseT) -> None: ...
 
 if sys.version_info >= (3, 10):
     class _SupportsAclose(Protocol):
         def aclose(self) -> Awaitable[object]: ...
     _SupportsAcloseT = TypeVar("_SupportsAcloseT", bound=_SupportsAclose)
-    class aclosing(AsyncContextManager[_SupportsAcloseT]):
+    class aclosing(AbstractAsyncContextManager[_SupportsAcloseT]):
         def __init__(self, thing: _SupportsAcloseT) -> None: ...
     _AF = TypeVar("_AF", bound=Callable[..., Awaitable[Any]])
     class AsyncContextDecorator:
         def __call__(self, func: _AF) -> _AF: ...
 
-class suppress(ContextManager[None]):
+class suppress(AbstractContextManager[None]):
     def __init__(self, *exceptions: Type[BaseException]) -> None: ...
     def __exit__(
         self, exctype: Type[BaseException] | None, excinst: BaseException | None, exctb: TracebackType | None
     ) -> bool: ...
 
-class redirect_stdout(ContextManager[_T_io]):
+class redirect_stdout(AbstractContextManager[_T_io]):
     def __init__(self, new_target: _T_io) -> None: ...
 
-class redirect_stderr(ContextManager[_T_io]):
+class redirect_stderr(AbstractContextManager[_T_io]):
     def __init__(self, new_target: _T_io) -> None: ...
 
 class ContextDecorator:
     def __call__(self, func: _F) -> _F: ...
 
-class ExitStack(ContextManager[ExitStack]):
+class ExitStack(AbstractContextManager[ExitStack]):
     def __init__(self) -> None: ...
-    def enter_context(self, cm: ContextManager[_T]) -> _T: ...
+    def enter_context(self, cm: AbstractContextManager[_T]) -> _T: ...
     def push(self, exit: _CM_EF) -> _CM_EF: ...
     def callback(self, __callback: Callable[..., Any], *args: Any, **kwds: Any) -> Callable[..., Any]: ...
     def pop_all(self: Self) -> Self: ...
@@ -88,11 +88,11 @@ class ExitStack(ContextManager[ExitStack]):
 if sys.version_info >= (3, 7):
     _ExitCoroFunc = Callable[[Optional[Type[BaseException]], Optional[BaseException], Optional[TracebackType]], Awaitable[bool]]
     _CallbackCoroFunc = Callable[..., Awaitable[Any]]
-    _ACM_EF = TypeVar("_ACM_EF", AsyncContextManager[Any], _ExitCoroFunc)
-    class AsyncExitStack(AsyncContextManager[AsyncExitStack]):
+    _ACM_EF = TypeVar("_ACM_EF", AbstractAsyncContextManager[Any], _ExitCoroFunc)
+    class AsyncExitStack(AbstractAsyncContextManager[AsyncExitStack]):
         def __init__(self) -> None: ...
-        def enter_context(self, cm: ContextManager[_T]) -> _T: ...
-        def enter_async_context(self, cm: AsyncContextManager[_T]) -> Awaitable[_T]: ...
+        def enter_context(self, cm: AbstractContextManager[_T]) -> _T: ...
+        def enter_async_context(self, cm: AbstractAsyncContextManager[_T]) -> Awaitable[_T]: ...
         def push(self, exit: _CM_EF) -> _CM_EF: ...
         def push_async_exit(self, exit: _ACM_EF) -> _ACM_EF: ...
         def callback(self, __callback: Callable[..., Any], *args: Any, **kwds: Any) -> Callable[..., Any]: ...

--- a/stdlib/contextlib.pyi
+++ b/stdlib/contextlib.pyi
@@ -20,6 +20,7 @@ from typing_extensions import ParamSpec, Protocol
 AbstractContextManager = ContextManager
 if sys.version_info >= (3, 7):
     from typing import AsyncContextManager
+
     AbstractAsyncContextManager = AsyncContextManager
 
 _T = TypeVar("_T")


### PR DESCRIPTION
This PR refactors `contextlib.pyi` so that classes inside the stub file use `contextlib.AbstractContextManager` and `contextlib.AbstractAsyncContextManager`, instead of the deprecated aliases from the `typing` module.