### PR TITLE
Add missing `asyncio` functions, part II

### DIFF
--- a/stdlib/asyncio/__init__.pyi
+++ b/stdlib/asyncio/__init__.pyi
@@ -97,7 +97,15 @@ if sys.version_info >= (3, 7):
     from .runners import run as run
 
 if sys.version_info >= (3, 7):
-    from .tasks import all_tasks as all_tasks, create_task as create_task, current_task as current_task
+    from .tasks import (
+        _enter_task as _enter_task,
+        _leave_task as _leave_task,
+        _register_task as _register_task,
+        _unregister_task as _unregister_task,
+        all_tasks as all_tasks,
+        create_task as create_task,
+        current_task as current_task,
+    )
 if sys.version_info >= (3, 9):
     from .threads import to_thread as to_thread
 

--- a/tests/stubtest_allowlists/py310.txt
+++ b/tests/stubtest_allowlists/py310.txt
@@ -157,10 +157,6 @@ ast.Tuple.dims
 ast.main
 asyncio.AbstractEventLoop.connect_accepted_socket
 asyncio.BufferedProtocol.eof_received
-asyncio._enter_task
-asyncio._leave_task
-asyncio._register_task
-asyncio._unregister_task
 asyncio.events.AbstractEventLoop.connect_accepted_socket
 asyncio.protocols.BufferedProtocol.eof_received
 bdb.Breakpoint.clearBreakpoints

--- a/tests/stubtest_allowlists/py37.txt
+++ b/tests/stubtest_allowlists/py37.txt
@@ -83,10 +83,6 @@ collections.Sequence.index  # Supporting None in end is not mandatory
 _dummy_thread.RLock
 _imp.source_hash
 asyncio.BufferedProtocol.eof_received
-asyncio._enter_task
-asyncio._leave_task
-asyncio._register_task
-asyncio._unregister_task
 asyncio.protocols.BufferedProtocol.eof_received
 contextvars.ContextVar.__class_getitem__
 distutils.command.bdist_wininst

--- a/tests/stubtest_allowlists/py38.txt
+++ b/tests/stubtest_allowlists/py38.txt
@@ -105,10 +105,6 @@ _thread._ExceptHookArgs.n_fields
 _thread._ExceptHookArgs.n_sequence_fields
 _thread._ExceptHookArgs.n_unnamed_fields
 asyncio.BufferedProtocol.eof_received
-asyncio._enter_task
-asyncio._leave_task
-asyncio._register_task
-asyncio._unregister_task
 asyncio.protocols.BufferedProtocol.eof_received
 contextvars.ContextVar.__class_getitem__
 distutils.command.bdist_wininst

--- a/tests/stubtest_allowlists/py39.txt
+++ b/tests/stubtest_allowlists/py39.txt
@@ -123,10 +123,6 @@ _thread._ExceptHookArgs.n_unnamed_fields
 ast.Tuple.dims
 ast.main
 asyncio.BufferedProtocol.eof_received
-asyncio._enter_task
-asyncio._leave_task
-asyncio._register_task
-asyncio._unregister_task
 asyncio.protocols.BufferedProtocol.eof_received
 collections.AsyncIterable.__class_getitem__
 collections.Awaitable.__class_getitem__


### PR DESCRIPTION
I added these to `asyncio.tasks` in #6418, but evidently forgot to add the import in `asyncio.__init__`.