### PR TITLE
Add `__all__` for `asyncio.unix_events` & `asyncio.taskgroups`, and simplify `asyncio.__init__`

### DIFF
--- a/stdlib/asyncio/__init__.pyi
+++ b/stdlib/asyncio/__init__.pyi
@@ -1,127 +1,31 @@
 import sys
 
-from .base_events import BaseEventLoop as BaseEventLoop
-from .coroutines import iscoroutine as iscoroutine, iscoroutinefunction as iscoroutinefunction
-from .events import (
-    AbstractEventLoop as AbstractEventLoop,
-    AbstractEventLoopPolicy as AbstractEventLoopPolicy,
-    AbstractServer as AbstractServer,
-    Handle as Handle,
-    TimerHandle as TimerHandle,
-    _get_running_loop as _get_running_loop,
-    _set_running_loop as _set_running_loop,
-    get_child_watcher as get_child_watcher,
-    get_event_loop as get_event_loop,
-    get_event_loop_policy as get_event_loop_policy,
-    new_event_loop as new_event_loop,
-    set_child_watcher as set_child_watcher,
-    set_event_loop as set_event_loop,
-    set_event_loop_policy as set_event_loop_policy,
-)
-from .futures import Future as Future, isfuture as isfuture, wrap_future as wrap_future
-from .locks import (
-    BoundedSemaphore as BoundedSemaphore,
-    Condition as Condition,
-    Event as Event,
-    Lock as Lock,
-    Semaphore as Semaphore,
-)
-from .protocols import (
-    BaseProtocol as BaseProtocol,
-    DatagramProtocol as DatagramProtocol,
-    Protocol as Protocol,
-    SubprocessProtocol as SubprocessProtocol,
-)
-from .queues import (
-    LifoQueue as LifoQueue,
-    PriorityQueue as PriorityQueue,
-    Queue as Queue,
-    QueueEmpty as QueueEmpty,
-    QueueFull as QueueFull,
-)
-from .streams import (
-    StreamReader as StreamReader,
-    StreamReaderProtocol as StreamReaderProtocol,
-    StreamWriter as StreamWriter,
-    open_connection as open_connection,
-    start_server as start_server,
-)
-from .subprocess import create_subprocess_exec as create_subprocess_exec, create_subprocess_shell as create_subprocess_shell
-from .tasks import (
-    ALL_COMPLETED as ALL_COMPLETED,
-    FIRST_COMPLETED as FIRST_COMPLETED,
-    FIRST_EXCEPTION as FIRST_EXCEPTION,
-    Task as Task,
-    as_completed as as_completed,
-    ensure_future as ensure_future,
-    gather as gather,
-    run_coroutine_threadsafe as run_coroutine_threadsafe,
-    shield as shield,
-    sleep as sleep,
-    wait as wait,
-    wait_for as wait_for,
-)
-from .transports import (
-    BaseTransport as BaseTransport,
-    DatagramTransport as DatagramTransport,
-    ReadTransport as ReadTransport,
-    SubprocessTransport as SubprocessTransport,
-    Transport as Transport,
-    WriteTransport as WriteTransport,
-)
-
-if sys.version_info < (3, 11):
-    from .coroutines import coroutine as coroutine
-
-if sys.version_info >= (3, 9):
-    from .threads import to_thread as to_thread
-
-if sys.version_info >= (3, 8):
-    from .exceptions import (
-        CancelledError as CancelledError,
-        IncompleteReadError as IncompleteReadError,
-        InvalidStateError as InvalidStateError,
-        LimitOverrunError as LimitOverrunError,
-        TimeoutError as TimeoutError,
-    )
-else:
-    from .futures import CancelledError as CancelledError, InvalidStateError as InvalidStateError, TimeoutError as TimeoutError
-    from .streams import IncompleteReadError as IncompleteReadError, LimitOverrunError as LimitOverrunError
-
-if sys.version_info >= (3, 8):
-    from .exceptions import SendfileNotAvailableError as SendfileNotAvailableError
-elif sys.version_info >= (3, 7):
-    from .events import SendfileNotAvailableError as SendfileNotAvailableError
+# As at runtime, this depends on all submodules defining __all__ accurately.
+from .base_events *
+from .coroutines *
+from .events import *
+from .futures import *
+from .locks import *
+from .protocols import *
+from .queues import *
+from .streams import *
+from .subprocess import *
+from .tasks import *
+from .transports import *
 
 if sys.version_info >= (3, 7):
