### PR TITLE
DO-NOT-MERGE: Testing incorrect platform spec

### DIFF
--- a/stdlib/winreg.pyi
+++ b/stdlib/winreg.pyi
@@ -4,7 +4,7 @@ from types import TracebackType
 from typing import Any, Type, Union
 from typing_extensions import Literal, final
 
-if sys.platform == "win32":
+if sys.platform == "win23":
     _KeyType = Union[HKEYType, int]
     def CloseKey(__hkey: _KeyType) -> None: ...
     def ConnectRegistry(__computer_name: str | None, __key: _KeyType) -> HKEYType: ...


### PR DESCRIPTION
I am wondering what will happen if someone makes a typo in a `sys.platform` spec.