### PR TITLE
Add missing `scope_id` property to `IPv6Address`

### DIFF
--- a/stdlib/ipaddress.pyi
+++ b/stdlib/ipaddress.pyi
@@ -127,6 +127,9 @@ class IPv6Address(_BaseAddress):
     def sixtofour(self) -> IPv4Address | None: ...
     @property
     def teredo(self) -> tuple[IPv4Address, IPv4Address] | None: ...
+    if sys.version_info >= (3, 9):
+        @property
+        def scope_id(self) -> str | None: ...
 
 class IPv6Network(_BaseNetwork[IPv6Address]):
     @property


### PR DESCRIPTION
Discovered by running `stubtest_stdlib` without the `--ignore-missing-stubs` option. Added to cpython in [this BPO issue](https://bugs.python.org/issue34788). Documentation for the function is [here](https://docs.python.org/3/library/ipaddress.html#ipaddress.IPv6Address.scope_id).