### PR TITLE
argparse: Use Literal for action & nargs add_argument parameter types

### DIFF
--- a/stdlib/argparse.pyi
+++ b/stdlib/argparse.pyi
@@ -1,5 +1,20 @@
 import sys
-from typing import IO, Any, Callable, Generator, Generic, Iterable, NoReturn, Pattern, Protocol, Sequence, TypeVar, overload
+from typing import (
+    IO,
+    Any,
+    Callable,
+    Generator,
+    Generic,
+    Iterable,
+    NewType,
+    NoReturn,
+    Pattern,
+    Protocol,
+    Sequence,
+    TypeVar,
+    overload,
+)
+from typing_extensions import Literal
 
 if sys.version_info >= (3, 9):
     __all__ = [
@@ -48,12 +63,13 @@ _ActionT = TypeVar("_ActionT", bound=Action)
 _ArgumentParserT = TypeVar("_ArgumentParserT", bound=ArgumentParser)
 _N = TypeVar("_N")
 
-ONE_OR_MORE: str
-OPTIONAL: str
-PARSER: str
-REMAINDER: str
-SUPPRESS: str
-ZERO_OR_MORE: str
+ONE_OR_MORE: Literal["+"]
+OPTIONAL: Literal["?"]
+PARSER: Literal["A..."]
+REMAINDER: Literal["..."]
+_SUPPRESS_T = NewType("_SUPPRESS_T", str)
+SUPPRESS: _SUPPRESS_T  # not using Literal because argparse sometimes compares SUPPRESS with is
+ZERO_OR_MORE: Literal["*"]
 _UNRECOGNIZED_ARGS_ATTR: str  # undocumented
 
 class ArgumentError(Exception):
@@ -89,8 +105,11 @@ class _ActionsContainer:
     def add_argument(
         self,
         *name_or_flags: str,
-        action: str | type[Action] = ...,
-        nargs: int | str = ...,
+        action: Literal[
+            "store", "store_const", "store_true", "store_false", "append", "append_const", "count", "help", "version", "extend"
+        ]
+        | type[Action] = ...,
+        nargs: int | Literal["?", "*", "+", "...", "A...", "==SUPPRESS=="] | _SUPPRESS_T = ...,
         const: Any = ...,
         default: Any = ...,
         type: Callable[[str], _T] | FileType = ...,

--- a/stdlib/argparse.pyi
+++ b/stdlib/argparse.pyi
@@ -68,7 +68,8 @@ OPTIONAL: Literal["?"]
 PARSER: Literal["A..."]
 REMAINDER: Literal["..."]
 _SUPPRESS_T = NewType("_SUPPRESS_T", str)
-SUPPRESS: _SUPPRESS_T  # not using Literal because argparse sometimes compares SUPPRESS with is
+SUPPRESS: _SUPPRESS_T | str  # not using Literal because argparse sometimes compares SUPPRESS with is
+# the | str is there so that foo = argparse.SUPPRESS; foo = "test" checks out in mypy
 ZERO_OR_MORE: Literal["*"]
 _UNRECOGNIZED_ARGS_ATTR: str  # undocumented
 

--- a/tests/stubtest_allowlists/py3_common.txt
+++ b/tests/stubtest_allowlists/py3_common.txt
@@ -236,7 +236,6 @@ xml.parsers.expat.expat_CAPI
 # Allowlist entries that cannot or should not be fixed
 # ==========
 _pydecimal.*  # See comments in file
-argparse.SUPPRESS  # See comment in file
 ast.NodeVisitor.visit_\w+  # Methods are discovered dynamically, see #3796
 # Weird special builtins that are typed as functions, but aren't functions
 builtins.copyright

--- a/tests/stubtest_allowlists/py3_common.txt
+++ b/tests/stubtest_allowlists/py3_common.txt
@@ -236,6 +236,7 @@ xml.parsers.expat.expat_CAPI
 # Allowlist entries that cannot or should not be fixed
 # ==========
 _pydecimal.*  # See comments in file
+argparse.SUPPRESS  # See comment in file
 ast.NodeVisitor.visit_\w+  # Methods are discovered dynamically, see #3796
 # Weird special builtins that are typed as functions, but aren't functions
 builtins.copyright


### PR DESCRIPTION
As has previously been discussed in https://github.com/python/typeshed/pull/6826#issuecomment-1005654071 the `argparse` module sometimes compares `argparse.SUPPRESS` with `is` meaning `Literal["==SUPPRESS=="]` is not suited. This PR solves this using `NewType`.

As reported by [mypy_primer](https://github.com/hauntsaninja/mypy_primer) the following fails with mypy:

```python
import argparse
x = argparse.SUPPRESS
x = "test"
```

because of:

```
foo.py:4: error: Incompatible types in assignment (expression has type "str", variable has type "_SUPPRESS_T")
```

This however seems to be due to a limitation in mypy not understanding that a newtype is backwards compatible with the original type as can be observed in the following example:

```python
import typing

X = typing.NewType('X', int)

def foo(a: X) -> int:
    return a
```

Mypy complains whereas Pyright says it's ok. With that in mind I think that the advantages of this PR (type safety against typos) outweigh the caused inconvenience (when reassigning SUPPRESS with mypy).