### PR TITLE
Make `asyncio.isfuture` a `TypeGuard`

### DIFF
--- a/stdlib/asyncio/base_futures.pyi
+++ b/stdlib/asyncio/base_futures.pyi
@@ -11,7 +11,7 @@ _PENDING: Literal["PENDING"]  # undocumented
 _CANCELLED: Literal["CANCELLED"]  # undocumented
 _FINISHED: Literal["FINISHED"]  # undocumented
 
-def isfuture(obj: object) -> TypeGuard[futures.Future]: ...
+def isfuture(obj: object) -> TypeGuard[futures.Future[Any]]: ...
 
 if sys.version_info >= (3, 7):
     def _format_callbacks(cb: Sequence[tuple[Callable[[futures.Future[Any]], None], Context]]) -> str: ...  # undocumented

--- a/stdlib/asyncio/base_futures.pyi
+++ b/stdlib/asyncio/base_futures.pyi
@@ -1,6 +1,6 @@
 import sys
 from typing import Any, Callable, Sequence
-from typing_extensions import Literal
+from typing_extensions import Literal, TypeGuard
 
 if sys.version_info >= (3, 7):
     from contextvars import Context
@@ -11,7 +11,7 @@ _PENDING: Literal["PENDING"]  # undocumented
 _CANCELLED: Literal["CANCELLED"]  # undocumented
 _FINISHED: Literal["FINISHED"]  # undocumented
 
-def isfuture(obj: object) -> bool: ...
+def isfuture(obj: object) -> TypeGuard[futures.Future]: ...
 
 if sys.version_info >= (3, 7):
     def _format_callbacks(cb: Sequence[tuple[Callable[[futures.Future[Any]], None], Context]]) -> str: ...  # undocumented


### PR DESCRIPTION
Docs https://docs.python.org/3/library/asyncio-future.html#asyncio.isfuture