### PR TITLE
Remove several unused `TypeVar`s

### DIFF
--- a/stdlib/bz2.pyi
+++ b/stdlib/bz2.pyi
@@ -2,7 +2,7 @@ import _compression
 import sys
 from _compression import BaseStream
 from _typeshed import ReadableBuffer, Self, StrOrBytesPath, WriteableBuffer
-from typing import IO, Any, Iterable, Protocol, TextIO, TypeVar, overload
+from typing import IO, Any, Iterable, Protocol, TextIO, overload
 from typing_extensions import Literal, SupportsIndex, final
 
 # The following attributes and methods are optional:
@@ -15,8 +15,6 @@ class _WritableFileobj(Protocol):
     # The following attributes and methods are optional:
     # def fileno(self) -> int: ...
     # def close(self) -> object: ...
-
-_T = TypeVar("_T")
 
 def compress(data: bytes, compresslevel: int = ...) -> bytes: ...
 def decompress(data: bytes) -> bytes: ...

--- a/stdlib/imp.pyi
+++ b/stdlib/imp.pyi
@@ -1,7 +1,7 @@
 import types
 from _typeshed import StrPath
 from os import PathLike
-from typing import IO, Any, Protocol, TypeVar
+from typing import IO, Any, Protocol
 
 from _imp import (
     acquire_lock as acquire_lock,
@@ -14,8 +14,6 @@ from _imp import (
     lock_held as lock_held,
     release_lock as release_lock,
 )
-
-_T = TypeVar("_T")
 
 SEARCH_ERROR: int
 PY_SOURCE: int

--- a/stdlib/multiprocessing/pool.pyi
+++ b/stdlib/multiprocessing/pool.pyi
@@ -9,7 +9,6 @@ if sys.version_info >= (3, 9):
 
 __all__ = ["Pool", "ThreadPool"]
 
-_PT = TypeVar("_PT", bound=Pool)
 _S = TypeVar("_S")
 _T = TypeVar("_T")
 

--- a/stdlib/socketserver.pyi
+++ b/stdlib/socketserver.pyi
@@ -2,9 +2,8 @@ import sys
 import types
 from _typeshed import Self
 from socket import socket as _socket
-from typing import Any, BinaryIO, Callable, ClassVar, Type, TypeVar, Union
+from typing import Any, BinaryIO, Callable, ClassVar, Type, Union
 
-_T = TypeVar("_T")
 _RequestType = Union[_socket, tuple[bytes, _socket]]
 _AddressType = Union[tuple[str, int], str]
 

--- a/stdlib/types.pyi
+++ b/stdlib/types.pyi
@@ -25,7 +25,6 @@ from typing_extensions import Literal, ParamSpec, final
 
 # Note, all classes "defined" here require special handling.
 
-_T = TypeVar("_T")
 _T1 = TypeVar("_T1")
 _T2 = TypeVar("_T2")
 _T_co = TypeVar("_T_co", covariant=True)

--- a/stdlib/weakref.pyi
+++ b/stdlib/weakref.pyi
@@ -11,7 +11,6 @@ from _weakref import (
     ref as ref,
 )
 
-_S = TypeVar("_S")
 _T = TypeVar("_T")
 _KT = TypeVar("_KT")
 _VT = TypeVar("_VT")

--- a/stubs/redis/redis/client.pyi
+++ b/stubs/redis/redis/client.pyi
@@ -23,8 +23,6 @@ from .connection import ConnectionPool
 from .lock import Lock
 from .retry import Retry
 
-_ScoreCastFuncReturn = TypeVar("_ScoreCastFuncReturn")
-
 _Value = Union[bytes, float, int, str]
 _Key = Union[str, bytes]
 

--- a/tests/check_new_syntax.py
+++ b/tests/check_new_syntax.py
@@ -2,6 +2,7 @@
 
 import ast
 import sys
+from collections import defaultdict
 from itertools import chain
 from pathlib import Path
 
@@ -151,6 +152,30 @@ def check_new_syntax(tree: ast.AST, path: Path) -> list[str]:
                     f"put the code for new Python versions first, e.g. `{new_syntax}`"
                 )
             self.generic_visit(node)
+
+    if "_typeshed" not in path.parts:
+        typevar_defs: dict[str, int] = {}  # Mapping of TypeVar names to the linenos where they're defined
+        all_name_occurences: defaultdict[str, int] = defaultdict(int)  # Mapping of each name in the file to the no. of occurences
+
+        class UnusedTypeVarFinder(ast.NodeVisitor):
+            def visit_Assign(self, node: ast.Assign) -> None:
+                if (
+                    isinstance(node.targets[0], ast.Name)
+                    and isinstance(node.value, ast.Call)
+                    and isinstance(node.value.func, ast.Name)
+                    and node.value.func.id == "TypeVar"
+                ):
+                    typevar_defs[node.targets[0].id] = node.lineno
+                self.generic_visit(node)
+
+            def visit_Name(self, node: ast.Name) -> None:
+                all_name_occurences[node.id] += 1
+                self.generic_visit(node)
+
+        UnusedTypeVarFinder().visit(tree)
+        for typevar_name, lineno in typevar_defs.items():
+            if all_name_occurences[typevar_name] == 1:
+                errors.append(f"{path}:{lineno}: TypeVar '{typevar_name}' is not used")
 
     if path != Path("stdlib/typing_extensions.pyi"):
         OldSyntaxFinder().visit(tree)


### PR DESCRIPTION
These were found by applying the following diff to `check_new_syntax.py`:

```diff
--- a/tests/check_new_syntax.py
+++ b/tests/check_new_syntax.py
@@ -2,6 +2,7 @@

 import ast
 import sys
+from collections import defaultdict
 from itertools import chain
 from pathlib import Path

@@ -152,6 +153,30 @@ def check_new_syntax(tree: ast.AST, path: Path) -> list[str]:
                 )
             self.generic_visit(node)

+    if "_typeshed" not in path.parts:
+        typevar_defs: dict[str, int] = {}  # Mapping of TypeVar names to the linenos where they're defined
+        all_name_occurences: defaultdict[str, int] = defaultdict(int)  # Mapping of each name in the file to the no. of occurences
+
+        class UnusedTypeVarFinder(ast.NodeVisitor):
+            def visit_Assign(self, node: ast.Assign) -> None:
+                if (
+                    isinstance(node.targets[0], ast.Name)
+                    and isinstance(node.value, ast.Call)
+                    and isinstance(node.value.func, ast.Name)
+                    and node.value.func.id == "TypeVar"
+                ):
+                    typevar_defs[node.targets[0].id] = node.lineno
+                self.generic_visit(node)
+
+            def visit_Name(self, node: ast.Name) -> None:
+                all_name_occurences[node.id] += 1
+                self.generic_visit(node)
+
+        UnusedTypeVarFinder().visit(tree)
+        for typevar_name, lineno in typevar_defs.items():
+            if all_name_occurences[typevar_name] == 1:
+                errors.append(f"{path}:{lineno}: TypeVar '{typevar_name}' is not used")
+
     if path != Path("stdlib/typing_extensions.pyi"):
         OldSyntaxFinder().visit(tree)
```