### PR TITLE
Use `Literal` types in `csv`

### DIFF
--- a/stdlib/_csv.pyi
+++ b/stdlib/_csv.pyi
@@ -1,9 +1,10 @@
 from typing import Any, Iterable, Iterator, Protocol, Type, Union
+from typing_extensions import Literal
 
-QUOTE_ALL: int
-QUOTE_MINIMAL: int
-QUOTE_NONE: int
-QUOTE_NONNUMERIC: int
+QUOTE_ALL: Literal[1]
+QUOTE_MINIMAL: Literal[0]
+QUOTE_NONE: Literal[3]
+QUOTE_NONNUMERIC: Literal[2]
 
 class Error(Exception): ...
 


### PR DESCRIPTION
These constants are re-exported in `csv.pyi`, so it is fine! 👍 