### PR TITLE
Use stricter transport types in asyncio subprocess methods

### DIFF
--- a/stdlib/asyncio/base_events.pyi
+++ b/stdlib/asyncio/base_events.pyi
@@ -6,7 +6,7 @@ from asyncio.events import AbstractEventLoop, AbstractServer, Handle, TimerHandl
 from asyncio.futures import Future
 from asyncio.protocols import BaseProtocol
 from asyncio.tasks import Task
-from asyncio.transports import BaseTransport
+from asyncio.transports import BaseTransport, ReadTransport, SubprocessTransport, WriteTransport
 from collections.abc import Iterable
 from socket import AddressFamily, SocketKind, _Address, _RetAddress, socket
 from typing import IO, Any, Awaitable, Callable, Generator, Sequence, TypeVar, Union, overload
@@ -317,10 +317,10 @@ class BaseEventLoop(AbstractEventLoop, metaclass=ABCMeta):
     # Pipes and subprocesses.
     async def connect_read_pipe(
         self, protocol_factory: Callable[[], _ProtocolT], pipe: Any
-    ) -> tuple[BaseTransport, _ProtocolT]: ...
+    ) -> tuple[ReadTransport, _ProtocolT]: ...
     async def connect_write_pipe(
         self, protocol_factory: Callable[[], _ProtocolT], pipe: Any
-    ) -> tuple[BaseTransport, _ProtocolT]: ...
+    ) -> tuple[WriteTransport, _ProtocolT]: ...
     async def subprocess_shell(
         self,
         protocol_factory: Callable[[], _ProtocolT],
@@ -336,7 +336,7 @@ class BaseEventLoop(AbstractEventLoop, metaclass=ABCMeta):
         errors: None = ...,
         text: Literal[False, None] = ...,
         **kwargs: Any,
-    ) -> tuple[BaseTransport, _ProtocolT]: ...
+    ) -> tuple[SubprocessTransport, _ProtocolT]: ...
     async def subprocess_exec(
         self,
         protocol_factory: Callable[[], _ProtocolT],
@@ -351,7 +351,7 @@ class BaseEventLoop(AbstractEventLoop, metaclass=ABCMeta):
         encoding: None = ...,
         errors: None = ...,
         **kwargs: Any,
-    ) -> tuple[BaseTransport, _ProtocolT]: ...
+    ) -> tuple[SubprocessTransport, _ProtocolT]: ...
     def add_reader(self, fd: FileDescriptorLike, callback: Callable[..., Any], *args: Any) -> None: ...
     def remove_reader(self, fd: FileDescriptorLike) -> None: ...
     def add_writer(self, fd: FileDescriptorLike, callback: Callable[..., Any], *args: Any) -> None: ...

--- a/stdlib/asyncio/events.pyi
+++ b/stdlib/asyncio/events.pyi
@@ -10,7 +10,7 @@ from .base_events import Server
 from .futures import Future
 from .protocols import BaseProtocol
 from .tasks import Task
-from .transports import BaseTransport
+from .transports import BaseTransport, ReadTransport, SubprocessTransport, WriteTransport
 from .unix_events import AbstractChildWatcher
 
 if sys.version_info >= (3, 7):
@@ -376,11 +376,11 @@ class AbstractEventLoop(metaclass=ABCMeta):
     @abstractmethod
     async def connect_read_pipe(
         self, protocol_factory: Callable[[], _ProtocolT], pipe: Any
-    ) -> tuple[BaseTransport, _ProtocolT]: ...
+    ) -> tuple[ReadTransport, _ProtocolT]: ...
     @abstractmethod
     async def connect_write_pipe(
         self, protocol_factory: Callable[[], _ProtocolT], pipe: Any
-    ) -> tuple[BaseTransport, _ProtocolT]: ...
+    ) -> tuple[WriteTransport, _ProtocolT]: ...
     @abstractmethod
     async def subprocess_shell(
         self,
@@ -397,7 +397,7 @@ class AbstractEventLoop(metaclass=ABCMeta):
         errors: None = ...,
         text: Literal[False, None] = ...,
         **kwargs: Any,
-    ) -> tuple[BaseTransport, _ProtocolT]: ...
+    ) -> tuple[SubprocessTransport, _ProtocolT]: ...
     @abstractmethod
     async def subprocess_exec(
         self,
@@ -413,7 +413,7 @@ class AbstractEventLoop(metaclass=ABCMeta):
         encoding: None = ...,
         errors: None = ...,
         **kwargs: Any,
-    ) -> tuple[BaseTransport, _ProtocolT]: ...
+    ) -> tuple[SubprocessTransport, _ProtocolT]: ...
     @abstractmethod
     def add_reader(self, fd: FileDescriptorLike, callback: Callable[..., Any], *args: Any) -> None: ...
     @abstractmethod


### PR DESCRIPTION
asyncio pipes and subprocess methods return specific transport types (which are documented). Currently it's necessary to use casts to access correct method, this patch makes casts unnecessary.