### PR TITLE
Fix bytes mixin labled as str in urllib.parse.pyi stub

### DIFF
--- a/stdlib/urllib/parse.pyi
+++ b/stdlib/urllib/parse.pyi
@@ -21,7 +21,7 @@ class _ResultMixinBase(Generic[AnyStr]):
 class _ResultMixinStr(_ResultMixinBase[str]):
     def encode(self, encoding: str = ..., errors: str = ...) -> _ResultMixinBytes: ...
 
-class _ResultMixinBytes(_ResultMixinBase[str]):
+class _ResultMixinBytes(_ResultMixinBase[bytes]):
     def decode(self, encoding: str = ..., errors: str = ...) -> _ResultMixinStr: ...
 
 class _NetlocResultMixinBase(Generic[AnyStr]):


### PR DESCRIPTION
This is causing ParseResultBytes.geturl() to be labelled with the return type str when it returns bytes by pyright.