### PR TITLE
bs4: expose bs4.PageElement

### DIFF
--- a/stubs/beautifulsoup4/bs4/__init__.pyi
+++ b/stubs/beautifulsoup4/bs4/__init__.pyi
@@ -2,7 +2,7 @@ from _typeshed import Self, SupportsRead
 from typing import Any, Sequence
 
 from .builder import TreeBuilder
-from .element import PageElement, SoupStrainer as SoupStrainer, Tag as Tag
+from .element import PageElement as PageElement, SoupStrainer as SoupStrainer, Tag as Tag
 from .formatter import Formatter
 
 class GuessedAtParserWarning(UserWarning): ...


### PR DESCRIPTION
This is generally useful. It's also imported in the source without being
used in bs4/__init__.py which in well maintained packages is a pretty
good marker of intention to export