### PR TITLE
Automatically create an issue if the nightly stubtest run fails

### DIFF
--- a/.github/workflows/stubtest.yml
+++ b/.github/workflows/stubtest.yml
@@ -60,18 +60,22 @@ jobs:
         if: ${{ failure() }}
         permissions:
           issues: write
-        uses: actions/github-script@v3
+
+  create-issue-on-failure:
+    name: Create an issue if stubtest failed
+    # https://github.community/t/run-github-actions-job-only-if-previous-job-has-failed/174786/2
+    needs: [stubtest-stdlib, stubtest-third-party]
+    if: ${{ always() && (needs.stubtest-stdlib.result=='failure' || needs.stubtest-third-party.result=='failure') }}
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v3
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            let forStub = ""
-            try {
-              forStub = "for " + /stubtest failed for (.*)/.exec(fs.readFileSync("output.txt", "utf-8"))[1]
-            } catch(e) { }
-
             await github.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: `Stubtest failed ${forStub} on ${new Date().toDateString()}`,
-              body: "Stubtest runs are listed [here](https://github.com/python/typeshed/actions/workflows/stubtest.yml)."
+              title: `Stubtest failed on ${new Date().toDateString()}`,
+              body: `Stubtest runs are listed here: https://github.com/${context.repo.owner}/${context.repo.repo}/actions/workflows/stubtest.yml`,
             })

--- a/.github/workflows/stubtest.yml
+++ b/.github/workflows/stubtest.yml
@@ -34,8 +34,8 @@ jobs:
         run: python -m pip install -U pip
       - name: Install dependencies
         run: pip install $(grep tomli== requirements-tests.txt) $(grep mypy== requirements-tests.txt)
-#      - name: Run stubtest
-#        run: python tests/stubtest_stdlib.py
+      - name: Run stubtest
+        run: python tests/stubtest_stdlib.py
 
   stubtest-third-party:
     name: Check third party stubs with stubtest
@@ -54,8 +54,8 @@ jobs:
         run: pip install $(grep tomli== requirements-tests.txt)
       - name: Install apt packages
         run: sudo apt install -y $(python tests/get_apt_packages.py)
-#      - name: Run stubtest
-#        run: python tests/stubtest_third_party.py --num-shards 4 --shard-index ${{ matrix.shard-index }}
+      - name: Run stubtest
+        run: python tests/stubtest_third_party.py --num-shards 4 --shard-index ${{ matrix.shard-index }}
 
   # https://github.community/t/run-github-actions-job-only-if-previous-job-has-failed/174786/2
   create-issue-on-failure:

--- a/.github/workflows/stubtest.yml
+++ b/.github/workflows/stubtest.yml
@@ -56,10 +56,6 @@ jobs:
         run: sudo apt install -y $(python tests/get_apt_packages.py)
       - name: Run stubtest
         run: python -u tests/stubtest_third_party.py --num-shards 4 --shard-index ${{ matrix.shard-index }} 2>&1 | tee output.txt
-      - name: If stubtest failed, create an issue
-        if: ${{ failure() }}
-        permissions:
-          issues: write
 
   create-issue-on-failure:
     name: Create an issue if stubtest failed

--- a/.github/workflows/stubtest.yml
+++ b/.github/workflows/stubtest.yml
@@ -57,10 +57,12 @@ jobs:
       - name: Run stubtest
         run: python -u tests/stubtest_third_party.py --num-shards 4 --shard-index ${{ matrix.shard-index }} 2>&1 | tee output.txt
 
+  # https://github.community/t/run-github-actions-job-only-if-previous-job-has-failed/174786/2
   create-issue-on-failure:
     name: Create an issue if stubtest failed
-    # https://github.community/t/run-github-actions-job-only-if-previous-job-has-failed/174786/2
+    runs-on: ubuntu-latest
     needs: [stubtest-stdlib, stubtest-third-party]
+    #if: ${{ always() && github.repository == 'python/typeshed' && (needs.stubtest-stdlib.result=='failure' || needs.stubtest-third-party.result=='failure') }}
     if: ${{ always() && (needs.stubtest-stdlib.result=='failure' || needs.stubtest-third-party.result=='failure') }}
     permissions:
       issues: write

--- a/.github/workflows/stubtest.yml
+++ b/.github/workflows/stubtest.yml
@@ -74,5 +74,5 @@ jobs:
               owner: "python",
               repo: "typeshed",
               title: `Stubtest failed on ${new Date().toDateString()}`,
