### PR TITLE
Clarify why some module-level objects in `typing` have default values

### DIFF
--- a/stdlib/@python2/typing.pyi
+++ b/stdlib/@python2/typing.pyi
@@ -23,12 +23,19 @@ _promote = object()
 class _SpecialForm(object):
     def __getitem__(self, typeargs: Any) -> object: ...
 
-Union: _SpecialForm = ...
-Optional: _SpecialForm
-Tuple: _SpecialForm
+# Unlike the vast majority module-level objects in stub files,
+# these `_SpecialForm` objects in typing need the default value `= ...`,
+# due to the fact that they are used elswhere in the same file.
+# Otherwise, flake8 erroneously flags them as undefined.
+# `_SpecialForm` objects in typing.py that are not used elswhere in the same file
+# do not need the default value assignment.
 Generic: _SpecialForm = ...
 Protocol: _SpecialForm = ...
 Callable: _SpecialForm = ...
+Union: _SpecialForm = ...
+
+Optional: _SpecialForm
+Tuple: _SpecialForm
 Type: _SpecialForm
 ClassVar: _SpecialForm
 Final: _SpecialForm

--- a/stdlib/@python2/typing_extensions.pyi
+++ b/stdlib/@python2/typing_extensions.pyi
@@ -14,7 +14,8 @@ from typing import (  # noqa Y022
     Mapping,
     NewType as NewType,
     NoReturn as NoReturn,
-    Protocol as _Protocol,
+    Protocol as Protocol,
+    runtime_checkable as runtime_checkable,
     Text as Text,
     Type as Type,
     TypeVar,
@@ -30,11 +31,8 @@ _TC = TypeVar("_TC", bound=type[object])
 class _SpecialForm:
     def __getitem__(self, typeargs: Any) -> Any: ...
 
-def runtime_checkable(cls: _TC) -> _TC: ...
-
 # This alias for above is kept here for backwards compatibility.
 runtime = runtime_checkable
-Protocol: _SpecialForm
 Final: _SpecialForm
 
 def final(f: _F) -> _F: ...
@@ -74,7 +72,7 @@ Annotated: _SpecialForm
 _AnnotatedAlias: Any  # undocumented
 
 @runtime_checkable
-class SupportsIndex(_Protocol, metaclass=abc.ABCMeta):
+class SupportsIndex(Protocol, metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def __index__(self) -> int: ...
 

--- a/stdlib/@python2/typing_extensions.pyi
+++ b/stdlib/@python2/typing_extensions.pyi
@@ -14,6 +14,7 @@ from typing import (  # noqa Y022
     Mapping,
     NewType as NewType,
     NoReturn as NoReturn,
+    Protocol as _Protocol,
     Text as Text,
     Type as Type,
     TypeVar,
@@ -33,7 +34,7 @@ def runtime_checkable(cls: _TC) -> _TC: ...
 
 # This alias for above is kept here for backwards compatibility.
 runtime = runtime_checkable
-Protocol: _SpecialForm = ...
+Protocol: _SpecialForm
 Final: _SpecialForm
 
 def final(f: _F) -> _F: ...
@@ -73,7 +74,7 @@ Annotated: _SpecialForm
 _AnnotatedAlias: Any  # undocumented
 
 @runtime_checkable
-class SupportsIndex(Protocol, metaclass=abc.ABCMeta):
+class SupportsIndex(_Protocol, metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def __index__(self) -> int: ...
 

--- a/stdlib/@python2/typing_extensions.pyi
+++ b/stdlib/@python2/typing_extensions.pyi
@@ -26,7 +26,6 @@ from typing import (  # noqa Y022
 
 _T = TypeVar("_T")
 _F = TypeVar("_F", bound=Callable[..., Any])
-_TC = TypeVar("_TC", bound=type[object])
 
 class _SpecialForm:
     def __getitem__(self, typeargs: Any) -> Any: ...

--- a/stdlib/typing.pyi
+++ b/stdlib/typing.pyi
@@ -41,16 +41,24 @@ _T = TypeVar("_T")
 
 def overload(func: _F) -> _F: ...
 
+
+# Unlike the vast majority module-level objects in stub files,
+# these `_SpecialForm` objects in typing need the default value `= ...`,
+# due to the fact that they are used elswhere in the same file.
+# Otherwise, flake8 erroneously flags them as undefined.
+# `_SpecialForm` objects in typing.py that are not used elswhere in the same file
+# do not need the default value assignment.
 Union: _SpecialForm = ...
-Optional: _SpecialForm
-Tuple: _SpecialForm
 Generic: _SpecialForm = ...
 # Protocol is only present in 3.8 and later, but mypy needs it unconditionally
 Protocol: _SpecialForm = ...
 Callable: _SpecialForm = ...
 Type: _SpecialForm = ...
-ClassVar: _SpecialForm
 NoReturn: _SpecialForm = ...
+
+Optional: _SpecialForm
+Tuple: _SpecialForm
+ClassVar: _SpecialForm
 if sys.version_info >= (3, 8):
     Final: _SpecialForm
     def final(f: _T) -> _T: ...

--- a/stdlib/typing_extensions.pyi
+++ b/stdlib/typing_extensions.pyi
@@ -34,7 +34,6 @@ from typing import (  # noqa Y022
 
 _T = TypeVar("_T")
 _F = TypeVar("_F", bound=Callable[..., Any])
-_TC = TypeVar("_TC", bound=type[object])
 
 class _SpecialForm:
     def __getitem__(self, typeargs: Any) -> Any: ...

--- a/stdlib/typing_extensions.pyi
+++ b/stdlib/typing_extensions.pyi
@@ -22,7 +22,8 @@ from typing import (  # noqa Y022
     Mapping,
     NewType as NewType,
     NoReturn as NoReturn,
-    Protocol as _Protocol,
+    Protocol as Protocol,
+    runtime_checkable as runtime_checkable,
     Text as Text,
     Type as Type,
     TypeVar,
@@ -38,11 +39,8 @@ _TC = TypeVar("_TC", bound=type[object])
 class _SpecialForm:
     def __getitem__(self, typeargs: Any) -> Any: ...
 
-def runtime_checkable(cls: _TC) -> _TC: ...
-
 # This alias for above is kept here for backwards compatibility.
 runtime = runtime_checkable
-Protocol: _SpecialForm
 Final: _SpecialForm
 Self: _SpecialForm
 Required: _SpecialForm
@@ -95,7 +93,7 @@ Annotated: _SpecialForm
 _AnnotatedAlias: Any  # undocumented
 
 @runtime_checkable
-class SupportsIndex(_Protocol, metaclass=abc.ABCMeta):
+class SupportsIndex(Protocol, metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def __index__(self) -> int: ...
 

--- a/stdlib/typing_extensions.pyi
+++ b/stdlib/typing_extensions.pyi
@@ -22,6 +22,7 @@ from typing import (  # noqa Y022
     Mapping,
     NewType as NewType,
     NoReturn as NoReturn,
+    Protocol as _Protocol,
     Text as Text,
     Type as Type,
     TypeVar,
@@ -41,7 +42,7 @@ def runtime_checkable(cls: _TC) -> _TC: ...
 
 # This alias for above is kept here for backwards compatibility.
 runtime = runtime_checkable
-Protocol: _SpecialForm = ...
+Protocol: _SpecialForm
 Final: _SpecialForm
 Self: _SpecialForm
 Required: _SpecialForm
@@ -94,7 +95,7 @@ Annotated: _SpecialForm
 _AnnotatedAlias: Any  # undocumented
 
 @runtime_checkable
-class SupportsIndex(Protocol, metaclass=abc.ABCMeta):
+class SupportsIndex(_Protocol, metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def __index__(self) -> int: ...
 


### PR DESCRIPTION
One possible solution to the issue raised in https://github.com/python/typeshed/pull/7036#discussion_r791847978.

cc. @JelleZijlstra 