### PR TITLE
Finish renaming stubtest.yml to daily.yml

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install dependencies
         # Use pre-release stubtest. Keep the following in sync:
         # - get_mypy_req in tests/stubtest_third_party.py
-        # - stubtest-stdlib in .github/workflows/stubtest.yml
+        # - stubtest-stdlib in .github/workflows/daily.yml
         # - stubtest-stdlib in .github/workflows/tests.yml
         run: pip install $(grep tomli== requirements-tests.txt) git+git://github.com/python/mypy@c7a81620bef7585cca6905861bb7ef34ec12da2f
       - name: Run stubtest
@@ -80,5 +80,5 @@ jobs:
               owner: "python",
               repo: "typeshed",
               title: `Stubtest failed on ${new Date().toDateString()}`,
-              body: "Stubtest runs are listed here: https://github.com/python/typeshed/actions/workflows/stubtest.yml",
+              body: "Stubtest runs are listed here: https://github.com/python/typeshed/actions/workflows/daily.yml",
             })

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Install dependencies
         # Use pre-release stubtest. Keep the following in sync:
         # - get_mypy_req in tests/stubtest_third_party.py
-        # - stubtest-stdlib in .github/workflows/stubtest.yml
+        # - stubtest-stdlib in .github/workflows/daily.yml
         # - stubtest-stdlib in .github/workflows/tests.yml
         run: pip install $(grep tomli== requirements-tests.txt) git+git://github.com/python/mypy@c7a81620bef7585cca6905861bb7ef34ec12da2f
       - name: Run stubtest

--- a/tests/stubtest_third_party.py
+++ b/tests/stubtest_third_party.py
@@ -20,7 +20,7 @@ import tomli
 def get_mypy_req():
     # Use pre-release stubtest. Keep the following in sync:
     # - get_mypy_req in tests/stubtest_third_party.py
-    # - stubtest-stdlib in .github/workflows/stubtest.yml
+    # - stubtest-stdlib in .github/workflows/daily.yml
     # - stubtest-stdlib in .github/workflows/tests.yml
     return "git+git://github.com/python/mypy@c7a81620bef7585cca6905861bb7ef34ec12da2f"
 


### PR DESCRIPTION
Related: #7445 

I noticed that the URLs in auto-generated issues (e.g. #7444) were wrong, and `git grep` showed a few other places  too.