-              body: `Stubtest runs are listed here: https://github.com/python/typeshed/actions/workflows/stubtest.yml`,
+              body: "Stubtest runs are listed here: https://github.com/python/typeshed/actions/workflows/stubtest.yml",
             })

--- a/.github/workflows/stubtest.yml
+++ b/.github/workflows/stubtest.yml
@@ -62,7 +62,7 @@ jobs:
     name: Create an issue if stubtest failed
     runs-on: ubuntu-latest
     needs: [stubtest-stdlib, stubtest-third-party]
-    if: ${{ always() && github.repository == 'Akuli/typeshed' && (needs.stubtest-stdlib.result=='failure' || needs.stubtest-third-party.result=='failure') }}
+    if: ${{ github.repository == 'Akuli/typeshed' && always() && (needs.stubtest-stdlib.result=='failure' || needs.stubtest-third-party.result=='failure') }}
     permissions:
       issues: write
     steps:

--- a/.github/workflows/stubtest.yml
+++ b/.github/workflows/stubtest.yml
@@ -62,7 +62,7 @@ jobs:
     name: Create an issue if stubtest failed
     runs-on: ubuntu-latest
     needs: [stubtest-stdlib, stubtest-third-party]
-    if: ${{ github.repository == 'python/typeshed' && always() && (needs.stubtest-stdlib.result=='failure' || needs.stubtest-third-party.result=='failure') }}
+    if: ${{ github.repository == 'python/typeshed' && always() && (needs.stubtest-stdlib.result == 'failure' || needs.stubtest-third-party.result == 'failure') }}
     permissions:
       issues: write
     steps:

--- a/.github/workflows/stubtest.yml
+++ b/.github/workflows/stubtest.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   stubtest-stdlib:
     name: Check stdlib with stubtest
-    if: github.repository == 'python/typeshed'
+    if: github.repository == 'Akuli/typeshed'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -39,7 +39,7 @@ jobs:
 
   stubtest-third-party:
     name: Check third party stubs with stubtest
-    if: github.repository == 'python/typeshed'
+    if: github.repository == 'Akuli/typeshed'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -62,7 +62,7 @@ jobs:
     name: Create an issue if stubtest failed
     runs-on: ubuntu-latest
     needs: [stubtest-stdlib, stubtest-third-party]
-    if: ${{ always() && github.repository == 'python/typeshed' && (needs.stubtest-stdlib.result=='failure' || needs.stubtest-third-party.result=='failure') }}
+    if: ${{ always() && github.repository == 'Akuli/typeshed' && (needs.stubtest-stdlib.result=='failure' || needs.stubtest-third-party.result=='failure') }}
     permissions:
       issues: write
     steps:

--- a/.github/workflows/stubtest.yml
+++ b/.github/workflows/stubtest.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Install apt packages
         run: sudo apt install -y $(python tests/get_apt_packages.py)
       - name: Run stubtest
-        run: python -u tests/stubtest_third_party.py --num-shards 4 --shard-index ${{ matrix.shard-index }} 2>&1 | tee output.txt
+        run: python tests/stubtest_third_party.py --num-shards 4 --shard-index ${{ matrix.shard-index }}
 
   # https://github.community/t/run-github-actions-job-only-if-previous-job-has-failed/174786/2
   create-issue-on-failure:

--- a/.github/workflows/stubtest.yml
+++ b/.github/workflows/stubtest.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   stubtest-stdlib:
     name: Check stdlib with stubtest
-    if: github.repository == 'Akuli/typeshed'
+    if: github.repository == 'python/typeshed'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -39,7 +39,7 @@ jobs:
 
   stubtest-third-party:
     name: Check third party stubs with stubtest
-    if: github.repository == 'Akuli/typeshed'
+    if: github.repository == 'python/typeshed'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -62,7 +62,7 @@ jobs:
     name: Create an issue if stubtest failed
     runs-on: ubuntu-latest
     needs: [stubtest-stdlib, stubtest-third-party]
-    if: ${{ github.repository == 'Akuli/typeshed' && always() && (needs.stubtest-stdlib.result=='failure' || needs.stubtest-third-party.result=='failure') }}
+    if: ${{ github.repository == 'python/typeshed' && always() && (needs.stubtest-stdlib.result=='failure' || needs.stubtest-third-party.result=='failure') }}
     permissions:
       issues: write
     steps:

