### PR TITLE
Fix shutil.make_archive stub

### DIFF
--- a/stdlib/shutil.pyi
+++ b/stdlib/shutil.pyi
@@ -85,7 +85,7 @@ else:
 def make_archive(
     base_name: str,
     format: str,
-    root_dir: StrPath | None = ...,
+    root_dir: StrOrBytesPath | None = ...,
     base_dir: StrPath | None = ...,
     verbose: bool = ...,
     dry_run: bool = ...,


### PR DESCRIPTION
`root_dir` is only used to change into the source directory and therefore can accept `bytes` and `PathLike[bytes]` arguments.
(The `base_dir` arg of `shutil.make_archive` must still be a `StrPath` since it gets joined with `base_name` and `format` which must be strings)

Examples:
```python
from pathlib import Path
import shutil
from typing import AnyStr, Generic


class DummyPathLike(Generic[AnyStr]):
    """Since pathlib.Path can't accept bytes itself."""

    def __init__(self, path: AnyStr) -> None:
        self._path: AnyStr = path

    def __fspath__(self) -> AnyStr:
        """Return the file system path representation of the object."""
        return self._path

Path("some_folder").mkdir()
Path("some_folder/test.txt").touch()

shutil.make_archive(base_name="my_archive", format="gztar", root_dir="some_folder", base_dir=".")
shutil.make_archive(base_name="my_archive", format="gztar", root_dir=Path("some_folder"), base_dir=".")
shutil.make_archive(base_name="my_archive", format="gztar", root_dir=b"some_folder", base_dir=".")
shutil.make_archive(base_name="my_archive", format="gztar", root_dir=DummyPathLike(b"some_folder"), base_dir=".")

Path("some_folder/test.txt").unlink()
Path("some_folder").rmdir()
Path("my_archive.tar.gz").unlink()
```