### PR TITLE
Add more ast.parse() mode overrides

### DIFF
--- a/stdlib/ast.pyi
+++ b/stdlib/ast.pyi
@@ -159,15 +159,7 @@ if sys.version_info >= (3, 8):
     def parse(
         source: str | bytes,
         filename: str | bytes = ...,
-        *,
-        type_comments: bool = ...,
-        feature_version: None | int | _typing.Tuple[int, int] = ...,
-    ) -> Module: ...
-    @overload
-    def parse(
-        source: str | bytes,
-        filename: str | bytes,
-        mode: Literal["exec"],
+        mode: Literal["exec"] = ...,
         *,
         type_comments: bool = ...,
         feature_version: None | int | _typing.Tuple[int, int] = ...,
@@ -199,14 +191,6 @@ if sys.version_info >= (3, 8):
         type_comments: bool = ...,
         feature_version: None | int | _typing.Tuple[int, int] = ...,
     ) -> Interactive: ...
-    @overload
-    def parse(
-        source: str | bytes,
-        *,
-        mode: Literal["exec"],
-        type_comments: bool = ...,
-        feature_version: None | int | _typing.Tuple[int, int] = ...,
-    ) -> Module: ...
     @overload
     def parse(
         source: str | bytes,
@@ -234,15 +218,11 @@ if sys.version_info >= (3, 8):
 
 else:
     @overload
-    def parse(source: str | bytes, filename: str | bytes = ...) -> Module: ...
-    @overload
-    def parse(source: str | bytes, filename: str | bytes, mode: Literal["exec"]) -> Module: ...
+    def parse(source: str | bytes, filename: str | bytes = ..., mode: Literal["exec"] = ...) -> Module: ...
     @overload
     def parse(source: str | bytes, filename: str | bytes, mode: Literal["eval"]) -> Expression: ...
     @overload
     def parse(source: str | bytes, filename: str | bytes, mode: Literal["single"]) -> Interactive: ...
-    @overload
-    def parse(source: str | bytes, *, mode: Literal["exec"]) -> Module: ...
     @overload
     def parse(source: str | bytes, *, mode: Literal["eval"]) -> Expression: ...
     @overload

--- a/stdlib/ast.pyi
+++ b/stdlib/ast.pyi
@@ -168,6 +168,33 @@ if sys.version_info >= (3, 8):
     def parse(
         source: str | bytes,
         filename: str | bytes = ...,
+        mode: Literal["eval"] = ...,
+        *,
+        type_comments: bool = ...,
+        feature_version: None | int | _typing.Tuple[int, int] = ...,
+    ) -> Expression: ...
+    @overload
+    def parse(
+        source: str | bytes,
+        filename: str | bytes = ...,
+        mode: Literal["func_type"] = ...,
+        *,
+        type_comments: bool = ...,
+        feature_version: None | int | _typing.Tuple[int, int] = ...,
+    ) -> FunctionType: ...
+    @overload
+    def parse(
+        source: str | bytes,
+        filename: str | bytes = ...,
+        mode: Literal["single"] = ...,
+        *,
+        type_comments: bool = ...,
+        feature_version: None | int | _typing.Tuple[int, int] = ...,
+    ) -> Interactive: ...
+    @overload
+    def parse(
+        source: str | bytes,
+        filename: str | bytes = ...,
         mode: str = ...,
         *,
         type_comments: bool = ...,
@@ -177,6 +204,10 @@ if sys.version_info >= (3, 8):
 else:
     @overload
     def parse(source: str | bytes, filename: str | bytes = ..., mode: Literal["exec"] = ...) -> Module: ...
+    @overload
+    def parse(source: str | bytes, filename: str | bytes = ..., mode: Literal["eval"] = ...) -> Expression: ...
+    @overload
+    def parse(source: str | bytes, filename: str | bytes = ..., mode: Literal["single"] = ...) -> Interactive: ...
     @overload
     def parse(source: str | bytes, filename: str | bytes = ..., mode: str = ...) -> AST: ...
 

--- a/stdlib/ast.pyi
+++ b/stdlib/ast.pyi
@@ -159,7 +159,6 @@ if sys.version_info >= (3, 8):
     def parse(
         source: str | bytes,
         filename: str | bytes = ...,
-        mode: Literal["exec"] = ...,
         *,
         type_comments: bool = ...,
         feature_version: None | int | _typing.Tuple[int, int] = ...,
@@ -167,8 +166,17 @@ if sys.version_info >= (3, 8):
     @overload
     def parse(
         source: str | bytes,
-        filename: str | bytes = ...,
-        mode: Literal["eval"] = ...,
+        filename: str | bytes,
+        mode: Literal["exec"],
+        *,
+        type_comments: bool = ...,
+        feature_version: None | int | _typing.Tuple[int, int] = ...,
+    ) -> Module: ...
+    @overload
+    def parse(
+        source: str | bytes,
+        filename: str | bytes,
+        mode: Literal["eval"],
         *,
         type_comments: bool = ...,
         feature_version: None | int | _typing.Tuple[int, int] = ...,
@@ -176,8 +184,8 @@ if sys.version_info >= (3, 8):
     @overload
     def parse(
         source: str | bytes,
-        filename: str | bytes = ...,
-        mode: Literal["func_type"] = ...,
+        filename: str | bytes,
+        mode: Literal["func_type"],
         *,
         type_comments: bool = ...,
         feature_version: None | int | _typing.Tuple[int, int] = ...,
@@ -185,8 +193,8 @@ if sys.version_info >= (3, 8):
     @overload
     def parse(
         source: str | bytes,
-        filename: str | bytes = ...,
-        mode: Literal["single"] = ...,
+        filename: str | bytes,
+        mode: Literal["single"],
         *,
         type_comments: bool = ...,
         feature_version: None | int | _typing.Tuple[int, int] = ...,
@@ -194,22 +202,51 @@ if sys.version_info >= (3, 8):
     @overload
     def parse(
         source: str | bytes,
-        filename: str | bytes = ...,
-        mode: str = ...,
         *,
+        mode: Literal["exec"],
         type_comments: bool = ...,
         feature_version: None | int | _typing.Tuple[int, int] = ...,
-    ) -> AST: ...
+    ) -> Module: ...
+    @overload
+    def parse(
+        source: str | bytes,
+        *,
+        mode: Literal["eval"],
+        type_comments: bool = ...,
+        feature_version: None | int | _typing.Tuple[int, int] = ...,
+    ) -> Expression: ...
+    @overload
+    def parse(
+        source: str | bytes,
+        *,
+        mode: Literal["func_type"],
+        type_comments: bool = ...,
+        feature_version: None | int | _typing.Tuple[int, int] = ...,
+    ) -> FunctionType: ...
+    @overload
+    def parse(
+        source: str | bytes,
+        *,
+        mode: Literal["single"],
+        type_comments: bool = ...,
+        feature_version: None | int | _typing.Tuple[int, int] = ...,
+    ) -> Interactive: ...
 
 else:
     @overload
-    def parse(source: str | bytes, filename: str | bytes = ..., mode: Literal["exec"] = ...) -> Module: ...
+    def parse(source: str | bytes, filename: str | bytes = ...) -> Module: ...
     @overload
-    def parse(source: str | bytes, filename: str | bytes = ..., mode: Literal["eval"] = ...) -> Expression: ...
+    def parse(source: str | bytes, filename: str | bytes, mode: Literal["exec"]) -> Module: ...
     @overload
-    def parse(source: str | bytes, filename: str | bytes = ..., mode: Literal["single"] = ...) -> Interactive: ...
+    def parse(source: str | bytes, filename: str | bytes, mode: Literal["eval"]) -> Expression: ...
     @overload
-    def parse(source: str | bytes, filename: str | bytes = ..., mode: str = ...) -> AST: ...
+    def parse(source: str | bytes, filename: str | bytes, mode: Literal["single"]) -> Interactive: ...
+    @overload
+    def parse(source: str | bytes, *, mode: Literal["exec"]) -> Module: ...
+    @overload
+    def parse(source: str | bytes, *, mode: Literal["eval"]) -> Expression: ...
+    @overload
+    def parse(source: str | bytes, *, mode: Literal["single"]) -> Interactive: ...
 
 if sys.version_info >= (3, 9):
     def unparse(ast_obj: AST) -> str: ...


### PR DESCRIPTION
Got a report about incomplete `ast.parse()` stub in PyCharm: [PY-49663](https://youtrack.jetbrains.com/issue/PY-49663).

`ast.parse()` has four modes affecting the return type (see docs for [`ast.parse()`](https://docs.python.org/3/library/ast.html#ast.parse) and [`compile()`](https://docs.python.org/3/library/functions.html#compile))

| mode | return type | note |
|---|---|---|
| `exec` | `Module` |  |
| `eval` | `Expression` |  |
| `func_type` | `FunctionType` | Python >= 3.8 |
| `single` | `Interactive` |  |

The fix looks trivial but `mypy` doesn't like the extra overrides (as was discovered in #3039) and complains about

```
Overloaded function signatures X and Y overlap with incompatible return types
```

I would appreciate any help while I am struggling to make it right. Atm looks like a bug or rather a limitation in `mypy`, or I am not there yet 🤔 