### PR TITLE
Remove unused allowlist entries in `babel` and `requests`

### DIFF
--- a/stubs/babel/@tests/stubtest_allowlist.txt
+++ b/stubs/babel/@tests/stubtest_allowlist.txt
@@ -1,3 +1,0 @@
-# In the stub we alias to OrderedDict, but it has positional-only differences
-babel.util.odict.fromkeys
-babel.util.odict.setdefault

--- a/stubs/requests/@tests/stubtest_allowlist.txt
+++ b/stubs/requests/@tests/stubtest_allowlist.txt
@@ -16,8 +16,6 @@ requests.api.patch
 requests.api.post
 requests.api.put
 requests.api.request
-requests.compat.OrderedDict.fromkeys
-requests.compat.OrderedDict.setdefault
 requests.delete
 requests.get
 requests.head
@@ -29,8 +27,6 @@ requests.patch
 requests.post
 requests.put
 requests.request
-requests.sessions.OrderedDict.fromkeys
-requests.sessions.OrderedDict.setdefault
 requests.sessions.Session.delete
 requests.sessions.Session.get
 requests.sessions.Session.head
@@ -41,5 +37,3 @@ requests.sessions.Session.put
 requests.sessions.SessionRedirectMixin.resolve_redirects
 requests.structures.LookupDict.__getattr__
 requests.structures.LookupDict.get
-requests.utils.OrderedDict.fromkeys
-requests.utils.OrderedDict.setdefault


### PR DESCRIPTION
Fixes #7232

All stubtest failures caused here were caused by https://github.com/python/typeshed/pull/7228, which corrected several positional-only errors in the stub for `collections.OrderedDict`.