### PR TITLE
Improve comments of builtins.function

### DIFF
--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -764,10 +764,10 @@ class tuple(Sequence[_T_co], Generic[_T_co]):
     if sys.version_info >= (3, 9):
         def __class_getitem__(cls, __item: Any) -> GenericAlias: ...
 
-# Make sure this class definition stays roughly in line with `types.FunctionType`
+# Doesn't exist at runtime, but deleting this breaks mypy.
 @final
 class function:
-    # TODO not defined in builtins!
+    # Make sure this class definition stays roughly in line with `types.FunctionType`
     __closure__: tuple[_Cell, ...] | None
     __code__: CodeType
     __defaults__: tuple[Any, ...] | None

--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -764,7 +764,7 @@ class tuple(Sequence[_T_co], Generic[_T_co]):
     if sys.version_info >= (3, 9):
         def __class_getitem__(cls, __item: Any) -> GenericAlias: ...
 
-# Doesn't exist at runtime, but deleting this breaks mypy.
+# Doesn't exist at runtime, but deleting this breaks mypy. See #2999
 @final
 class function:
     # Make sure this class definition stays roughly in line with `types.FunctionType`


### PR DESCRIPTION
`builtins.function` is a mypy-specific hack, and removing it breaks mypy. Rewrite comments to make this clear.