### PR TITLE
remove unused cryptography allowlist entries

### DIFF
--- a/stubs/cryptography/@tests/stubtest_allowlist.txt
+++ b/stubs/cryptography/@tests/stubtest_allowlist.txt
@@ -8,9 +8,6 @@ cryptography.hazmat.backends.interfaces.DHBackend.dh_parameters_supported
 cryptography.hazmat.backends.interfaces.HMACBackend.cmac_algorithm_supported
 cryptography.hazmat.bindings.openssl.binding.Binding.init_static_locks
 cryptography.hazmat.primitives.asymmetric.dh.DHParameterNumbers.__init__
-cryptography.hazmat.primitives.asymmetric.dsa.AsymmetricVerificationContext
-cryptography.hazmat.primitives.asymmetric.ec.AsymmetricVerificationContext
-cryptography.hazmat.primitives.asymmetric.rsa.AsymmetricVerificationContext
 cryptography.hazmat.primitives.ciphers.aead.AESCCM.__init__
 cryptography.hazmat.primitives.cmac.CMAC.__init__
 cryptography.hazmat.primitives.hashes.BLAKE2b.__init__


### PR DESCRIPTION
These caused last night's stubtest run to fail: https://github.com/python/typeshed/runs/4612941002?check_suite_focus=true