### PR TITLE
ssl: mark ssl{object,socket}_class as Instance-Var

### DIFF
--- a/stdlib/ssl.pyi
+++ b/stdlib/ssl.pyi
@@ -2,7 +2,7 @@ import enum
 import socket
 import sys
 from _typeshed import ReadableBuffer, Self, StrOrBytesPath, WriteableBuffer
-from typing import Any, Callable, ClassVar, Iterable, NamedTuple, Optional, Union, overload
+from typing import Any, Callable, Iterable, NamedTuple, Optional, Union, overload
 from typing_extensions import Literal, TypedDict, final
 
 _PCTRTT = tuple[tuple[str, str], ...]

--- a/stdlib/ssl.pyi
+++ b/stdlib/ssl.pyi
@@ -393,8 +393,8 @@ class SSLContext:
         maximum_version: TLSVersion
         minimum_version: TLSVersion
         sni_callback: Callable[[SSLObject, str, SSLContext], None | int] | None
-        sslobject_class: ClassVar[type[SSLObject]]
-        sslsocket_class: ClassVar[type[SSLSocket]]
+        sslobject_class: type[SSLObject]
+        sslsocket_class: type[SSLSocket]
     if sys.version_info >= (3, 8):
         keylog_filename: str
         post_handshake_auth: bool

--- a/stdlib/ssl.pyi
+++ b/stdlib/ssl.pyi
@@ -393,6 +393,9 @@ class SSLContext:
         maximum_version: TLSVersion
         minimum_version: TLSVersion
         sni_callback: Callable[[SSLObject, str, SSLContext], None | int] | None
+        # The following two attributes have class-level defaults.
+        # However, the docs explicitly state that it's OK to override these attributes on instances,
+        # so making these ClassVars wouldn't be appropriate
         sslobject_class: type[SSLObject]
         sslsocket_class: type[SSLSocket]
     if sys.version_info >= (3, 8):


### PR DESCRIPTION
See #7459 and https://docs.python.org/3/library/ssl.html#ssl.SSLContext.sslsocket_class

This change will mark `SSLContext.sslobject_class` and `SSLContext.sslsocket_class` as Instance-Variable, which is correct according to its documentation.

Fixes #7459