### PR TITLE
Delete `SupportsAnyComparison` type in `_typeshed`

### DIFF
--- a/stdlib/_typeshed/__init__.pyi
+++ b/stdlib/_typeshed/__init__.pyi
@@ -53,7 +53,6 @@ class SupportsAllComparisons(SupportsDunderLT, SupportsDunderGT, SupportsDunderL
 
 SupportsRichComparison = Union[SupportsDunderLT, SupportsDunderGT]
 SupportsRichComparisonT = TypeVar("SupportsRichComparisonT", bound=SupportsRichComparison)  # noqa: Y001
-SupportsAnyComparison = Union[SupportsDunderLE, SupportsDunderGE, SupportsDunderGT, SupportsDunderLT]
 
 class SupportsDivMod(Protocol[_T_contra, _T_co]):
     def __divmod__(self, __other: _T_contra) -> _T_co: ...


### PR DESCRIPTION
It is no longer used anywhere, following #7093