### PR TITLE
bs4: Expose bs4.SoupStrainer and bs4.Tag

### DIFF
--- a/stubs/beautifulsoup4/bs4/__init__.pyi
+++ b/stubs/beautifulsoup4/bs4/__init__.pyi
@@ -2,7 +2,7 @@ from _typeshed import Self, SupportsRead
 from typing import Any, Sequence
 
 from .builder import TreeBuilder
-from .element import PageElement, SoupStrainer as SoupStainer, Tag as Tag
+from .element import PageElement, SoupStrainer as SoupStrainer, Tag as Tag
 from .formatter import Formatter
 
 class GuessedAtParserWarning(UserWarning): ...

--- a/stubs/beautifulsoup4/bs4/__init__.pyi
+++ b/stubs/beautifulsoup4/bs4/__init__.pyi
@@ -2,7 +2,7 @@ from _typeshed import Self, SupportsRead
 from typing import Any, Sequence
 
 from .builder import TreeBuilder
-from .element import PageElement, SoupStrainer, Tag
+from .element import PageElement, SoupStrainer as SoupStainer, Tag as Tag
 from .formatter import Formatter
 
 class GuessedAtParserWarning(UserWarning): ...


### PR DESCRIPTION
These are mentioned in https://www.crummy.com/software/BeautifulSoup/bs4/doc/index.html?highlight=soupstrainer as public objects.

See microsoft/pyright#2922.