### PR TITLE
Correct print_exception for 3.10.

### DIFF
--- a/stdlib/traceback.pyi
+++ b/stdlib/traceback.pyi
@@ -9,7 +9,7 @@ def print_tb(tb: TracebackType | None, limit: int | None = ..., file: IO[str] | 
 
 if sys.version_info >= (3, 10):
     def print_exception(
-        __exc: Type[BaseException] | None,
+        __exc: Type[BaseException] | BaseException | None,
         value: BaseException | None = ...,
         tb: TracebackType | None = ...,
         limit: int | None = ...,


### PR DESCRIPTION
https://docs.python.org/3/library/traceback.html#traceback.print_exception

The first arg of `print_exception` accepts an exception object in 3.10.