### PR TITLE
fix(stdlib/types): FrameType.f_lineno can be None

### DIFF
--- a/stdlib/@python2/types.pyi
+++ b/stdlib/@python2/types.pyi
@@ -148,7 +148,7 @@ class FrameType:
     f_exc_traceback: None
     f_globals: Dict[str, Any]
     f_lasti: int
-    f_lineno: int
+    f_lineno: int | None
     f_locals: Dict[str, Any]
     f_restricted: bool
     f_trace: Callable[[], None]

--- a/stdlib/types.pyi
+++ b/stdlib/types.pyi
@@ -353,7 +353,7 @@ class FrameType:
     f_code: CodeType
     f_globals: dict[str, Any]
     f_lasti: int
-    f_lineno: int
+    f_lineno: int | None
     f_locals: dict[str, Any]
     f_trace: Callable[[FrameType, str, Any], Any] | None
     if sys.version_info >= (3, 7):


### PR DESCRIPTION
In very rare (error?) cases, f_lineno can actually be None.