### PR TITLE
Use `Literal` types in `calendar`

### DIFF
--- a/stdlib/calendar.pyi
+++ b/stdlib/calendar.pyi
@@ -4,6 +4,13 @@ from time import struct_time
 from typing import Any, Iterable, Optional, Sequence
 from typing_extensions import Literal
 
+__all__ = ["IllegalMonthError", "IllegalWeekdayError", "setfirstweekday",
+           "firstweekday", "isleap", "leapdays", "weekday", "monthrange",
+           "monthcalendar", "prmonth", "month", "prcal", "calendar",
+           "timegm", "month_name", "month_abbr", "day_name", "day_abbr",
+           "Calendar", "TextCalendar", "HTMLCalendar", "LocaleTextCalendar",
+           "LocaleHTMLCalendar", "weekheader"]
+
 _LocaleType = tuple[Optional[str], Optional[str]]
 
 class IllegalMonthError(ValueError):

--- a/stdlib/calendar.pyi
+++ b/stdlib/calendar.pyi
@@ -113,3 +113,5 @@ THURSDAY: Literal[3]
 FRIDAY: Literal[4]
 SATURDAY: Literal[5]
 SUNDAY: Literal[6]
+
+EPOCH: Literal[1970]

--- a/stdlib/calendar.pyi
+++ b/stdlib/calendar.pyi
@@ -4,12 +4,32 @@ from time import struct_time
 from typing import Any, Iterable, Optional, Sequence
 from typing_extensions import Literal
 
-__all__ = ["IllegalMonthError", "IllegalWeekdayError", "setfirstweekday",
-           "firstweekday", "isleap", "leapdays", "weekday", "monthrange",
-           "monthcalendar", "prmonth", "month", "prcal", "calendar",
-           "timegm", "month_name", "month_abbr", "day_name", "day_abbr",
-           "Calendar", "TextCalendar", "HTMLCalendar", "LocaleTextCalendar",
-           "LocaleHTMLCalendar", "weekheader"]
+__all__ = [
+    "IllegalMonthError",
+    "IllegalWeekdayError",
+    "setfirstweekday",
+    "firstweekday",
+    "isleap",
+    "leapdays",
+    "weekday",
+    "monthrange",
+    "monthcalendar",
+    "prmonth",
+    "month",
+    "prcal",
+    "calendar",
+    "timegm",
+    "month_name",
+    "month_abbr",
+    "day_name",
+    "day_abbr",
+    "Calendar",
+    "TextCalendar",
+    "HTMLCalendar",
+    "LocaleTextCalendar",
+    "LocaleHTMLCalendar",
+    "weekheader",
+]
 
 _LocaleType = tuple[Optional[str], Optional[str]]
 

--- a/stdlib/calendar.pyi
+++ b/stdlib/calendar.pyi
@@ -2,6 +2,7 @@ import datetime
 import sys
 from time import struct_time
 from typing import Any, Iterable, Optional, Sequence
+from typing_extensions import Literal
 
 _LocaleType = tuple[Optional[str], Optional[str]]
 
@@ -105,13 +106,10 @@ day_abbr: Sequence[str]
 month_name: Sequence[str]
 month_abbr: Sequence[str]
 
-# Below constants are not in docs or __all__, but enough people have used them
-# they are now effectively public.
-
-MONDAY: int
-TUESDAY: int
-WEDNESDAY: int
-THURSDAY: int
-FRIDAY: int
-SATURDAY: int
-SUNDAY: int
+MONDAY: Literal[0]
+TUESDAY: Literal[1]
+WEDNESDAY: Literal[2]
+THURSDAY: Literal[3]
+FRIDAY: Literal[4]
+SATURDAY: Literal[5]
+SUNDAY: Literal[6]


### PR DESCRIPTION
Note that constants are now documented https://docs.python.org/3/library/calendar.html#calendar.setfirstweekday