### PR TITLE
Change `get_cache_token` to return a `NewType` in `_py_abc`

### DIFF
--- a/stdlib/_py_abc.pyi
+++ b/stdlib/_py_abc.pyi
@@ -1,8 +1,9 @@
-from typing import Any, TypeVar, NewType
+from typing import Any, NewType, TypeVar
 
 _T = TypeVar("_T")
 
 _CacheToken = NewType("_CacheToken", int)
+
 def get_cache_token() -> _CacheToken: ...
 
 class ABCMeta(type):

--- a/stdlib/_py_abc.pyi
+++ b/stdlib/_py_abc.pyi
@@ -1,9 +1,9 @@
-from typing import Any, TypeVar
+from typing import Any, TypeVar, NewType
 
 _T = TypeVar("_T")
 
-# TODO: Change the return into a NewType bound to int after pytype/#597
-def get_cache_token() -> object: ...
+_CacheToken = NewType("_CacheToken", int)
+def get_cache_token() -> _CacheToken: ...
 
 class ABCMeta(type):
     def __new__(__mcls, __name: str, __bases: tuple[type[Any], ...], __namespace: dict[str, Any]) -> ABCMeta: ...


### PR DESCRIPTION
Looks like it is supported by pytype now: https://github.com/google/pytype/issues/597