### PR TITLE
Fix several mypy errors when run on the 3.11 stdlib

### DIFF
--- a/stdlib/asyncio/base_events.pyi
+++ b/stdlib/asyncio/base_events.pyi
@@ -298,7 +298,7 @@ class BaseEventLoop(AbstractEventLoop):
             self, protocol_factory: Callable[[], _ProtocolT], sock: socket, *, ssl: _SSLContext = ...
         ) -> tuple[BaseTransport, _ProtocolT]: ...
     if sys.version_info >= (3, 11):
-        async def create_datagram_endpoint(
+        async def create_datagram_endpoint(  # type: ignore[override]
             self,
             protocol_factory: Callable[[], _ProtocolT],
             local_addr: tuple[str, int] | None = ...,

--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -1710,7 +1710,7 @@ if sys.version_info >= (3, 10):
     class EncodingWarning(Warning): ...
 
 if sys.version_info >= (3, 11):
-    _SplitCondition = type[BaseException] | tuple[type[BaseException], ...] | Callable[[BaseException], bool]
+    _SplitCondition = Union[type[BaseException], tuple[type[BaseException], ...], Callable[[BaseException], bool]]
 
     class BaseExceptionGroup(BaseException):
         def __new__(cls: type[Self], __message: str, __exceptions: Sequence[BaseException]) -> Self: ...

--- a/stdlib/enum.pyi
+++ b/stdlib/enum.pyi
@@ -140,7 +140,6 @@ if sys.version_info >= (3, 11):
         def __set_name__(self, ownerclass: type[Enum], name: str) -> None: ...
         name: str
         clsname: str
-
     _magic_enum_attr = property
 else:
     _magic_enum_attr = types.DynamicClassAttribute


### PR DESCRIPTION
If you apply @hauntsaninja's patch to `mypy_test.py` in https://github.com/python/mypy/issues/12220, here is the output when running `python tests/mypy_test.py -p3.11` on the master branch (using Python 3.10, mypy 0.931):

```
stdlib\typing.pyi:1166: error: Variable "typing.Never" is not valid as a type  [valid-type]
stdlib\typing.pyi:1166: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases
stdlib\builtins.pyi:1713: error: Value of type "Type[type]" is not indexable  [index]
stdlib\builtins.pyi:1721: error: Variable "builtins._SplitCondition" is not valid as a type  [valid-type]
stdlib\builtins.pyi:1721: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases
stdlib\builtins.pyi:1722: error: Variable "builtins._SplitCondition" is not valid as a type  [valid-type]
stdlib\builtins.pyi:1722: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases
stdlib\enum.pyi:141: error: Decorated property not supported  [misc]
stdlib\enum.pyi:143: error: Decorated property not supported  [misc]
stdlib\enum.pyi:172: error: Decorated property not supported  [misc]
stdlib\enum.pyi:192: error: Signature of "value" incompatible with supertype "Flag"  [override]
stdlib\enum.pyi:203: error: Decorated property not supported  [misc]
stdlib\enum.pyi:205: error: Decorated property not supported  [misc]
stdlib\enum.pyi:233: error: Decorated property not supported  [misc]
stdlib\enum.pyi:236: error: Cannot inherit from final class "StrEnum"  [misc]
stdlib\enum.pyi:248: error: Cannot inherit from final class "StrEnum"  [misc]
stdlib\asyncio\base_events.pyi:301: error: Signature of "create_datagram_endpoint" incompatible with supertype "AbstractEventLoop"  [override]
stdlib\asyncio\base_events.pyi:301: note:      Superclass:
stdlib\asyncio\base_events.pyi:301: note:          def [_ProtocolT <: BaseProtocol] create_datagram_endpoint(self, protocol_factory: Callable[[], _ProtocolT], local_addr: Optional[Tuple[str, int]] = ..., remote_addr: Optional[Tuple[str, int]] = ..., *, family: int = ..., proto: int = ..., flags: int = ..., reuse_address: Optional[bool] = ..., reuse_port: Optional[bool] = ..., allow_broadcast: Optional[bool] = ..., sock: Optional[socket] = ...) -> Coroutine[Any, Any, Tuple[BaseTransport, _ProtocolT]]
stdlib\asyncio\base_events.pyi:301: note:      Subclass:
stdlib\asyncio\base_events.pyi:301: note:          def [_ProtocolT <: BaseProtocol] create_datagram_endpoint(self, protocol_factory: Callable[[], _ProtocolT], local_addr: Optional[Tuple[str, int]] = ..., remote_addr: Optional[Tuple[str, int]] = ..., *, family: int = ..., proto: int = ..., flags: int = ..., reuse_port: Optional[bool] = ..., allow_broadcast: Optional[bool] = ..., sock: Optional[socket] = ...) -> Coroutine[Any, Any, Tuple[BaseTransport, _ProtocolT]]
```

Here is the output when running `python tests/mypy_test.py -p3.11` with this patch applied:

```
stdlib\typing.pyi:1166: error: Variable "typing.Never" is not valid as a type  [valid-type]
stdlib\typing.pyi:1166: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases
stdlib\enum.pyi:222: error: Cannot inherit from final class "StrEnum"  [misc]
stdlib\enum.pyi:234: error: Cannot inherit from final class "StrEnum"  [misc]
```