### PR TITLE
Improve `re` stubs

### DIFF
--- a/stdlib/re.pyi
+++ b/stdlib/re.pyi
@@ -1,4 +1,5 @@
 import enum
+import sre_compile
 import sys
 from sre_constants import error as error
 from typing import Any, AnyStr, Callable, Iterator, Union, overload
@@ -107,25 +108,25 @@ else:
     ]
 
 class RegexFlag(enum.IntFlag):
-    A: int = ...
+    A = sre_compile.SRE_FLAG_ASCII
     ASCII = A
-    DEBUG: int = ...
-    I: int = ...
+    DEBUG = sre_compile.SRE_FLAG_DEBUG
+    I = sre_compile.SRE_FLAG_IGNORECASE
     IGNORECASE = I
-    L: int = ...
+    L = sre_compile.SRE_FLAG_LOCALE
     LOCALE = L
-    M: int = ...
+    M = sre_compile.SRE_FLAG_MULTILINE
     MULTILINE = M
-    S: int = ...
+    S = sre_compile.SRE_FLAG_DOTALL
     DOTALL = S
-    X: int = ...
+    X = sre_compile.SRE_FLAG_VERBOSE
     VERBOSE = X
-    U: int = ...
+    U = sre_compile.SRE_FLAG_UNICODE
     UNICODE = U
-    T: int = ...
+    T = sre_compile.SRE_FLAG_TEMPLATE
     TEMPLATE = T
     if sys.version_info >= (3, 11):
-        NO_FLAG: int = ...
+        NO_FLAG: int
 
 A = RegexFlag.A
 ASCII = RegexFlag.ASCII

--- a/stdlib/re.pyi
+++ b/stdlib/re.pyi
@@ -108,22 +108,24 @@ else:
 
 class RegexFlag(enum.IntFlag):
     A: int
-    ASCII: int
+    ASCII = A
     DEBUG: int
     I: int
-    IGNORECASE: int
+    IGNORECASE = I
     L: int
-    LOCALE: int
+    LOCALE = L
     M: int
-    MULTILINE: int
+    MULTILINE = M
     S: int
-    DOTALL: int
+    DOTALL = S
     X: int
-    VERBOSE: int
+    VERBOSE = X
     U: int
-    UNICODE: int
+    UNICODE = U
     T: int
-    TEMPLATE: int
+    TEMPLATE = T
+    if sys.version_info >= (3, 11):
+        NO_FLAG: int
 
 A = RegexFlag.A
 ASCII = RegexFlag.ASCII
@@ -142,6 +144,8 @@ U = RegexFlag.U
 UNICODE = RegexFlag.UNICODE
 T = RegexFlag.T
 TEMPLATE = RegexFlag.TEMPLATE
+if sys.version_info >= (3, 11):
+    NO_FLAG = RegexFlag.NO_FLAG
 _FlagsType = Union[int, RegexFlag]
 
 if sys.version_info < (3, 7):
@@ -165,8 +169,6 @@ def search(pattern: Pattern[AnyStr], string: AnyStr, flags: _FlagsType = ...) ->
 def match(pattern: AnyStr, string: AnyStr, flags: _FlagsType = ...) -> Match[AnyStr] | None: ...
 @overload
 def match(pattern: Pattern[AnyStr], string: AnyStr, flags: _FlagsType = ...) -> Match[AnyStr] | None: ...
-
-# New in Python 3.4
 @overload
 def fullmatch(pattern: AnyStr, string: AnyStr, flags: _FlagsType = ...) -> Match[AnyStr] | None: ...
 @overload

--- a/stdlib/re.pyi
+++ b/stdlib/re.pyi
@@ -107,25 +107,25 @@ else:
     ]
 
 class RegexFlag(enum.IntFlag):
-    A: int
+    A: int = ...
     ASCII = A
-    DEBUG: int
-    I: int
+    DEBUG: int = ...
+    I: int = ...
     IGNORECASE = I
-    L: int
+    L: int = ...
     LOCALE = L
-    M: int
+    M: int = ...
     MULTILINE = M
-    S: int
+    S: int = ...
     DOTALL = S
-    X: int
+    X: int = ...
     VERBOSE = X
-    U: int
+    U: int = ...
     UNICODE = U
-    T: int
+    T: int = ...
     TEMPLATE = T
     if sys.version_info >= (3, 11):
-        NO_FLAG: int
+        NO_FLAG: int = ...
 
 A = RegexFlag.A
 ASCII = RegexFlag.ASCII


### PR DESCRIPTION
- Add `NO_FLAG`, new in 3.11
- Delete very old comment
- Several members in `RegexFlag` are aliases of other members; the stub should reflect that