### PR TITLE
ssl: Add missing VerifyFlags

### DIFF
--- a/stdlib/ssl.pyi
+++ b/stdlib/ssl.pyi
@@ -144,7 +144,7 @@ VERIFY_CRL_CHECK_LEAF: VerifyFlags
 VERIFY_CRL_CHECK_CHAIN: VerifyFlags
 VERIFY_X509_STRICT: VerifyFlags
 VERIFY_X509_TRUSTED_FIRST: VerifyFlags
-    
+
 if sys.version_info >= (3, 10):
     VERIFY_ALLOW_PROXY_CERTS: VerifyFlags
     VERIFY_X509_PARTIAL_CHAIN: VerifyFlags

--- a/stdlib/ssl.pyi
+++ b/stdlib/ssl.pyi
@@ -135,12 +135,19 @@ class VerifyFlags(enum.IntFlag):
     VERIFY_CRL_CHECK_CHAIN: int
     VERIFY_X509_STRICT: int
     VERIFY_X509_TRUSTED_FIRST: int
+    if sys.version_info >= (3, 10):
+        VERIFY_ALLOW_PROXY_CERTS: int
+        VERIFY_X509_PARTIAL_CHAIN: int
 
 VERIFY_DEFAULT: VerifyFlags
 VERIFY_CRL_CHECK_LEAF: VerifyFlags
 VERIFY_CRL_CHECK_CHAIN: VerifyFlags
 VERIFY_X509_STRICT: VerifyFlags
 VERIFY_X509_TRUSTED_FIRST: VerifyFlags
+    
+if sys.version_info >= (3, 10):
+    VERIFY_ALLOW_PROXY_CERTS: VerifyFlags
+    VERIFY_X509_PARTIAL_CHAIN: VerifyFlags
 
 class _SSLMethod(enum.IntEnum):
     PROTOCOL_SSLv23: int


### PR DESCRIPTION
The documentation assures me that these were both added in 3.10: https://docs.python.org/3/library/ssl.html