### PR TITLE
Remove `__slots__` from `builtins.object`

### DIFF
--- a/stdlib/@python2/__builtin__.pyi
+++ b/stdlib/@python2/__builtin__.pyi
@@ -66,7 +66,6 @@ _TBE = TypeVar("_TBE", bound="BaseException")
 class object:
     __doc__: str | None
     __dict__: Dict[str, Any]
-    __slots__: Text | Iterable[Text]
     __module__: str
     @property
     def __class__(self: _T) -> Type[_T]: ...

--- a/stdlib/@python2/builtins.pyi
+++ b/stdlib/@python2/builtins.pyi
@@ -66,7 +66,6 @@ _TBE = TypeVar("_TBE", bound="BaseException")
 class object:
     __doc__: str | None
     __dict__: Dict[str, Any]
-    __slots__: Text | Iterable[Text]
     __module__: str
     @property
     def __class__(self: _T) -> Type[_T]: ...

--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -85,7 +85,6 @@ class _SupportsAiter(Protocol[_T_co]):
 class object:
     __doc__: str | None
     __dict__: dict[str, Any]
-    __slots__: str | Iterable[str]
     __module__: str
     __annotations__: dict[str, Any]
     @property


### PR DESCRIPTION
I invite everyone to discuss this problem 🙂 

Technically, `object` does not have `__slots__` defined:

```python
>>> object.__slots__
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: type object 'object' has no attribute '__slots__'. Did you mean: '__class__'?
>>> object().__slots__
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'object' object has no attribute '__slots__'. Did you mean: '__class__'?
```

And its subclasses do not have `__slots__`:

```python
>>> class Bar(object):
...     ...
... 
>>> Bar.__slots__
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: type object 'Bar' has no attribute '__slots__'. Did you mean: '__class__'?
>>> Bar().__slots__
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'Bar' object has no attribute '__slots__'. Did you mean: '__class__'?
```

We need to explicitly specify that some type has `__slots__`.

Maybe it is better to special-case `__slots__` in type-checker? It is not hard to check that class-level field named `__slots__` is `str | Iterable[str]` 🤔 

Related https://github.com/python/mypy/issues/11891 and https://github.com/python/mypy/pull/11885