### PR TITLE
Use relax_strict_optional_primitives on protobuf generated code

### DIFF
--- a/scripts/generate_proto_stubs.sh
+++ b/scripts/generate_proto_stubs.sh
@@ -69,7 +69,7 @@ PROTO_FILES=$(grep "generate_proto.*google" $PYTHON_PROTOBUF_DIR/python/setup.py
 )
 
 # And regenerate!
-protoc_install/bin/protoc --proto_path="$PYTHON_PROTOBUF_DIR/src" --mypy_out="$REPO_ROOT/stubs/protobuf" $PROTO_FILES
+protoc_install/bin/protoc --proto_path="$PYTHON_PROTOBUF_DIR/src" --mypy_out="relax_strict_optional_primitives:$REPO_ROOT/stubs/protobuf" $PROTO_FILES
 
 isort "$REPO_ROOT/stubs/protobuf"
 black "$REPO_ROOT/stubs/protobuf"

--- a/stubs/protobuf/google/protobuf/any_pb2.pyi
+++ b/stubs/protobuf/google/protobuf/any_pb2.pyi
@@ -133,8 +133,8 @@ class Any(google.protobuf.message.Message, google.protobuf.internal.well_known_t
 
     def __init__(self,
         *,
-        type_url: typing.Text = ...,
-        value: builtins.bytes = ...,
+        type_url: typing.Optional[typing.Text] = ...,
+        value: typing.Optional[builtins.bytes] = ...,
         ) -> None: ...
     def ClearField(self, field_name: typing_extensions.Literal["type_url",b"type_url","value",b"value"]) -> None: ...
 global___Any = Any

--- a/stubs/protobuf/google/protobuf/api_pb2.pyi
+++ b/stubs/protobuf/google/protobuf/api_pb2.pyi
@@ -82,13 +82,13 @@ class Api(google.protobuf.message.Message):
 
     def __init__(self,
         *,
-        name: typing.Text = ...,
+        name: typing.Optional[typing.Text] = ...,
         methods: typing.Optional[typing.Iterable[global___Method]] = ...,
         options: typing.Optional[typing.Iterable[google.protobuf.type_pb2.Option]] = ...,
-        version: typing.Text = ...,
+        version: typing.Optional[typing.Text] = ...,
         source_context: typing.Optional[google.protobuf.source_context_pb2.SourceContext] = ...,
         mixins: typing.Optional[typing.Iterable[global___Mixin]] = ...,
-        syntax: google.protobuf.type_pb2.Syntax.ValueType = ...,
+        syntax: typing.Optional[google.protobuf.type_pb2.Syntax.ValueType] = ...,
         ) -> None: ...
     def HasField(self, field_name: typing_extensions.Literal["source_context",b"source_context"]) -> builtins.bool: ...
     def ClearField(self, field_name: typing_extensions.Literal["methods",b"methods","mixins",b"mixins","name",b"name","options",b"options","source_context",b"source_context","syntax",b"syntax","version",b"version"]) -> None: ...
@@ -128,13 +128,13 @@ class Method(google.protobuf.message.Message):
 
     def __init__(self,
         *,
-        name: typing.Text = ...,
-        request_type_url: typing.Text = ...,
-        request_streaming: builtins.bool = ...,
-        response_type_url: typing.Text = ...,
-        response_streaming: builtins.bool = ...,
+        name: typing.Optional[typing.Text] = ...,
+        request_type_url: typing.Optional[typing.Text] = ...,
+        request_streaming: typing.Optional[builtins.bool] = ...,
+        response_type_url: typing.Optional[typing.Text] = ...,
+        response_streaming: typing.Optional[builtins.bool] = ...,
         options: typing.Optional[typing.Iterable[google.protobuf.type_pb2.Option]] = ...,
-        syntax: google.protobuf.type_pb2.Syntax.ValueType = ...,
+        syntax: typing.Optional[google.protobuf.type_pb2.Syntax.ValueType] = ...,
         ) -> None: ...
     def ClearField(self, field_name: typing_extensions.Literal["name",b"name","options",b"options","request_streaming",b"request_streaming","request_type_url",b"request_type_url","response_streaming",b"response_streaming","response_type_url",b"response_type_url","syntax",b"syntax"]) -> None: ...
 global___Method = Method
@@ -232,8 +232,8 @@ class Mixin(google.protobuf.message.Message):
 
     def __init__(self,
         *,
-        name: typing.Text = ...,
-        root: typing.Text = ...,
+        name: typing.Optional[typing.Text] = ...,
+        root: typing.Optional[typing.Text] = ...,
         ) -> None: ...
     def ClearField(self, field_name: typing_extensions.Literal["name",b"name","root",b"root"]) -> None: ...
 global___Mixin = Mixin

--- a/stubs/protobuf/google/protobuf/duration_pb2.pyi
+++ b/stubs/protobuf/google/protobuf/duration_pb2.pyi
@@ -6,6 +6,7 @@ import builtins
 import google.protobuf.descriptor
 import google.protobuf.internal.well_known_types
 import google.protobuf.message
+import typing
 import typing_extensions
 
 DESCRIPTOR: google.protobuf.descriptor.FileDescriptor
@@ -90,8 +91,8 @@ class Duration(google.protobuf.message.Message, google.protobuf.internal.well_kn
 
     def __init__(self,
         *,
-        seconds: builtins.int = ...,
-        nanos: builtins.int = ...,
+        seconds: typing.Optional[builtins.int] = ...,
+        nanos: typing.Optional[builtins.int] = ...,
         ) -> None: ...
     def ClearField(self, field_name: typing_extensions.Literal["nanos",b"nanos","seconds",b"seconds"]) -> None: ...
 global___Duration = Duration

--- a/stubs/protobuf/google/protobuf/source_context_pb2.pyi
+++ b/stubs/protobuf/google/protobuf/source_context_pb2.pyi
@@ -23,7 +23,7 @@ class SourceContext(google.protobuf.message.Message):
 
     def __init__(self,
         *,
-        file_name: typing.Text = ...,
+        file_name: typing.Optional[typing.Text] = ...,
         ) -> None: ...
     def ClearField(self, field_name: typing_extensions.Literal["file_name",b"file_name"]) -> None: ...
 global___SourceContext = SourceContext

--- a/stubs/protobuf/google/protobuf/struct_pb2.pyi
+++ b/stubs/protobuf/google/protobuf/struct_pb2.pyi
@@ -55,7 +55,7 @@ class Struct(google.protobuf.message.Message, google.protobuf.internal.well_know
         def value(self) -> global___Value: ...
         def __init__(self,
             *,
-            key: typing.Text = ...,
+            key: typing.Optional[typing.Text] = ...,
             value: typing.Optional[global___Value] = ...,
             ) -> None: ...
         def HasField(self, field_name: typing_extensions.Literal["value",b"value"]) -> builtins.bool: ...
@@ -110,10 +110,10 @@ class Value(google.protobuf.message.Message):
         pass
     def __init__(self,
         *,
-        null_value: global___NullValue.ValueType = ...,
-        number_value: builtins.float = ...,
-        string_value: typing.Text = ...,
-        bool_value: builtins.bool = ...,
+        null_value: typing.Optional[global___NullValue.ValueType] = ...,
+        number_value: typing.Optional[builtins.float] = ...,
+        string_value: typing.Optional[typing.Text] = ...,
+        bool_value: typing.Optional[builtins.bool] = ...,
         struct_value: typing.Optional[global___Struct] = ...,
         list_value: typing.Optional[global___ListValue] = ...,
         ) -> None: ...

--- a/stubs/protobuf/google/protobuf/timestamp_pb2.pyi
+++ b/stubs/protobuf/google/protobuf/timestamp_pb2.pyi
@@ -6,6 +6,7 @@ import builtins
 import google.protobuf.descriptor
 import google.protobuf.internal.well_known_types
 import google.protobuf.message
+import typing
 import typing_extensions
 
 DESCRIPTOR: google.protobuf.descriptor.FileDescriptor
@@ -121,8 +122,8 @@ class Timestamp(google.protobuf.message.Message, google.protobuf.internal.well_k
 
     def __init__(self,
         *,
-        seconds: builtins.int = ...,
-        nanos: builtins.int = ...,
+        seconds: typing.Optional[builtins.int] = ...,
+        nanos: typing.Optional[builtins.int] = ...,
         ) -> None: ...
     def ClearField(self, field_name: typing_extensions.Literal["nanos",b"nanos","seconds",b"seconds"]) -> None: ...
 global___Timestamp = Timestamp

--- a/stubs/protobuf/google/protobuf/type_pb2.pyi
+++ b/stubs/protobuf/google/protobuf/type_pb2.pyi
@@ -71,12 +71,12 @@ class Type(google.protobuf.message.Message):
 
     def __init__(self,
         *,
-        name: typing.Text = ...,
+        name: typing.Optional[typing.Text] = ...,
         fields: typing.Optional[typing.Iterable[global___Field]] = ...,
         oneofs: typing.Optional[typing.Iterable[typing.Text]] = ...,
         options: typing.Optional[typing.Iterable[global___Option]] = ...,
         source_context: typing.Optional[google.protobuf.source_context_pb2.SourceContext] = ...,
-        syntax: global___Syntax.ValueType = ...,
+        syntax: typing.Optional[global___Syntax.ValueType] = ...,
         ) -> None: ...
     def HasField(self, field_name: typing_extensions.Literal["source_context",b"source_context"]) -> builtins.bool: ...
     def ClearField(self, field_name: typing_extensions.Literal["fields",b"fields","name",b"name","oneofs",b"oneofs","options",b"options","source_context",b"source_context","syntax",b"syntax"]) -> None: ...
@@ -290,16 +290,16 @@ class Field(google.protobuf.message.Message):
 
     def __init__(self,
         *,
-        kind: global___Field.Kind.ValueType = ...,
-        cardinality: global___Field.Cardinality.ValueType = ...,
-        number: builtins.int = ...,
-        name: typing.Text = ...,
-        type_url: typing.Text = ...,
-        oneof_index: builtins.int = ...,
-        packed: builtins.bool = ...,
+        kind: typing.Optional[global___Field.Kind.ValueType] = ...,
+        cardinality: typing.Optional[global___Field.Cardinality.ValueType] = ...,
+        number: typing.Optional[builtins.int] = ...,
+        name: typing.Optional[typing.Text] = ...,
+        type_url: typing.Optional[typing.Text] = ...,
+        oneof_index: typing.Optional[builtins.int] = ...,
+        packed: typing.Optional[builtins.bool] = ...,
         options: typing.Optional[typing.Iterable[global___Option]] = ...,
-        json_name: typing.Text = ...,
-        default_value: typing.Text = ...,
+        json_name: typing.Optional[typing.Text] = ...,
+        default_value: typing.Optional[typing.Text] = ...,
         ) -> None: ...
     def ClearField(self, field_name: typing_extensions.Literal["cardinality",b"cardinality","default_value",b"default_value","json_name",b"json_name","kind",b"kind","name",b"name","number",b"number","oneof_index",b"oneof_index","options",b"options","packed",b"packed","type_url",b"type_url"]) -> None: ...
 global___Field = Field
@@ -332,11 +332,11 @@ class Enum(google.protobuf.message.Message):
 
     def __init__(self,
         *,
-        name: typing.Text = ...,
+        name: typing.Optional[typing.Text] = ...,
         enumvalue: typing.Optional[typing.Iterable[global___EnumValue]] = ...,
         options: typing.Optional[typing.Iterable[global___Option]] = ...,
         source_context: typing.Optional[google.protobuf.source_context_pb2.SourceContext] = ...,
-        syntax: global___Syntax.ValueType = ...,
+        syntax: typing.Optional[global___Syntax.ValueType] = ...,
         ) -> None: ...
     def HasField(self, field_name: typing_extensions.Literal["source_context",b"source_context"]) -> builtins.bool: ...
     def ClearField(self, field_name: typing_extensions.Literal["enumvalue",b"enumvalue","name",b"name","options",b"options","source_context",b"source_context","syntax",b"syntax"]) -> None: ...
@@ -360,8 +360,8 @@ class EnumValue(google.protobuf.message.Message):
         pass
     def __init__(self,
         *,
-        name: typing.Text = ...,
-        number: builtins.int = ...,
+        name: typing.Optional[typing.Text] = ...,
+        number: typing.Optional[builtins.int] = ...,
         options: typing.Optional[typing.Iterable[global___Option]] = ...,
         ) -> None: ...
     def ClearField(self, field_name: typing_extensions.Literal["name",b"name","number",b"number","options",b"options"]) -> None: ...
@@ -391,7 +391,7 @@ class Option(google.protobuf.message.Message):
         pass
     def __init__(self,
         *,
-        name: typing.Text = ...,
+        name: typing.Optional[typing.Text] = ...,
         value: typing.Optional[google.protobuf.any_pb2.Any] = ...,
         ) -> None: ...
     def HasField(self, field_name: typing_extensions.Literal["value",b"value"]) -> builtins.bool: ...

--- a/stubs/protobuf/google/protobuf/wrappers_pb2.pyi
+++ b/stubs/protobuf/google/protobuf/wrappers_pb2.pyi
@@ -22,7 +22,7 @@ class DoubleValue(google.protobuf.message.Message):
 
     def __init__(self,
         *,
-        value: builtins.float = ...,
+        value: typing.Optional[builtins.float] = ...,
         ) -> None: ...
     def ClearField(self, field_name: typing_extensions.Literal["value",b"value"]) -> None: ...
 global___DoubleValue = DoubleValue
@@ -39,7 +39,7 @@ class FloatValue(google.protobuf.message.Message):
 
     def __init__(self,
         *,
-        value: builtins.float = ...,
+        value: typing.Optional[builtins.float] = ...,
         ) -> None: ...
     def ClearField(self, field_name: typing_extensions.Literal["value",b"value"]) -> None: ...
 global___FloatValue = FloatValue
@@ -56,7 +56,7 @@ class Int64Value(google.protobuf.message.Message):
 
     def __init__(self,
         *,
-        value: builtins.int = ...,
+        value: typing.Optional[builtins.int] = ...,
         ) -> None: ...
     def ClearField(self, field_name: typing_extensions.Literal["value",b"value"]) -> None: ...
 global___Int64Value = Int64Value
@@ -73,7 +73,7 @@ class UInt64Value(google.protobuf.message.Message):
 
     def __init__(self,
         *,
-        value: builtins.int = ...,
+        value: typing.Optional[builtins.int] = ...,
         ) -> None: ...
     def ClearField(self, field_name: typing_extensions.Literal["value",b"value"]) -> None: ...
 global___UInt64Value = UInt64Value
@@ -90,7 +90,7 @@ class Int32Value(google.protobuf.message.Message):
 
     def __init__(self,
         *,
-        value: builtins.int = ...,
+        value: typing.Optional[builtins.int] = ...,
         ) -> None: ...
     def ClearField(self, field_name: typing_extensions.Literal["value",b"value"]) -> None: ...
 global___Int32Value = Int32Value
@@ -107,7 +107,7 @@ class UInt32Value(google.protobuf.message.Message):
 
     def __init__(self,
         *,
-        value: builtins.int = ...,
+        value: typing.Optional[builtins.int] = ...,
         ) -> None: ...
     def ClearField(self, field_name: typing_extensions.Literal["value",b"value"]) -> None: ...
 global___UInt32Value = UInt32Value
@@ -124,7 +124,7 @@ class BoolValue(google.protobuf.message.Message):
 
     def __init__(self,
         *,
-        value: builtins.bool = ...,
+        value: typing.Optional[builtins.bool] = ...,
         ) -> None: ...
     def ClearField(self, field_name: typing_extensions.Literal["value",b"value"]) -> None: ...
 global___BoolValue = BoolValue
@@ -141,7 +141,7 @@ class StringValue(google.protobuf.message.Message):
 
     def __init__(self,
         *,
-        value: typing.Text = ...,
+        value: typing.Optional[typing.Text] = ...,
         ) -> None: ...
     def ClearField(self, field_name: typing_extensions.Literal["value",b"value"]) -> None: ...
 global___StringValue = StringValue
@@ -158,7 +158,7 @@ class BytesValue(google.protobuf.message.Message):
 
     def __init__(self,
         *,
-        value: builtins.bytes = ...,
+        value: typing.Optional[builtins.bytes] = ...,
         ) -> None: ...
     def ClearField(self, field_name: typing_extensions.Literal["value",b"value"]) -> None: ...
 global___BytesValue = BytesValue


### PR DESCRIPTION
Per the suggestion in https://github.com/dropbox/mypy-protobuf/issues/344
This generates more permissive constructors (which protobuf itself actually
accepts).

Philosophically, I think it makes sense for the generated code hosted on
typeshed to be most permissive, while the generated code of individual
projects can make individual decisions (defaulting to less permissive).