### PR TITLE
Remove misleading comment from `staticmethod` and `classmethod`

### DIFF
--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -111,7 +111,7 @@ class object:
     def __dir__(self) -> Iterable[str]: ...
     def __init_subclass__(cls) -> None: ...
 
-class staticmethod(Generic[_R]):  # Special, only valid as a decorator.
+class staticmethod(Generic[_R]):
     __func__: Callable[..., _R]
     __isabstractmethod__: bool
     def __init__(self: staticmethod[_R], __f: Callable[..., _R]) -> None: ...
@@ -123,7 +123,7 @@ class staticmethod(Generic[_R]):  # Special, only valid as a decorator.
         __wrapped__: Callable[..., _R]
         def __call__(self, *args: Any, **kwargs: Any) -> _R: ...
 
-class classmethod(Generic[_R]):  # Special, only valid as a decorator.
+class classmethod(Generic[_R]):
     __func__: Callable[..., _R]
     __isabstractmethod__: bool
     def __init__(self: classmethod[_R], __f: Callable[..., _R]) -> None: ...


### PR DESCRIPTION
Thay are also valid as regular calls:

```python
def func(arg: int) -> int:
    return arg

class Some(object):
    # Both are ok:
    x = staticmethod(func)
    y = classmethod(func)
```