### PR TITLE
`property`: `fget`, `fset`, `fdel` are read-only

### DIFF
--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -970,9 +970,12 @@ class range(Sequence[int]):
     def __reversed__(self) -> Iterator[int]: ...
 
 class property:
-    fget: Callable[[Any], Any] | None
-    fset: Callable[[Any, Any], None] | None
-    fdel: Callable[[Any], None] | None
+    @property
+    def fget(self) -> Callable[[Any], Any] | None: ...
+    @property
+    def fset(self) -> Callable[[Any, Any], None] | None: ...
+    @property
+    def fdel(self) -> Callable[[Any], None] | None: ...
     def __init__(
         self,
         fget: Callable[[Any], Any] | None = ...,

--- a/tests/stubtest_allowlists/py36.txt
+++ b/tests/stubtest_allowlists/py36.txt
@@ -44,6 +44,11 @@ random.randrange  # missing undocumented arg _int
 sched.Event.__doc__  # __slots__ is overridden
 stringprep.unicodedata  # re-exported from unicodedata
 sre_compile.dis
+# In the stub we lie and say DynamicClassAttribute is an alias for property
+# These three attributes are read-only for `property` but writable for `DynamicClassAttribute`
+types.DynamicClassAttribute.fget
+types.DynamicClassAttribute.fset
+types.DynamicClassAttribute.fdel
 typing.AsyncGenerator.ag_await
 typing.AsyncGenerator.ag_code
 typing.AsyncGenerator.ag_frame

--- a/tests/stubtest_allowlists/py37.txt
+++ b/tests/stubtest_allowlists/py37.txt
@@ -43,6 +43,11 @@ sched.Event.__doc__  # __slots__ is overridden
 ssl.PROTOCOL_SSLv3  # Depends on ssl compilation
 ssl.RAND_egd  # Depends on openssl compilation
 types.ClassMethodDescriptorType.__get__
+# In the stub we lie and say DynamicClassAttribute is an alias for property
+# These three attributes are read-only for `property` but writable for `DynamicClassAttribute`
+types.DynamicClassAttribute.fget
+types.DynamicClassAttribute.fset
+types.DynamicClassAttribute.fdel
 types.MethodDescriptorType.__get__
 types.WrapperDescriptorType.__get__
 typing.NamedTuple._asdict

--- a/tests/stubtest_allowlists/py38.txt
+++ b/tests/stubtest_allowlists/py38.txt
@@ -54,6 +54,11 @@ ssl.RAND_egd  # Depends on openssl compilation
 sys.UnraisableHookArgs  # Not exported from sys
 types.ClassMethodDescriptorType.__get__
 types.CodeType.replace  # stubtest thinks default values are None but None doesn't work at runtime
+# In the stub we lie and say DynamicClassAttribute is an alias for property
+# These three attributes are read-only for `property` but writable for `DynamicClassAttribute`
+types.DynamicClassAttribute.fget
+types.DynamicClassAttribute.fset
+types.DynamicClassAttribute.fdel
 types.MethodDescriptorType.__get__
 types.WrapperDescriptorType.__get__
 typing.NamedTuple.__new__

--- a/tests/stubtest_allowlists/py39.txt
+++ b/tests/stubtest_allowlists/py39.txt
@@ -65,6 +65,11 @@ symtable.SymbolTable.has_exec
 sys.UnraisableHookArgs  # Not exported from sys
 types.ClassMethodDescriptorType.__get__
 types.CodeType.replace  # stubtest thinks default values are None but None doesn't work at runtime
+# In the stub we lie and say DynamicClassAttribute is an alias for property
+# These three attributes are read-only for `property` but writable for `DynamicClassAttribute`
+types.DynamicClassAttribute.fget
+types.DynamicClassAttribute.fset
+types.DynamicClassAttribute.fdel
 types.GenericAlias.__getattr__
 types.GenericAlias.__call__  # Would be complicated to fix properly, Any could silence problems. #6392
 types.MethodDescriptorType.__get__


### PR DESCRIPTION
It feels a bit weird to have `@property` in the stub for `property` itself, but mypy seems cool with it... it's turtles all the way down, I guess!