### PR TITLE
re.Match.lastgroup is str rather than AnyStr

### DIFF
--- a/stdlib/typing.pyi
+++ b/stdlib/typing.pyi
@@ -574,7 +574,7 @@ class Match(Generic[AnyStr]):
     pos: int
     endpos: int
     lastindex: int | None
-    lastgroup: AnyStr | None
+    lastgroup: str | None
     string: AnyStr
 
     # The regular expression object whose match() or search() method produced


### PR DESCRIPTION
Another tweak to `re` that I spotted when working through the `regex` stubs.

`re.Match.lastgroup` is derived from `indexgroup` (inverse of `groupindex`) and therefore must be a str:
https://github.com/python/cpython/blob/0b58bac3e7877d722bdbd3c38913dba2cb212f13/Modules/_sre.c#L2375-L2388

Group names are always stored as strings, even if the pattern and string are bytes:
```
>>> import re
>>> re.compile(b"(?P<letter>\w)").match(b"a1").lastgroup
'letter'
```