### PR TITLE
Stop running `mypy_primer` on precommit pushes

### DIFF
--- a/.github/workflows/mypy_primer.yml
+++ b/.github/workflows/mypy_primer.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   mypy_primer:
+    if: "!contains(github.event.commits[0].message, '[pre-commit.ci]')"
     name: Run
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
If pre-commit makes a change immediately after a PR has been made, it's important that the stubtest/mypy/pytype/pyright checks are run again, as line numbers might have changed. However, there's no reason to start a new run of `mypy_primer`, since pre-commit will make no _substantative_ changes to a PR, only _cosmetic_ changes, and that shouldn't affect the diff from `mypy_primer`.

I _believe_ the change proposed in this PR will mean that `mypy_primer` is only run on a push event if the commit message does not include `[pre-commit.ci]` (all the pre-commit pushes contain that tag).