### PR TITLE
Add iterable and ServerPool types to ldap3 Connection.server parameter 

### DIFF
--- a/stubs/ldap3/ldap3/core/connection.pyi
+++ b/stubs/ldap3/ldap3/core/connection.pyi
@@ -1,8 +1,9 @@
 from _typeshed import Self
 from types import TracebackType
-from typing import Any
+from typing import Any, Iterable
 from typing_extensions import Literal
 
+from .pooling import ServerPool
 from .server import Server
 
 SASL_AVAILABLE_MECHANISMS: Any
@@ -59,7 +60,7 @@ class Connection:
     post_send_search: Any
     def __init__(
         self,
-        server: Server | str,
+        server: Server | str | Iterable[Server] | ServerPool,
         user: str | None = ...,
         password: str | None = ...,
         auto_bind: Literal["DEFAULT", "NONE", "NO_TLS", "TLS_BEFORE_BIND", "TLS_AFTER_BIND"] = ...,

--- a/stubs/ldap3/ldap3/core/connection.pyi
+++ b/stubs/ldap3/ldap3/core/connection.pyi
@@ -1,6 +1,7 @@
+from _collections_abc import Generator, dict_keys
 from _typeshed import Self
 from types import TracebackType
-from typing import Any, Iterable
+from typing import Any
 from typing_extensions import Literal
 
 from .pooling import ServerPool
@@ -8,6 +9,8 @@ from .server import Server
 
 SASL_AVAILABLE_MECHANISMS: Any
 CLIENT_STRATEGIES: Any
+
+_ServerSequence = set[Server] | list[Server] | tuple[Server, ...] | Generator[Server, None, None] | dict_keys[Server, Any]
 
 class Connection:
     connection_lock: Any
@@ -60,7 +63,7 @@ class Connection:
     post_send_search: Any
     def __init__(
         self,
-        server: Server | str | Iterable[Server] | ServerPool,
+        server: Server | str | _ServerSequence | ServerPool,
         user: str | None = ...,
         password: str | None = ...,
         auto_bind: Literal["DEFAULT", "NONE", "NO_TLS", "TLS_BEFORE_BIND", "TLS_AFTER_BIND"] = ...,


### PR DESCRIPTION
The ldap3 package Connection class supports additional types in the server parameter. These can be either a ServerPool instance or an iterable containing Server instances.

See the source implementation [here](https://github.com/cannatag/ldap3/blob/dev/ldap3/core/connection.py#L310)