### PR TITLE
flask-cors: remove unused allowlist

### DIFF
--- a/stubs/Flask-Cors/@tests/stubtest_allowlist.txt
+++ b/stubs/Flask-Cors/@tests/stubtest_allowlist.txt
@@ -1,2 +1,0 @@
-# Caused by https://github.com/python/mypy/pull/12040
-flask_cors.core.DEFAULT_OPTIONS


### PR DESCRIPTION
Helps with https://github.com/python/typeshed/issues/7307