### PR TITLE
fix type of selenium.webdriver.chrome.webdriver

### DIFF
--- a/stubs/selenium/selenium/webdriver/chrome/webdriver.pyi
+++ b/stubs/selenium/selenium/webdriver/chrome/webdriver.pyi
@@ -2,8 +2,8 @@ from typing import Any
 
 from selenium.webdriver.remote.webdriver import WebDriver as RemoteWebDriver
 
-from .remote_connection import ChromeRemoteConnection as ChromeRemoteConnection
 from .options import Options
+from .remote_connection import ChromeRemoteConnection as ChromeRemoteConnection
 from .service import Service
 
 class WebDriver(RemoteWebDriver):

--- a/stubs/selenium/selenium/webdriver/chrome/webdriver.pyi
+++ b/stubs/selenium/selenium/webdriver/chrome/webdriver.pyi
@@ -3,6 +3,8 @@ from typing import Any
 from selenium.webdriver.remote.webdriver import WebDriver as RemoteWebDriver
 
 from .remote_connection import ChromeRemoteConnection as ChromeRemoteConnection
+from .options import Options
+from .service import Service
 
 class WebDriver(RemoteWebDriver):
     service: Any
@@ -10,11 +12,12 @@ class WebDriver(RemoteWebDriver):
         self,
         executable_path: str = ...,
         port: int = ...,
-        options: Any | None = ...,
+        options: Options | None = ...,
         service_args: Any | None = ...,
         desired_capabilities: Any | None = ...,
         service_log_path: Any | None = ...,
         chrome_options: Any | None = ...,
+        service: Service | None = ...,
         keep_alive: bool = ...,
     ) -> None: ...
     def launch_app(self, id): ...


### PR DESCRIPTION
Add the `service` init param for the latest selenium `selenium.webdriver.chrome.webdriver.

https://github.com/SeleniumHQ/selenium/blob/3f75c6bc10caf67c606a2f74855320907927973e/py/selenium/webdriver/chrome/webdriver.py#L39