### PR TITLE
psycopg2: Error and Warning are Exceptions

### DIFF
--- a/stubs/psycopg2/psycopg2/errors.pyi
+++ b/stubs/psycopg2/psycopg2/errors.pyi
@@ -1,6 +1,6 @@
 from typing import Any
 
-class Error:
+class Error(Exception):
     def __init__(self, *args, **kwargs): ...
     args: Any
     cursor: Any
@@ -9,7 +9,7 @@ class Error:
     pgerror: Any
     with_traceback: Any
 
-class Warning:
+class Warning(Exception):
     args: Any
     with_traceback: Any
 

--- a/stubs/psycopg2/psycopg2/errors.pyi
+++ b/stubs/psycopg2/psycopg2/errors.pyi
@@ -1,17 +1,4 @@
-from typing import Any
-
-class Error(Exception):
-    def __init__(self, *args, **kwargs): ...
-    args: Any
-    cursor: Any
-    diag: Any
-    pgcode: Any
-    pgerror: Any
-    with_traceback: Any
-
-class Warning(Exception):
-    args: Any
-    with_traceback: Any
+from psycopg2._psycopg import Error as Error, Warning as Warning
 
 class DatabaseError(Error): ...
 class InterfaceError(Error): ...


### PR DESCRIPTION
Psycopg2: inherit `Error` and `Warning` from `Exception`

I don't know why stubgen got it wrong, but:
```python
Python 3.10.0 (default, Oct  4 2021, 22:09:55) [GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import psycopg2
>>> psycopg2.__version__
'2.9.2 (dt dec pq3 ext lo64)'
>>> psycopg2.errors.Error.__mro__
(<class 'psycopg2.Error'>, <class 'Exception'>, <class 'BaseException'>, <class 'object'>)
>>> psycopg2.errors.Warning.__mro__
(<class 'psycopg2.Warning'>, <class 'Exception'>, <class 'BaseException'>, <class 'object'>)
```

`Error` and `Warning` classes are `Exception` and not presenting them as such leads to mypy saying:
```
error: Exception type must be derived from BaseException
```