### PR TITLE
scripts/create_baseline_stubs.py: Fix invoking stubgen

### DIFF
--- a/scripts/create_baseline_stubs.py
+++ b/scripts/create_baseline_stubs.py
@@ -44,7 +44,7 @@ def get_installed_package_info(project: str) -> Optional[Tuple[str, str]]:
 
 def run_stubgen(package: str) -> None:
     print(f"Running stubgen: stubgen -p {package}")
-    subprocess.run(["python", "-m", "mypy.stubgen", "-p", package], check=True)
+    subprocess.run(["stubgen", "-p", package], check=True)
 
 
 def copy_stubs(src_base_dir: str, package: str, stub_dir: str) -> None:


### PR DESCRIPTION
With mypy 0.930, `python3 -m mypy.stubgen` no longer works, but `stubgen` does work:

```
(env) akuli@akuli-desktop:~/typeshed$ mypy --version
mypy 0.930

(env) akuli@akuli-desktop:~/typeshed$ python3 -m mypy.stubgen -p requests
/home/akuli/typeshed/env/bin/python3: No code object available for mypy.stubgen

(env) akuli@akuli-desktop:~/typeshed$ stubgen -p requests
Processed 18 modules
Generated files under out/requests/
```