### PR TITLE
flake8: Turn off Y034 in typing.pyi

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -34,7 +34,7 @@ per-file-ignores =
   stubs/*.pyi: E301, E302, E305, E501, E701, E741, F401, F403, F405, F822, Y026, Y027
   stdlib/@python2/*.pyi: E301, E302, E305, E501, E701, E741, F401, F403, F405, F822, Y026, Y027
   stdlib/@python2/typing.pyi: E301, E302, E305, E501, E701, E741, F401, F403, F405, F811, F822, Y026, Y027
-  stdlib/typing.pyi: E301, E302, E305, E501, E701, E741, F401, F403, F405, F811, F822, Y026
+  stdlib/typing.pyi: E301, E302, E305, E501, E701, E741, F401, F403, F405, F811, F822, Y026, Y034
 
 # We are checking with Python 3 but many of the stubs are Python 2 stubs.
 builtins = buffer,file,long,raw_input,unicode,xrange


### PR DESCRIPTION
See PyCQA/flake8-pyi#186. flake8-pyi doesn't like us renaming `_typeshed.Self` to `_TypeshedSelf`.

cc @AlexWaygood