### PR TITLE
bs4: expose several other classes

### DIFF
--- a/stubs/beautifulsoup4/bs4/__init__.pyi
+++ b/stubs/beautifulsoup4/bs4/__init__.pyi
@@ -2,7 +2,21 @@ from _typeshed import Self, SupportsRead
 from typing import Any, Sequence
 
 from .builder import TreeBuilder
-from .element import PageElement as PageElement, SoupStrainer as SoupStrainer, Tag as Tag
+from .element import (
+    CData as CData,
+    Comment as Comment,
+    Declaration as Declaration,
+    Doctype as Doctype,
+    NavigableString as NavigableString,
+    PageElement as PageElement,
+    ProcessingInstruction as ProcessingInstruction,
+    ResultSet as ResultSet,
+    Script as Script,
+    Stylesheet as Stylesheet,
+    SoupStrainer as SoupStrainer,
+    Tag as Tag,
+    TemplateString as TemplateString,
+)
 from .formatter import Formatter
 
 class GuessedAtParserWarning(UserWarning): ...


### PR DESCRIPTION
On the same lines as #7419

These are all imports that are not used within bs4/__init__.py
My main interest here is in exposing NavigableString