### PR TITLE
stubtest_third_party: do not install apt packages in the same script

### DIFF
--- a/.github/workflows/stubtest.yml
+++ b/.github/workflows/stubtest.yml
@@ -53,7 +53,6 @@ jobs:
       - name: Install dependencies
         run: pip install $(grep tomli== requirements-tests.txt)
       - name: Install apt packages
-        run: |
-          sudo apt install -y $(python tests/get_apt_packages.py)
+        run: sudo apt install -y $(python tests/get_apt_packages.py)
       - name: Run stubtest
         run: python tests/stubtest_third_party.py --num-shards 4 --shard-index ${{ matrix.shard-index }}

--- a/.github/workflows/stubtest.yml
+++ b/.github/workflows/stubtest.yml
@@ -52,5 +52,8 @@ jobs:
           python-version: 3.9
       - name: Install dependencies
         run: pip install $(grep tomli== requirements-tests.txt)
+      - name: Install apt packages
+        run: |
+          sudo apt install -y $(python tests/get_apt_packages.py)
       - name: Run stubtest
-        run: python tests/stubtest_third_party.py --num-shards 4 --shard-index ${{ matrix.shard-index }} --sudo-install-apt
+        run: python tests/stubtest_third_party.py --num-shards 4 --shard-index ${{ matrix.shard-index }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -131,7 +131,12 @@ jobs:
           STUBS=$(git diff --name-only origin/${{ github.base_ref }} HEAD | egrep ^stubs/ | cut -d "/" -f 2 | sort -u | (while read stub; do [ -d stubs/$stub ] && echo $stub || true; done))
           if test -n "$STUBS"; then
             echo "Testing $STUBS..."
-            python tests/stubtest_third_party.py --sudo-install-apt $STUBS
+            APT_PACKAGES=$(python tests/get_apt_packages.py $STUBS)
+            if test -n "$APT_PACKAGES"; then
+              echo "Installing apt packages: $APT_PACKAGES"
+              sudo apt install -y $APT_PACKAGES
+            fi
+            python tests/stubtest_third_party.py $STUBS
           else
             echo "Nothing to test"
           fi

--- a/tests/get_apt_packages.py
+++ b/tests/get_apt_packages.py
@@ -4,7 +4,6 @@ import sys
 
 import tomli
 
-
 distributions = sys.argv[1:]
 if not distributions:
     distributions = os.listdir("stubs")

--- a/tests/get_apt_packages.py
+++ b/tests/get_apt_packages.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+import os
+import sys
+
+import tomli
+
+
+distributions = sys.argv[1:]
+if not distributions:
+    distributions = os.listdir("stubs")
+
+for distribution in distributions:
+    with open(f"stubs/{distribution}/METADATA.toml", "rb") as file:
+        for apt_package in tomli.load(file).get("stubtest_apt_dependencies", []):
+            print(apt_package)

--- a/tests/stubtest_third_party.py
+++ b/tests/stubtest_third_party.py
@@ -11,7 +11,7 @@ import tempfile
 import venv
 from glob import glob
 from pathlib import Path
-from typing import Any, NoReturn
+from typing import NoReturn
 
 import tomli
 
@@ -22,16 +22,13 @@ def get_mypy_req():
         return next(line.strip() for line in f if "mypy" in line)
 
 
-def run_stubtest(dist: Path, *, install_apt: bool = False) -> bool:
+def run_stubtest(dist: Path) -> bool:
     with open(dist / "METADATA.toml") as f:
         metadata = dict(tomli.loads(f.read()))
 
     if not has_py3_stubs(dist):
         print(f"Skipping stubtest for {dist.name}\n\n")
         return True
-
-    if not install_apt_packages(dist, metadata, install_apt):
-        return False
 
     with tempfile.TemporaryDirectory() as tmp:
         venv_dir = Path(tmp)
@@ -117,31 +114,10 @@ def has_py3_stubs(dist: Path) -> bool:
     return len(glob(f"{dist}/*.pyi")) > 0 or len(glob(f"{dist}/[!@]*/__init__.pyi")) > 0
 
 
-def install_apt_packages(dist: Path, metadata: dict[str, Any], install: bool) -> bool:
-    apt_packages = metadata.get("stubtest_apt_dependencies", [])
-    if not apt_packages:
-        return True
-    if not install:
-        print(f"Ensure the following apt packages are installed for {dist.name}: {', '.join(apt_packages)}", file=sys.stderr)
-        return True
-    try:
-        apt_cmd = ["sudo", "apt", "install", "-y", *apt_packages]
-        print(" ".join(apt_cmd), file=sys.stderr)
-        subprocess.run(apt_cmd, check=True, capture_output=True)
-    except subprocess.CalledProcessError as e:
-        print(f"Failed to install APT packages for {dist.name}: {', '.join(apt_packages)}", file=sys.stderr)
-        print(e.stdout.decode(), file=sys.stderr)
-        print(e.stderr.decode(), file=sys.stderr)
-        return False
-    else:
-        return True
-
-
 def main() -> NoReturn:
     parser = argparse.ArgumentParser()
     parser.add_argument("--num-shards", type=int, default=1)
     parser.add_argument("--shard-index", type=int, default=0)
-    parser.add_argument("--sudo-install-apt", action="store_true")
     parser.add_argument("dists", metavar="DISTRIBUTION", type=str, nargs=argparse.ZERO_OR_MORE)
     args = parser.parse_args()
 
@@ -155,7 +131,7 @@ def main() -> NoReturn:
     for i, dist in enumerate(dists):
         if i % args.num_shards != args.shard_index:
             continue
-        if not run_stubtest(dist, install_apt=args.sudo_install_apt):
+        if not run_stubtest(dist):
             result = 1
     sys.exit(result)
 


### PR DESCRIPTION
Having a script do `sudo apt -y install foo` felt weird to me, even with a command-line option named `--sudo-install-apt`. This PR introduces a separate script that prints the names of packages to install instead. The scripts no longer need root privileges.