### PR TITLE
Replace some literal types in logging with int

### DIFF
--- a/stdlib/logging/__init__.pyi
+++ b/stdlib/logging/__init__.pyi
@@ -290,14 +290,14 @@ class Logger(Filterer):
     def hasHandlers(self) -> bool: ...
     def callHandlers(self, record: LogRecord) -> None: ...  # undocumented
 
-CRITICAL: Literal[50]
-FATAL: Literal[50]
-ERROR: Literal[40]
-WARNING: Literal[30]
-WARN: Literal[30]
-INFO: Literal[20]
-DEBUG: Literal[10]
-NOTSET: Literal[0]
+CRITICAL: int
+FATAL: int
+ERROR: int
+WARNING: int
+WARN: int
+INFO: int
+DEBUG: int
+NOTSET: int
 
 class Handler(Filterer):
     level: int  # undocumented


### PR DESCRIPTION
See #7258 for an extended discussion. In summary, for mypy these
would be better written as follows, but this would not work with
every type checker:
```
CRITICAL: Final = 50
```