### PR TITLE
Add missing sre_constants opcodes

### DIFF
--- a/stdlib/sre_constants.pyi
+++ b/stdlib/sre_constants.pyi
@@ -75,6 +75,14 @@ SUBPATTERN: _NamedIntConstant
 MIN_REPEAT_ONE: _NamedIntConstant
 if sys.version_info >= (3, 7):
     RANGE_UNI_IGNORE: _NamedIntConstant
+    GROUPREF_LOC_IGNORE: _NamedIntConstant
+    GROUPREF_UNI_IGNORE: _NamedIntConstant
+    IN_LOC_IGNORE: _NamedIntConstant
+    IN_UNI_IGNORE: _NamedIntConstant
+    LITERAL_LOC_IGNORE: _NamedIntConstant
+    LITERAL_UNI_IGNORE: _NamedIntConstant
+    NOT_LITERAL_LOC_IGNORE: _NamedIntConstant
+    NOT_LITERAL_UNI_IGNORE: _NamedIntConstant
 else:
     RANGE_IGNORE: _NamedIntConstant
 MIN_REPEAT: _NamedIntConstant


### PR DESCRIPTION
These were added in 3.7: https://bugs.python.org/issue31690