### PR TITLE
fix typing for psutil sconn

### DIFF
--- a/stubs/psutil/psutil/_common.pyi
+++ b/stubs/psutil/psutil/_common.pyi
@@ -130,8 +130,8 @@ class sconn(NamedTuple):
     fd: int
     family: AddressFamily
     type: SocketKind
-    laddr: str
-    raddr: str
+    laddr: addr | tuple[()]
+    raddr: addr | tuple[()]
     status: str
     pid: int
 


### PR DESCRIPTION
here's some example output:

```python
import psutil

for conn in psutil.net_connections():
    print(conn.raddr, type(conn.raddr))
```

```console
$ python3 t.py 
() <class 'tuple'>
addr(ip='192.168.1.254', port=67) <class 'psutil._common.addr'>
() <class 'tuple'>
() <class 'tuple'>
```