### PR TITLE
Set `IO_REPARSE_TAG_*` variables in `stat.pyi`

### DIFF
--- a/stdlib/stat.pyi
+++ b/stdlib/stat.pyi
@@ -95,6 +95,6 @@ FILE_ATTRIBUTE_TEMPORARY: Literal[256]
 FILE_ATTRIBUTE_VIRTUAL: Literal[65536]
 
 if sys.platform == "win32" and sys.version_info >= (3, 8):
-    IO_REPARSE_TAG_SYMLINK: int
-    IO_REPARSE_TAG_MOUNT_POINT: int
-    IO_REPARSE_TAG_APPEXECLINK: int
+    IO_REPARSE_TAG_SYMLINK: Literal[1]
+    IO_REPARSE_TAG_MOUNT_POINT: Literal[2]
+    IO_REPARSE_TAG_APPEXECLINK: Literal[3]


### PR DESCRIPTION
First, I want to test that windows constants also fail the CI.
Then, I will add correct ones.