### PR TITLE
delete duplicate comment

### DIFF
--- a/tests/stubtest_allowlists/py3_common.txt
+++ b/tests/stubtest_allowlists/py3_common.txt
@@ -49,7 +49,6 @@ codecs.CodecInfo.incrementaldecoder
 codecs.CodecInfo.incrementalencoder
 codecs.CodecInfo.streamreader
 codecs.CodecInfo.streamwriter
-# Coroutine and Generator properties are added programmatically
 collections.ChainMap.get  # Adding None to the underlying Mapping Union messed up mypy
 collections.ChainMap.fromkeys  # Runtime has *args which can really only be one argument
 # Coroutine and Generator properties are added programmatically


### PR DESCRIPTION
`stubtest_allowlists/py3_common.txt` previously repeated this line 3 times. I removed the one repetition that was not directly above `Coroutine` and `Generator` entries.