### PR TITLE
Add `os.waitstatus_to_exitcode`

### DIFF
--- a/stdlib/os/__init__.pyi
+++ b/stdlib/os/__init__.pyi
@@ -897,3 +897,6 @@ if sys.version_info >= (3, 8):
         MFD_HUGE_2GB: int
         MFD_HUGE_16GB: int
         def memfd_create(name: str, flags: int = ...) -> int: ...
+
+if sys.version_info >= (3, 9):
+    def waitstatus_to_exitcode(status: int) -> int: ...


### PR DESCRIPTION
Documentation here: https://docs.python.org/3/library/os.html#os.waitstatus_to_exitcode

In reality, it only accepts a positive integer, but there's no way of succinctly expressing that.