### PR TITLE
Add a generic overload for bz2.open as exists in gzip.open and lzma.open

### DIFF
--- a/stdlib/bz2.pyi
+++ b/stdlib/bz2.pyi
@@ -80,6 +80,16 @@ def open(
     errors: str | None = ...,
     newline: str | None = ...,
 ) -> TextIO: ...
+@overload
+def open(
+    filename: StrOrBytesPath | _ReadableFileobj | _WritableFileobj,
+    mode: str,
+    compresslevel: int = ...,
+    encoding: str | None = ...,
+    errors: str | None = ...,
+    newline: str | None = ...,
+) -> BZ2File | TextIO: ...
+
 
 class BZ2File(BaseStream, IO[bytes]):
     def __enter__(self: Self) -> Self: ...

--- a/stdlib/bz2.pyi
+++ b/stdlib/bz2.pyi
@@ -90,7 +90,6 @@ def open(
     newline: str | None = ...,
 ) -> BZ2File | TextIO: ...
 
-
 class BZ2File(BaseStream, IO[bytes]):
     def __enter__(self: Self) -> Self: ...
     if sys.version_info >= (3, 9):


### PR DESCRIPTION
This is consistent with the provided options for `gzip.open` and `lzma.open`. Gzip and lzma both provide the `Literal['rb']` etc. mode options as well as an overload that accepts `str` for mode. `bz2.open` does not have this. This PR makes the code consistent by also adding such an overload to the `bz2.open` method.