### PR TITLE
Add Y027 to list of ignored `.flake8` error codes

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -23,7 +23,7 @@
 [flake8]
 per-file-ignores =
   *.py: E203, E501
-  *.pyi: E301, E302, E305, E501, E701, E741, F401, F403, F405, F822, Y026
+  *.pyi: E301, E302, E305, E501, E701, E741, F401, F403, F405, F822, Y026, Y027
   # Since typing.pyi defines "overload" this is not recognized by flake8 as typing.overload.
   # Unfortunately, flake8 does not allow to "noqa" just a specific error inside the file itself.
   # https://github.com/PyCQA/flake8/issues/1079

--- a/.flake8
+++ b/.flake8
@@ -23,12 +23,15 @@
 [flake8]
 per-file-ignores =
   *.py: E203, E501
-  *.pyi: E301, E302, E305, E501, E701, E741, F401, F403, F405, F822, Y026, Y027
+  *.pyi: E301, E302, E305, E501, E701, E741, F401, F403, F405, F822, Y026
   # Since typing.pyi defines "overload" this is not recognized by flake8 as typing.overload.
   # Unfortunately, flake8 does not allow to "noqa" just a specific error inside the file itself.
   # https://github.com/PyCQA/flake8/issues/1079
   #     F811 redefinition of unused '...'
-  typing.pyi: E301, E302, E305, E501, E701, E741, F401, F403, F405, F811, F822, Y026
+  stubs/*.pyi: E301, E302, E305, E501, E701, E741, F401, F403, F405, F822, Y026, Y027
+  stdlib/@python2/*.pyi: E301, E302, E305, E501, E701, E741, F401, F403, F405, F822, Y026, Y027
+  stdlib/@python2/typing.pyi: E301, E302, E305, E501, E701, E741, F401, F403, F405, F811, F822, Y026, Y027
+  stdlib/typing.pyi: E301, E302, E305, E501, E701, E741, F401, F403, F405, F811, F822, Y026
 
 # We are checking with Python 3 but many of the stubs are Python 2 stubs.
 builtins = buffer,file,long,raw_input,unicode,xrange

--- a/.flake8
+++ b/.flake8
@@ -19,6 +19,9 @@
 
 # Rules that we'd like to enable in the future:
 #       Y026 Use typing_extensions.TypeAlias for type aliases (blocked by #4913)
+#       Y027 Disallow importing typing.ContextManager, typing.OrderedDict &
+#            typing_extensions.OrderedDict (cannot be globally enabled while typeshed
+#            still contains stubs supporting Python 2).
 
 [flake8]
 per-file-ignores =

--- a/stdlib/contextlib.pyi
+++ b/stdlib/contextlib.pyi
@@ -1,7 +1,7 @@
 import sys
 from _typeshed import Self, StrOrBytesPath
 from types import TracebackType
-from typing import (
+from typing import (  # noqa Y027
     IO,
     Any,
     AsyncGenerator,


### PR DESCRIPTION
Refs https://github.com/PyCQA/flake8-pyi/pull/104

There are a number of stubs in typeshed that still support Python 2. Each subdirectory of stubs specifies whether or not it supports Python 2 in the `METADATA.toml` file. However, there's no easy way for flake8 to read those files, and I don't particularly like the idea of duplicating that information in the `.flake8` config file. As such, I think it's easiest if we just globally ignore this check for the whole of typeshed. We can still keep the equivalent check in `check_new_syntax.py`, where it's easier to dynamically specific filepaths that we want to check things for.