### PR TITLE
fix mypy_primer_comment workflow for more shards

### DIFF
--- a/.github/workflows/mypy_primer_comment.yml
+++ b/.github/workflows/mypy_primer_comment.yml
@@ -46,8 +46,10 @@ jobs:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             const fs = require('fs')
+            const fileNames = fs.readdirSync('.').filter(name => /^diff_[0-9]+\.txt$/.exec(name));
+            console.log(fileNames);
             const data = (
-              ['diff_0.txt', 'diff_1.txt']
+              fileNames
               .map(fileName => fs.readFileSync(fileName, { encoding: 'utf8' }))
               .join('')
               .substr(0, 30000)  // About 300 lines


### PR DESCRIPTION
Tested locally:

```
akuli@akuli-desktop:~$ ls *diff*
diff_0.txt  diff_1.txt  diff_1.txtö  foodiff_1.txt

akuli@akuli-desktop:~$ node
Welcome to Node.js v12.9.1.
Type ".help" for more information.
> fs.readdirSync('.').filter(name => /^diff_[0-9]+\.txt$/.exec(name))
[ 'diff_0.txt', 'diff_1.txt' ]
```