### PR TITLE
Upgrade daily stubtest workflow to stubtest 0.920

### DIFF
--- a/.github/workflows/stubtest.yml
+++ b/.github/workflows/stubtest.yml
@@ -33,9 +33,7 @@ jobs:
       - name: Update pip
         run: python -m pip install -U pip
       - name: Install dependencies
-        # Temporarily hard-code the mypy version used for stubtest
-        # run: pip install $(grep tomli== requirements-tests.txt) (grep mypy== requirements-tests.txt)
-        run: pip install mypy==0.910
+        run: pip install $(grep tomli== requirements-tests.txt) $(grep mypy== requirements-tests.txt)
       - name: Run stubtest
         run: python tests/stubtest_stdlib.py
 


### PR DESCRIPTION
This will most likely cause this workflow to fail, but only during the daily run or when manually triggered. Together with #6613, we can easily work on stubtest failures.