-    from .events import get_running_loop as get_running_loop
-    from .protocols import BufferedProtocol as BufferedProtocol
-    from .runners import run as run
-    from .tasks import (
-        _enter_task as _enter_task,
-        _leave_task as _leave_task,
-        _register_task as _register_task,
-        _unregister_task as _unregister_task,
-        all_tasks as all_tasks,
-        create_task as create_task,
-        current_task as current_task,
-    )
+    from .runners import *
+
+if sys.version_info >= (3, 8):
+    from .exceptions import *
+
+if sys.version_info >= (3, 9):
+    from .threads import *
 
 if sys.version_info >= (3, 11):
-    from .taskgroups import TaskGroup as TaskGroup
-
-DefaultEventLoopPolicy: type[AbstractEventLoopPolicy]
+    from .taskgroups import *
 
 if sys.platform == "win32":
     from .windows_events import *
 else:
-    from .streams import open_unix_connection as open_unix_connection, start_unix_server as start_unix_server
-    from .unix_events import (
-        AbstractChildWatcher as AbstractChildWatcher,
-        FastChildWatcher as FastChildWatcher,
-        SafeChildWatcher as SafeChildWatcher,
-        SelectorEventLoop as SelectorEventLoop,
-    )
-
-    if sys.version_info >= (3, 8):
-        from .unix_events import MultiLoopChildWatcher as MultiLoopChildWatcher, ThreadedChildWatcher as ThreadedChildWatcher
+    from .unix_events import *

--- a/stdlib/asyncio/taskgroups.pyi
+++ b/stdlib/asyncio/taskgroups.pyi
@@ -6,6 +6,8 @@ from typing import Any, Coroutine, Generator, TypeVar
 
 from .tasks import Task
 
+__all__ = ["TaskGroup"]
+
 _T = TypeVar("_T")
 
 class TaskGroup:

--- a/stdlib/asyncio/unix_events.pyi
+++ b/stdlib/asyncio/unix_events.pyi
@@ -22,6 +22,32 @@ class AbstractChildWatcher:
         def is_active(self) -> bool: ...
 
 if sys.platform != "win32":
+    if sys.version_info >= (3, 9):
+        __all__ = (
+            "SelectorEventLoop",
+            "AbstractChildWatcher",
+            "SafeChildWatcher",
+            "FastChildWatcher",
+            "PidfdChildWatcher",
+            "MultiLoopChildWatcher",
+            "ThreadedChildWatcher",
+            "DefaultEventLoopPolicy",
+        )
+    elif sys.version_info >= (3, 8):
+        __all__ = (
+            "SelectorEventLoop",
+            "AbstractChildWatcher",
+            "SafeChildWatcher",
+            "FastChildWatcher",
+            "MultiLoopChildWatcher",
+            "ThreadedChildWatcher",
+            "DefaultEventLoopPolicy",
+        )
+    elif sys.version_info >= (3, 7):
+        __all__ = ("SelectorEventLoop", "AbstractChildWatcher", "SafeChildWatcher", "FastChildWatcher", "DefaultEventLoopPolicy")
+    else:
+        __all__ = ["SelectorEventLoop", "AbstractChildWatcher", "SafeChildWatcher", "FastChildWatcher", "DefaultEventLoopPolicy"]
+
     class BaseChildWatcher(AbstractChildWatcher):
         def __init__(self) -> None: ...
 


### PR DESCRIPTION
Now that all `asyncio` submodules have accurate `__all__`s, we can drastically simplify the imports in `asyncio.__init__.pyi` and do something much more similar to what's done at runtime.