### PR TITLE
Make `mapping` attribute read-only on dict views classes

### DIFF
--- a/stdlib/_collections_abc.pyi
+++ b/stdlib/_collections_abc.pyi
@@ -65,14 +65,17 @@ _VT_co = TypeVar("_VT_co", covariant=True)  # Value type covariant containers.
 @final
 class dict_keys(KeysView[_KT_co], Generic[_KT_co, _VT_co]):  # undocumented
     if sys.version_info >= (3, 10):
-        mapping: MappingProxyType[_KT_co, _VT_co]
+        @property
+        def mapping(self): -> MappingProxyType[_KT_co, _VT_co]: ...
 
 @final
 class dict_values(ValuesView[_VT_co], Generic[_KT_co, _VT_co]):  # undocumented
     if sys.version_info >= (3, 10):
-        mapping: MappingProxyType[_KT_co, _VT_co]
+        @property
+        def mapping(self): -> MappingProxyType[_KT_co, _VT_co]: ...
 
 @final
 class dict_items(ItemsView[_KT_co, _VT_co], Generic[_KT_co, _VT_co]):  # undocumented
     if sys.version_info >= (3, 10):
-        mapping: MappingProxyType[_KT_co, _VT_co]
+        @property
+        def mapping(self): -> MappingProxyType[_KT_co, _VT_co]: ...

--- a/stdlib/_collections_abc.pyi
+++ b/stdlib/_collections_abc.pyi
@@ -66,16 +66,16 @@ _VT_co = TypeVar("_VT_co", covariant=True)  # Value type covariant containers.
 class dict_keys(KeysView[_KT_co], Generic[_KT_co, _VT_co]):  # undocumented
     if sys.version_info >= (3, 10):
         @property
-        def mapping(self): -> MappingProxyType[_KT_co, _VT_co]: ...
+        def mapping(self) -> MappingProxyType[_KT_co, _VT_co]: ...
 
 @final
 class dict_values(ValuesView[_VT_co], Generic[_KT_co, _VT_co]):  # undocumented
     if sys.version_info >= (3, 10):
         @property
-        def mapping(self): -> MappingProxyType[_KT_co, _VT_co]: ...
+        def mapping(self) -> MappingProxyType[_KT_co, _VT_co]: ...
 
 @final
 class dict_items(ItemsView[_KT_co, _VT_co], Generic[_KT_co, _VT_co]):  # undocumented
     if sys.version_info >= (3, 10):
         @property
-        def mapping(self): -> MappingProxyType[_KT_co, _VT_co]: ...
+        def mapping(self) -> MappingProxyType[_KT_co, _VT_co]: ...


### PR DESCRIPTION
Completely orthogonal to the other issues around the dict views classes that have been discussed recently — but something I noticed.