### PR TITLE
Use `dbm._TFlags` in `shelve.open`

### DIFF
--- a/stdlib/shelve.pyi
+++ b/stdlib/shelve.pyi
@@ -1,8 +1,8 @@
 from _typeshed import Self
 from collections.abc import Iterator, MutableMapping
+from dbm import _TFlags
 from types import TracebackType
 from typing import TypeVar, overload
-from dbm import _TFlags
 
 _T = TypeVar("_T")
 _VT = TypeVar("_VT")

--- a/stdlib/shelve.pyi
+++ b/stdlib/shelve.pyi
@@ -2,6 +2,7 @@ from _typeshed import Self
 from collections.abc import Iterator, MutableMapping
 from types import TracebackType
 from typing import TypeVar, overload
+from dbm import _TFlags
 
 _T = TypeVar("_T")
 _VT = TypeVar("_VT")
@@ -34,6 +35,6 @@ class BsdDbShelf(Shelf[_VT]):
     def last(self) -> tuple[str, _VT]: ...
 
 class DbfilenameShelf(Shelf[_VT]):
-    def __init__(self, filename: str, flag: str = ..., protocol: int | None = ..., writeback: bool = ...) -> None: ...
+    def __init__(self, filename: str, flag: _TFlags = ..., protocol: int | None = ..., writeback: bool = ...) -> None: ...
 
-def open(filename: str, flag: str = ..., protocol: int | None = ..., writeback: bool = ...) -> Shelf[object]: ...
+def open(filename: str, flag: _TFlags = ..., protocol: int | None = ..., writeback: bool = ...) -> Shelf[object]: ...


### PR DESCRIPTION
`shelve.open` passes its args to `dbm.open`, so args must be the same: https://github.com/python/cpython/blob/8fb36494501aad5b0c1d34311c9743c60bb9926c/Lib/shelve.py#L218-L243