### PR TITLE
`queue.Queue.queue` is a `MutableSequence`

### DIFF
--- a/stdlib/queue.pyi
+++ b/stdlib/queue.pyi
@@ -1,6 +1,6 @@
 import sys
 from threading import Condition, Lock
-from typing import Any, Generic, MutableSequence, TypeVar
+from typing import Any, Generic, TypeVar, List
 
 if sys.version_info >= (3, 9):
     from types import GenericAlias
@@ -18,7 +18,9 @@ class Queue(Generic[_T]):
     not_full: Condition  # undocumented
     all_tasks_done: Condition  # undocumented
     unfinished_tasks: int  # undocumented
-    queue: MutableSequence[_T]  # undocumented
+    # Despite the fact that `queue` has `deque` type,
+    # we treat it as `Any` to allow different implementations in subtypes.
+    queue: Any  # undocumented
     def __init__(self, maxsize: int = ...) -> None: ...
     def _init(self, maxsize: int) -> None: ...
     def empty(self) -> bool: ...
@@ -36,8 +38,10 @@ class Queue(Generic[_T]):
     if sys.version_info >= (3, 9):
         def __class_getitem__(cls, item: Any) -> GenericAlias: ...
 
-class PriorityQueue(Queue[_T]): ...
-class LifoQueue(Queue[_T]): ...
+class PriorityQueue(Queue[_T]):
+    queue: List[_T]
+class LifoQueue(Queue[_T]):
+    queue: List[_T]
 
 if sys.version_info >= (3, 7):
     class SimpleQueue(Generic[_T]):

--- a/stdlib/queue.pyi
+++ b/stdlib/queue.pyi
@@ -1,6 +1,6 @@
 import sys
 from threading import Condition, Lock
-from typing import Any, Generic, TypeVar
+from typing import Any, Generic, TypeVar, MutableSequence
 
 if sys.version_info >= (3, 9):
     from types import GenericAlias
@@ -18,7 +18,7 @@ class Queue(Generic[_T]):
     not_full: Condition  # undocumented
     all_tasks_done: Condition  # undocumented
     unfinished_tasks: int  # undocumented
-    queue: Any  # undocumented
+    queue: MutableSequence[_T]  # undocumented
     def __init__(self, maxsize: int = ...) -> None: ...
     def _init(self, maxsize: int) -> None: ...
     def empty(self) -> bool: ...

--- a/stdlib/queue.pyi
+++ b/stdlib/queue.pyi
@@ -1,6 +1,6 @@
 import sys
 from threading import Condition, Lock
-from typing import Any, Generic, TypeVar, MutableSequence
+from typing import Any, Generic, MutableSequence, TypeVar
 
 if sys.version_info >= (3, 9):
     from types import GenericAlias

--- a/stdlib/queue.pyi
+++ b/stdlib/queue.pyi
@@ -1,6 +1,6 @@
 import sys
 from threading import Condition, Lock
-from typing import Any, Generic, List, TypeVar
+from typing import Any, Generic, TypeVar
 
 if sys.version_info >= (3, 9):
     from types import GenericAlias
@@ -39,10 +39,10 @@ class Queue(Generic[_T]):
         def __class_getitem__(cls, item: Any) -> GenericAlias: ...
 
 class PriorityQueue(Queue[_T]):
-    queue: List[_T]
+    queue: list[_T]
 
 class LifoQueue(Queue[_T]):
-    queue: List[_T]
+    queue: list[_T]
 
 if sys.version_info >= (3, 7):
     class SimpleQueue(Generic[_T]):

--- a/stdlib/queue.pyi
+++ b/stdlib/queue.pyi
@@ -1,6 +1,6 @@
 import sys
 from threading import Condition, Lock
-from typing import Any, Generic, TypeVar, List
+from typing import Any, Generic, List, TypeVar
 
 if sys.version_info >= (3, 9):
     from types import GenericAlias
@@ -40,6 +40,7 @@ class Queue(Generic[_T]):
 
 class PriorityQueue(Queue[_T]):
     queue: List[_T]
+
 class LifoQueue(Queue[_T]):
     queue: List[_T]
 


### PR DESCRIPTION
It is `deque` in `Queue` and `list` in `LifoQueue` and `PriorityQueue`
Source: 
- https://github.com/python/cpython/blob/3a5afc14e16370c1f4f72d43cb553298ad9a1fa4/Lib/queue.py#L207
- https://github.com/python/cpython/blob/3a5afc14e16370c1f4f72d43cb553298ad9a1fa4/Lib/queue.py#L230
- https://github.com/python/cpython/blob/3a5afc14e16370c1f4f72d43cb553298ad9a1fa4/Lib/queue.py#L246


Refs https://github.com/python/typeshed/issues/3472
Refs https://github.com/python/typeshed/pull/3879