### PR TITLE
make contextmanager return AbstractContextManager

### DIFF
--- a/stdlib/contextlib.pyi
+++ b/stdlib/contextlib.pyi
@@ -36,7 +36,7 @@ class _GeneratorContextManager(AbstractContextManager[_T_co]):
     def __call__(self, func: _F) -> _F: ...
 
 # type ignore to deal with incomplete ParamSpec support in mypy
-def contextmanager(func: Callable[_P, Iterator[_T]]) -> Callable[_P, _GeneratorContextManager[_T]]: ...  # type: ignore[misc]
+def contextmanager(func: Callable[_P, Iterator[_T]]) -> Callable[_P, AbstractContextManager[_T]]: ...  # type: ignore[misc]
 
 if sys.version_info >= (3, 7):
     def asynccontextmanager(func: Callable[_P, AsyncIterator[_T]]) -> Callable[_P, AbstractAsyncContextManager[_T]]: ...  # type: ignore[misc]


### PR DESCRIPTION
Fixes #6520.

There might be a good reason to keep the current implementation, but I want to see what CI says. I believe mypy has a plugin for `@contextmanager`, so it may not show that much.

I found no motivation for the separate class in https://github.com/python/typeshed/pulls?q=is%3Aissue+GeneratorContextManager+.