### PR TITLE
Improve `toml.pyi` by removing old versions

### DIFF
--- a/stubs/toml/toml.pyi
+++ b/stubs/toml/toml.pyi
@@ -1,19 +1,9 @@
-import sys
 from _typeshed import StrPath, SupportsWrite
 from typing import IO, Any, Mapping, MutableMapping, Text, Union
 
-if sys.version_info >= (3, 6):
-    _PathLike = StrPath
-elif sys.version_info >= (3, 4):
-    import pathlib
-
-    _PathLike = Union[StrPath, pathlib.PurePath]
-else:
-    _PathLike = StrPath
-
 class TomlDecodeError(Exception): ...
 
-def load(f: _PathLike | list[Text] | IO[str], _dict: type[MutableMapping[str, Any]] = ...) -> MutableMapping[str, Any]: ...
+def load(f: StrPath | list[Text] | IO[str], _dict: type[MutableMapping[str, Any]] = ...) -> MutableMapping[str, Any]: ...
 def loads(s: Text, _dict: type[MutableMapping[str, Any]] = ...) -> MutableMapping[str, Any]: ...
 def dump(o: Mapping[str, Any], f: SupportsWrite[str]) -> str: ...
 def dumps(o: Mapping[str, Any]) -> str: ...

--- a/stubs/toml/toml.pyi
+++ b/stubs/toml/toml.pyi
@@ -1,5 +1,5 @@
 from _typeshed import StrPath, SupportsWrite
-from typing import IO, Any, Mapping, MutableMapping, Text, Union
+from typing import IO, Any, Mapping, MutableMapping, Text
 
 class TomlDecodeError(Exception): ...
 


### PR DESCRIPTION
No other modules use `>= (3, 6)`.
I am not even saying about `(3, 4)` 🙂 