### PR TITLE
Improve `types.pyi`

### DIFF
--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -809,8 +809,10 @@ class function:
     __qualname__: str
     __annotations__: dict[str, Any]
     __kwdefaults__: dict[str, Any]
-    @property
-    def __builtins__(self) -> dict[str, Any]: ...
+    if sys.version_info >= (3,10):
+        @property
+        def __builtins__(self) -> dict[str, Any]: ...
+
     __module__: str
     # mypy uses `builtins.function.__get__` to represent methods, properties, and getset_descriptors so we type the return as Any.
     def __get__(self, obj: object | None, type: type | None = ...) -> Any: ...

--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -809,7 +809,7 @@ class function:
     __qualname__: str
     __annotations__: dict[str, Any]
     __kwdefaults__: dict[str, Any]
-    if sys.version_info >= (3,10):
+    if sys.version_info >= (3, 10):
         @property
         def __builtins__(self) -> dict[str, Any]: ...
 

--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -798,15 +798,19 @@ class tuple(Sequence[_T_co], Generic[_T_co]):
 @final
 class function:
     # Make sure this class definition stays roughly in line with `types.FunctionType`
-    __closure__: tuple[_Cell, ...] | None
+    @property
+    def __closure__(self) -> tuple[_Cell, ...] | None: ...
     __code__: CodeType
     __defaults__: tuple[Any, ...] | None
     __dict__: dict[str, Any]
-    __globals__: dict[str, Any]
+    @property
+    def __globals__(self) -> dict[str, Any]: ...
     __name__: str
     __qualname__: str
     __annotations__: dict[str, Any]
     __kwdefaults__: dict[str, Any]
+    @property
+    def __builtins__(self) -> dict[str, Any]: ...
     __module__: str
     # mypy uses `builtins.function.__get__` to represent methods, properties, and getset_descriptors so we type the return as Any.
     def __get__(self, obj: object | None, type: type | None = ...) -> Any: ...

--- a/stdlib/types.pyi
+++ b/stdlib/types.pyi
@@ -184,15 +184,19 @@ class _Cell:
 # Make sure this class definition stays roughly in line with `builtins.function`
 @final
 class FunctionType:
-    __closure__: tuple[_Cell, ...] | None
+    @property
+    def __closure__(self) -> tuple[_Cell, ...] | None: ...
     __code__: CodeType
     __defaults__: tuple[Any, ...] | None
     __dict__: dict[str, Any]
-    __globals__: dict[str, Any]
+    @property
+    def __globals__(self) -> dict[str, Any]: ...
     __name__: str
     __qualname__: str
     __annotations__: dict[str, Any]
     __kwdefaults__: dict[str, Any]
