### PR TITLE
Improved type hints for redis scan and zset methods

### DIFF
--- a/stubs/redis/redis/client.pyi
+++ b/stubs/redis/redis/client.pyi
@@ -544,13 +544,15 @@ class Pipeline(Redis[_StrType], Generic[_StrType]):
         groups: bool = ...,
     ) -> Pipeline[_StrType]: ...
     def scan(self, cursor: int = ..., match: _Key | None = ..., count: int | None = ..., _type: str | None = ...) -> Pipeline[_StrType]: ...  # type: ignore[override]
-    def scan_iter(self, match: str | None = ..., count: int | None = ..., _type: str | None = ...) -> Iterator[Any]: ...  # type: ignore[override]
-    def sscan(self, name: _Key, cursor: int = ..., match: str | None = ..., count: int | None = ...) -> Pipeline[_StrType]: ...  # type: ignore[override]
-    def sscan_iter(self, name: _Key, match: str | None = ..., count: int | None = ...) -> Iterator[Any]: ...
-    def hscan(self, name: _Key, cursor: int = ..., match: str | None = ..., count: int | None = ...) -> Pipeline[_StrType]: ...  # type: ignore[override]
-    def hscan_iter(self, name, match=..., count=...) -> Iterator[Any]: ...
-    def zscan(self, name, cursor=..., match=..., count=..., score_cast_func=...) -> Pipeline[_StrType]: ...  # type: ignore[override]
-    def zscan_iter(self, name, match=..., count=..., score_cast_func=...) -> Iterator[Any]: ...
+    def scan_iter(self, match: _Key | None = ..., count: int | None = ..., _type: str | None = ...) -> Iterator[Any]: ...  # type: ignore[override]
+    def sscan(self, name: _Key, cursor: int = ..., match: _Key | None = ..., count: int | None = ...) -> Pipeline[_StrType]: ...  # type: ignore[override]
+    def sscan_iter(self, name: _Key, match: _Key | None = ..., count: int | None = ...) -> Iterator[Any]: ...
+    def hscan(self, name: _Key, cursor: int = ..., match: _Key | None = ..., count: int | None = ...) -> Pipeline[_StrType]: ...  # type: ignore[override]
+    def hscan_iter(self, name, match: _Key | None = ..., count: int | None = ...) -> Iterator[Any]: ...
+    def zscan(self, name: _Key, cursor: int = ..., match: _Key | None = ..., count: int | None = ..., score_cast_func: Callable[[_StrType], _ScoreCastFuncReturn] = ...) -> Pipeline[_StrType]: ...  # type: ignore[override]
+    def zscan_iter(
+        self, name: _Key, match: _Key | None = ..., count: int | None = ..., score_cast_func: Callable[[_StrType], Any] = ...
+    ) -> Iterator[Any]: ...
     def sadd(self, name: _Key, *values: _Value) -> Pipeline[_StrType]: ...  # type: ignore[override]
     def scard(self, name: _Key) -> Pipeline[_StrType]: ...  # type: ignore[override]
     def sdiff(self, keys: _Key | Iterable[_Key], *args: _Key) -> Pipeline[_StrType]: ...  # type: ignore[override]
@@ -613,7 +615,7 @@ class Pipeline(Redis[_StrType], Generic[_StrType]):
         end: int,
         desc: bool = ...,
         withscores: bool = ...,
-        score_cast_func: Callable[[Any], Any] = ...,
+        score_cast_func: Callable[[_StrType], Any] = ...,
         byscore: bool = ...,
         bylex: bool = ...,
         offset: int | None = ...,
@@ -628,7 +630,7 @@ class Pipeline(Redis[_StrType], Generic[_StrType]):
         start: int | None = ...,
         num: int | None = ...,
         withscores: bool = ...,
-        score_cast_func: Callable[[Any], Any] = ...,
+        score_cast_func: Callable[[_StrType], Any] = ...,
     ) -> Pipeline[_StrType]: ...
     def zrank(self, name: _Key, value: _Value) -> Pipeline[_StrType]: ...  # type: ignore[override]
     def zrem(self, name: _Key, *values: _Value) -> Pipeline[_StrType]: ...  # type: ignore[override]
