### PR TITLE
Revert "Temporarily fix redis version to 4.1.0"

### DIFF
--- a/stubs/redis/@tests/stubtest_allowlist.txt
+++ b/stubs/redis/@tests/stubtest_allowlist.txt
@@ -1,2 +1,3 @@
 redis.client.Pipeline.transaction  # instance attribute has same name as superclass method
 redis.ocsp  # requires cryptography to be installed
+redis.*  # temporary, see #6951

--- a/stubs/redis/METADATA.toml
+++ b/stubs/redis/METADATA.toml
@@ -1,1 +1,1 @@
-version = "4.1.0"
+version = "4.1.*"


### PR DESCRIPTION
Reverts python/typeshed#6952

This is causing all uploads to fail (#6956). As a quick fix, let's restore the previous version.