### PR TITLE
Fix mistyped `get_by_id` class methods

### DIFF
--- a/stubs/google-cloud-ndb/google/cloud/ndb/model.pyi
+++ b/stubs/google-cloud-ndb/google/cloud/ndb/model.pyi
@@ -320,7 +320,7 @@ class Model(_NotEqualMixin, metaclass=MetaModel):
         max_memcache_items: int | None = ...,
         force_writes: bool | None = ...,
         _options=...,
-    ) -> tasklets_module.Future: ...
+    ) -> Model | None: ...
     @classmethod
     def get_by_id_async(
         cls: type[Model],
@@ -344,7 +344,7 @@ class Model(_NotEqualMixin, metaclass=MetaModel):
         max_memcache_items: int | None = ...,
         force_writes: bool | None = ...,
         _options=...,
-    ) -> Model | None: ...
+    ) -> tasklets_module.Future: ...
     @classmethod
     def get_or_insert(
         cls: type[Model],


### PR DESCRIPTION
The types for these class methods were mixed up. The async method
returned an optional `Model`, while the synchronous method returned a
`Future`. It should be the other way around.

Fixes #7103