### PR TITLE
python-datetutil: update WEEKDAYS and MONTHS attributes

### DIFF
--- a/stubs/python-dateutil/dateutil/parser/__init__.pyi
+++ b/stubs/python-dateutil/dateutil/parser/__init__.pyi
@@ -7,8 +7,8 @@ _FileOrStr = Union[bytes, Text, IO[str], IO[Any]]
 
 class parserinfo(object):
     JUMP: list[str]
-    WEEKDAYS: list[tuple[str, str]]
-    MONTHS: list[tuple[str, str]]
+    WEEKDAYS: list[tuple[str, ...]]
+    MONTHS: list[tuple[str, ...]]
     HMS: list[tuple[str, str, str]]
     AMPM: list[tuple[str, str]]
     UTCZONE: list[str]


### PR DESCRIPTION
Fixes #6682.
As mentioned in the issue the `MONTHS` attribute on `parserinfo` can have three variations on the name. Likewise `WEEKDAYS` has TODO comments indicating that additional variations will be added in the future.

Updated both to `list[tuple[str, ...]]`