### PR TITLE
Improve `sock` typing in Paramiko stub

### DIFF
--- a/stubs/paramiko/paramiko/client.pyi
+++ b/stubs/paramiko/paramiko/client.pyi
@@ -8,6 +8,8 @@ from paramiko.sftp_client import SFTPClient
 from paramiko.transport import Transport
 from paramiko.util import ClosingContextManager
 
+from .transport import _SocketLike
+
 class SSHClient(ClosingContextManager):
     def __init__(self) -> None: ...
     def load_system_host_keys(self, filename: str | None = ...) -> None: ...
@@ -28,7 +30,7 @@ class SSHClient(ClosingContextManager):
         allow_agent: bool = ...,
         look_for_keys: bool = ...,
         compress: bool = ...,
-        sock: socket | Channel | None = ...,
+        sock: _SocketLike | None = ...,
         gss_auth: bool = ...,
         gss_kex: bool = ...,
         gss_deleg_creds: bool = ...,

--- a/stubs/paramiko/paramiko/client.pyi
+++ b/stubs/paramiko/paramiko/client.pyi
@@ -28,7 +28,7 @@ class SSHClient(ClosingContextManager):
         allow_agent: bool = ...,
         look_for_keys: bool = ...,
         compress: bool = ...,
-        sock: socket | None = ...,
+        sock: socket | Channel | None = ...,
         gss_auth: bool = ...,
         gss_kex: bool = ...,
         gss_deleg_creds: bool = ...,

--- a/stubs/paramiko/paramiko/client.pyi
+++ b/stubs/paramiko/paramiko/client.pyi
@@ -1,4 +1,3 @@
-from socket import socket
 from typing import Iterable, Mapping, NoReturn
 
 from paramiko.channel import Channel, ChannelFile, ChannelStderrFile, ChannelStdinFile

--- a/stubs/paramiko/paramiko/transport.pyi
+++ b/stubs/paramiko/paramiko/transport.pyi
@@ -2,7 +2,7 @@ from logging import Logger
 from socket import socket
 from threading import Condition, Event, Lock, Thread
 from types import ModuleType
-from typing import Any, Callable, Iterable, Protocol, Sequence
+from typing import Any, Callable, Iterable, Protocol, Sequence, Tuple, Union
 
 from paramiko.auth_handler import AuthHandler, _InteractiveCallback
 from paramiko.channel import Channel
@@ -14,8 +14,8 @@ from paramiko.sftp_client import SFTPClient
 from paramiko.ssh_gss import _SSH_GSSAuth
 from paramiko.util import ClosingContextManager
 
-_Addr = tuple[str, int]
-_SocketLike = str | _Addr | socket | Channel
+_Addr = Tuple[str, int]
+_SocketLike = Union[str, _Addr, socket, Channel]
 
 class _KexEngine(Protocol):
     def start_kex(self) -> None: ...

--- a/stubs/paramiko/paramiko/transport.pyi
+++ b/stubs/paramiko/paramiko/transport.pyi
@@ -23,7 +23,7 @@ class _KexEngine(Protocol):
 class Transport(Thread, ClosingContextManager):
     active: bool
     hostname: str | None
-    sock: socket
+    sock: socket | Channel
     packetizer: Packetizer
     local_version: str
     remote_version: str

--- a/stubs/paramiko/paramiko/transport.pyi
+++ b/stubs/paramiko/paramiko/transport.pyi
@@ -71,7 +71,7 @@ class Transport(Thread, ClosingContextManager):
     sys: ModuleType
     def __init__(
         self,
-        sock: str | tuple[str, int] | socket,
+        sock: str | tuple[str, int] | socket | Channel,
         default_window_size: int = ...,
         default_max_packet_size: int = ...,
         gss_kex: bool = ...,

--- a/stubs/paramiko/paramiko/transport.pyi
+++ b/stubs/paramiko/paramiko/transport.pyi
@@ -2,7 +2,7 @@ from logging import Logger
 from socket import socket
 from threading import Condition, Event, Lock, Thread
 from types import ModuleType
-from typing import Any, Callable, Iterable, Protocol, Sequence, Tuple, Union
+from typing import Any, Callable, Iterable, Protocol, Sequence, Union
 
 from paramiko.auth_handler import AuthHandler, _InteractiveCallback
 from paramiko.channel import Channel
@@ -14,7 +14,7 @@ from paramiko.sftp_client import SFTPClient
 from paramiko.ssh_gss import _SSH_GSSAuth
 from paramiko.util import ClosingContextManager
 
-_Addr = Tuple[str, int]
+_Addr = tuple[str, int]
 _SocketLike = Union[str, _Addr, socket, Channel]
 
 class _KexEngine(Protocol):

--- a/stubs/paramiko/paramiko/transport.pyi
+++ b/stubs/paramiko/paramiko/transport.pyi
@@ -15,6 +15,7 @@ from paramiko.ssh_gss import _SSH_GSSAuth
 from paramiko.util import ClosingContextManager
 
 _Addr = tuple[str, int]
+_SocketLike = str | _Addr | socket | Channel
 
 class _KexEngine(Protocol):
     def start_kex(self) -> None: ...
@@ -71,7 +72,7 @@ class Transport(Thread, ClosingContextManager):
     sys: ModuleType
     def __init__(
         self,
-        sock: str | tuple[str, int] | socket | Channel,
+        sock: _SocketLike,
         default_window_size: int = ...,
         default_max_packet_size: int = ...,
         gss_kex: bool = ...,


### PR DESCRIPTION
Fixes #6983.

Note: I also updated the typing of `paramiko.transport.Transport`, as that made sense to me after taking a look at the source code of `paramiko.client.SSHClient` - see [these](https://github.com/paramiko/paramiko/blob/88f35a537428e430f7f26eee8026715e357b55d6/paramiko/client.py#L370-L371) and [these](https://github.com/paramiko/paramiko/blob/88f35a537428e430f7f26eee8026715e357b55d6/paramiko/transport.py#L371-L372) lines).