### PR TITLE
Make `name` and `value` read-only for `Enum`s

### DIFF
--- a/stdlib/enum.pyi
+++ b/stdlib/enum.pyi
@@ -92,8 +92,16 @@ if sys.version_info >= (3, 11):
     EnumType = EnumMeta
 
 class Enum(metaclass=EnumMeta):
-    name: str
-    value: Any
+    if sys.version_info >= (3, 11):
+        @property
+        def name(self) -> str: ...
+        @property
+        def value(self) -> Any: ...
+    else:
+        @types.DynamicClassAttribute
+        def name(self) -> str: ...
+        @types.DynamicClassAttribute
+        def value(self) -> Any: ...
     _name_: str
     _value_: Any
     if sys.version_info >= (3, 7):

--- a/tests/stubtest_allowlists/py3_common.txt
+++ b/tests/stubtest_allowlists/py3_common.txt
@@ -83,6 +83,8 @@ distutils.command.bdist_packager  # It exists in docs as package name but not in
 distutils.version.Version._cmp  # class should have declared this
 distutils.version.Version.parse  # class should have declared this
 email.headerregistry.BaseHeader.max_count  # docs say subclasses should have this property
+enum.Enum.name  # A special property that exists at runtime, but stubtest can't detect https://github.com/python/typeshed/pull/6576#issuecomment-992538677
+enum.Enum.value  # A special property that exists at runtime, but stubtest can't detect https://github.com/python/typeshed/pull/6576#issuecomment-992538677
 http.HTTPStatus.description  # set in __new__
 http.HTTPStatus.phrase  # set in __new__
 http.client.HTTPConnection.response_class  # the actual type at runtime is abc.ABCMeta


### PR DESCRIPTION
These attributes are read-only properties at runtime; they should be read-only properties in the stub, also.

The following snippet currently fails at runtime, but passes mypy:

```python
from enum import Enum

class Menu(Enum):
    SPAM = 1
    HAM = 2

Colours = Enum('Colours', 'RED YELLOW BLUE')

Menu.SPAM.name = 'BACON'
Menu.HAM.value = 4
Colours.RED.name = 'PURPLE'
Colours.YELLOW.value = 5
```

With this proposed patch applied, mypy yields the following true-positive errors for the above snippet:

```
test_enum.py:9: error: Property "name" defined in "Enum" is read-only
test_enum.py:10: error: Property "value" defined in "Enum" is read-only
test_enum.py:11: error: Property "name" defined in "Enum" is read-only
test_enum.py:12: error: Property "value" defined in "Enum" is read-only
```