### PR TITLE
Fix the `pickle_function` parameter from `copyreg.pickle`

### DIFF
--- a/stdlib/copyreg.pyi
+++ b/stdlib/copyreg.pyi
@@ -1,19 +1,19 @@
 from typing import Any, Callable, Hashable, Optional, SupportsInt, TypeVar, Union
 
-_TypeT = TypeVar("_TypeT", bound=type)
-_Reduce = Union[tuple[Callable[..., _TypeT], tuple[Any, ...]], tuple[Callable[..., _TypeT], tuple[Any, ...], Optional[Any]]]
+_T = TypeVar("_T")
+_Reduce = Union[tuple[Callable[..., _T], tuple[Any, ...]], tuple[Callable[..., _T], tuple[Any, ...], Optional[Any]]]
 
 __all__ = ["pickle", "constructor", "add_extension", "remove_extension", "clear_extension_cache"]
 
 def pickle(
-    ob_type: _TypeT,
-    pickle_function: Callable[[_TypeT], str | _Reduce[_TypeT]],
-    constructor_ob: Callable[[_Reduce[_TypeT]], _TypeT] | None = ...,
+    ob_type: type[_T],
+    pickle_function: Callable[[_T], str | _Reduce[_T]],
+    constructor_ob: Callable[[_Reduce[_T]], _T] | None = ...,
 ) -> None: ...
-def constructor(object: Callable[[_Reduce[_TypeT]], _TypeT]) -> None: ...
+def constructor(object: Callable[[_Reduce[_T]], _T]) -> None: ...
 def add_extension(module: Hashable, name: Hashable, code: SupportsInt) -> None: ...
 def remove_extension(module: Hashable, name: Hashable, code: int) -> None: ...
 def clear_extension_cache() -> None: ...
 
-_DispatchTableType = dict[type, Callable[[type], str | _Reduce[type]]]  # imported by multiprocessing.reduction
+_DispatchTableType = dict[type, Callable[[Any], str | _Reduce[Any]]]  # imported by multiprocessing.reduction
 dispatch_table: _DispatchTableType  # undocumented


### PR DESCRIPTION
The callback passed to `pickle_function` should accept an instance of a to-be pickled object; not the respective type object itself.