### PR TITLE
Add __call__ to AsyncContextManager on Python 3.10+

### DIFF
--- a/stdlib/typing.pyi
+++ b/stdlib/typing.pyi
@@ -42,6 +42,7 @@ class _SpecialForm:
 _F = TypeVar("_F", bound=Callable[..., Any])
 _P = _ParamSpec("_P")
 _T = TypeVar("_T")
+_C = TypeVar("_C", bound=Callable[..., Coroutine])
 
 def overload(func: _F) -> _F: ...
 
@@ -449,6 +450,8 @@ class AsyncContextManager(Protocol[_T_co]):
     def __aexit__(
         self, __exc_type: Type[BaseException] | None, __exc_value: BaseException | None, __traceback: TracebackType | None
     ) -> Awaitable[bool | None]: ...
+    if sys.version_info >= (3, 10):
+        def __call__(self, func: _C) -> _C: ...
 
 class Mapping(Collection[_KT], Generic[_KT, _VT_co]):
     # TODO: We wish the key type could also be covariant, but that doesn't work,


### PR DESCRIPTION
On Python 3.10+ AsyncContextManager implements __call__
so it can be used as a context manager on async functions.