### PR TITLE
Sync asyncio.isfuture definitions by sharing asyncio.base_futures.isfuture definition

### DIFF
--- a/stdlib/asyncio/base_futures.pyi
+++ b/stdlib/asyncio/base_futures.pyi
@@ -1,6 +1,6 @@
 import sys
 from typing import Any, Callable, Sequence
-from typing_extensions import Literal, TypeGuard
+from typing_extensions import Literal
 
 if sys.version_info >= (3, 7):
     from contextvars import Context
@@ -12,11 +12,14 @@ if sys.version_info >= (3, 7):
 else:
     __all__: list[str] = []
 
+# asyncio defines 'isfuture()' in base_futures.py and re-imports it in futures.py
+# but it leads to circular import error in pytype tool.
+# That's why the import order is reversed.
+from .futures import isfuture as isfuture
+
 _PENDING: Literal["PENDING"]  # undocumented
 _CANCELLED: Literal["CANCELLED"]  # undocumented
 _FINISHED: Literal["FINISHED"]  # undocumented
-
-def isfuture(obj: object) -> TypeGuard[futures.Future[Any]]: ...
 
 if sys.version_info >= (3, 7):
     def _format_callbacks(cb: Sequence[tuple[Callable[[futures.Future[Any]], None], Context]]) -> str: ...  # undocumented

--- a/stdlib/asyncio/futures.pyi
+++ b/stdlib/asyncio/futures.pyi
@@ -3,6 +3,7 @@ from _typeshed import Self
 from concurrent.futures._base import Error, Future as _ConcurrentFuture
 from typing import Any, Awaitable, Callable, Generator, Iterable, TypeVar
 
+from .base_futures import isfuture
 from .events import AbstractEventLoop
 
 if sys.version_info < (3, 8):
@@ -33,8 +34,6 @@ if sys.version_info < (3, 7):
         def activate(self) -> None: ...
         def clear(self) -> None: ...
         def __del__(self) -> None: ...
-
-def isfuture(obj: object) -> bool: ...
 
 class Future(Awaitable[_T], Iterable[_T]):
     _state: str

--- a/stdlib/asyncio/futures.pyi
+++ b/stdlib/asyncio/futures.pyi
@@ -1,9 +1,8 @@
 import sys
 from _typeshed import Self
 from concurrent.futures._base import Error, Future as _ConcurrentFuture
-from typing import Any, Awaitable, Callable, Generator, Iterable, TypeVar
+from typing import Any, Awaitable, Callable, Generator, Iterable, TypeGuard, TypeVar
 
-from .base_futures import isfuture as isfuture
 from .events import AbstractEventLoop
 
 if sys.version_info < (3, 8):
@@ -25,6 +24,13 @@ else:
     __all__ = ["CancelledError", "TimeoutError", "InvalidStateError", "Future", "wrap_future", "isfuture"]
 
 _T = TypeVar("_T")
+
+
+# asyncio defines 'isfuture()' in base_futures.py and re-imports it in futures.py
+# but it leads to circular import error in pytype tool.
+# That's why the import order is reversed.
+def isfuture(obj: object) -> TypeGuard[futures.Future[Any]]: ...
+
 
 if sys.version_info < (3, 7):
     class _TracebackLogger:

--- a/stdlib/asyncio/futures.pyi
+++ b/stdlib/asyncio/futures.pyi
@@ -25,12 +25,10 @@ else:
 
 _T = TypeVar("_T")
 
-
 # asyncio defines 'isfuture()' in base_futures.py and re-imports it in futures.py
 # but it leads to circular import error in pytype tool.
 # That's why the import order is reversed.
 def isfuture(obj: object) -> TypeGuard[futures.Future[Any]]: ...
-
 
 if sys.version_info < (3, 7):
     class _TracebackLogger:

--- a/stdlib/asyncio/futures.pyi
+++ b/stdlib/asyncio/futures.pyi
@@ -29,7 +29,7 @@ _T = TypeVar("_T")
 # asyncio defines 'isfuture()' in base_futures.py and re-imports it in futures.py
 # but it leads to circular import error in pytype tool.
 # That's why the import order is reversed.
-def isfuture(obj: object) -> TypeGuard[futures.Future[Any]]: ...
+def isfuture(obj: object) -> TypeGuard[Future[Any]]: ...
 
 if sys.version_info < (3, 7):
     class _TracebackLogger:

--- a/stdlib/asyncio/futures.pyi
+++ b/stdlib/asyncio/futures.pyi
@@ -1,7 +1,8 @@
 import sys
 from _typeshed import Self
 from concurrent.futures._base import Error, Future as _ConcurrentFuture
-from typing import Any, Awaitable, Callable, Generator, Iterable, TypeGuard, TypeVar
+from typing import Any, Awaitable, Callable, Generator, Iterable, TypeVar
+from typing_extensions import TypeGuard
 
 from .events import AbstractEventLoop
 

--- a/stdlib/asyncio/futures.pyi
+++ b/stdlib/asyncio/futures.pyi
@@ -3,7 +3,7 @@ from _typeshed import Self
 from concurrent.futures._base import Error, Future as _ConcurrentFuture
 from typing import Any, Awaitable, Callable, Generator, Iterable, TypeVar
 
-from .base_futures import isfuture
+from .base_futures import isfuture as isfuture
 from .events import AbstractEventLoop
 
 if sys.version_info < (3, 8):


### PR DESCRIPTION
`asyncio.base_futures.isfuture()` has a correct typeguard signature already but it was hidden by `asyncio.futures.isfuture()` redefinition.

Now `asyncio.futures.isfuture` is an alias to `asyncio.base_futures.isfuture()`. The same structure is used in original asyncio source.