### PR TITLE
urllib.request: loosen data type

### DIFF
--- a/stdlib/urllib/request.pyi
+++ b/stdlib/urllib/request.pyi
@@ -10,7 +10,7 @@ from urllib.response import addclosehook, addinfourl
 
 _T = TypeVar("_T")
 _UrlopenRet = Any
-_DataType = bytes | SupportsRead[bytes] | Iterable[bytes]
+_DataType = bytes | SupportsRead[bytes] | Iterable[bytes] | None
 
 def urlopen(
     url: str | Request,
@@ -52,7 +52,7 @@ class Request:
     host: str
     origin_req_host: str
     selector: str
-    data: _DataType | None
+    data: _DataType
     headers: MutableMapping[str, str]
     unredirected_hdrs: dict[str, str]
     unverifiable: bool
@@ -61,7 +61,7 @@ class Request:
     def __init__(
         self,
         url: str,
-        data: _DataType | None = ...,
+        data: _DataType = ...,
         headers: MutableMapping[str, str] = ...,
         origin_req_host: str | None = ...,
         unverifiable: bool = ...,
@@ -84,7 +84,7 @@ class Request:
 class OpenerDirector:
     addheaders: list[tuple[str, str]]
     def add_handler(self, handler: BaseHandler) -> None: ...
-    def open(self, fullurl: str | Request, data: bytes | None = ..., timeout: float | None = ...) -> _UrlopenRet: ...
+    def open(self, fullurl: str | Request, data: _DataType = ..., timeout: float | None = ...) -> _UrlopenRet: ...
     def error(self, proto: str, *args: Any) -> _UrlopenRet: ...
     def close(self) -> None: ...
 
@@ -242,7 +242,7 @@ def urlretrieve(
     url: str,
     filename: StrOrBytesPath | None = ...,
     reporthook: Callable[[int, int, int], None] | None = ...,
-    data: _DataType | None = ...,
+    data: _DataType = ...,
 ) -> tuple[str, HTTPMessage]: ...
 def urlcleanup() -> None: ...
 

--- a/stdlib/urllib/request.pyi
+++ b/stdlib/urllib/request.pyi
@@ -1,19 +1,20 @@
 import ssl
 import sys
-from _typeshed import StrOrBytesPath
+from _typeshed import StrOrBytesPath, SupportsRead
 from email.message import Message
 from http.client import HTTPMessage, HTTPResponse, _HTTPConnectionProtocol
 from http.cookiejar import CookieJar
-from typing import IO, Any, Callable, ClassVar, Mapping, MutableMapping, NoReturn, Pattern, Sequence, TypeVar, overload
+from typing import IO, Any, Callable, ClassVar, Iterable, Mapping, MutableMapping, NoReturn, Pattern, Sequence, TypeVar, overload
 from urllib.error import HTTPError
 from urllib.response import addclosehook, addinfourl
 
 _T = TypeVar("_T")
 _UrlopenRet = Any
+_DataType = bytes | SupportsRead[bytes] | Iterable[bytes]
 
 def urlopen(
     url: str | Request,
-    data: bytes | None = ...,
+    data: _DataType | None = ...,
     timeout: float | None = ...,
     *,
     cafile: str | None = ...,
@@ -51,7 +52,7 @@ class Request:
     host: str
     origin_req_host: str
     selector: str
-    data: bytes | None
+    data: _DataType | None
     headers: MutableMapping[str, str]
     unredirected_hdrs: dict[str, str]
     unverifiable: bool
@@ -60,7 +61,7 @@ class Request:
     def __init__(
         self,
         url: str,
-        data: bytes | None = ...,
+        data: _DataType | None = ...,
         headers: MutableMapping[str, str] = ...,
         origin_req_host: str | None = ...,
         unverifiable: bool = ...,
@@ -241,7 +242,7 @@ def urlretrieve(
     url: str,
     filename: StrOrBytesPath | None = ...,
     reporthook: Callable[[int, int, int], None] | None = ...,
-    data: bytes | None = ...,
+    data: _DataType | None = ...,
 ) -> tuple[str, HTTPMessage]: ...
 def urlcleanup() -> None: ...
 


### PR DESCRIPTION
Fixes #7208

This is what urllib.request claims to support over here:
https://github.com/python/cpython/blob/ad4e8d2b871c4f5bce27520627bbb2e0e544bc24/Lib/urllib/request.py#L1276

There is additional validation logic (e.g. strs don't work), but a lot
of what determines what works is over here:
https://github.com/python/cpython/blob/ad4e8d2b871c4f5bce27520627bbb2e0e544bc24/Lib/http/client.py#L1039