### PR TITLE
Fix unittest.case for Python < 3.9

### DIFF
--- a/stdlib/unittest/case.pyi
+++ b/stdlib/unittest/case.pyi
@@ -43,11 +43,9 @@ else:
     # this is generic over the logging watcher, but in lower versions
     # the watcher is hard-coded.
     _L = TypeVar("_L")
-
     class _LoggingWatcher(NamedTuple):
         records: list[logging.LogRecord]
         output: list[str]
-
     class _AssertLogsContext(_BaseTestCaseContext, Generic[_L]):
         LOGGING_FORMAT: ClassVar[str]
         test_case: TestCase

--- a/stdlib/unittest/case.pyi
+++ b/stdlib/unittest/case.pyi
@@ -10,10 +10,12 @@ from typing import (
     Any,
     AnyStr,
     Callable,
+    ClassVar,
     Container,
     Generic,
     Iterable,
     Mapping,
+    NamedTuple,
     NoReturn,
     Pattern,
     Sequence,
@@ -22,7 +24,6 @@ from typing import (
     TypeVar,
     overload,
 )
-from unittest._log import _AssertLogsContext, _LoggingWatcher
 from warnings import WarningMessage
 
 if sys.version_info >= (3, 9):
@@ -30,6 +31,34 @@ if sys.version_info >= (3, 9):
 
 _E = TypeVar("_E", bound=BaseException)
 _FT = TypeVar("_FT", bound=Callable[..., Any])
+
+class _BaseTestCaseContext:
+    def __init__(self, test_case: TestCase) -> None: ...
+    def _raiseFailure(self, standardMsg: str) -> NoReturn: ...
+
+if sys.version_info >= (3, 9):
+    from unittest._log import _AssertLogsContext, _LoggingWatcher
+else:
+    # Unused dummy for _AssertLogsContext. Starting with Python 3.10,
+    # this is generic over the logging watcher, but in lower versions
+    # the watcher is hard-coded.
+    _L = TypeVar("_L")
+
+    class _LoggingWatcher(NamedTuple):
+        records: list[logging.LogRecord]
+        output: list[str]
+
+    class _AssertLogsContext(_BaseTestCaseContext, Generic[_L]):
+        LOGGING_FORMAT: ClassVar[str]
+        test_case: TestCase
+        logger_name: str
+        level: int
+        msg: None
+        def __init__(self, test_case: TestCase, logger_name: str, level: int) -> None: ...
+        def __enter__(self) -> _LoggingWatcher: ...
+        def __exit__(
+            self, exc_type: Type[BaseException] | None, exc_val: BaseException | None, exc_tb: TracebackType | None
+        ) -> bool | None: ...
 
 if sys.version_info >= (3, 8):
     def addModuleCleanup(__function: Callable[..., Any], *args: Any, **kwargs: Any) -> None: ...

--- a/stdlib/unittest/case.pyi
+++ b/stdlib/unittest/case.pyi
@@ -34,7 +34,6 @@ _FT = TypeVar("_FT", bound=Callable[..., Any])
 
 class _BaseTestCaseContext:
     def __init__(self, test_case: TestCase) -> None: ...
-    def _raiseFailure(self, standardMsg: str) -> NoReturn: ...
 
 if sys.version_info >= (3, 9):
     from unittest._log import _AssertLogsContext, _LoggingWatcher


### PR DESCRIPTION
_LoggingWatcher and _AssertLogsContext were moved to unittest._log in
Python 3.9, but were in unittest.case until 3.8.