### PR TITLE
Add missing `scanner()` method for `re.Pattern` objects

### DIFF
--- a/stdlib/typing.pyi
+++ b/stdlib/typing.pyi
@@ -597,12 +597,23 @@ class Match(Generic[AnyStr]):
     if sys.version_info >= (3, 9):
         def __class_getitem__(cls, item: Any) -> GenericAlias: ...
 
+# Not actually defined in typing (or re!) - is _sre.SRE_Scanner at runtime
+# Also not documented anywhere
+@_final
+class _SRE_Scanner(Generic[AnyStr]):
+    pattern: Pattern[AnyStr]
+    # Cannot be directly instantiated
+    def __new__(cls, *args: Any, **kwargs: Any) -> NoReturn: ...  # type: ignore
+    def match(self) -> Match[AnyStr] | None: ...
+    def search(self) -> Match[AnyStr] | None: ...
+
 @_final
 class Pattern(Generic[AnyStr]):
     flags: int
     groupindex: Mapping[str, int]
     groups: int
     pattern: AnyStr
+    def scanner(self, string: AnyStr, pos: int = ..., endpos: int = ...) -> _SRE_Scanner[AnyStr]: ...  # undocumented
     def search(self, string: AnyStr, pos: int = ..., endpos: int = ...) -> Match[AnyStr] | None: ...
     def match(self, string: AnyStr, pos: int = ..., endpos: int = ...) -> Match[AnyStr] | None: ...
     def fullmatch(self, string: AnyStr, pos: int = ..., endpos: int = ...) -> Match[AnyStr] | None: ...

--- a/stdlib/typing.pyi
+++ b/stdlib/typing.pyi
@@ -602,8 +602,8 @@ class Match(Generic[AnyStr]):
 @_final
 class _SRE_Scanner(Generic[AnyStr]):
     pattern: Pattern[AnyStr]
-    # Cannot be directly instantiated
-    def __new__(cls, *args: Any, **kwargs: Any) -> NoReturn: ...  # type: ignore
+    # Cannot be directly instantiated, but mypy doesn't like __new__ returning NoReturn
+    def __new__(cls, *args: Any, **kwargs: Any) -> NoReturn: ...  # type: ignore[misc]
     def match(self) -> Match[AnyStr] | None: ...
     def search(self) -> Match[AnyStr] | None: ...
 


### PR DESCRIPTION
This one's a bit weird; feedback welcome!