### PR TITLE
Fix return type of ParserBase.error

### DIFF
--- a/stdlib/_markupbase.pyi
+++ b/stdlib/_markupbase.pyi
@@ -1,5 +1,5 @@
 import sys
-from typing import NoReturn
+from typing import Any, NoReturn
 
 class ParserBase:
     def __init__(self) -> None: ...
@@ -12,6 +12,6 @@ class ParserBase:
     def updatepos(self, i: int, j: int) -> int: ...  # undocumented
     if sys.version_info < (3, 10):
         # Removed from ParserBase: https://bugs.python.org/issue31844
-        def error(self, message: str) -> NoReturn: ...  # undocumented
+        def error(self, message: str) -> Any: ...  # undocumented
     lineno: int  # undocumented
     offset: int  # undocumented

--- a/stdlib/_markupbase.pyi
+++ b/stdlib/_markupbase.pyi
@@ -1,5 +1,5 @@
 import sys
-from typing import Any, NoReturn
+from typing import Any
 
 class ParserBase:
     def __init__(self) -> None: ...


### PR DESCRIPTION
As this is an abstract method, NoReturn is problematic as deriving
classes (for example in beautifulsoup4 or fpdf2) have an incompatible
return type.