### PR TITLE
Improve `unittest.removeHandler` in Python 2

### DIFF
--- a/stdlib/@python2/unittest.pyi
+++ b/stdlib/@python2/unittest.pyi
@@ -2,9 +2,11 @@ import datetime
 import types
 from abc import ABCMeta, abstractmethod
 from typing import Any, Callable, Iterable, Iterator, Mapping, NoReturn, Pattern, Sequence, Text, TextIO, TypeVar, Union, overload
+from typing_extensions import ParamSpec
 
 _T = TypeVar("_T")
 _FT = TypeVar("_FT")
+_P = ParamSpec("_P")
 
 _ExceptionType = Union[type[BaseException], tuple[type[BaseException], ...]]
 _Regexp = Union[Text, Pattern[Text]]
@@ -251,7 +253,7 @@ def removeResult(result: TestResult) -> bool: ...
 @overload
 def removeHandler() -> None: ...
 @overload
-def removeHandler(function: Callable[..., Any]) -> Callable[..., Any]: ...
+def removeHandler(function: Callable[_P, _T]) -> Callable[_P, _T]: ...
 
 # private but occasionally used
 util: types.ModuleType


### PR DESCRIPTION
This brings the signature in line with the signature of `removeHandler` in Python 3:

https://github.com/python/typeshed/blob/a54e21992c26485edb374e1287a7e9c073d6a9ae/stdlib/unittest/signals.pyi#L11-L14