### PR TITLE
Always import Protocol from typing in stubs

### DIFF
--- a/stdlib/@python2/_typeshed/xml.pyi
+++ b/stdlib/@python2/_typeshed/xml.pyi
@@ -1,7 +1,6 @@
 # Stub-only types. This module does not exist at runtime.
 
-from typing import Any
-from typing_extensions import Protocol
+from typing import Any, Protocol
 
 # As defined https://docs.python.org/3/library/xml.dom.html#domimplementation-objects
 class DOMImplementation(Protocol):

--- a/stdlib/@python2/contextlib.pyi
+++ b/stdlib/@python2/contextlib.pyi
@@ -1,6 +1,5 @@
 from types import TracebackType
-from typing import IO, Any, Callable, ContextManager, Iterable, Iterator, Optional, Type, TypeVar
-from typing_extensions import Protocol
+from typing import IO, Any, Callable, ContextManager, Iterable, Iterator, Optional, Protocol, Type, TypeVar
 
 _T = TypeVar("_T")
 _T_co = TypeVar("_T_co", covariant=True)

--- a/stdlib/_typeshed/xml.pyi
+++ b/stdlib/_typeshed/xml.pyi
@@ -1,7 +1,6 @@
 # See the README.md file in this directory for more information.
 
-from typing import Any
-from typing_extensions import Protocol
+from typing import Any, Protocol
 
 # As defined https://docs.python.org/3/library/xml.dom.html#domimplementation-objects
 class DOMImplementation(Protocol):

--- a/stdlib/asyncio/proactor_events.pyi
+++ b/stdlib/asyncio/proactor_events.pyi
@@ -1,7 +1,7 @@
 import sys
 from socket import socket
-from typing import Any, Mapping, Type
-from typing_extensions import Literal, Protocol
+from typing import Any, Mapping, Protocol, Type
+from typing_extensions import Literal
 
 from . import base_events, constants, events, futures, streams, transports
 

--- a/stdlib/contextlib.pyi
+++ b/stdlib/contextlib.pyi
@@ -11,11 +11,12 @@ from typing import (
     Generic,
     Iterator,
     Optional,
+    Protocol,
     Type,
     TypeVar,
     overload,
 )
-from typing_extensions import ParamSpec, Protocol
+from typing_extensions import ParamSpec
 
 AbstractContextManager = ContextManager
 if sys.version_info >= (3, 7):

--- a/stdlib/dataclasses.pyi
+++ b/stdlib/dataclasses.pyi
@@ -1,7 +1,6 @@
 import sys
 import types
-from typing import Any, Callable, Generic, Iterable, Mapping, Tuple, Type, TypeVar, overload
-from typing_extensions import Protocol
+from typing import Any, Callable, Generic, Iterable, Mapping, Protocol, Tuple, Type, TypeVar, overload
 
 if sys.version_info >= (3, 9):
     from types import GenericAlias

--- a/stubs/click-spinner/click_spinner/__init__.pyi
+++ b/stubs/click-spinner/click_spinner/__init__.pyi
@@ -1,7 +1,7 @@
 import threading
 from types import TracebackType
-from typing import Iterator, Type
-from typing_extensions import Literal, Protocol
+from typing import Iterator, Protocol, Type
+from typing_extensions import Literal
 
 __version__: str
 

--- a/stubs/redis/redis/lock.pyi
+++ b/stubs/redis/redis/lock.pyi
@@ -1,6 +1,5 @@
 from types import TracebackType
-from typing import Any, ClassVar, Type
-from typing_extensions import Protocol
+from typing import Any, ClassVar, Protocol, Type
 
 from redis.client import Redis
 

--- a/stubs/toposort/toposort.pyi
+++ b/stubs/toposort/toposort.pyi
@@ -1,6 +1,5 @@
 from _typeshed import SupportsItems
-from typing import Any, Iterable, Iterator, TypeVar
-from typing_extensions import Protocol
+from typing import Any, Iterable, Iterator, Protocol, TypeVar
 
 _KT_co = TypeVar("_KT_co", covariant=True)
 _VT_co = TypeVar("_VT_co", covariant=True)


### PR DESCRIPTION
To be consistent, don't import from typing_extensions.

In #6614, I wasn't sure whether to `from typing import Protocol` or `from typing_extensions import Protocol` because I saw both in the stubs. This changeset replaces every case of the latter with the former.

It's a very minor uniformity thing, but for new contributors to typeshed, every little bit counts! 😄 

I updated library stubs, stdlib stubs, and `@python2` stdlib stubs. If one of these categories should be omitted, or causes some issue, please let me know and I can revert part of the change.