### PR TITLE
Add IPPROTO_MPTCP option

### DIFF
--- a/stdlib/_socket.pyi
+++ b/stdlib/_socket.pyi
@@ -356,6 +356,9 @@ if sys.platform == "linux" and sys.version_info >= (3, 9):
 
     J1939_FILTER_MAX: int
 
+if sys.platform == "linux" and sys.version_info >= (3, 10):
+    IPPROTO_MPTCP: int
+
 if sys.platform == "linux":
     AF_PACKET: int
     PF_PACKET: int

--- a/stdlib/socket.pyi
+++ b/stdlib/socket.pyi
@@ -366,6 +366,10 @@ if sys.platform == "linux" and sys.version_info >= (3, 9):
         SO_J1939_PROMISC as SO_J1939_PROMISC,
         SO_J1939_SEND_PRIO as SO_J1939_SEND_PRIO,
     )
+if sys.platform == "linux" and sys.version_info >= (3, 10):
+    from _socket import (
+        IPPROTO_MPTCP as IPPROTO_MPTCP,
+    )
 if sys.platform == "win32":
     from _socket import (
         RCVALL_IPLEVEL as RCVALL_IPLEVEL,

--- a/stdlib/socket.pyi
+++ b/stdlib/socket.pyi
@@ -367,9 +367,7 @@ if sys.platform == "linux" and sys.version_info >= (3, 9):
         SO_J1939_SEND_PRIO as SO_J1939_SEND_PRIO,
     )
 if sys.platform == "linux" and sys.version_info >= (3, 10):
-    from _socket import (
-        IPPROTO_MPTCP as IPPROTO_MPTCP,
-    )
+    from _socket import IPPROTO_MPTCP as IPPROTO_MPTCP
 if sys.platform == "win32":
     from _socket import (
         RCVALL_IPLEVEL as RCVALL_IPLEVEL,


### PR DESCRIPTION
Hello!

In Python 3.10 a new option to create MPTCP sockets has been added (https://bugs.python.org/issue43571).

This simple PR adds that missing option. 