@@ -636,7 +638,7 @@ class Pipeline(Redis[_StrType], Generic[_StrType]):
     def zremrangebyrank(self, name: _Key, min: _Value, max: _Value) -> Pipeline[_StrType]: ...  # type: ignore[override]
     def zremrangebyscore(self, name: _Key, min: _Value, max: _Value) -> Pipeline[_StrType]: ...  # type: ignore[override]
     def zrevrange(  # type: ignore[override]
-        self, name: _Key, start: int, end: int, withscores: bool = ..., score_cast_func: Callable[[Any], Any] = ...
+        self, name: _Key, start: int, end: int, withscores: bool = ..., score_cast_func: Callable[[_StrType], Any] = ...
     ) -> Pipeline[_StrType]: ...
     def zrevrangebyscore(  # type: ignore[override]
         self,
@@ -646,7 +648,7 @@ class Pipeline(Redis[_StrType], Generic[_StrType]):
         start: int | None = ...,
         num: int | None = ...,
         withscores: bool = ...,
-        score_cast_func: Callable[[Any], Any] = ...,
+        score_cast_func: Callable[[_StrType], Any] = ...,
     ) -> Pipeline[_StrType]: ...
     def zrevrangebylex(  # type: ignore[override]
         self, name: _Key, max: _Value, min: _Value, start: int | None = ..., num: int | None = ...

--- a/stubs/redis/redis/commands/core.pyi
+++ b/stubs/redis/redis/commands/core.pyi
@@ -298,18 +298,33 @@ class ScanCommands(Generic[_StrType]):
         self, cursor: int = ..., match: _Key | None = ..., count: int | None = ..., _type: str | None = ..., **kwargs
     ) -> tuple[int, list[_StrType]]: ...
     def scan_iter(
-        self, match: str | None = ..., count: int | None = ..., _type: str | None = ..., **kwargs
+        self, match: _Key | None = ..., count: int | None = ..., _type: str | None = ..., **kwargs
     ) -> Iterator[_StrType]: ...
     def sscan(
-        self, name: _Key, cursor: int = ..., match: str | None = ..., count: int | None = ...
+        self, name: _Key, cursor: int = ..., match: _Key | None = ..., count: int | None = ...
     ) -> tuple[int, list[_StrType]]: ...
-    def sscan_iter(self, name: _Key, match: str | None = ..., count: int | None = ...): ...
+    def sscan_iter(self, name: _Key, match: _Key | None = ..., count: int | None = ...) -> Iterator[_StrType]: ...
     def hscan(
-        self, name: _Key, cursor: int = ..., match: str | None = ..., count: int | None = ...
+        self, name: _Key, cursor: int = ..., match: _Key | None = ..., count: int | None = ...
     ) -> tuple[int, dict[_StrType, _StrType]]: ...
-    def hscan_iter(self, name: _Key, match: str | None = ..., count: int | None = ...): ...
-    def zscan(self, name, cursor: int = ..., match: Any | None = ..., count: Any | None = ..., score_cast_func=...): ...
-    def zscan_iter(self, name, match: Any | None = ..., count: Any | None = ..., score_cast_func=...): ...
+    def hscan_iter(
+        self, name: _Key, match: _Key | None = ..., count: int | None = ...
+    ) -> Iterator[tuple[_StrType, _StrType]]: ...
+    def zscan(
+        self,
+        name: _Key,
+        cursor: int = ...,
+        match: _Key | None = ...,
+        count: int | None = ...,
+        score_cast_func: Callable[[_StrType], _ScoreCastFuncReturn] = ...,
+    ) -> tuple[int, list[tuple[_StrType, _ScoreCastFuncReturn]]]: ...
+    def zscan_iter(
+        self,
+        name: _Key,
+        match: _Key | None = ...,
+        count: int | None = ...,
+        score_cast_func: Callable[[_StrType], _ScoreCastFuncReturn] = ...,
+    ) -> Iterator[tuple[_StrType, _ScoreCastFuncReturn]]: ...
 
 class SetCommands(Generic[_StrType]):
     def sadd(self, name: _Key, *values: _Value) -> int: ...
