### PR TITLE
Fix stubtest for third-party mock package

### DIFF
--- a/pyrightconfig.stricter.json
+++ b/pyrightconfig.stricter.json
@@ -38,6 +38,7 @@
         "stubs/jsonschema",
         "stubs/ldap3",
         "stubs/Markdown",
+        "stubs/mock",
         "stubs/mysqlclient",
         "stubs/oauthlib",
         "stubs/Pillow",

--- a/stubs/mock/@tests/stubtest_allowlist.txt
+++ b/stubs/mock/@tests/stubtest_allowlist.txt
@@ -2,3 +2,12 @@ mock.NonCallableMock.__new__
 mock.patch
 mock.mock.NonCallableMock.__new__
 mock.mock.patch
+
+# Methods with a first argument that's not called "self"
+mock.mock.AsyncMockMixin.assert_any_await
+mock.mock.AsyncMockMixin.assert_awaited
+mock.mock.AsyncMockMixin.assert_awaited_once
+mock.mock.AsyncMockMixin.assert_awaited_once_with
+mock.mock.AsyncMockMixin.assert_awaited_with
+mock.mock.AsyncMockMixin.assert_has_awaits
+mock.mock.AsyncMockMixin.assert_not_awaited

--- a/stubs/mock/mock/mock.pyi
+++ b/stubs/mock/mock/mock.pyi
@@ -1,12 +1,12 @@
 from collections.abc import Callable, Mapping, Sequence
-from typing import Any, Generic, List, Tuple, Type, TypeVar, overload
+from typing import Any, Generic, Type, TypeVar, overload
 
 _F = TypeVar("_F", bound=Callable[..., Any])
 _T = TypeVar("_T")
 _TT = TypeVar("_TT", bound=Type[Any])
 _R = TypeVar("_R")
 
-__all__ = [
+__all__ = (
     "Mock",
     "MagicMock",
     "patch",
@@ -22,25 +22,15 @@ __all__ = [
     "mock_open",
     "PropertyMock",
     "seal",
-]
+)
 __version__: str
 
 FILTER_DIR: Any
 
-class _slotted: ...
-
-class _SentinelObject:
-    name: Any
-    def __init__(self, name: Any) -> None: ...
-
-class _Sentinel:
-    def __init__(self) -> None: ...
-    def __getattr__(self, name: str) -> Any: ...
-
 sentinel: Any
 DEFAULT: Any
 
-class _Call(Tuple[Any, ...]):
+class _Call(tuple[Any, ...]):
     def __new__(
         cls, value: Any = ..., name: Any | None = ..., parent: Any | None = ..., two: bool = ..., from_kall: bool = ...
     ) -> Any: ...
@@ -53,21 +43,17 @@ class _Call(Tuple[Any, ...]):
     def __eq__(self, other: Any) -> bool: ...
     __ne__: Any
     def __call__(self, *args: Any, **kwargs: Any) -> _Call: ...
-    def __getattr__(self, attr: Any) -> Any: ...
-    def count(self, *args: Any, **kwargs: Any) -> Any: ...
-    def index(self, *args: Any, **kwargs: Any) -> Any: ...
-    def call_list(self) -> Any: ...
+    def __getattr__(self, attr: str) -> Any: ...
+    @property
+    def args(self): ...
+    @property
+    def kwargs(self): ...
+    def call_list(self) -> _CallList: ...
 
 call: _Call
 
-class _CallList(List[_Call]):
+class _CallList(list[_Call]):
     def __contains__(self, value: Any) -> bool: ...
-
-class _MockIter:
-    obj: Any
-    def __init__(self, obj: Any) -> None: ...
-    def __iter__(self) -> Any: ...
-    def __next__(self) -> Any: ...
 
 class Base:
     def __init__(self, *args: Any, **kwargs: Any) -> None: ...
@@ -113,7 +99,7 @@ class NonCallableMock(Base, Any):
     call_args_list: _CallList
     mock_calls: _CallList
     def _format_mock_call_signature(self, args: Any, kwargs: Any) -> str: ...
-    def _call_matcher(self, _call: Tuple[_Call, ...]) -> _Call: ...
+    def _call_matcher(self, _call: tuple[_Call, ...]) -> _Call: ...
     def _get_child_mock(self, **kw: Any) -> NonCallableMock: ...
 
 class CallableMixin(Base):
@@ -149,23 +135,6 @@ class _patch(Generic[_T]):
     autospec: Any
     kwargs: Mapping[str, Any]
     additional_patchers: Any
-    @overload
-    def __init__(
-        self: _patch[MagicMock | AsyncMock],
-        getter: Callable[[], Any],
-        attribute: str,
-        *,
-        spec: Any | None,
-        create: bool,
-        spec_set: Any | None,
-        autospec: Any | None,
-        new_callable: Any | None,
-        kwargs: Mapping[str, Any],
-    ) -> None: ...
-    # This overload also covers the case, where new==DEFAULT. In this case, self is _patch[Any].
-    # Ideally we'd be able to add an overload for it so that self is _patch[MagicMock],
-    # but that's impossible with the current type system.
-    @overload
     def __init__(
         self: _patch[_T],
         getter: Callable[[], Any],
@@ -284,7 +253,6 @@ class MagicMock(MagicMixin, Mock):
 
 class AsyncMockMixin(Base):
     def __init__(self, *args: Any, **kwargs: Any) -> None: ...
-    async def _execute_mock_call(self, *args: Any, **kwargs: Any) -> Any: ...
     def assert_awaited(self) -> None: ...
     def assert_awaited_once(self) -> None: ...
     def assert_awaited_with(self, *args: Any, **kwargs: Any) -> None: ...
@@ -302,11 +270,10 @@ class AsyncMagicMixin(MagicMixin):
 
 class AsyncMock(AsyncMockMixin, AsyncMagicMixin, Mock): ...
 
-class MagicProxy:
-    name: Any
+class MagicProxy(Base):
+    name: str
     parent: Any
-    def __init__(self, name: Any, parent: Any) -> None: ...
-    def __call__(self, *args: Any, **kwargs: Any) -> Any: ...
+    def __init__(self, name: str, parent) -> None: ...
     def create_mock(self) -> Any: ...
     def __get__(self, obj: Any, _type: Any | None = ...) -> Any: ...
 


### PR DESCRIPTION
Removed a few "Any" annotations that could be typed. (There are more.) Add
package to pyrightconfig.stricter.json ignore list.

Also removed a few unused private classes and methods. They can be re-added
if a user reports them missing.