### PR TITLE
urllib3: allow allowed_methods to be False

### DIFF
--- a/stubs/urllib3/urllib3/util/retry.pyi
+++ b/stubs/urllib3/urllib3/util/retry.pyi
@@ -35,7 +35,7 @@ class Retry:
     redirect: Literal[True] | int | None
     status: int | None
     other: int | None
-    allowed_methods: Collection[str] | None
+    allowed_methods: Collection[str] | Literal[False] | None
     status_forcelist: Collection[int]
     backoff_factor: float
     raise_on_redirect: bool
@@ -51,7 +51,7 @@ class Retry:
         redirect: bool | int | None = ...,
         status: int | None = ...,
         other: int | None = ...,
-        allowed_methods: Collection[str] | None = ...,
+        allowed_methods: Collection[str] | Literal[False] | None = ...,
         status_forcelist: Collection[int] | None = ...,
         backoff_factor: float = ...,
         raise_on_redirect: bool = ...,


### PR DESCRIPTION
This is explicitly documented at https://github.com/urllib3/urllib3/blob/1.26.8/src/urllib3/util/retry.py#L179. See https://github.com/python/typeshed/commit/6907d7f7c6c2aca7d1653e524ac4f690d47feb1b#r63815945.