### PR TITLE
Fix unittest.TextTestResult showAll name

### DIFF
--- a/stdlib/unittest/runner.pyi
+++ b/stdlib/unittest/runner.pyi
@@ -11,7 +11,6 @@ class TextTestResult(unittest.result.TestResult):
     separator1: str
     separator2: str
     showAll: bool  # undocumented
-    dots: bool  # undocumented
     stream: TextIO  # undocumented
     def __init__(self, stream: TextIO, descriptions: bool, verbosity: int) -> None: ...
     def getDescription(self, test: unittest.case.TestCase) -> str: ...

--- a/stdlib/unittest/runner.pyi
+++ b/stdlib/unittest/runner.pyi
@@ -10,7 +10,8 @@ class TextTestResult(unittest.result.TestResult):
     dots: bool  # undocumented
     separator1: str
     separator2: str
-    showall: bool  # undocumented
+    showAll: bool  # undocumented
+    dots: bool  # undocumented
     stream: TextIO  # undocumented
     def __init__(self, stream: TextIO, descriptions: bool, verbosity: int) -> None: ...
     def getDescription(self, test: unittest.case.TestCase) -> str: ...


### PR DESCRIPTION
`showall` -> `showAll` - it has always been camel-cased and didn't change - [python 2.7 source](https://github.com/python/cpython/blob/2.7/Lib/unittest/runner.py) , [main](https://github.com/python/cpython/blob/main/Lib/unittest/runner.py)