### PR TITLE
Give precise return type for asyncio.gather(*aws)

### DIFF
--- a/stdlib/asyncio/tasks.pyi
+++ b/stdlib/asyncio/tasks.pyi
@@ -119,20 +119,20 @@ if sys.version_info >= (3, 10):
     ) -> Future[tuple[_T1, _T2, _T3, _T4, _T5]]: ...
     @overload
     def gather(
-        __coro_or_future1: _FutureT[Any],
-        __coro_or_future2: _FutureT[Any],
-        __coro_or_future3: _FutureT[Any],
-        __coro_or_future4: _FutureT[Any],
-        __coro_or_future5: _FutureT[Any],
-        __coro_or_future6: _FutureT[Any],
-        *coros_or_futures: _FutureT[Any],
-        return_exceptions: bool = ...,
-    ) -> Future[list[Any]]: ...
+        __coro_or_future1: _FutureT[_T],
+        __coro_or_future2: _FutureT[_T],
+        __coro_or_future3: _FutureT[_T],
+        __coro_or_future4: _FutureT[_T],
+        __coro_or_future5: _FutureT[_T],
+        __coro_or_future6: _FutureT[_T],
+        *coros_or_futures: _FutureT[_T],
+        return_exceptions: Literal[False] = ...,
+    ) -> Future[list[_T]]: ...
     @overload
-    def gather(__coro_or_future1: _FutureT[_T1], *, return_exceptions: bool = ...) -> Future[tuple[_T1 | BaseException]]: ...
+    def gather(__coro_or_future1: _FutureT[_T1], *, return_exceptions: bool) -> Future[tuple[_T1 | BaseException]]: ...
     @overload
     def gather(
-        __coro_or_future1: _FutureT[_T1], __coro_or_future2: _FutureT[_T2], *, return_exceptions: bool = ...
+        __coro_or_future1: _FutureT[_T1], __coro_or_future2: _FutureT[_T2], *, return_exceptions: bool
     ) -> Future[tuple[_T1 | BaseException, _T2 | BaseException]]: ...
     @overload
     def gather(
@@ -140,7 +140,7 @@ if sys.version_info >= (3, 10):
         __coro_or_future2: _FutureT[_T2],
         __coro_or_future3: _FutureT[_T3],
         *,
-        return_exceptions: bool = ...,
+        return_exceptions: bool,
     ) -> Future[tuple[_T1 | BaseException, _T2 | BaseException, _T3 | BaseException]]: ...
     @overload
     def gather(
@@ -149,7 +149,7 @@ if sys.version_info >= (3, 10):
         __coro_or_future3: _FutureT[_T3],
         __coro_or_future4: _FutureT[_T4],
         *,
-        return_exceptions: bool = ...,
+        return_exceptions: bool,
     ) -> Future[tuple[_T1 | BaseException, _T2 | BaseException, _T3 | BaseException, _T4 | BaseException]]: ...
     @overload
     def gather(
@@ -159,10 +159,21 @@ if sys.version_info >= (3, 10):
         __coro_or_future4: _FutureT[_T4],
         __coro_or_future5: _FutureT[_T5],
         *,
-        return_exceptions: bool = ...,
+        return_exceptions: bool,
     ) -> Future[
         tuple[_T1 | BaseException, _T2 | BaseException, _T3 | BaseException, _T4 | BaseException, _T5 | BaseException]
     ]: ...
+    @overload
+    def gather(
+        __coro_or_future1: _FutureT[_T],
+        __coro_or_future2: _FutureT[_T],
+        __coro_or_future3: _FutureT[_T],
+        __coro_or_future4: _FutureT[_T],
+        __coro_or_future5: _FutureT[_T],
+        __coro_or_future6: _FutureT[_T],
+        *coros_or_futures: _FutureT[_T],
+        return_exceptions: bool,
+    ) -> Future[list[_T | BaseException]]: ...
 
 else:
     @overload
