### PR TITLE
Remove `_NNTPBase` from `nntplib`

### DIFF
--- a/stdlib/nntplib.pyi
+++ b/stdlib/nntplib.pyi
@@ -35,7 +35,7 @@ def decode_header(header_str: str) -> str: ...
 
 _list = list  # conflicts with a method named "list"
 
-class NNTP:     
+class NNTP:
     encoding: ClassVar[str]
     errors: ClassVar[str]
 

--- a/stdlib/nntplib.pyi
+++ b/stdlib/nntplib.pyi
@@ -36,8 +36,8 @@ def decode_header(header_str: str) -> str: ...
 _list = list  # conflicts with a method named "list"
 
 class NNTP:
-    encoding: ClassVar[str]
-    errors: ClassVar[str]
+    encoding: str
+    errors: str
 
     host: str
     port: int
@@ -99,6 +99,7 @@ class NNTP:
 
 class NNTP_SSL(NNTP):
     ssl_context: ssl.SSLContext | None
+    sock: ssl.SSLSocket
     def __init__(
         self,
         host: str,

--- a/stdlib/nntplib.pyi
+++ b/stdlib/nntplib.pyi
@@ -3,7 +3,7 @@ import socket
 import ssl
 import sys
 from _typeshed import Self
-from typing import IO, Any, ClassVar, Iterable, NamedTuple, Union
+from typing import IO, Any, Iterable, NamedTuple, Union
 from typing_extensions import Literal
 
 _File = Union[IO[bytes], bytes, str, None]

--- a/stdlib/nntplib.pyi
+++ b/stdlib/nntplib.pyi
@@ -3,7 +3,8 @@ import socket
 import ssl
 import sys
 from _typeshed import Self
-from typing import IO, Any, Iterable, NamedTuple, Union
+from typing import IO, Any, ClassVar, Iterable, NamedTuple, Union
+from typing_extensions import Literal
 
 _File = Union[IO[bytes], bytes, str, None]
 
@@ -16,8 +17,8 @@ class NNTPPermanentError(NNTPError): ...
 class NNTPProtocolError(NNTPError): ...
 class NNTPDataError(NNTPError): ...
 
-NNTP_PORT: int
-NNTP_SSL_PORT: int
+NNTP_PORT: Literal[119]
+NNTP_SSL_PORT: Literal[563]
 
 class GroupInfo(NamedTuple):
     group: str
@@ -34,11 +35,13 @@ def decode_header(header_str: str) -> str: ...
 
 _list = list  # conflicts with a method named "list"
 
-class _NNTPBase:
-    encoding: str
-    errors: str
+class NNTP:     
+    encoding: ClassVar[str]
+    errors: ClassVar[str]
 
     host: str
+    port: int
+    sock: socket.socket
     file: IO[bytes]
     debugging: int
     welcome: str
@@ -47,7 +50,16 @@ class _NNTPBase:
     authenticated: bool
     nntp_implementation: str
     nntp_version: int
-    def __init__(self, file: IO[bytes], host: str, readermode: bool | None = ..., timeout: float = ...) -> None: ...
+    def __init__(
+        self,
+        host: str,
+        port: int = ...,
+        user: str | None = ...,
+        password: str | None = ...,
+        readermode: bool | None = ...,
+        usenetrc: bool = ...,
+        timeout: float = ...,
+    ) -> None: ...
     def __enter__(self: Self) -> Self: ...
     def __exit__(self, *args: Any) -> None: ...
     def getwelcome(self) -> str: ...
@@ -85,21 +97,7 @@ class _NNTPBase:
     def login(self, user: str | None = ..., password: str | None = ..., usenetrc: bool = ...) -> None: ...
     def starttls(self, context: ssl.SSLContext | None = ...) -> None: ...
 
-class NNTP(_NNTPBase):
-    port: int
-    sock: socket.socket
-    def __init__(
-        self,
-        host: str,
-        port: int = ...,
-        user: str | None = ...,
-        password: str | None = ...,
-        readermode: bool | None = ...,
-        usenetrc: bool = ...,
-        timeout: float = ...,
-    ) -> None: ...
-
-class NNTP_SSL(_NNTPBase):
+class NNTP_SSL(NNTP):
     sock: socket.socket
     def __init__(
         self,

--- a/stdlib/nntplib.pyi
+++ b/stdlib/nntplib.pyi
@@ -98,7 +98,7 @@ class NNTP:
     def starttls(self, context: ssl.SSLContext | None = ...) -> None: ...
 
 class NNTP_SSL(NNTP):
-    sock: socket.socket
+    ssl_context: ssl.SSLContext | None
     def __init__(
         self,
         host: str,


### PR DESCRIPTION
It was always a protected name, but it was removed from CPython 2 years ago.
See https://github.com/python/cpython/blob/2945f5a7c51200bfc5c493ccb626fc414e1385b1/Lib/nntplib.py#L490