### PR TITLE
fix several typos

### DIFF
--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -847,7 +847,7 @@ class dict(MutableMapping[_KT, _VT], Generic[_KT, _VT]):
     def values(self) -> dict_values[_KT, _VT]: ...
     def items(self) -> dict_items[_KT, _VT]: ...
     # Signature of `dict.fromkeys` should be kept identical to `fromkeys` methods of `OrderedDict`/`ChainMap`/`UserDict` in `collections`
-    # TODO: the true signature of `dict.fromkeys` is not expressable in the current type system.
+    # TODO: the true signature of `dict.fromkeys` is not expressible in the current type system.
     # See #3800 & https://github.com/python/typing/issues/548#issuecomment-683336963.
     @classmethod
     @overload

--- a/stdlib/collections/__init__.pyi
+++ b/stdlib/collections/__init__.pyi
@@ -56,7 +56,7 @@ class UserDict(MutableMapping[_KT, _VT], Generic[_KT, _VT]):
     def __contains__(self, key: object) -> bool: ...
     def copy(self: Self) -> Self: ...
     # `UserDict.fromkeys` has the same semantics as `dict.fromkeys`, so should be kept in line with `dict.fromkeys`.
-    # TODO: Much like `dict.fromkeys`, the true signature of `UserDict.fromkeys` is inexpressable in the current type system.
+    # TODO: Much like `dict.fromkeys`, the true signature of `UserDict.fromkeys` is inexpressible in the current type system.
     # See #3800 & https://github.com/python/typing/issues/548#issuecomment-683336963.
     @classmethod
     @overload
@@ -277,7 +277,7 @@ class OrderedDict(dict[_KT, _VT], Reversible[_KT], Generic[_KT, _VT]):
     def items(self) -> _OrderedDictItemsView[_KT, _VT]: ...
     def values(self) -> _OrderedDictValuesView[_KT, _VT]: ...
     # `fromkeys` is actually inherited from `dict` at runtime, so the signature should be kept in line with `dict.fromkeys`.
-    # Ideally we would not redefine it here, but the true signature of `dict.fromkeys` is not expressable in the current type system.
+    # Ideally we would not redefine it here, but the true signature of `dict.fromkeys` is not expressible in the current type system.
     # See #3800 & https://github.com/python/typing/issues/548#issuecomment-683336963.
     @classmethod
     @overload

--- a/stdlib/os/__init__.pyi
+++ b/stdlib/os/__init__.pyi
@@ -352,7 +352,7 @@ class stat_result(structseq[float], tuple[int, int, int, int, int, int, int, flo
     if sys.platform == "darwin":
         @property
         def st_flags(self) -> int: ...  # user defined flags for file
-    # Atributes documented as sometimes appearing, but deliberately omitted from the stub: `st_creator`, `st_rsize`, `st_type`.
+    # Attributes documented as sometimes appearing, but deliberately omitted from the stub: `st_creator`, `st_rsize`, `st_type`.
     # See https://github.com/python/typeshed/pull/6560#issuecomment-991253327
 
 @runtime_checkable


### PR DESCRIPTION
Found by running `codespell stdlib/ stubs/ *.md`, installed with `pip install codespell==2.1.0`.

It would be possible to add codespell to our CI, but it doesn't seem like a good idea to me:
- It flags several false positives.
- stubtest already ensures that most things are spelled correctly.
- Outside comments, the only typo I have seen is misspelling `suite_mask` as `suite_mast`, fixed in #6816. It was in code that isn't very stubtest-friendly. But codespell doesn't flag it either, because `mast` is also a valid word.