@@ -209,19 +220,19 @@ else:
     ) -> Future[tuple[_T1, _T2, _T3, _T4, _T5]]: ...
     @overload
     def gather(
-        __coro_or_future1: _FutureT[Any],
-        __coro_or_future2: _FutureT[Any],
-        __coro_or_future3: _FutureT[Any],
-        __coro_or_future4: _FutureT[Any],
-        __coro_or_future5: _FutureT[Any],
-        __coro_or_future6: _FutureT[Any],
-        *coros_or_futures: _FutureT[Any],
+        __coro_or_future1: _FutureT[_T],
+        __coro_or_future2: _FutureT[_T],
+        __coro_or_future3: _FutureT[_T],
+        __coro_or_future4: _FutureT[_T],
+        __coro_or_future5: _FutureT[_T],
+        __coro_or_future6: _FutureT[_T],
+        *coros_or_futures: _FutureT[_T],
         loop: AbstractEventLoop | None = ...,
-        return_exceptions: bool = ...,
-    ) -> Future[list[Any]]: ...
+        return_exceptions: Literal[False] = ...,
+    ) -> Future[list[_T]]: ...
     @overload
     def gather(
-        __coro_or_future1: _FutureT[_T1], *, loop: AbstractEventLoop | None = ..., return_exceptions: bool = ...
+        __coro_or_future1: _FutureT[_T1], *, loop: AbstractEventLoop | None = ..., return_exceptions: bool
     ) -> Future[tuple[_T1 | BaseException]]: ...
     @overload
     def gather(
@@ -229,7 +240,7 @@ else:
         __coro_or_future2: _FutureT[_T2],
         *,
         loop: AbstractEventLoop | None = ...,
-        return_exceptions: bool = ...,
+        return_exceptions: bool,
     ) -> Future[tuple[_T1 | BaseException, _T2 | BaseException]]: ...
     @overload
     def gather(
@@ -238,7 +249,7 @@ else:
         __coro_or_future3: _FutureT[_T3],
         *,
         loop: AbstractEventLoop | None = ...,
-        return_exceptions: bool = ...,
+        return_exceptions: bool,
     ) -> Future[tuple[_T1 | BaseException, _T2 | BaseException, _T3 | BaseException]]: ...
     @overload
     def gather(
@@ -248,7 +259,7 @@ else:
         __coro_or_future4: _FutureT[_T4],
         *,
         loop: AbstractEventLoop | None = ...,
-        return_exceptions: bool = ...,
+        return_exceptions: bool,
     ) -> Future[tuple[_T1 | BaseException, _T2 | BaseException, _T3 | BaseException, _T4 | BaseException]]: ...
     @overload
     def gather(
@@ -259,10 +270,22 @@ else:
         __coro_or_future5: _FutureT[_T5],
         *,
         loop: AbstractEventLoop | None = ...,
-        return_exceptions: bool = ...,
+        return_exceptions: bool,
     ) -> Future[
         tuple[_T1 | BaseException, _T2 | BaseException, _T3 | BaseException, _T4 | BaseException, _T5 | BaseException]
     ]: ...
+    @overload
+    def gather(
+        __coro_or_future1: _FutureT[_T],
+        __coro_or_future2: _FutureT[_T],
+        __coro_or_future3: _FutureT[_T],
+        __coro_or_future4: _FutureT[_T],
+        __coro_or_future5: _FutureT[_T],
+        __coro_or_future6: _FutureT[_T],
+        *coros_or_futures: _FutureT[_T],
+        loop: AbstractEventLoop | None = ...,
+        return_exceptions: bool,
+    ) -> Future[list[_T | BaseException]]: ...
 
 def run_coroutine_threadsafe(coro: _FutureT[_T], loop: AbstractEventLoop) -> concurrent.futures.Future[_T]: ...
 


### PR DESCRIPTION
Previously this used Any types. Caller `*args` looks like a fairly
common use case, so it would be nice to give a precise type in that
case. This could give a too general return type if `gather` is called
with a large number of positional arguments with non-uniform types,
but I'd expect this to be fairly rare.