### PR TITLE
Remove unused `requests` allowlist entry

### DIFF
--- a/stubs/requests/@tests/stubtest_allowlist.txt
+++ b/stubs/requests/@tests/stubtest_allowlist.txt
@@ -5,7 +5,6 @@ requests.Session.options
 requests.Session.patch
 requests.Session.post
 requests.Session.put
-requests.adapters.HTTPResponse.__init__
 requests.adapters.PoolManager.connection_from_host
 requests.adapters.PoolManager.connection_from_url
 requests.adapters.PoolManager.urlopen


### PR DESCRIPTION
It's causing stubtest to fail, e.g. https://github.com/python/typeshed/runs/4755528470?check_suite_focus=true