### PR TITLE
Use `ParamSpec` for `*GeneratorContextManager` in `contextlib`

### DIFF
--- a/stdlib/contextlib.pyi
+++ b/stdlib/contextlib.pyi
@@ -41,7 +41,7 @@ class _GeneratorContextManager(AbstractContextManager[_T_co], ContextDecorator, 
     # In Python <= 3.6, __init__ and all instance attributes are defined directly on this class.
     # In Python >= 3.7, __init__ and all instance attributes are inherited from _GeneratorContextManagerBase
     # _GeneratorContextManagerBase is more trouble than it's worth to include in the stub; see #6676
-    def __init__(self, func: Callable[..., Iterator[_T_co]], args: tuple[Any, ...], kwds: dict[str, Any]) -> None: ...
+    def __init__(self, func: Callable[_P, Iterator[_T_co]], args: _P.args, kwds: _P.kwargs) -> None: ...
     gen: Generator[_T_co, Any, Any]
     func: Callable[..., Generator[_T_co, Any, Any]]
     args: tuple[Any, ...]
@@ -56,7 +56,7 @@ if sys.version_info >= (3, 10):
     class _AsyncGeneratorContextManager(AbstractAsyncContextManager[_T_co], AsyncContextDecorator, Generic[_T_co]):
         # __init__ and these attributes are actually defined in the base class _GeneratorContextManagerBase,
         # which is more trouble than it's worth to include in the stub (see #6676)
-        def __init__(self, func: Callable[..., AsyncIterator[_T_co]], args: tuple[Any, ...], kwds: dict[str, Any]) -> None: ...
+        def __init__(self, func: Callable[_P, AsyncIterator[_T_co]], args: _P.args, kwds: _P.kwargs) -> None: ...
         gen: AsyncGenerator[_T_co, Any]
         func: Callable[..., AsyncGenerator[_T_co, Any]]
         args: tuple[Any, ...]
@@ -64,7 +64,7 @@ if sys.version_info >= (3, 10):
 
 elif sys.version_info >= (3, 7):
     class _AsyncGeneratorContextManager(AbstractAsyncContextManager[_T_co], Generic[_T_co]):
-        def __init__(self, func: Callable[..., AsyncIterator[_T_co]], args: tuple[Any, ...], kwds: dict[str, Any]) -> None: ...
+        def __init__(self, func: Callable[_P, AsyncIterator[_T_co]], args: _P.args, kwds: _P.kwargs) -> None: ...
         gen: AsyncGenerator[_T_co, Any]
         func: Callable[..., AsyncGenerator[_T_co, Any]]
         args: tuple[Any, ...]


### PR DESCRIPTION
Source: https://github.com/python/cpython/blob/d45cd2d20770f72a000ba6dfa9ac88dd49423c27/Lib/contextlib.py#L105