### PR TITLE
Add abstract methods to BaseTzInfo

### DIFF
--- a/stubs/pytz/@tests/stubtest_allowlist.txt
+++ b/stubs/pytz/@tests/stubtest_allowlist.txt
@@ -1,0 +1,5 @@
+# "Abstract" methods, see the .pyi file for more details.
+pytz.BaseTzInfo.localize
+pytz.BaseTzInfo.normalize
+pytz.tzinfo.BaseTzInfo.localize
+pytz.tzinfo.BaseTzInfo.normalize

--- a/stubs/pytz/pytz/tzinfo.pyi
+++ b/stubs/pytz/pytz/tzinfo.pyi
@@ -1,8 +1,21 @@
 import datetime
+from abc import abstractmethod
 from typing import Any
 
 class BaseTzInfo(datetime.tzinfo):
     zone: str | None  # Actually None but should be set on concrete subclasses
+    # The follow abstract methods don't exist in the implementation, but
+    # are implemented by all sub-classes.
+    @abstractmethod
+    def localize(self, dt: datetime.datetime) -> datetime.datetime: ...
+    @abstractmethod
+    def normalize(self, dt: datetime.datetime) -> datetime.datetime: ...
+    @abstractmethod
+    def tzname(self, dt: datetime.datetime | None) -> str: ...
+    @abstractmethod
+    def utcoffset(self, dt: datetime.datetime | None) -> datetime.timedelta | None: ...
+    @abstractmethod
+    def dst(self, dt: datetime.datetime | None) -> datetime.timedelta | None: ...
 
 class StaticTzInfo(BaseTzInfo):
     def fromutc(self, dt: datetime.datetime) -> datetime.datetime: ...

--- a/stubs/pytz/pytz/tzinfo.pyi
+++ b/stubs/pytz/pytz/tzinfo.pyi
@@ -4,7 +4,7 @@ from typing import Any
 
 class BaseTzInfo(datetime.tzinfo):
     zone: str | None  # Actually None but should be set on concrete subclasses
-    # The follow abstract methods don't exist in the implementation, but
+    # The following abstract methods don't exist in the implementation, but
     # are implemented by all sub-classes.
     @abstractmethod
     def localize(self, dt: datetime.datetime) -> datetime.datetime: ...


### PR DESCRIPTION
While these abstract methods don't exist at runtime, all sub-classes of
BaseTzInfo implement them. It can be useful to annotate variables with
BaseTzInfo and being able to call these methods on it.

Cf #6551