### PR TITLE
Improve `pydoc` stubs

### DIFF
--- a/stdlib/pydoc.pyi
+++ b/stdlib/pydoc.pyi
@@ -109,7 +109,7 @@ class HTMLDoc(Doc):
         *ignored: Any,
     ) -> str: ...
     def formatvalue(self, object: object) -> str: ...
-    def docroutine(
+    def docroutine(  # type: ignore[override]
         self,
         object: object,
         name: str | None = ...,
@@ -118,15 +118,10 @@ class HTMLDoc(Doc):
         classes: Mapping[str, str] = ...,
         methods: Mapping[str, str] = ...,
         cl: type | None = ...,
-        *ignored: Any,
     ) -> str: ...
-    def docproperty(
-        self, object: object, name: str | None = ..., mod: str | None = ..., cl: Any | None = ..., *ignored: Any
-    ) -> str: ...
+    def docproperty(self, object: object, name: str | None = ..., mod: str | None = ..., cl: Any | None = ...) -> str: ...  # type: ignore[override]
     def docother(self, object: object, name: str | None = ..., mod: Any | None = ..., *ignored: Any) -> str: ...
-    def docdata(
-        self, object: object, name: str | None = ..., mod: Any | None = ..., cl: Any | None = ..., *ignored: Any
-    ) -> str: ...
+    def docdata(self, object: object, name: str | None = ..., mod: Any | None = ..., cl: Any | None = ...) -> str: ...  # type: ignore[override]
     def index(self, dir: str, shadowed: MutableMapping[str, bool] | None = ...) -> str: ...
     def filelink(self, url: str, path: str) -> str: ...
 
@@ -150,19 +145,13 @@ class TextDoc(Doc):
     def formattree(
         self, tree: list[tuple[type, Tuple[type, ...]] | list[Any]], modname: str, parent: type | None = ..., prefix: str = ...
     ) -> str: ...
-    def docmodule(self, object: object, name: str | None = ..., mod: Any | None = ..., *ignored: Any) -> str: ...
+    def docmodule(self, object: object, name: str | None = ..., mod: Any | None = ...) -> str: ...  # type: ignore[override]
     def docclass(self, object: object, name: str | None = ..., mod: str | None = ..., *ignored: Any) -> str: ...
     def formatvalue(self, object: object) -> str: ...
-    def docroutine(
-        self, object: object, name: str | None = ..., mod: str | None = ..., cl: Any | None = ..., *ignored: Any
-    ) -> str: ...
-    def docproperty(
-        self, object: object, name: str | None = ..., mod: Any | None = ..., cl: Any | None = ..., *ignored: Any
-    ) -> str: ...
-    def docdata(
-        self, object: object, name: str | None = ..., mod: str | None = ..., cl: Any | None = ..., *ignored: Any
-    ) -> str: ...
-    def docother(
+    def docroutine(self, object: object, name: str | None = ..., mod: str | None = ..., cl: Any | None = ...) -> str: ...  # type: ignore[override]
+    def docproperty(self, object: object, name: str | None = ..., mod: Any | None = ..., cl: Any | None = ...) -> str: ...  # type: ignore[override]
+    def docdata(self, object: object, name: str | None = ..., mod: str | None = ..., cl: Any | None = ...) -> str: ...  # type: ignore[override]
+    def docother(  # type: ignore[override]
         self,
         object: object,
         name: str | None = ...,
@@ -170,7 +159,6 @@ class TextDoc(Doc):
         parent: str | None = ...,
         maxlen: int | None = ...,
         doc: Any | None = ...,
-        *ignored: Any,
     ) -> str: ...
 
 def pager(text: str) -> None: ...

--- a/tests/stubtest_allowlists/py3_common.txt
+++ b/tests/stubtest_allowlists/py3_common.txt
@@ -160,14 +160,6 @@ optparse.Values.__getattr__  # Some attributes are set in __init__ using setattr
 pickle.Pickler.persistent_id  # C pickler persistent_id is an attribute
 pickle.Unpickler.persistent_load  # C unpickler persistent_load is an attribute
 poplib.POP3_SSL.stls  # bad declaration of inherited function. See poplib.pyi
-pydoc.HTMLDoc.docdata
-pydoc.HTMLDoc.docproperty
-pydoc.HTMLDoc.docroutine
-pydoc.TextDoc.docdata
-pydoc.TextDoc.docmodule
-pydoc.TextDoc.docother
-pydoc.TextDoc.docproperty
-pydoc.TextDoc.docroutine
 select.poll  # Depends on configuration
 selectors.DevpollSelector  # Depends on configuration
 socketserver.BaseServer.fileno  # implemented in derived classes


### PR DESCRIPTION
Several method definitions in the `pydoc` stub differ from how they are at runtime. These methods violate LSP, but we should work around that by adding relevant `# type: ignore` comments rather than having incorrect method signatures in the stub.