### PR TITLE
put redis.client._ScoreCastFuncReturn back

### DIFF
--- a/stubs/redis/redis/client.pyi
+++ b/stubs/redis/redis/client.pyi
@@ -17,6 +17,7 @@ _StrType = TypeVar("_StrType", bound=Union[str, bytes])
 
 _VT = TypeVar("_VT")
 _T = TypeVar("_T")
+_ScoreCastFuncReturn = TypeVar("_ScoreCastFuncReturn")
 
 SYM_EMPTY: bytes
 EMPTY_RESPONSE: str


### PR DESCRIPTION
#6829 removed it as unused but #6790 added a usage.