### PR TITLE
Removed unused `# noqa: F403`

### DIFF
--- a/stdlib/@python2/curses/__init__.pyi
+++ b/stdlib/@python2/curses/__init__.pyi
@@ -1,4 +1,4 @@
-from _curses import *  # noqa: F403
+from _curses import *
 from _curses import _CursesWindow as _CursesWindow
 from typing import Any, Callable, TypeVar
 

--- a/stdlib/@python2/sqlite3/__init__.pyi
+++ b/stdlib/@python2/sqlite3/__init__.pyi
@@ -1,1 +1,1 @@
-from sqlite3.dbapi2 import *  # noqa: F403
+from sqlite3.dbapi2 import *

--- a/stdlib/@python2/xml/etree/cElementTree.pyi
+++ b/stdlib/@python2/xml/etree/cElementTree.pyi
@@ -1,1 +1,1 @@
-from xml.etree.ElementTree import *  # noqa: F403
+from xml.etree.ElementTree import *

--- a/stdlib/curses/__init__.pyi
+++ b/stdlib/curses/__init__.pyi
@@ -2,7 +2,7 @@ import sys
 from typing import Any, Callable, TypeVar
 
 if sys.platform != "win32":
-    from _curses import *  # noqa: F403
+    from _curses import *
     from _curses import _CursesWindow as _CursesWindow
 
     _T = TypeVar("_T")

--- a/stdlib/sqlite3/__init__.pyi
+++ b/stdlib/sqlite3/__init__.pyi
@@ -1,1 +1,1 @@
-from sqlite3.dbapi2 import *  # noqa: F403
+from sqlite3.dbapi2 import *

--- a/stdlib/tokenize.pyi
+++ b/stdlib/tokenize.pyi
@@ -1,7 +1,7 @@
 import sys
 from _typeshed import StrOrBytesPath
 from builtins import open as _builtin_open
-from token import *  # noqa: F403
+from token import *
 from typing import Any, Callable, Generator, Iterable, NamedTuple, Pattern, Sequence, TextIO, Union
 
 if sys.version_info < (3, 7):

--- a/stdlib/xml/etree/cElementTree.pyi
+++ b/stdlib/xml/etree/cElementTree.pyi
@@ -1,1 +1,1 @@
-from xml.etree.ElementTree import *  # noqa: F403
+from xml.etree.ElementTree import *


### PR DESCRIPTION
Since `F403` is ignored for all `.pyi` files, it is not required to be inline ignored as well.

https://github.com/python/typeshed/blob/0238956f909fca5f60a60f715314974c06ac3918/.flake8#L29
