### PR TITLE
`_typeshed.structseq`: Use `Final` instead of `ClassVar`

### DIFF
--- a/stdlib/_typeshed/__init__.pyi
+++ b/stdlib/_typeshed/__init__.pyi
@@ -8,7 +8,7 @@ import mmap
 import sys
 from os import PathLike
 from typing import AbstractSet, Any, Awaitable, Container, Generic, Iterable, Protocol, Type, TypeVar, Union
-from typing_extensions import Literal, Final, final
+from typing_extensions import Final, Literal, final
 
 _KT = TypeVar("_KT")
 _KT_co = TypeVar("_KT_co", covariant=True)

--- a/stdlib/_typeshed/__init__.pyi
+++ b/stdlib/_typeshed/__init__.pyi
@@ -7,8 +7,8 @@ import ctypes
 import mmap
 import sys
 from os import PathLike
-from typing import AbstractSet, Any, Awaitable, ClassVar, Container, Generic, Iterable, Protocol, Type, TypeVar, Union
-from typing_extensions import Literal, final
+from typing import AbstractSet, Any, Awaitable, Container, Generic, Iterable, Protocol, Type, TypeVar, Union
+from typing_extensions import Literal, Final, final
 
 _KT = TypeVar("_KT")
 _KT_co = TypeVar("_KT_co", covariant=True)
@@ -206,9 +206,9 @@ else:
 # See discussion at #6546 & #6560
 # `structseq` classes are unsubclassable, so are all decorated with `@final`.
 class structseq(Generic[_T_co]):
-    n_fields: ClassVar[int]
-    n_unnamed_fields: ClassVar[int]
-    n_sequence_fields: ClassVar[int]
+    n_fields: Final[int]
+    n_unnamed_fields: Final[int]
+    n_sequence_fields: Final[int]
     # The first parameter will generally only take an iterable of a specific length.
     # E.g. `os.uname_result` takes any iterable of length exactly 5.
     #


### PR DESCRIPTION
As discussed in https://github.com/python/typeshed/pull/6816, for some `structseq` classes these attributes are writeable `ClassVar`s, but for other classes, they're read-only `ClassVar`s. Either way, however, it's probably a bad idea to be modifying these attributes, so it makes sense to simply annotate them with `Final` rather than `ClassVar`.

Note that [PEP 591](https://www.python.org/dev/peps/pep-0591/) specifically states:

> Type checkers should infer a final attribute that is initialized in a class body as being a class variable. Variables should not be annotated with both ClassVar and Final.

As such, annotating these attributes as `Final[ClassVar[int]]` would be neither necessary nor possible.