--- a/.github/workflows/stubtest.yml
+++ b/.github/workflows/stubtest.yml
@@ -34,8 +34,8 @@ jobs:
         run: python -m pip install -U pip
       - name: Install dependencies
         run: pip install $(grep tomli== requirements-tests.txt) $(grep mypy== requirements-tests.txt)
-      - name: Run stubtest
-        run: python tests/stubtest_stdlib.py
+#      - name: Run stubtest
+#        run: python tests/stubtest_stdlib.py
 
   stubtest-third-party:
     name: Check third party stubs with stubtest
@@ -54,8 +54,8 @@ jobs:
         run: pip install $(grep tomli== requirements-tests.txt)
       - name: Install apt packages
         run: sudo apt install -y $(python tests/get_apt_packages.py)
-      - name: Run stubtest
-        run: python tests/stubtest_third_party.py --num-shards 4 --shard-index ${{ matrix.shard-index }}
+#      - name: Run stubtest
+#        run: python tests/stubtest_third_party.py --num-shards 4 --shard-index ${{ matrix.shard-index }}
 
   # https://github.community/t/run-github-actions-job-only-if-previous-job-has-failed/174786/2
   create-issue-on-failure:

--- a/.github/workflows/stubtest.yml
+++ b/.github/workflows/stubtest.yml
@@ -62,8 +62,7 @@ jobs:
     name: Create an issue if stubtest failed
     runs-on: ubuntu-latest
     needs: [stubtest-stdlib, stubtest-third-party]
-    #if: ${{ always() && github.repository == 'python/typeshed' && (needs.stubtest-stdlib.result=='failure' || needs.stubtest-third-party.result=='failure') }}
-    if: ${{ always() && (needs.stubtest-stdlib.result=='failure' || needs.stubtest-third-party.result=='failure') }}
+    if: ${{ always() && github.repository == 'python/typeshed' && (needs.stubtest-stdlib.result=='failure' || needs.stubtest-third-party.result=='failure') }}
     permissions:
       issues: write
     steps:

--- a/.github/workflows/stubtest.yml
+++ b/.github/workflows/stubtest.yml
@@ -5,6 +5,7 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+# Please keep the permissions minimal, as stubtest runs arbitrary code from pypi.
 permissions:
   contents: read
 
@@ -54,4 +55,23 @@ jobs:
       - name: Install apt packages
         run: sudo apt install -y $(python tests/get_apt_packages.py)
       - name: Run stubtest
-        run: python tests/stubtest_third_party.py --num-shards 4 --shard-index ${{ matrix.shard-index }}
+        run: python -u tests/stubtest_third_party.py --num-shards 4 --shard-index ${{ matrix.shard-index }} 2>&1 | tee output.txt
+      - name: If stubtest failed, create an issue
+        if: ${{ failure() }}
+        permissions:
+          issues: write
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            let forStub = ""
+            try {
+              forStub = "for " + /stubtest failed for (.*)/.exec(fs.readFileSync("output.txt", "utf-8"))[1]
+            } catch(e) { }
+
+            await github.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `Stubtest failed ${forStub} on ${new Date().toDateString()}`,
+              body: "Stubtest runs are listed [here](https://github.com/python/typeshed/actions/workflows/stubtest.yml)."
+            })

--- a/.github/workflows/stubtest.yml
+++ b/.github/workflows/stubtest.yml
@@ -71,8 +71,8 @@ jobs:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             await github.issues.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
+              owner: "python",
+              repo: "typeshed",
               title: `Stubtest failed on ${new Date().toDateString()}`,
-              body: `Stubtest runs are listed here: https://github.com/${context.repo.owner}/${context.repo.repo}/actions/workflows/stubtest.yml`,
+              body: `Stubtest runs are listed here: https://github.com/python/typeshed/actions/workflows/stubtest.yml`,
             })


### PR DESCRIPTION
Fixes #6972 

Example issue: https://github.com/Akuli/typeshed/issues/21

It would be nice to include the name of the failing library in the issue title. This isn't as easy as I expected, because we can't give the `issues: write` permission to the same job that runs stubtest (and executes code from pypi). We could do this with upload-artifact and download-artifact, or by downloading raw logs of the failed jobs. But this is already much better than a script that runs only on my computer, and can be improved later.