### PR TITLE
Adds `EnumType` class to `enum.pyi`

### DIFF
--- a/stdlib/enum.pyi
+++ b/stdlib/enum.pyi
@@ -12,7 +12,7 @@ _S = TypeVar("_S", bound=Type[Enum])
 # such as str as mixins, which due to the handling of ABCs of builtin types, cause
 # spurious inconsistent metaclass structure. See #1595.
 # Structurally: Iterable[T], Reversible[T], Container[T] where T is the enum itself
-class EnumType(ABCMeta):
+class EnumMeta(ABCMeta):
     def __iter__(self: Type[_T]) -> Iterator[_T]: ...
     def __reversed__(self: Type[_T]) -> Iterator[_T]: ...
     def __contains__(self: Type[Any], member: object) -> bool: ...
@@ -24,9 +24,9 @@ class EnumType(ABCMeta):
     _member_map_: dict[str, Enum]  # undocumented
     _value2member_map_: dict[Any, Enum]  # undocumented
 
-EnumMeta = EnumType
+EnumType = EnumMeta
 
-class Enum(metaclass=EnumType):
+class Enum(metaclass=EnumMeta):
     name: str
     value: Any
     _name_: str

--- a/stdlib/enum.pyi
+++ b/stdlib/enum.pyi
@@ -24,8 +24,9 @@ class EnumMeta(ABCMeta):
     _member_map_: dict[str, Enum]  # undocumented
     _value2member_map_: dict[Any, Enum]  # undocumented
 
-# In 3.11 `EnumMeta` metaclass is renamed to `EnumType`, but old name also exists.
-EnumType = EnumMeta
+if sys.version_info >= (3, 11):
+    # In 3.11 `EnumMeta` metaclass is renamed to `EnumType`, but old name also exists.
+    EnumType = EnumMeta
 
 class Enum(metaclass=EnumMeta):
     name: str

--- a/stdlib/enum.pyi
+++ b/stdlib/enum.pyi
@@ -24,7 +24,9 @@ class EnumMeta(ABCMeta):
     _member_map_: dict[str, Enum]  # undocumented
     _value2member_map_: dict[Any, Enum]  # undocumented
 
-EnumType = EnumMeta
+if sys.version_info >= (3, 11):
+    # In 3.11 `EnumMeta` metaclass is renamed to `EnumType`, but old name also exists.
+    EnumType = EnumMeta
 
 class Enum(metaclass=EnumMeta):
     name: str

--- a/stdlib/enum.pyi
+++ b/stdlib/enum.pyi
@@ -12,7 +12,7 @@ _S = TypeVar("_S", bound=Type[Enum])
 # such as str as mixins, which due to the handling of ABCs of builtin types, cause
 # spurious inconsistent metaclass structure. See #1595.
 # Structurally: Iterable[T], Reversible[T], Container[T] where T is the enum itself
-class EnumMeta(ABCMeta):
+class EnumType(ABCMeta):
     def __iter__(self: Type[_T]) -> Iterator[_T]: ...
     def __reversed__(self: Type[_T]) -> Iterator[_T]: ...
     def __contains__(self: Type[Any], member: object) -> bool: ...
@@ -23,6 +23,8 @@ class EnumMeta(ABCMeta):
     _member_names_: list[str]  # undocumented
     _member_map_: dict[str, Enum]  # undocumented
     _value2member_map_: dict[Any, Enum]  # undocumented
+
+EnumMeta = EnumType
 
 class Enum(metaclass=EnumMeta):
     name: str

--- a/stdlib/enum.pyi
+++ b/stdlib/enum.pyi
@@ -26,7 +26,7 @@ class EnumType(ABCMeta):
 
 EnumMeta = EnumType
 
-class Enum(metaclass=EnumMeta):
+class Enum(metaclass=EnumType):
     name: str
     value: Any
     _name_: str

--- a/stdlib/enum.pyi
+++ b/stdlib/enum.pyi
@@ -24,9 +24,8 @@ class EnumMeta(ABCMeta):
     _member_map_: dict[str, Enum]  # undocumented
     _value2member_map_: dict[Any, Enum]  # undocumented
 
-if sys.version_info >= (3, 11):
-    # In 3.11 `EnumMeta` metaclass is renamed to `EnumType`, but old name also exists.
-    EnumType = EnumMeta
+# In 3.11 `EnumMeta` metaclass is renamed to `EnumType`, but old name also exists.
+EnumType = EnumMeta
 
 class Enum(metaclass=EnumMeta):
     name: str


### PR DESCRIPTION
`EnumMeta` is an alias to `EnumType`.
Source: https://github.com/python/cpython/blob/4fe5585240f64c3d14eb635ff82b163f92074b3a/Lib/enum.py#L946