@@ -423,7 +438,7 @@ class SortedSetCommands(Generic[_StrType]):
         end: int,
         desc: bool,
         withscores: Literal[True],
-        score_cast_func: Callable[[float], _ScoreCastFuncReturn] = ...,
+        score_cast_func: Callable[[_StrType], _ScoreCastFuncReturn] = ...,
         byscore: bool = ...,
         bylex: bool = ...,
         offset: int | None = ...,
@@ -438,7 +453,7 @@ class SortedSetCommands(Generic[_StrType]):
         desc: bool = ...,
         *,
         withscores: Literal[True],
-        score_cast_func: Callable[[float], _ScoreCastFuncReturn] = ...,
+        score_cast_func: Callable[[_StrType], _ScoreCastFuncReturn] = ...,
         byscore: bool = ...,
         bylex: bool = ...,
         offset: int | None = ...,
@@ -452,7 +467,7 @@ class SortedSetCommands(Generic[_StrType]):
         end: int,
         desc: bool = ...,
         withscores: bool = ...,
-        score_cast_func: Callable[[Any], Any] = ...,
+        score_cast_func: Callable[[_StrType], Any] = ...,
         byscore: bool = ...,
         bylex: bool = ...,
         offset: int | None = ...,
@@ -465,7 +480,7 @@ class SortedSetCommands(Generic[_StrType]):
         start: int,
         end: int,
         withscores: Literal[True],
-        score_cast_func: Callable[[float], _ScoreCastFuncReturn] = ...,
+        score_cast_func: Callable[[_StrType], _ScoreCastFuncReturn] = ...,
     ) -> list[tuple[_StrType, _ScoreCastFuncReturn]]: ...
     @overload
     def zrevrange(
@@ -499,7 +514,7 @@ class SortedSetCommands(Generic[_StrType]):
         num: int | None = ...,
         *,
         withscores: Literal[True],
-        score_cast_func: Callable[[float], _ScoreCastFuncReturn] = ...,
+        score_cast_func: Callable[[_StrType], _ScoreCastFuncReturn] = ...,
     ) -> list[tuple[_StrType, _ScoreCastFuncReturn]]: ...
     @overload
     def zrangebyscore(
@@ -510,7 +525,7 @@ class SortedSetCommands(Generic[_StrType]):
         start: int | None = ...,
         num: int | None = ...,
         withscores: bool = ...,
-        score_cast_func: Callable[[Any], Any] = ...,
+        score_cast_func: Callable[[_StrType], Any] = ...,
     ) -> list[_StrType]: ...
     @overload
     def zrevrangebyscore(
@@ -522,7 +537,7 @@ class SortedSetCommands(Generic[_StrType]):
         num: int | None = ...,
         *,
         withscores: Literal[True],
-        score_cast_func: Callable[[float], _ScoreCastFuncReturn] = ...,
+        score_cast_func: Callable[[_StrType], _ScoreCastFuncReturn] = ...,
     ) -> list[tuple[_StrType, _ScoreCastFuncReturn]]: ...
     @overload
     def zrevrangebyscore(
@@ -533,7 +548,7 @@ class SortedSetCommands(Generic[_StrType]):
         start: int | None = ...,
         num: int | None = ...,
         withscores: bool = ...,
-        score_cast_func: Callable[[Any], Any] = ...,
+        score_cast_func: Callable[[_StrType], Any] = ...,
     ) -> list[_StrType]: ...
     def zrank(self, name: _Key, value: _Value) -> int | None: ...
     def zrem(self, name: _Key, *values: _Value) -> int: ...


### PR DESCRIPTION
* The ``score_cast_func`` parameter accepted by various ZSET methods is a method which will be passed a str or bytes parameter, rather than a float (the default value of the parameter is the float class constructor)

* ``scan_iter`` and related methods take a ``match`` parameter which was declared as str, but can actually be either bytes or str (the ``_Key`` type)

* Added return type annotations for ``sscan_iter``, ``hscan_iter``, ``zscan`` and ``zscan_iter`` which were missing