### PR TITLE
builtins.function type alias

### DIFF
--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -23,7 +23,7 @@ from _typeshed import (
     SupportsWrite,
 )
 from io import BufferedRandom, BufferedReader, BufferedWriter, FileIO, TextIOWrapper
-from types import CodeType, TracebackType
+from types import CodeType, FunctionType, TracebackType
 from typing import (
     IO,
     AbstractSet,
@@ -764,13 +764,7 @@ class tuple(Sequence[_T_co], Generic[_T_co]):
     if sys.version_info >= (3, 9):
         def __class_getitem__(cls, __item: Any) -> GenericAlias: ...
 
-class function:
-    # TODO not defined in builtins!
-    __name__: str
-    __module__: str
-    __code__: CodeType
-    __qualname__: str
-    __annotations__: dict[str, Any]
+function = FunctionType
 
 class list(MutableSequence[_T], Generic[_T]):
     @overload

--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -764,7 +764,7 @@ class tuple(Sequence[_T_co], Generic[_T_co]):
     if sys.version_info >= (3, 9):
         def __class_getitem__(cls, __item: Any) -> GenericAlias: ...
 
-function = FunctionType
+function: Type[FunctionType] = FunctionType
 
 class list(MutableSequence[_T], Generic[_T]):
     @overload

--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -764,7 +764,7 @@ class tuple(Sequence[_T_co], Generic[_T_co]):
     if sys.version_info >= (3, 9):
         def __class_getitem__(cls, __item: Any) -> GenericAlias: ...
 
-function: Type[FunctionType] = FunctionType
+function: Type[FunctionType]
 
 class list(MutableSequence[_T], Generic[_T]):
     @overload


### PR DESCRIPTION
Ran into an issue where mypy was giving me a false positive when trying to access the `__defaults__` argument of a function: https://github.com/python/mypy/issues/11896#issuecomment-1004371113

As @AlexWaygood pointed out in the issue the methods and attributes are there in `types.FunctionType` but not `builtins.function`.

As noted in https://github.com/python/typeshed/pull/5799 we can't remove `builtins.function` so rather than manually copying over the attributes I first want to try using a type alias to define `function` since it saves duplicating code. If that fails I'm happy to just copy over the attributes 👍 