### PR TITLE
improve tkinter.Treeview.heading and tkinter.Treeview.item

### DIFF
--- a/stdlib/tkinter/ttk.pyi
+++ b/stdlib/tkinter/ttk.pyi
@@ -1002,7 +1002,7 @@ class Treeview(Widget, tkinter.XView, tkinter.YView):
     @overload
     def heading(self, column: _TreeviewColumnId, option: str) -> Any: ...
     @overload
-    def heading(
+    def heading(  # type: ignore[misc]
         self,
         column: _TreeviewColumnId,
         option: None = ...,
@@ -1050,7 +1050,7 @@ class Treeview(Widget, tkinter.XView, tkinter.YView):
     @overload
     def item(self, item: str, option: str) -> Any: ...
     @overload
-    def item(
+    def item(  # type: ignore[misc]
         self,
         item: str,
         option: None = ...,

--- a/stdlib/tkinter/ttk.pyi
+++ b/stdlib/tkinter/ttk.pyi
@@ -1002,11 +1002,7 @@ class Treeview(Widget, tkinter.XView, tkinter.YView):
     @overload
     def heading(self, column: _TreeviewColumnId, option: str) -> Any: ...
     @overload
-    def heading(  # type: ignore[misc]
-        self,
-        column: _TreeviewColumnId,
-        option: None = ...,
-    ) -> _TreeviewHeaderDict: ...
+    def heading(self, column: _TreeviewColumnId, option: None = ...) -> _TreeviewHeaderDict: ...  # type: ignore[misc]
     @overload
     def heading(
         self,
@@ -1050,11 +1046,7 @@ class Treeview(Widget, tkinter.XView, tkinter.YView):
     @overload
     def item(self, item: str, option: str) -> Any: ...
     @overload
-    def item(  # type: ignore[misc]
-        self,
-        item: str,
-        option: None = ...,
-    ) -> _TreeviewItemDict: ...
+    def item(self, item: str, option: None = ...) -> _TreeviewItemDict: ...  # type: ignore[misc]
     @overload
     def item(
         self,

--- a/stdlib/tkinter/ttk.pyi
+++ b/stdlib/tkinter/ttk.pyi
@@ -902,7 +902,7 @@ class _TreeviewTagDict(TypedDict):
 
 class _TreeviewHeaderDict(TypedDict):
     text: str
-    image: list[str]
+    image: list[str] | Literal[""]
     anchor: tkinter._Anchor
     command: str
     state: str  # Doesn't seem to appear anywhere else than in these dicts
@@ -994,7 +994,7 @@ class Treeview(Widget, tkinter.XView, tkinter.YView):
     @overload
     def heading(self, column: _TreeviewColumnId, option: Literal["text"]) -> str: ...
     @overload
-    def heading(self, column: _TreeviewColumnId, option: Literal["image"]) -> tuple[str]: ...
+    def heading(self, column: _TreeviewColumnId, option: Literal["image"]) -> tuple[str] | str: ...
     @overload
     def heading(self, column: _TreeviewColumnId, option: Literal["anchor"]) -> _tkinter.Tcl_Obj: ...
     @overload
@@ -1006,12 +1006,18 @@ class Treeview(Widget, tkinter.XView, tkinter.YView):
         self,
         column: _TreeviewColumnId,
         option: None = ...,
+    ) -> _TreeviewHeaderDict: ...
+    @overload
+    def heading(
+        self,
+        column: _TreeviewColumnId,
+        option: None = ...,
         *,
         text: str = ...,
         image: tkinter._ImageSpec = ...,
         anchor: tkinter._Anchor = ...,
         command: str | Callable[[], Any] = ...,
-    ) -> _TreeviewHeaderDict | None: ...
+    ) -> None: ...
     def identify(self, component, x, y): ...
     def identify_row(self, y: int) -> str: ...
     def identify_column(self, x: int) -> str: ...
@@ -1048,13 +1054,19 @@ class Treeview(Widget, tkinter.XView, tkinter.YView):
         self,
         item: str,
         option: None = ...,
+    ) -> _TreeviewItemDict: ...
+    @overload
+    def item(
+        self,
+        item: str,
+        option: None = ...,
         *,
         text: str = ...,
         image: tkinter._ImageSpec = ...,
         values: list[Any] | tuple[Any, ...] | Literal[""] = ...,
         open: bool = ...,
         tags: str | list[str] | tuple[str, ...] = ...,
-    ) -> _TreeviewItemDict | None: ...
+    ) -> None: ...
     def move(self, item: str, parent: str, index: int) -> None: ...
     reattach = move
     def next(self, item: str) -> str: ...  # returning empty string means last item


### PR DESCRIPTION
There's some `>>>` prompt experimentation on https://github.com/PyCQA/flake8-pyi/pull/135. This is inconsistent, because tkinter returns the objects however Tcl happens to represent them internally, and Tcl's internal representations are meant to be a transparent optimization that can be ignored.

I also realized that it's possible to distinguish "no `**kwargs` arguments given" and "at least one keyword argument given" with overloads, and used that to get rid of a union return type.