### PR TITLE
Allowlists: delete redundant `collections.abc` entries

### DIFF
--- a/tests/stubtest_allowlists/py310.txt
+++ b/tests/stubtest_allowlists/py310.txt
@@ -3,13 +3,6 @@ _collections_abc.AsyncGenerator.ag_await
 _collections_abc.AsyncGenerator.ag_code
 _collections_abc.AsyncGenerator.ag_frame
 _collections_abc.AsyncGenerator.ag_running
-_collections_abc.AsyncGenerator.asend
-_collections_abc.AsyncGenerator.athrow
-_collections_abc.Container.__contains__
-_collections_abc.Coroutine.send
-_collections_abc.Coroutine.throw
-_collections_abc.Generator.send
-_collections_abc.Generator.throw
 _collections_abc.ItemsView.__reversed__
 _collections_abc.KeysView.__reversed__
 _collections_abc.ValuesView.__reversed__
@@ -37,13 +30,6 @@ asyncio.Future._callbacks  # Usually initialized from c object
 asyncio.futures.Future.__init__  # Usually initialized from c object
 asyncio.futures.Future._callbacks  # Usually initialized from c object
 builtins.dict.get
-collections.abc.AsyncGenerator.ag_await
-collections.abc.AsyncGenerator.ag_code
-collections.abc.AsyncGenerator.ag_frame
-collections.abc.AsyncGenerator.ag_running
-collections.abc.ItemsView.__reversed__
-collections.abc.KeysView.__reversed__
-collections.abc.ValuesView.__reversed__
 contextvars.Context.__init__  # Default C __init__ signature is wrong
 dataclasses.field
 dataclasses.KW_ONLY
@@ -107,13 +93,13 @@ builtins.bytearray.pop
 builtins.bytearray.remove
 collections.OrderedDict.fromkeys
 collections.OrderedDict.setdefault
-collections.abc.AsyncGenerator.asend
-collections.abc.AsyncGenerator.athrow
-collections.abc.Container.__contains__
-collections.abc.Coroutine.send
-collections.abc.Coroutine.throw
-collections.abc.Generator.send
-collections.abc.Generator.throw
+_collections_abc.AsyncGenerator.asend
+_collections_abc.AsyncGenerator.athrow
+_collections_abc.Container.__contains__
+_collections_abc.Coroutine.send
+_collections_abc.Coroutine.throw
+_collections_abc.Generator.send
+_collections_abc.Generator.throw
 contextvars.ContextVar.reset
 contextvars.ContextVar.set
 io.IncrementalNewlineDecoder.setstate

--- a/tests/stubtest_allowlists/py37.txt
+++ b/tests/stubtest_allowlists/py37.txt
@@ -21,10 +21,6 @@ collections.AsyncGenerator.ag_frame
 collections.AsyncGenerator.ag_running
 collections.Callable
 collections.UserString.maketrans
-collections.abc.AsyncGenerator.ag_await
-collections.abc.AsyncGenerator.ag_code
-collections.abc.AsyncGenerator.ag_frame
-collections.abc.AsyncGenerator.ag_running
 contextvars.Context.__init__  # Default C __init__ signature is wrong
 contextvars.ContextVar.get
 dataclasses.field

--- a/tests/stubtest_allowlists/py38.txt
+++ b/tests/stubtest_allowlists/py38.txt
@@ -26,13 +26,6 @@ collections.Callable
 collections.ItemsView.__reversed__
 collections.KeysView.__reversed__
 collections.ValuesView.__reversed__
-collections.abc.AsyncGenerator.ag_await
-collections.abc.AsyncGenerator.ag_code
-collections.abc.AsyncGenerator.ag_frame
-collections.abc.AsyncGenerator.ag_running
-collections.abc.ItemsView.__reversed__
-collections.abc.KeysView.__reversed__
-collections.abc.ValuesView.__reversed__
 contextvars.Context.__init__  # Default C __init__ signature is wrong
 dataclasses.field
 enum.Enum._generate_next_value_

--- a/tests/stubtest_allowlists/py39.txt
+++ b/tests/stubtest_allowlists/py39.txt
@@ -28,13 +28,6 @@ collections.Callable
 collections.ItemsView.__reversed__
 collections.KeysView.__reversed__
 collections.ValuesView.__reversed__
-collections.abc.AsyncGenerator.ag_await
-collections.abc.AsyncGenerator.ag_code
-collections.abc.AsyncGenerator.ag_frame
-collections.abc.AsyncGenerator.ag_running
-collections.abc.ItemsView.__reversed__
-collections.abc.KeysView.__reversed__
-collections.abc.ValuesView.__reversed__
 contextvars.Context.__init__  # Default C __init__ signature is wrong
 dataclasses.field
 enum.Enum._generate_next_value_

--- a/tests/stubtest_allowlists/py3_common.txt
+++ b/tests/stubtest_allowlists/py3_common.txt
@@ -56,15 +56,6 @@ codecs.CodecInfo.streamwriter
 collections.ChainMap.get  # Adding None to the underlying Mapping Union messed up mypy
 collections.ChainMap.fromkeys  # Runtime has *args which can really only be one argument
 collections.UserList.sort  # Runtime has *args but will error if any are supplied
-# Coroutine and Generator properties are added programmatically
-collections.abc.Coroutine.cr_await
-collections.abc.Coroutine.cr_code
-collections.abc.Coroutine.cr_frame
-collections.abc.Coroutine.cr_running
-collections.abc.Generator.gi_code
-collections.abc.Generator.gi_frame
-collections.abc.Generator.gi_running
-collections.abc.Generator.gi_yieldfrom
 configparser.SectionProxy.__getattr__  # SectionProxy can have arbitrary attributes when custom converters are used
 # SectionProxy get functions are set in __init__
 configparser.SectionProxy.getboolean


### PR DESCRIPTION
`py3_common.txt` includes a `collections.abc.*` entry, with the comment:

> Types are re-exported from _collections_abc, so errors should be fixed there

This seems correct, but means that we should be able to delete many `collections.abc` entries as redundant