### PR TITLE
bisect: insort_*, unlike bisect_*, expects x to match type of elements of a

### DIFF
--- a/stdlib/_bisect.pyi
+++ b/stdlib/_bisect.pyi
@@ -27,27 +27,21 @@ if sys.version_info >= (3, 10):
         *,
         key: Callable[[_T], SupportsRichComparisonT] = ...,
     ) -> int: ...
-    @overload
-    def insort_left(a: MutableSequence[_T], x: _T, lo: int = ..., hi: int | None = ..., *, key: None = ...) -> None: ...
-    @overload
     def insort_left(
         a: MutableSequence[_T],
-        x: SupportsRichComparisonT,
+        x: _T,
         lo: int = ...,
         hi: int | None = ...,
         *,
-        key: Callable[[_T], SupportsRichComparisonT] = ...,
+        key: Callable[[_T], SupportsRichComparison] | None = ...,
     ) -> None: ...
-    @overload
-    def insort_right(a: MutableSequence[_T], x: _T, lo: int = ..., hi: int | None = ..., *, key: None = ...) -> None: ...
-    @overload
     def insort_right(
         a: MutableSequence[_T],
-        x: SupportsRichComparisonT,
+        x: _T,
         lo: int = ...,
         hi: int | None = ...,
         *,
-        key: Callable[[_T], SupportsRichComparisonT] = ...,
+        key: Callable[[_T], SupportsRichComparison] | None = ...,
     ) -> None: ...
 
 else:

--- a/stdlib/_bisect.pyi
+++ b/stdlib/_bisect.pyi
@@ -1,5 +1,5 @@
 import sys
-from _typeshed import SupportsRichComparisonT
+from _typeshed import SupportsRichComparison, SupportsRichComparisonT
 from typing import Callable, MutableSequence, Sequence, TypeVar, overload
 
 _T = TypeVar("_T")


### PR DESCRIPTION
See https://github.com/python/cpython/pull/20556/files#r432997024 for reference.