### PR TITLE
Fix incorrect type definition for `validator`

### DIFF
--- a/stubs/google-cloud-ndb/google/cloud/ndb/model.pyi
+++ b/stubs/google-cloud-ndb/google/cloud/ndb/model.pyi
@@ -1,7 +1,7 @@
 import datetime
 from _typeshed import Self
 from collections.abc import Iterable, Sequence
-from typing import Callable, NoReturn, Any
+from typing import Any, Callable, NoReturn
 from typing_extensions import Literal
 
 from google.cloud.ndb import exceptions, key as key_module, query as query_module, tasklets as tasklets_module

--- a/stubs/google-cloud-ndb/google/cloud/ndb/model.pyi
+++ b/stubs/google-cloud-ndb/google/cloud/ndb/model.pyi
@@ -1,7 +1,7 @@
 import datetime
 from _typeshed import Self
 from collections.abc import Iterable, Sequence
-from typing import Callable, NoReturn
+from typing import Callable, NoReturn, TypeVar
 from typing_extensions import Literal
 
 from google.cloud.ndb import exceptions, key as key_module, query as query_module, tasklets as tasklets_module
@@ -80,7 +80,7 @@ class Property(ModelAttribute):
         required: bool | None = ...,
         default: object | None = ...,
         choices: Iterable[object] | None = ...,
-        validator: Callable[[Property], object] | None = ...,
+        validator: Callable[[Property, object], bool] | None = ...,
         verbose_name: str | None = ...,
         write_empty_list: bool | None = ...,
     ) -> None: ...
@@ -125,7 +125,7 @@ class BlobProperty(Property):
         required: bool | None = ...,
         default: bytes | None = ...,
         choices: Iterable[bytes] | None = ...,
-        validator: Callable[[Property], object] | None = ...,
+        validator: Callable[[Property, object], bool] | None = ...,
         verbose_name: str | None = ...,
         write_empty_list: bool | None = ...,
     ) -> None: ...
@@ -156,7 +156,7 @@ class JsonProperty(BlobProperty):
         required: bool | None = ...,
         default: object | None = ...,
         choices: Iterable[object] | None = ...,
-        validator: Callable[[Property], object] | None = ...,
+        validator: Callable[[Property, object], bool] | None = ...,
         verbose_name: str | None = ...,
         write_empty_list: bool | None = ...,
     ) -> None: ...
@@ -182,7 +182,7 @@ class UserProperty(Property):
         required: bool | None = ...,
         default: bytes | None = ...,
         choices: Iterable[bytes] | None = ...,
-        validator: Callable[[Property], object] | None = ...,
+        validator: Callable[[Property, object], bool] | None = ...,
         verbose_name: str | None = ...,
         write_empty_list: bool | None = ...,
     ) -> None: ...

--- a/stubs/google-cloud-ndb/google/cloud/ndb/model.pyi
+++ b/stubs/google-cloud-ndb/google/cloud/ndb/model.pyi
@@ -1,7 +1,7 @@
 import datetime
 from _typeshed import Self
 from collections.abc import Iterable, Sequence
-from typing import Callable, NoReturn, TypeVar
+from typing import Callable, NoReturn
 from typing_extensions import Literal
 
 from google.cloud.ndb import exceptions, key as key_module, query as query_module, tasklets as tasklets_module

--- a/stubs/google-cloud-ndb/google/cloud/ndb/model.pyi
+++ b/stubs/google-cloud-ndb/google/cloud/ndb/model.pyi
@@ -1,7 +1,7 @@
 import datetime
 from _typeshed import Self
 from collections.abc import Iterable, Sequence
-from typing import Callable, NoReturn
+from typing import Callable, NoReturn, Any
 from typing_extensions import Literal
 
 from google.cloud.ndb import exceptions, key as key_module, query as query_module, tasklets as tasklets_module
@@ -80,7 +80,7 @@ class Property(ModelAttribute):
         required: bool | None = ...,
         default: object | None = ...,
         choices: Iterable[object] | None = ...,
-        validator: Callable[[Property, object], bool] | None = ...,
+        validator: Callable[[Property, Any], object] | None = ...,
         verbose_name: str | None = ...,
         write_empty_list: bool | None = ...,
     ) -> None: ...
@@ -125,7 +125,7 @@ class BlobProperty(Property):
         required: bool | None = ...,
         default: bytes | None = ...,
         choices: Iterable[bytes] | None = ...,
-        validator: Callable[[Property, object], bool] | None = ...,
+        validator: Callable[[Property, Any], object] | None = ...,
         verbose_name: str | None = ...,
         write_empty_list: bool | None = ...,
     ) -> None: ...
@@ -156,7 +156,7 @@ class JsonProperty(BlobProperty):
         required: bool | None = ...,
         default: object | None = ...,
         choices: Iterable[object] | None = ...,
-        validator: Callable[[Property, object], bool] | None = ...,
+        validator: Callable[[Property, Any], object] | None = ...,
         verbose_name: str | None = ...,
         write_empty_list: bool | None = ...,
     ) -> None: ...
@@ -182,7 +182,7 @@ class UserProperty(Property):
         required: bool | None = ...,
         default: bytes | None = ...,
         choices: Iterable[bytes] | None = ...,
-        validator: Callable[[Property, object], bool] | None = ...,
+        validator: Callable[[Property, Any], object] | None = ...,
         verbose_name: str | None = ...,
         write_empty_list: bool | None = ...,
     ) -> None: ...
@@ -197,7 +197,7 @@ class KeyProperty(Property):
         required: bool | None = ...,
         default: key_module.Key | None = ...,
         choices: Iterable[key_module.Key] | None = ...,
-        validator: Callable[[Property, key_module.Key], bool] | None = ...,
+        validator: Callable[[Property, key_module.Key], key_module.Key] | None = ...,
         verbose_name: str | None = ...,
         write_empty_list: bool | None = ...,
     ) -> None: ...
@@ -216,7 +216,7 @@ class DateTimeProperty(Property):
         required: bool | None = ...,
         default: datetime.datetime | None = ...,
         choices: Iterable[datetime.datetime] | None = ...,
-        validator: Callable[[Property, object], bool] | None = ...,
+        validator: Callable[[Property, Any], object] | None = ...,
         verbose_name: str | None = ...,
         write_empty_list: bool | None = ...,
     ) -> None: ...


### PR DESCRIPTION
This function was mistakenly typed as `Callable[[Property], object] |
None`, however the actual function accepts two parameters of type
`Property, value`. The value can be of any type. Strictly speaking, the
type corresponds to the type of the property which is defined at runtime.

Relates to #7103