### PR TITLE
Use `Literal` type and improve callbacks in `gc`

### DIFF
--- a/stdlib/gc.pyi
+++ b/stdlib/gc.pyi
@@ -1,12 +1,21 @@
 import sys
-from typing import Any
+from typing import Any, Callable
+from typing_extensions import Literal, TypedDict
 
-DEBUG_COLLECTABLE: int
-DEBUG_LEAK: int
-DEBUG_SAVEALL: int
-DEBUG_STATS: int
-DEBUG_UNCOLLECTABLE: int
-callbacks: list[Any]
+DEBUG_COLLECTABLE: Literal[2]
+DEBUG_LEAK: Literal[38]
+DEBUG_SAVEALL: Literal[32]
+DEBUG_STATS: Literal[1]
+DEBUG_UNCOLLECTABLE: Literal[4]
+
+class _CallbackInfo(TypedDict):
+    generation: int
+    collected: int
+    uncollectable: int    
+
+_CallbackType = Callable[[Literal["start" | "stop"], _CallbackInfo], Any]
+
+callbacks: list[_CallbackType]
 garbage: list[Any]
 
 def collect(generation: int = ...) -> int: ...

--- a/stdlib/gc.pyi
+++ b/stdlib/gc.pyi
@@ -13,7 +13,7 @@ class _CallbackInfo(TypedDict):
     collected: int
     uncollectable: int
 
-_CallbackType = Callable[[Literal["start" | "stop"], _CallbackInfo], Any]
+_CallbackType = Callable[[Literal["start", "stop"], _CallbackInfo], Any]
 
 callbacks: list[_CallbackType]
 garbage: list[Any]

--- a/stdlib/gc.pyi
+++ b/stdlib/gc.pyi
@@ -1,6 +1,6 @@
 import sys
-from typing import Any, Callable
-from typing_extensions import Literal, TypedDict
+from typing import Any, Callable, Mapping
+from typing_extensions import Literal
 
 DEBUG_COLLECTABLE: Literal[2]
 DEBUG_LEAK: Literal[38]
@@ -8,12 +8,7 @@ DEBUG_SAVEALL: Literal[32]
 DEBUG_STATS: Literal[1]
 DEBUG_UNCOLLECTABLE: Literal[4]
 
-class _CallbackInfo(TypedDict):
-    generation: int
-    collected: int
-    uncollectable: int
-
-_CallbackType = Callable[[Literal["start", "stop"], _CallbackInfo], Any]
+_CallbackType = Callable[[Literal["start", "stop"], Mapping[str, int]], Any]
 
 callbacks: list[_CallbackType]
 garbage: list[Any]

--- a/stdlib/gc.pyi
+++ b/stdlib/gc.pyi
@@ -8,7 +8,7 @@ DEBUG_SAVEALL: Literal[32]
 DEBUG_STATS: Literal[1]
 DEBUG_UNCOLLECTABLE: Literal[4]
 
-_CallbackType = Callable[[Literal["start", "stop"], dict[str, int]], Any]
+_CallbackType = Callable[[Literal["start", "stop"], dict[str, int]], object]
 
 callbacks: list[_CallbackType]
 garbage: list[Any]

--- a/stdlib/gc.pyi
+++ b/stdlib/gc.pyi
@@ -11,7 +11,7 @@ DEBUG_UNCOLLECTABLE: Literal[4]
 class _CallbackInfo(TypedDict):
     generation: int
     collected: int
-    uncollectable: int    
+    uncollectable: int
 
 _CallbackType = Callable[[Literal["start" | "stop"], _CallbackInfo], Any]
 

--- a/stdlib/gc.pyi
+++ b/stdlib/gc.pyi
@@ -1,5 +1,5 @@
 import sys
-from typing import Any, Callable, Mapping
+from typing import Any, Callable
 from typing_extensions import Literal
 
 DEBUG_COLLECTABLE: Literal[2]
@@ -8,7 +8,7 @@ DEBUG_SAVEALL: Literal[32]
 DEBUG_STATS: Literal[1]
 DEBUG_UNCOLLECTABLE: Literal[4]
 
-_CallbackType = Callable[[Literal["start", "stop"], Mapping[str, int]], Any]
+_CallbackType = Callable[[Literal["start", "stop"], dict[str, int]], Any]
 
 callbacks: list[_CallbackType]
 garbage: list[Any]


### PR DESCRIPTION
Types of `callback` arguments are well-defined: https://docs.python.org/3/library/gc.html#gc.callbacks

Checked that mypy is ok with that:

```python
from typing import Any, Callable, Literal, TypedDict

class _CallbackInfo(TypedDict):
    generation: int
    collected: int
    uncollectable: int

_C  = Callable[[Literal["start" | "stop"], _CallbackInfo], Any]
x: list[_C]

def some(arg: str, other):
    pass

x.append(some)
```