### PR TITLE
Use Literal instead of int for logging levels

### DIFF
--- a/stdlib/logging/__init__.pyi
+++ b/stdlib/logging/__init__.pyi
@@ -244,14 +244,14 @@ class Logger(Filterer):
     def hasHandlers(self) -> bool: ...
     def callHandlers(self, record: LogRecord) -> None: ...  # undocumented
 
-CRITICAL: int
-FATAL: int
-ERROR: int
-WARNING: int
-WARN: int
-INFO: int
-DEBUG: int
-NOTSET: int
+CRITICAL: Literal[50]
+FATAL: Literal[50]
+ERROR: Literal[40]
+WARNING: Literal[30]
+WARN: Literal[30]
+INFO: Literal[20]
+DEBUG: Literal[10]
+NOTSET: Literal[0]
 
 class Handler(Filterer):
     level: int  # undocumented


### PR DESCRIPTION
According to PEP 586:

> Literal may also be parameterized by other literal types, or type aliases to other literal types. For example, the following is legal:
> ```py
> ReadOnlyMode         = Literal["r", "r+"]
> WriteAndTruncateMode = Literal["w", "w+", "wt", "w+t"]
> WriteNoTruncateMode  = Literal["r+", "r+t"]
> AppendMode           = Literal["a", "a+", "at", "a+t"]
> 
> AllModes = Literal[ReadOnlyMode, WriteAndTruncateMode,
>                    WriteNoTruncateMode, AppendMode]
> ```
> This feature is again intended to help make using and reusing literal types more ergonomic.

Having the above in mind, I've ran into an issue with MyPy while trying to implement an argument parser with arguments setting different logging levels, and trying to type a variable with `Literal[logging.NOTSET, logging.DEBUG]`. Because they're constants and are typed as `int` here, MyPy has rejected such a type as valid. Specifying them as `Literal` types instead should fix this issue.

I did consider this introducing a potential inconsistency problem, however I'd imagine it'd be quite unlikely for a user to overwrite the default logging level's values, and rather treat them as constants only.