### PR TITLE
`poplib.POP3_SSL.stls` unconditionally raises an exception

### DIFF
--- a/stdlib/poplib.pyi
+++ b/stdlib/poplib.pyi
@@ -1,6 +1,6 @@
 import socket
 import ssl
-from typing import Any, BinaryIO, Pattern, overload
+from typing import Any, BinaryIO, NoReturn, Pattern, overload
 from typing_extensions import Literal
 
 _LongResp = tuple[bytes, list[bytes], int]
@@ -59,4 +59,4 @@ class POP3_SSL(POP3):
         context: ssl.SSLContext | None = ...,
     ) -> None: ...
     # "context" is actually the last argument, but that breaks LSP and it doesn't really matter because all the arguments are ignored
-    def stls(self, context: Any = ..., keyfile: Any = ..., certfile: Any = ...) -> bytes: ...
+    def stls(self, context: Any = ..., keyfile: Any = ..., certfile: Any = ...) -> NoReturn: ...


### PR DESCRIPTION
Source code here: https://github.com/python/cpython/blob/0ae40191793da1877a12d512f0116d99301b2c51/Lib/poplib.py#L460

We have to keep the method in the stub, as it's overriding a method in the superclass that doesn't unconditionally raise.