### PR TITLE
Add `__all__` to `opcode` and use `Literal` for constants

### DIFF
--- a/stdlib/opcode.pyi
+++ b/stdlib/opcode.pyi
@@ -1,11 +1,22 @@
 import sys
 from typing_extensions import Literal
 
-__all__ = ["cmp_op", "hasconst", "hasname", "hasjrel", "hasjabs",
-           "haslocal", "hascompare", "hasfree", "opname", "opmap",
-           "HAVE_ARGUMENT", "EXTENDED_ARG", "hasnargs",
-           "stack_effect",
-          ]
+__all__ = [
+    "cmp_op",
+    "hasconst",
+    "hasname",
+    "hasjrel",
+    "hasjabs",
+    "haslocal",
+    "hascompare",
+    "hasfree",
+    "opname",
+    "opmap",
+    "HAVE_ARGUMENT",
+    "EXTENDED_ARG",
+    "hasnargs",
+    "stack_effect",
+]
 
 if sys.version_info >= (3, 9):
     cmp_op: tuple[Literal["<"], Literal["<="], Literal["=="], Literal["!="], Literal[">"], Literal[">="]]

--- a/stdlib/opcode.pyi
+++ b/stdlib/opcode.pyi
@@ -1,6 +1,12 @@
 import sys
 from typing_extensions import Literal
 
+__all__ = ["cmp_op", "hasconst", "hasname", "hasjrel", "hasjabs",
+           "haslocal", "hascompare", "hasfree", "opname", "opmap",
+           "HAVE_ARGUMENT", "EXTENDED_ARG", "hasnargs",
+           "stack_effect",
+          ]
+
 if sys.version_info >= (3, 9):
     cmp_op: tuple[Literal["<"], Literal["<="], Literal["=="], Literal["!="], Literal[">"], Literal[">="]]
 else:
@@ -28,8 +34,8 @@ hasfree: list[int]
 opname: list[str]
 
 opmap: dict[str, int]
-HAVE_ARGUMENT: int
-EXTENDED_ARG: int
+HAVE_ARGUMENT: Literal[90]
+EXTENDED_ARG: Literal[144]
 
 if sys.version_info >= (3, 8):
     def stack_effect(__opcode: int, __oparg: int | None = ..., *, jump: bool | None = ...) -> int: ...


### PR DESCRIPTION
We are going to use `__all__` here: https://github.com/python/typeshed/blob/master/stdlib/dis.pyi#L3-L18

Because in real life `dis` re-exports all `opcode` public defs:

```python
from opcode import *
from opcode import __all__ as _opcodes_all
from opcode import _nb_ops

__all__ = ["code_info", "dis", "disassemble", "distb", "disco",
           "findlinestarts", "findlabels", "show_code",
           "get_instructions", "Instruction", "Bytecode"] + _opcodes_all
del _opcodes_all
```