### PR TITLE
Add missing `__call__` method to `types.GenericAlias`

### DIFF
--- a/stdlib/types.pyi
+++ b/stdlib/types.pyi
@@ -398,6 +398,7 @@ if sys.version_info >= (3, 9):
         __parameters__: Tuple[Any, ...]
         def __init__(self, origin: type, args: Any) -> None: ...
         def __getattr__(self, name: str) -> Any: ...  # incomplete
+        def __call__(self, *args: Any, **kwargs: Any) -> Any: ...
 
 if sys.version_info >= (3, 10):
     @final


### PR DESCRIPTION
If you run stubtest_stdlib without the `--ignore-missing-stubs` option, it complains about the fact that `GenericAlias` has a `__call__` method at runtime, but not in the stubs.

You could probably make `GenericAlias`... generic... to avoid using `Any`, but I don't think it's worth the effort, personally.