### PR TITLE
Allow ExitStack.push callbacks to return None

### DIFF
--- a/stdlib/contextlib.pyi
+++ b/stdlib/contextlib.pyi
@@ -31,7 +31,7 @@ _T_io = TypeVar("_T_io", bound=Optional[IO[str]])
 _F = TypeVar("_F", bound=Callable[..., Any])
 _P = ParamSpec("_P")
 
-_ExitFunc = Callable[[Optional[type[BaseException]], Optional[BaseException], Optional[TracebackType]], bool]
+_ExitFunc = Callable[[Optional[type[BaseException]], Optional[BaseException], Optional[TracebackType]], Optional[bool]]
 _CM_EF = TypeVar("_CM_EF", AbstractContextManager[Any], _ExitFunc)
 
 class ContextDecorator:


### PR DESCRIPTION
This is used here: https://github.com/python/cpython/blob/8fb36494501aad5b0c1d34311c9743c60bb9926c/Lib/contextlib.py#L576

I found a place in our codebase where we push a function that returns None. That's pretty normal for `__exit__` functions, so I think we should allow it.