### PR TITLE
ci: fix stubtest_third_party while loop

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -126,7 +126,7 @@ jobs:
         run: pip install $(grep tomli== requirements-tests-py3.txt)
       - name: Run stubtest
         run: |
-          STUBS=$(git diff --name-only origin/${{ github.base_ref }} HEAD | egrep ^stubs/ | cut -d "/" -f 2 | sort -u | (while read stub; do [ -d stubs/$stub ] && echo $stub; done))
+          STUBS=$(git diff --name-only origin/${{ github.base_ref }} HEAD | egrep ^stubs/ | cut -d "/" -f 2 | sort -u | (while read stub; do [ -d stubs/$stub ] && echo $stub || true; done))
           if test -n "$STUBS"; then
             echo "Testing $STUBS..."
             python tests/stubtest_third_party.py $STUBS

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -126,7 +126,7 @@ jobs:
         run: pip install $(grep tomli== requirements-tests-py3.txt)
       - name: Run stubtest
         run: |
-          STUBS=$(git diff --name-only origin/${{ github.base_ref }} HEAD | egrep ^stubs/ | cut -d "/" -f 2 | sort -u | (while read stub; do [ -d stubs/$stub ] && echo $stub; done))
+          STUBS=$(git diff --name-only origin/${{ github.base_ref }} HEAD | egrep ^stubs/ | cut -d "/" -f 2 | sort -u | (while read stub; do if [ -d stubs/$stub ]; then echo $stub; fi; done))
           if test -n "$STUBS"; then
             echo "Testing $STUBS..."
             python tests/stubtest_third_party.py $STUBS

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -126,7 +126,7 @@ jobs:
         run: pip install $(grep tomli== requirements-tests-py3.txt)
       - name: Run stubtest
         run: |
-          STUBS=$(git diff --name-only origin/${{ github.base_ref }} HEAD | egrep ^stubs/ | cut -d "/" -f 2 | sort -u | (while read stub; do if [ -d stubs/$stub ]; then echo $stub; fi; done))
+          STUBS=$(git diff --name-only origin/${{ github.base_ref }} HEAD | egrep ^stubs/ | cut -d "/" -f 2 | sort -u | (while read stub; do [ -d stubs/$stub ] && echo $stub; done))
           if test -n "$STUBS"; then
             echo "Testing $STUBS..."
             python tests/stubtest_third_party.py $STUBS


### PR DESCRIPTION
`foo && bar` as a short way to `if foo; then bar; fi` wasn't great, because it makes the CI fail when `foo` is false.