### PR TITLE
Add missing constant from urllib3.util.ssl_

### DIFF
--- a/stubs/urllib3/urllib3/util/ssl_.pyi
+++ b/stubs/urllib3/urllib3/util/ssl_.pyi
@@ -12,6 +12,7 @@ create_default_context: Any
 OP_NO_SSLv2: Any
 OP_NO_SSLv3: Any
 OP_NO_COMPRESSION: Any
+DEFAULT_CIPHERS: str
 
 def assert_fingerprint(cert, fingerprint): ...
 def resolve_cert_reqs(candidate): ...


### PR DESCRIPTION
This constant is missing from type stubs but present in the source.
Importing it works, and it's used in various different places.