### PR TITLE
Add `--disallow-untyped-decorators` to `mypy_test`

### DIFF
--- a/tests/mypy_test.py
+++ b/tests/mypy_test.py
@@ -205,6 +205,8 @@ def get_mypy_flags(args, major: int, minor: int, temp_name: str, *, custom_types
         "--no-site-packages",
         "--show-traceback",
         "--no-implicit-optional",
+        "--no-implicit-reexport",
+        "--disallow-untyped-decorators",
         "--disallow-any-generics",
         "--warn-incomplete-stub",
         "--show-error-codes",

--- a/tests/mypy_test.py
+++ b/tests/mypy_test.py
@@ -205,7 +205,6 @@ def get_mypy_flags(args, major: int, minor: int, temp_name: str, *, custom_types
         "--no-site-packages",
         "--show-traceback",
         "--no-implicit-optional",
-        "--no-implicit-reexport",
         "--disallow-untyped-decorators",
         "--disallow-any-generics",
         "--warn-incomplete-stub",


### PR DESCRIPTION
This can possibly catch if we apply `(*Any, **Any) -> Any` to some existing typed function.
Right now, we don't do that anywhere in the code base 🙂 