### PR TITLE
Fix zero exponent for `int`s

### DIFF
--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -176,7 +176,7 @@ class super:
     @overload
     def __init__(self) -> None: ...
 
-_PositiveInteger = Literal[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]
+_PositiveInteger = Literal[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]
 _NegativeInteger = Literal[-1, -2, -3, -4, -5, -6, -7, -8, -9, -10, -11, -12, -13, -14, -15, -16, -17, -18, -19, -20]
 
 class int:
@@ -227,6 +227,8 @@ class int:
     def __pow__(self, __x: int, __modulo: Literal[0]) -> NoReturn: ...
     @overload
     def __pow__(self, __x: int, __modulo: int) -> int: ...
+    @overload
+    def __pow__(self, __x: Literal[0], __modulo: None = ...) -> Literal[1]: ...
     @overload
     def __pow__(self, __x: _PositiveInteger, __modulo: None = ...) -> int: ...
     @overload

--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -1387,7 +1387,7 @@ else:
     @overload
     def pow(__base: int, __exp: int, __mod: int) -> int: ...
     @overload
-    def pow(base: int, exp: Literal[0], mod: None = ...) -> Literal[1]: ...  # type: ignore[misc]
+    def pow(__base: int, __exp: Literal[0], __mod: None = ...) -> Literal[1]: ...  # type: ignore[misc]
     @overload
     def pow(__base: int, __exp: _PositiveInteger, __mod: None = ...) -> int: ...  # type: ignore[misc]
     @overload

--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -176,7 +176,7 @@ class super:
     @overload
     def __init__(self) -> None: ...
 
-_PositiveInteger = Literal[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]
+_PositiveInteger = Literal[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]
 _NegativeInteger = Literal[-1, -2, -3, -4, -5, -6, -7, -8, -9, -10, -11, -12, -13, -14, -15, -16, -17, -18, -19, -20]
 
 class int:

--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -1352,6 +1352,8 @@ if sys.version_info >= (3, 8):
     @overload
     def pow(base: int, exp: int, mod: int) -> int: ...
     @overload
+    def pow(base: int, exp: Literal[0], mod: None = ...) -> Literal[1]: ...  # type: ignore[misc]
+    @overload
     def pow(base: int, exp: _PositiveInteger, mod: None = ...) -> int: ...  # type: ignore[misc]
     @overload
     def pow(base: int, exp: _NegativeInteger, mod: None = ...) -> float: ...  # type: ignore[misc]
@@ -1384,6 +1386,8 @@ else:
     def pow(__base: int, __exp: int, __mod: Literal[0]) -> NoReturn: ...
     @overload
     def pow(__base: int, __exp: int, __mod: int) -> int: ...
+    @overload
+    def pow(base: int, exp: Literal[0], mod: None = ...) -> Literal[1]: ...  # type: ignore[misc]
     @overload
     def pow(__base: int, __exp: _PositiveInteger, __mod: None = ...) -> int: ...  # type: ignore[misc]
     @overload


### PR DESCRIPTION
It is typed as `int` instead of `Any` after this PR.

Followup to https://github.com/python/typeshed/pull/6325#discussion_r797710621