### PR TITLE
Changed typing_extensions.pyi to declare its own private version of `Protocol`

### DIFF
--- a/stdlib/typing_extensions.pyi
+++ b/stdlib/typing_extensions.pyi
@@ -28,11 +28,11 @@ from typing import (  # noqa Y022
     ValuesView,
     _Alias,
     overload as overload,
-    runtime_checkable as runtime_checkable,
 )
 
 _T = TypeVar("_T")
 _F = TypeVar("_F", bound=Callable[..., Any])
+_TC = TypeVar("_TC", bound=Type[object])
 
 # unfortunately we have to duplicate this class definition from typing.pyi or we break pytype
 class _SpecialForm:
@@ -41,19 +41,21 @@ class _SpecialForm:
         def __or__(self, other: Any) -> _SpecialForm: ...
         def __ror__(self, other: Any) -> _SpecialForm: ...
 
+# Do not import (and re-export) Protocol or runtime_checkable from
+# typing module because type checkers need to be able to distinguish
+# typing.Protocol and typing_extensions.Protocol so they can properly
+# warn users about potential runtime exceptions when using typing.Protocol
+# on older versions of Python.
+Protocol: _SpecialForm = ...
+
+def runtime_checkable(cls: _TC) -> _TC: ...
+
 # This alias for above is kept here for backwards compatibility.
 runtime = runtime_checkable
 Final: _SpecialForm
 Self: _SpecialForm
 Required: _SpecialForm
 NotRequired: _SpecialForm
-
-# Do not import (and re-export) Protocol from typing module because
-# type checkers need to be able to distinguish typing.Protocol and
-# typing_extensions.Protocol so they can properly warn users about
-# potential runtime exceptions when using typing.Protocol on older
-# versions of Python.
-Protocol: _SpecialForm = ...
 
 def final(f: _F) -> _F: ...
 

--- a/stdlib/typing_extensions.pyi
+++ b/stdlib/typing_extensions.pyi
@@ -22,7 +22,6 @@ from typing import (  # noqa Y022
     Mapping,
     NewType as NewType,
     NoReturn as NoReturn,
-    Protocol as Protocol,
     Text as Text,
     Type as Type,
     TypeVar,
@@ -48,6 +47,13 @@ Final: _SpecialForm
 Self: _SpecialForm
 Required: _SpecialForm
 NotRequired: _SpecialForm
+
+# Do not import (and re-export) Protocol from typing module because
+# type checkers need to be able to distinguish typing.Protocol and
+# typing_extensions.Protocol so they can properly warn users about
+# potential runtime exceptions when using typing.Protocol on older
+# versions of Python.
+Protocol: _SpecialForm
 
 def final(f: _F) -> _F: ...
 

--- a/stdlib/typing_extensions.pyi
+++ b/stdlib/typing_extensions.pyi
@@ -53,7 +53,7 @@ NotRequired: _SpecialForm
 # typing_extensions.Protocol so they can properly warn users about
 # potential runtime exceptions when using typing.Protocol on older
 # versions of Python.
-Protocol: _SpecialForm
+Protocol: _SpecialForm = ...
 
 def final(f: _F) -> _F: ...
 


### PR DESCRIPTION
Changed typing_extensions.pyi to declare its own private version of `Protocol` rather than re-exporting the symbol imported from `typing`. This allows pyright to warn users about runtime exceptions when they attempt to use typing.Protocol on versions of Python prior to 3.7.