### PR TITLE
Fix dataclasses.Field to use _MISSING_TYPE

### DIFF
--- a/stdlib/dataclasses.pyi
+++ b/stdlib/dataclasses.pyi
@@ -72,15 +72,15 @@ class _DefaultFactory(Protocol[_T_co]):
 class Field(Generic[_T]):
     name: str
     type: Type[_T]
-    default: _T
-    default_factory: _DefaultFactory[_T]
+    default: _T | _MISSING_TYPE
+    default_factory: _DefaultFactory[_T] | _MISSING_TYPE
     repr: bool
     hash: bool | None
     init: bool
     compare: bool
     metadata: types.MappingProxyType[Any, Any]
     if sys.version_info >= (3, 10):
-        kw_only: bool
+        kw_only: bool | _MISSING_TYPE
         def __init__(
             self,
             default: _T,


### PR DESCRIPTION
default, default_factory, and kw_only are all attributes of Field objects which may have a value of MISSING. This is likely to arise when examining Field objects and checking attributes.

For example,

     [f for f in fields(obj) if f.default is MISSING]

The types for the attributes should therefore be `... | _MISSING_TYPE`
This adjustment is only applied to the attributes of Field, not the arguments to functions and methods.

---

I believe this is the correct resolution for https://github.com/python/mypy/issues/12124