### PR TITLE
Widen the `cmdclass` parameter of `setuptools.setup`

### DIFF
--- a/stubs/setuptools/setuptools/__init__.pyi
+++ b/stubs/setuptools/setuptools/__init__.pyi
@@ -43,7 +43,7 @@ def setup(
     license: str = ...,
     keywords: list[str] | str = ...,
     platforms: list[str] | str = ...,
-    cmdclass: Mapping[str, type[Command]] = ...,
+    cmdclass: Mapping[str, type[_Command]] = ...,
     data_files: list[tuple[str, list[str]]] = ...,
     package_dir: Mapping[str, str] = ...,
     obsoletes: list[str] = ...,


### PR DESCRIPTION
Alternative to https://github.com/python/typeshed/pull/7418.

As pointed out in abovementioned PR, classes that one might pass to the `cmdclass` parameters (such as the setuptools `build_ext` class) are not guaranteed to inherit from `setuptools.Command`, resulting in type check errors when one attempts to do so. This PR fixes the relevant false positives by relaxing value-type from `setuptools.Command` to the `distutils.core.Command` superclass.

``` python
from setuptools import setup, Extension
from setuptools.command.build_ext import build_ext

class build_test_ext(build_ext):
    def build_extension(self, ext: Extension) -> None: ...

setup(
    # error: dict entry 0 has incompatible type "str": "Type[build_test_ext]"; expected "str": "Type[Command]"
    cmdclass={"build_ext": build_test_ext},
)
```