+    @property
+    def __builtins__(self) -> dict[str, Any]: ...
     def __init__(
         self,
         code: CodeType,
@@ -211,23 +215,40 @@ LambdaType = FunctionType
 
 @final
 class CodeType:
-    co_argcount: int
+    @property
+    def co_argcount(self) -> int: ...
     if sys.version_info >= (3, 8):
-        co_posonlyargcount: int
-    co_kwonlyargcount: int
-    co_nlocals: int
-    co_stacksize: int
-    co_flags: int
-    co_code: bytes
-    co_consts: tuple[Any, ...]
-    co_names: tuple[str, ...]
-    co_varnames: tuple[str, ...]
-    co_filename: str
-    co_name: str
-    co_firstlineno: int
-    co_lnotab: bytes
-    co_freevars: tuple[str, ...]
-    co_cellvars: tuple[str, ...]
+        @property
+        def co_posonlyargcount(self) -> int: ...
+
+    @property
+    def co_kwonlyargcount(self) -> int: ...
+    @property
+    def co_nlocals(self) -> int: ...
+    @property
+    def co_stacksize(self) -> int: ...
+    @property
+    def co_flags(self) -> int: ...
+    @property
+    def co_code(self) -> bytes: ...
+    @property
+    def co_consts(self) -> tuple[Any, ...]: ...
+    @property
+    def co_names(self) -> tuple[str, ...]: ...
+    @property
+    def co_varnames(self) -> tuple[str, ...]: ...
+    @property
+    def co_filename(self) -> str: ...
+    @property
+    def co_name(self) -> str: ...
+    @property
+    def co_firstlineno(self) -> int: ...
+    @property
+    def co_lnotab(self) -> bytes: ...
+    @property
+    def co_freevars(self) -> tuple[str, ...]: ...
+    @property
+    def co_cellvars(self) -> tuple[str, ...]: ...
     if sys.version_info >= (3, 8):
         def __init__(
             self,
@@ -289,7 +310,8 @@ class CodeType:
             co_linetable: object = ...,
         ) -> CodeType: ...
         def co_lines(self) -> Iterator[tuple[int, int, int | None]]: ...
-        co_linetable: object
+        @property
+        def co_linetable(self) -> object: ...
     elif sys.version_info >= (3, 8):
         def replace(
             self,
@@ -341,7 +363,8 @@ class SimpleNamespace:
 class ModuleType:
     __name__: str
     __file__: str | None
-    __dict__: dict[str, Any]
+    @property
+    def __dict__(self) -> dict[str, Any]: ...  # type: ignore[override]
     __loader__: _LoaderProtocol | None
     __package__: str | None
     __path__: MutableSequence[str]
@@ -354,10 +377,14 @@ class ModuleType:
 
 @final
 class GeneratorType(Generator[_T_co, _T_contra, _V_co]):
-    gi_code: CodeType
-    gi_frame: FrameType
-    gi_running: bool
-    gi_yieldfrom: GeneratorType[_T_co, _T_contra, Any] | None
+    @property
+    def gi_code(self) -> CodeType: ...
+    @property
+    def gi_frame(self) -> FrameType: ...
+    @property
+    def gi_running(self) -> bool: ...
+    @property
+    def gi_yieldfrom(self) -> GeneratorType[_T_co, _T_contra, Any] | None: ...
     __name__: str
     __qualname__: str
     def __iter__(self) -> GeneratorType[_T_co, _T_contra, _V_co]: ...
@@ -373,10 +400,14 @@ class GeneratorType(Generator[_T_co, _T_contra, _V_co]):
 
 @final
 class AsyncGeneratorType(AsyncGenerator[_T_co, _T_contra]):
-    ag_await: Awaitable[Any] | None
-    ag_frame: FrameType
-    ag_running: bool
-    ag_code: CodeType
+    @property
+    def ag_await(self) -> Awaitable[Any] | None: ...
+    @property
+    def ag_frame(self) -> FrameType: ...
+    @property
+    def ag_running(self) -> bool: ...
+    @property
+    def ag_code(self) -> CodeType: ...
     __name__: str
     __qualname__: str
     def __aiter__(self) -> AsyncGeneratorType[_T_co, _T_contra]: ...
@@ -396,10 +427,14 @@ class AsyncGeneratorType(AsyncGenerator[_T_co, _T_contra]):
 class CoroutineType(Coroutine[_T_co, _T_contra, _V_co]):
     __name__: str
     __qualname__: str
-    cr_await: Any | None
-    cr_code: CodeType
-    cr_frame: FrameType
-    cr_running: bool
+    @property
+    def cr_await(self) -> Any | None: ...
+    @property
+    def cr_code(self) -> CodeType: ...
+    @property
+    def cr_frame(self) -> FrameType: ...
+    @property
+    def cr_running(self) -> bool: ...
     def close(self) -> None: ...
     def __await__(self) -> Generator[Any, None, _V_co]: ...
     def send(self, __arg: _T_contra) -> _T_co: ...
@@ -424,20 +459,29 @@ class _StaticFunctionType:
 
 @final
 class MethodType:
-    __closure__: tuple[_Cell, ...] | None  # inherited from the added function
-    __defaults__: tuple[Any, ...] | None  # inherited from the added function
-    __func__: _StaticFunctionType
-    __self__: object
-    __name__: str  # inherited from the added function
-    __qualname__: str  # inherited from the added function
-    def __init__(self, func: Callable[..., Any], obj: object) -> None: ...
+    @property
+    def __closure__(self) -> tuple[_Cell, ...] | None: ...  # inherited from the added function
+    @property
+    def __defaults__(self) -> tuple[Any, ...] | None: ...  # inherited from the added function
+    @property
+    def __func__(self) -> _StaticFunctionType: ...
+    @property
+    def __self__(self) -> object: ...
+    @property
+    def __name__(self) -> str: ...  # inherited from the added function
+    @property
+    def __qualname__(self) -> str: ...  # inherited from the added function
+    def __init__(self, __func: Callable[..., Any], __obj: object) -> None: ...
     def __call__(self, *args: Any, **kwargs: Any) -> Any: ...
 
 @final
 class BuiltinFunctionType:
-    __self__: object | ModuleType
-    __name__: str
-    __qualname__: str
+    @property
+    def __self__(self) -> object | ModuleType: ...
+    @property
+    def __name__(self) -> str: ...
+    @property
+    def __qualname__(self) -> str: ...
     def __call__(self, *args: Any, **kwargs: Any) -> Any: ...
 
 BuiltinMethodType = BuiltinFunctionType
@@ -445,35 +489,48 @@ BuiltinMethodType = BuiltinFunctionType
 if sys.version_info >= (3, 7):
     @final
     class WrapperDescriptorType:
-        __name__: str
-        __qualname__: str
-        __objclass__: type
+        @property
+        def __name__(self) -> str: ...
+        @property
+        def __qualname__(self) -> str: ...
+        @property
+        def __objclass__(self) -> type: ...
         def __call__(self, *args: Any, **kwargs: Any) -> Any: ...
         def __get__(self, __obj: Any, __type: type = ...) -> Any: ...
 
     @final
     class MethodWrapperType:
-        __self__: object
-        __name__: str
-        __qualname__: str
-        __objclass__: type
+        @property
+        def __self__(self) -> object: ...
+        @property
+        def __name__(self) -> str: ...
+        @property
+        def __qualname__(self) -> str: ...
+        @property
+        def __objclass__(self) -> type: ...
         def __call__(self, *args: Any, **kwargs: Any) -> Any: ...
         def __eq__(self, __other: object) -> bool: ...
         def __ne__(self, __other: object) -> bool: ...
 
     @final
     class MethodDescriptorType:
-        __name__: str
-        __qualname__: str
-        __objclass__: type
+        @property
+        def __name__(self) -> str: ...
+        @property
+        def __qualname__(self) -> str: ...
+        @property
+        def __objclass__(self) -> type: ...
         def __call__(self, *args: Any, **kwargs: Any) -> Any: ...
         def __get__(self, obj: Any, type: type = ...) -> Any: ...
 
     @final
     class ClassMethodDescriptorType:
-        __name__: str
-        __qualname__: str
-        __objclass__: type
+        @property
+        def __name__(self) -> str: ...
+        @property
+        def __qualname__(self) -> str: ...
+        @property
+        def __objclass__(self) -> type: ...
         def __call__(self, *args: Any, **kwargs: Any) -> Any: ...
         def __get__(self, obj: Any, type: type = ...) -> Any: ...
 
@@ -495,16 +552,23 @@ class TracebackType:
 
 @final
 class FrameType:
-    f_back: FrameType | None
-    f_builtins: dict[str, Any]
-    f_code: CodeType
-    f_globals: dict[str, Any]
-    f_lasti: int
+    @property
+    def f_back(self) -> FrameType | None: ...
+    @property
+    def f_builtins(self) -> dict[str, Any]: ...
+    @property
+    def f_code(self) -> CodeType: ...
+    @property
+    def f_globals(self) -> dict[str, Any]: ...
+    @property
+    def f_lasti(self) -> int: ...
     # see discussion in #6769: f_lineno *can* sometimes be None,
     # but you should probably file a bug report with CPython if you encounter it being None in the wild.
     # An `int | None` annotation here causes too many false-positive errors.
-    f_lineno: int | Any
-    f_locals: dict[str, Any]
+    @property
+    def f_lineno(self) -> int | Any: ...
+    @property
+    def f_locals(self) -> dict[str, Any]: ...
     f_trace: Callable[[FrameType, str, Any], Any] | None
     if sys.version_info >= (3, 7):
         f_trace_lines: bool
@@ -513,18 +577,24 @@ class FrameType:
 
 @final
 class GetSetDescriptorType:
-    __name__: str
-    __qualname__: str
-    __objclass__: type
+    @property
+    def __name__(self) -> str: ...
+    @property
+    def __qualname__(self) -> str: ...
+    @property
+    def __objclass__(self) -> type: ...
     def __get__(self, __obj: Any, __type: type = ...) -> Any: ...
     def __set__(self, __instance: Any, __value: Any) -> None: ...
     def __delete__(self, __obj: Any) -> None: ...
 
 @final
 class MemberDescriptorType:
-    __name__: str
-    __qualname__: str
-    __objclass__: type
+    @property
+    def __name__(self) -> str: ...
+    @property
+    def __qualname__(self) -> str: ...
+    @property
+    def __objclass__(self) -> type: ...
     def __get__(self, __obj: Any, __type: type = ...) -> Any: ...
     def __set__(self, __instance: Any, __value: Any) -> None: ...
     def __delete__(self, __obj: Any) -> None: ...
@@ -569,9 +639,12 @@ if sys.version_info >= (3, 8):
 
 if sys.version_info >= (3, 9):
     class GenericAlias:
-        __origin__: type
-        __args__: tuple[Any, ...]
-        __parameters__: tuple[Any, ...]
+        @property
+        def __origin__(self) -> type: ...
+        @property
+        def __args__(self) -> tuple[Any, ...]: ...
+        @property
+        def __parameters__(self) -> tuple[Any, ...]: ...
         def __init__(self, origin: type, args: Any) -> None: ...
         def __getattr__(self, name: str) -> Any: ...  # incomplete
 
@@ -585,6 +658,7 @@ if sys.version_info >= (3, 10):
     NotImplementedType = _NotImplementedType  # noqa F811 from builtins
     @final
     class UnionType:
-        __args__: tuple[Any, ...]
+        @property
+        def __args__(self) -> tuple[Any, ...]: ...
         def __or__(self, __obj: Any) -> UnionType: ...
         def __ror__(self, __obj: Any) -> UnionType: ...

--- a/stdlib/types.pyi
+++ b/stdlib/types.pyi
@@ -195,8 +195,10 @@ class FunctionType:
     __qualname__: str
     __annotations__: dict[str, Any]
     __kwdefaults__: dict[str, Any]
-    @property
-    def __builtins__(self) -> dict[str, Any]: ...
+    if sys.version_info >= (3, 10):
+        @property
+        def __builtins__(self) -> dict[str, Any]: ...
+
     def __init__(
         self,
         code: CodeType,

--- a/tests/stubtest_allowlists/py3_common.txt
+++ b/tests/stubtest_allowlists/py3_common.txt
@@ -211,6 +211,9 @@ tkinter.font.Font.__getitem__  # Argument name differs (doesn't matter for __dun
 traceback.TracebackException.from_exception  # explicitly expanding arguments going into TracebackException __init__
 types.GetSetDescriptorType.__get__  # this function can accept no value for the type parameter.
 types.MemberDescriptorType.__get__  # this function can accept no value for the type parameter.
+types.MethodType.__closure__  # read-only but not actually a property; stubtest thinks it doesn't exist.
+types.MethodType.__defaults__  # read-only but not actually a property; stubtest thinks it doesn't exist.
+types.ModuleType.__dict__  # read-only but not actually a property; stubtest thinks it's a mutable attribute.
 types.ModuleType.__getattr__  # this doesn't exist at runtime
 types.SimpleNamespace.__init__  # class doesn't accept positional arguments but has default C signature
 typing.IO.__iter__  # Added because IO streams are iterable. See https://github.com/python/typeshed/commit/97bc450acd60c1bcdafef3ce8fbe3b95a9c0cac3


### PR DESCRIPTION
- Add `types.FunctionType.__builtins__` (and `types.LambdaType.__builtins__`), currently missing from the stub.
- Make many fields on many classes read-only, as they are at runtime.
- All parameters in `types.MethodType.__init__` are positional-only.