### PR TITLE
Use `Literal` type in `multiprocessing/pool` and add `__all__`

### DIFF
--- a/stdlib/multiprocessing/pool.pyi
+++ b/stdlib/multiprocessing/pool.pyi
@@ -2,9 +2,12 @@ import sys
 from _typeshed import Self
 from contextlib import AbstractContextManager
 from typing import Any, Callable, Generic, Iterable, Iterator, Mapping, TypeVar
+from typing_extensions import Literal
 
 if sys.version_info >= (3, 9):
     from types import GenericAlias
+    
+__all__ = ['Pool', 'ThreadPool']
 
 _PT = TypeVar("_PT", bound=Pool)
 _S = TypeVar("_S")
@@ -115,11 +118,11 @@ class ThreadPool(Pool, AbstractContextManager[ThreadPool]):
 
 # undocumented
 if sys.version_info >= (3, 8):
-    INIT: str
-    RUN: str
-    CLOSE: str
-    TERMINATE: str
+    INIT: Literal["INIT"]
+    RUN: Literal["RUN"]
+    CLOSE: Literal["CLOSE"]
+    TERMINATE: Literal["TERMINATE"]
 else:
-    RUN: int
-    CLOSE: int
-    TERMINATE: int
+    RUN: Literal[0]
+    CLOSE: Literal[1]
+    TERMINATE: Literal[2]

--- a/stdlib/multiprocessing/pool.pyi
+++ b/stdlib/multiprocessing/pool.pyi
@@ -6,8 +6,8 @@ from typing_extensions import Literal
 
 if sys.version_info >= (3, 9):
     from types import GenericAlias
-    
-__all__ = ['Pool', 'ThreadPool']
+
+__all__ = ["Pool", "ThreadPool"]
 
 _PT = TypeVar("_PT", bound=Pool)
 _S = TypeVar("_S")


### PR DESCRIPTION
Source: https://github.com/python/cpython/blob/f4c03484da59049eb62a9bf7777b963e2267d187/Lib/multiprocessing/pool.py