### PR TITLE
tkinter Pack,Grid,Place: delete commented-out aliases, explain in allowlist

### DIFF
--- a/stdlib/tkinter/__init__.pyi
+++ b/stdlib/tkinter/__init__.pyi
@@ -740,14 +740,6 @@ class Pack:
     pack = pack_configure
     forget = pack_forget
     propagate = Misc.pack_propagate
-    # commented out to avoid mypy getting confused with multiple
-    # inheritance and how things get overridden with different things
-    # info = pack_info
-    # pack_propagate = Misc.pack_propagate
-    # configure = pack_configure
-    # config = pack_configure
-    # slaves = Misc.pack_slaves
-    # pack_slaves = Misc.pack_slaves
 
 class _PlaceInfo(_InMiscNonTotal):  # empty dict if widget hasn't been placed
     anchor: _Anchor
@@ -784,13 +776,6 @@ class Place:
     def place_info(self) -> _PlaceInfo: ...
     place = place_configure
     info = place_info
-    # commented out to avoid mypy getting confused with multiple
-    # inheritance and how things get overridden with different things
-    # config = place_configure
-    # configure = place_configure
-    # forget = place_forget
-    # slaves = Misc.place_slaves
-    # place_slaves = Misc.place_slaves
 
 class _GridInfo(_InMiscNonTotal):  # empty dict if widget hasn't been gridded
     column: int
@@ -826,24 +811,6 @@ class Grid:
     grid = grid_configure
     location = Misc.grid_location
     size = Misc.grid_size
-    # commented out to avoid mypy getting confused with multiple
-    # inheritance and how things get overridden with different things
-    # bbox = Misc.grid_bbox
-    # grid_bbox = Misc.grid_bbox
-    # forget = grid_forget
-    # info = grid_info
-    # grid_location = Misc.grid_location
-    # grid_propagate = Misc.grid_propagate
-    # grid_size = Misc.grid_size
-    # rowconfigure = Misc.grid_rowconfigure
-    # grid_rowconfigure = Misc.grid_rowconfigure
-    # grid_columnconfigure = Misc.grid_columnconfigure
-    # columnconfigure = Misc.grid_columnconfigure
-    # config = grid_configure
-    # configure = grid_configure
-    # propagate = Misc.grid_propagate
-    # slaves = Misc.grid_slaves
-    # grid_slaves = Misc.grid_slaves
 
 class BaseWidget(Misc):
     master: Misc

--- a/tests/stubtest_allowlists/py3_common.txt
+++ b/tests/stubtest_allowlists/py3_common.txt
@@ -286,6 +286,37 @@ socket.AF_DECnet
 socket.[A-Z0-9_]+
 (termios.[A-Z0-9_]+)?
 
+# Missing aliases to existing methods that not many people seem to use.
+# Complicated multiple inheritance, confuses type checkers.
+tkinter.Grid.bbox
+tkinter.Grid.columnconfigure
+tkinter.Grid.config
+tkinter.Grid.configure
+tkinter.Grid.forget
+tkinter.Grid.grid_bbox
+tkinter.Grid.grid_columnconfigure
+tkinter.Grid.grid_location
+tkinter.Grid.grid_propagate
+tkinter.Grid.grid_rowconfigure
+tkinter.Grid.grid_size
+tkinter.Grid.grid_slaves
+tkinter.Grid.info
+tkinter.Grid.propagate
+tkinter.Grid.rowconfigure
+tkinter.Grid.slaves
+tkinter.Pack.config
+tkinter.Pack.configure
+tkinter.Pack.info
+tkinter.Pack.pack_propagate
+tkinter.Pack.pack_slaves
+tkinter.Pack.slaves
+tkinter.Place.config
+tkinter.Place.configure
+tkinter.Place.forget
+tkinter.Place.place_slaves
+tkinter.Place.slaves
+
+
 # ==========
 # Missing from distutils module (deprecated, to be removed in 3.12)
 # Any of these can be added if someone needs them
@@ -624,34 +655,7 @@ sunau.Au_write.initfp
 threading.Event.isSet
 tkinter.EventType.Button
 tkinter.EventType.Key
-tkinter.Grid.bbox
-tkinter.Grid.columnconfigure
-tkinter.Grid.config
-tkinter.Grid.configure
-tkinter.Grid.forget
-tkinter.Grid.grid_bbox
-tkinter.Grid.grid_columnconfigure
-tkinter.Grid.grid_location
-tkinter.Grid.grid_propagate
-tkinter.Grid.grid_rowconfigure
-tkinter.Grid.grid_size
-tkinter.Grid.grid_slaves
-tkinter.Grid.info
-tkinter.Grid.propagate
-tkinter.Grid.rowconfigure
-tkinter.Grid.slaves
 tkinter.Misc.config
-tkinter.Pack.config
-tkinter.Pack.configure
-tkinter.Pack.info
-tkinter.Pack.pack_propagate
-tkinter.Pack.pack_slaves
-tkinter.Pack.slaves
-tkinter.Place.config
-tkinter.Place.configure
-tkinter.Place.forget
-tkinter.Place.place_slaves
-tkinter.Place.slaves
 tkinter.font.Font.counter
 tkinter.simpledialog.Dialog.apply
 tkinter.simpledialog.Dialog.cancel


### PR DESCRIPTION
Tkinter is complicated. It does this at runtime:

```python3
class Misc:
    ...
    def grid_rowconfigure(self, ...): ...
    rowconfigure = grid_rowconfigure
    def grid_size(self): ...
    size = grid_size
    ...

class Grid:
    ...
    rowconfigure = grid_rowconfigure = Misc.grid_rowconfigure
    size = grid_size = Misc.grid_size
    ...

class BaseWidget(Misc):
    ...

class Widget(BaseWidget, Pack, Place, Grid):
    ...
```

The intent with `rowconfigure = Misc.grid_rowconfigure` is that you can do `tkinter.Grid.rowconfigure(widget, blah)` instead of `widget.grid_rowconfigure(blah)`, but nobody seems to be doing that in practice.

It is even worse with some methods: **each** of `Pack`, `Grid`, `Place` and `Misc` has a method named `configure`, and they all do different things!

If someone wants to use the weird aliases of the methods, I can try to add them to the stubs, but for now I just want them all allowlisted.