### PR TITLE
Tag.attrs are Mutable

### DIFF
--- a/stubs/beautifulsoup4/bs4/element.pyi
+++ b/stubs/beautifulsoup4/bs4/element.pyi
@@ -1,6 +1,6 @@
 from _typeshed import Self
 from collections.abc import Iterator
-from typing import Any, Callable, Generic, Iterable, Mapping, Pattern, TypeVar, Union, overload
+from typing import Any, Callable, Generic, Iterable, Pattern, TypeVar, Union, overload
 
 from . import BeautifulSoup
 from .builder import TreeBuilder
@@ -234,7 +234,7 @@ class Tag(PageElement):
     sourceline: int | None
     sourcepos: int | None
     known_xml: bool | None
-    attrs: Mapping[str, str]
+    attrs: dict[str, str]
     contents: list[PageElement]
     hidden: bool
     can_be_empty_element: bool | None
@@ -247,7 +247,7 @@ class Tag(PageElement):
         name: str | None = ...,
         namespace: str | None = ...,
         prefix: str | None = ...,
-        attrs: Mapping[str, str] | None = ...,
+        attrs: dict[str, str] | None = ...,
         parent: Tag | None = ...,
         previous: PageElement | None = ...,
         is_xml: bool | None = ...,


### PR DESCRIPTION
I keep getting errors like: `"Mapping[str, str]" has no attribute "__delitem__"; maybe "__getitem__"?`

Real type is a python `dict`.

```py
>>> type(item.attrs)
<class 'dict'>
```

So I need to add `isinstance(tag.attrs, dict)` to force the type (maybe there is a better way? I haven't written python mypy in about 8 months)

For example, without `and isinstance(tag.attrs, dict)` this would result in the above error:
```py
# No custom styles
if 'style' in tag.attrs and isinstance(tag.attrs, dict):
    del tag.attrs['style']
```