### PR TITLE
Unpin 3.10.1

### DIFF
--- a/.github/workflows/stubtest.yml
+++ b/.github/workflows/stubtest.yml
@@ -20,8 +20,7 @@ jobs:
       matrix:
         # macos-11 does not have tcl/tk installed, needed for stubtesting tkinter
         os: ["ubuntu-latest", "windows-latest", "macos-10.15"]
-        # Temporarily hard-coded 3.10.1 due to stubtest incompatibilities.
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10.1"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
       fail-fast: false
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -96,8 +96,7 @@ jobs:
       matrix:
         # macos-11 does not have tcl/tk installed, needed for stubtesting tkinter
         os: ["ubuntu-latest", "windows-latest", "macos-10.15"]
-        # Temporarily hard-coded 3.10.1 due to stubtest incompatibilities.
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10.1"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
       fail-fast: false
 
     steps:


### PR DESCRIPTION
I assume that by now all workers should have upgraded to 3.10.1 or even 3.10.2.