### PR TITLE
Add comment to LogRecord.message

### DIFF
--- a/stdlib/logging/__init__.pyi
+++ b/stdlib/logging/__init__.pyi
@@ -336,6 +336,8 @@ class LogRecord:
     lineno: int
     module: str
     msecs: float
+    # Only created when logging.Formatter.format is called. See #6132.
+    message: str
     msg: str
     name: str
     pathname: str

--- a/stdlib/logging/__init__.pyi
+++ b/stdlib/logging/__init__.pyi
@@ -336,7 +336,6 @@ class LogRecord:
     lineno: int
     module: str
     msecs: float
-    message: str
     msg: str
     name: str
     pathname: str


### PR DESCRIPTION
Fixes #6132 

This does not exist by default, only when a method on a different object is called. There is no indication that people rely on its existence.