### PR TITLE
Fix unittest.TextTestResult.printErrorList()

### DIFF
--- a/stdlib/unittest/runner.pyi
+++ b/stdlib/unittest/runner.pyi
@@ -1,7 +1,7 @@
 import unittest.case
 import unittest.result
 import unittest.suite
-from typing import Callable, TextIO
+from typing import Callable, Iterable, TextIO
 
 _ResultClassType = Callable[[TextIO, bool, int], unittest.result.TestResult]
 
@@ -15,7 +15,7 @@ class TextTestResult(unittest.result.TestResult):
     def __init__(self, stream: TextIO, descriptions: bool, verbosity: int) -> None: ...
     def getDescription(self, test: unittest.case.TestCase) -> str: ...
     def printErrors(self) -> None: ...
-    def printErrorList(self, flavour: str, errors: tuple[unittest.case.TestCase, str]) -> None: ...
+    def printErrorList(self, flavour: str, errors: Iterable[tuple[unittest.case.TestCase, str]]) -> None: ...
 
 class TextTestRunner:
     resultclass: _ResultClassType


### PR DESCRIPTION
This function is passed either `self.errors` or `self.failures` which are defined as `list`s of such tuples: https://github.com/python/typeshed/blob/4d169eaa83bfde68e0abc55670b73c1f0f408043/stdlib/unittest/result.pyi#L16-L17

This can be seen from [Python 2.7 source](https://github.com/python/cpython/blob/2.7/Lib/unittest/runner.py#L105) and up.

(Sorry for not merging in #7340 - I was still untangling some type check errors 😅)