### PR TITLE
Correct `signal.pyi`

### DIFF
--- a/stdlib/signal.pyi
+++ b/stdlib/signal.pyi
@@ -17,6 +17,8 @@ class Signals(IntEnum):
         SIGALRM: int
     if sys.platform == "win32":
         SIGBREAK: int
+        CTRL_C_EVENT: int
+        CTRL_BREAK_EVENT: int
     if sys.platform != "win32":
         SIGBUS: int
         SIGCHLD: int
@@ -134,8 +136,8 @@ if sys.platform != "win32":
     SIGXFSZ: Signals
 
 if sys.platform == "win32":
-    CTRL_C_EVENT: int
-    CTRL_BREAK_EVENT: int
+    CTRL_C_EVENT: Signals
+    CTRL_BREAK_EVENT: Signals
 
 if sys.platform != "win32" and sys.platform != "darwin":
     class struct_siginfo(Tuple[int, int, int, int, int, int, int]):

--- a/tests/stubtest_allowlists/win32.txt
+++ b/tests/stubtest_allowlists/win32.txt
@@ -49,8 +49,6 @@ msvcrt.SetErrorMode
 os.get_handle_inheritable
 os.set_handle_inheritable
 os.statvfs_result
-signal.Signals.CTRL_BREAK_EVENT
-signal.Signals.CTRL_C_EVENT
 socket.MsgFlag.MSG_BCAST
 socket.MsgFlag.MSG_MCAST
 ssl.SSLSocket.recvmsg


### PR DESCRIPTION
On Windows, `signal.CTRL_C_EVENT` and `signal.CTRL_BREAK_EVENT` are global-variable aliases for members of the `Signals` enum, not integers. Correcting this means we can take them off the allowlist.