### PR TITLE
Relax the signature of logging.config.loadConfig

### DIFF
--- a/stdlib/logging/config.pyi
+++ b/stdlib/logging/config.pyi
@@ -43,7 +43,12 @@ class _OptionalDictConfigArgs(TypedDict, total=False):
 class _DictConfigArgs(_OptionalDictConfigArgs, TypedDict):
     version: Literal[1]
 
-def dictConfig(config: _DictConfigArgs) -> None: ...
+# Accept dict[str, Any] to avoid false positives if called with a dict
+# type, since dict types are not compatible with TypedDicts.
+#
+# Also accept a TypedDict type, to allow callers to use TypedDict
+# types, and for somewhat stricter type checking of dict literals.
+def dictConfig(config: _DictConfigArgs | dict[str, Any]) -> None: ...
 
 if sys.version_info >= (3, 10):
     def fileConfig(


### PR DESCRIPTION
I did a a cursory investigation using GitHub search and also looked at
a big internal codebase, and a significant fraction of callsites used
a dict type instead of a TypedDict or a dict literal.

It seems that it's a common use case to store the config within an
attribute. For example, something like this:

```
CONFIG = {
   ...
}

...
logging.config.dictConfig(CONFIG)
```

Another use case that was not properly supported is reading the
config from a file, and the config is given `dict[str, Any]` as
the type.

Mypy can still do some type checking of the argument if called
with a dict literal, so I feel this is a reasonable compromise
between type checking strictness and usability.