### PR TITLE
Add socketserver.UDPServer.max_packet_size

### DIFF
--- a/stdlib/socketserver.pyi
+++ b/stdlib/socketserver.pyi
@@ -55,6 +55,7 @@ class TCPServer(BaseServer):
     def close_request(self, request: _RequestType) -> None: ...  # undocumented
 
 class UDPServer(BaseServer):
+    max_packet_size: int
     def __init__(
         self,
         server_address: tuple[str, int],

--- a/stdlib/socketserver.pyi
+++ b/stdlib/socketserver.pyi
@@ -55,7 +55,7 @@ class TCPServer(BaseServer):
     def close_request(self, request: _RequestType) -> None: ...  # undocumented
 
 class UDPServer(BaseServer):
-    max_packet_size: int
+    max_packet_size: ClassVar[int]
     def __init__(
         self,
         server_address: tuple[str, int],


### PR DESCRIPTION
It looks like an int in the source code: https://github.com/python/cpython/blob/8d1a5800645575ec876932bbb9aed3aa65d18f46/Lib/socketserver.py#L524.

Stubtest flagged it as being missing in all supported Python versions, on all platforms: https://github.com/python/typeshed/pull/6403/files