### PR TITLE
Add overload annotation for stripe DeletableAPIResource delete classmethod

### DIFF
--- a/stubs/stripe/@tests/stubtest_allowlist.txt
+++ b/stubs/stripe/@tests/stubtest_allowlist.txt
@@ -1,0 +1,2 @@
+# DeletableAPIResource.delete is has a custom classmethod overload
+stripe\..*\.delete

--- a/stubs/stripe/stripe/api_resources/abstract/deletable_api_resource.pyi
+++ b/stubs/stripe/stripe/api_resources/abstract/deletable_api_resource.pyi
@@ -4,9 +4,5 @@ from typing import overload
 from stripe.api_resources.abstract.api_resource import APIResource as APIResource
 
 class DeletableAPIResource(APIResource):
-    @overload
     @classmethod
-    def delete(cls: type[Self], **params) -> Self: ...
-    @overload
-    @classmethod
-    def delete(cls: type[Self], sid: str, **params) -> Self: ...
+    def delete(cls: type[Self], sid: str = ..., **params) -> Self: ...

--- a/stubs/stripe/stripe/api_resources/abstract/deletable_api_resource.pyi
+++ b/stubs/stripe/stripe/api_resources/abstract/deletable_api_resource.pyi
@@ -1,5 +1,4 @@
 from _typeshed import Self
-from typing import overload
 
 from stripe.api_resources.abstract.api_resource import APIResource as APIResource
 

--- a/stubs/stripe/stripe/api_resources/abstract/deletable_api_resource.pyi
+++ b/stubs/stripe/stripe/api_resources/abstract/deletable_api_resource.pyi
@@ -3,7 +3,7 @@ from typing import TypeVar, overload
 
 from stripe.api_resources.abstract.api_resource import APIResource as APIResource
 
-_T = TypeVar("_T", bound="DeletableAPIResource")
+_T = TypeVar("_T", bound=DeletableAPIResource)
 
 class DeletableAPIResource(APIResource):
     @overload

--- a/stubs/stripe/stripe/api_resources/abstract/deletable_api_resource.pyi
+++ b/stubs/stripe/stripe/api_resources/abstract/deletable_api_resource.pyi
@@ -1,4 +1,3 @@
-from _typeshed import Self
 from typing import TypeVar, overload
 
 from stripe.api_resources.abstract.api_resource import APIResource as APIResource
@@ -7,7 +6,8 @@ _T = TypeVar("_T", bound=DeletableAPIResource)
 
 class DeletableAPIResource(APIResource):
     @overload
-    def delete(self: Self, **params) -> Self: ...
+    @classmethod
+    def delete(cls: type[_T], **params) -> _T: ...
     @overload
     @classmethod
     def delete(cls: type[_T], sid: str, **params) -> _T: ...

--- a/stubs/stripe/stripe/api_resources/abstract/deletable_api_resource.pyi
+++ b/stubs/stripe/stripe/api_resources/abstract/deletable_api_resource.pyi
@@ -1,13 +1,12 @@
-from typing import TypeVar, overload
+from _typeshed import Self
+from typing import overload
 
 from stripe.api_resources.abstract.api_resource import APIResource as APIResource
-
-_T = TypeVar("_T", bound=DeletableAPIResource)
 
 class DeletableAPIResource(APIResource):
     @overload
     @classmethod
-    def delete(cls: type[_T], **params) -> _T: ...
+    def delete(cls: type[Self], **params) -> Self: ...
     @overload
     @classmethod
-    def delete(cls: type[_T], sid: str, **params) -> _T: ...
+    def delete(cls: type[Self], sid: str, **params) -> Self: ...

--- a/stubs/stripe/stripe/api_resources/abstract/deletable_api_resource.pyi
+++ b/stubs/stripe/stripe/api_resources/abstract/deletable_api_resource.pyi
@@ -1,4 +1,13 @@
+from _typeshed import Self
+from typing import TypeVar, overload
+
 from stripe.api_resources.abstract.api_resource import APIResource as APIResource
 
+_T = TypeVar("_T", bound="DeletableAPIResource")
+
 class DeletableAPIResource(APIResource):
-    def delete(self, **params): ...
+    @overload
+    def delete(self: Self, **params) -> Self: ...
+    @overload
+    @classmethod
+    def delete(cls: type[_T], sid: str, **params) -> _T: ...


### PR DESCRIPTION
Fixes stripe/stripe-python#770

`stripe`'s `DeletableAPIResource.delete` [instance method](https://github.com/stripe/stripe-python/blob/cf794375df6e1d1adaef5ff5d12b9bcb31a845c0/stripe/api_resources/abstract/deletable_api_resource.py#L14) has a [wrapper](https://github.com/stripe/stripe-python/blob/cf794375df6e1d1adaef5ff5d12b9bcb31a845c0/stripe/util.py#L213) that effectively overloads the method to add a class method version.

Both
```python
s = stripe.Subscription.create(...)
s.delete()
```
and
```python
s = stripe.Subscription.create(...)
stripe.Subscription.delete(s.id)
```
should work, but the latter raises a type error.