### PR TITLE
Add `csv.__version__`

### DIFF
--- a/stdlib/_csv.pyi
+++ b/stdlib/_csv.pyi
@@ -1,6 +1,8 @@
 from typing import Any, Iterable, Iterator, Protocol, Union
 from typing_extensions import Literal
 
+__version__: str
+
 QUOTE_ALL: Literal[1]
 QUOTE_MINIMAL: Literal[0]
 QUOTE_NONE: Literal[3]

--- a/stdlib/csv.pyi
+++ b/stdlib/csv.pyi
@@ -6,6 +6,7 @@ from _csv import (
     QUOTE_NONNUMERIC as QUOTE_NONNUMERIC,
     Dialect as Dialect,
     Error as Error,
+    __version__ as __version__,
     _DialectLike,
     _reader,
     _writer,
@@ -16,7 +17,6 @@ from _csv import (
     register_dialect as register_dialect,
     unregister_dialect as unregister_dialect,
     writer as writer,
-    __version__ as __version__
 )
 from _typeshed import Self
 from collections.abc import Collection, Iterable, Iterator, Mapping, Sequence

--- a/stdlib/csv.pyi
+++ b/stdlib/csv.pyi
@@ -16,6 +16,7 @@ from _csv import (
     register_dialect as register_dialect,
     unregister_dialect as unregister_dialect,
     writer as writer,
+    __version__ as __version__
 )
 from _typeshed import Self
 from collections.abc import Collection, Iterable, Iterator, Mapping, Sequence

--- a/tests/stubtest_allowlists/py3_common.txt
+++ b/tests/stubtest_allowlists/py3_common.txt
@@ -65,7 +65,6 @@ configparser.SectionProxy.getboolean
 configparser.SectionProxy.getfloat
 configparser.SectionProxy.getint
 copy.PyStringMap  # defined only in Jython
-csv.__version__  # Always "1.0". Using this is likely a bug. #6398
 # The Dialect properties are initialized as None in Dialect but their values are enforced in _Dialect
 csv.Dialect.delimiter
 csv.Dialect.doublequote


### PR DESCRIPTION
We previously discussed this in #6398, and decided not to include it in the stub. However, it is declared as a publicly exported object in the module's `__all__` at runtime, so not including it in the stub creates an inconsistency in the stub's `__all__` (see https://github.com/python/typeshed/pull/7356). Moreover, there doesn't really seem to be any harm in adding it to the stub. So, I think we should add it.