### PR TITLE
find_all ResultSet return type

### DIFF
--- a/stubs/beautifulsoup4/bs4/element.pyi
+++ b/stubs/beautifulsoup4/bs4/element.pyi
@@ -319,7 +319,7 @@ class Tag(PageElement):
         text: _Strainable | None = ...,
         limit: int | None = ...,
         **kwargs: _Strainable,
-    ) -> ResultSet[Any]: ...
+    ) -> ResultSet[PageElement]: ...
     __call__ = find_all
     findAll = find_all
     findChildren = find_all


### PR DESCRIPTION
`Tag.find_all` should return a ResultSet of something descended from `PageElement`.

A `Tag` or a `NavigableString`, or a `Comment` likely, but the parent class is used in other places so this should be close enough.