### PR TITLE
ci: Do not run stubtest_third_party for deleted stubs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -126,7 +126,7 @@ jobs:
         run: pip install $(grep tomli== requirements-tests-py3.txt)
       - name: Run stubtest
         run: |
-          STUBS=$(git diff --name-only origin/${{ github.base_ref }} HEAD | egrep ^stubs/ | cut -d "/" -f 2)
+          STUBS=$(git diff --name-only origin/${{ github.base_ref }} HEAD | egrep ^stubs/ | cut -d "/" -f 2 | sort -u | (while read stub; do [ -d stubs/$stub ] && echo $stub; done))
           if test -n "$STUBS"; then
             echo "Testing $STUBS..."
             python tests/stubtest_third_party.py $STUBS


### PR DESCRIPTION
Fixes the error in https://github.com/python/typeshed/runs/4384343930