### PR TITLE
Python2: fix groupindex and lastgroup for re

### DIFF
--- a/stdlib/@python2/typing.pyi
+++ b/stdlib/@python2/typing.pyi
@@ -395,8 +395,7 @@ class Match(Generic[AnyStr]):
     # string.
     re: Pattern[Any]
     # Can be None if there are no groups or if the last group was unnamed;
-    # otherwise matches the type of the pattern.
-    lastgroup: Any | None
+    lastgroup: str | None
     def expand(self, template: str | Text) -> Any: ...
     @overload
     def group(self, group1: int = ...) -> AnyStr: ...
@@ -422,7 +421,7 @@ _AnyStr2 = TypeVar("_AnyStr2", bytes, Text)
 
 class Pattern(Generic[AnyStr]):
     flags: int
-    groupindex: Dict[AnyStr, int]
+    groupindex: Mapping[str, int]
     groups: int
     pattern: AnyStr
     def search(self, string: _AnyStr2, pos: int = ..., endpos: int = ...) -> Match[_AnyStr2] | None: ...


### PR DESCRIPTION
Follow up PR to #6776.

I checked these types for Python 2.7 as well and observed the same behaviour:
```
>>> import re
>>> re.compile(r"(?P<test>\w)").groupindex
{'test': 1}
>>> re.compile(b"(?P<test>\w)").groupindex
{'test': 1}
>>> re.compile(r"(?P<test>\w)").search("a1").lastgroup
'test'
>>> re.compile(b"(?P<test>\w)").search(b"a1").lastgroup
'test'
```

N.B. I also checked if #6763 also applies to Python 2 and observed that Nones are not produced so the current Python 2 typing for `re.Pattern.split()` is correct.