### PR TITLE
Use TypeVar for `pkgutil.extend_path`

### DIFF
--- a/stdlib/@python2/pkgutil.pyi
+++ b/stdlib/@python2/pkgutil.pyi
@@ -1,13 +1,14 @@
 from _typeshed import SupportsRead
-from typing import IO, Any, Callable, Iterable, Iterator, Union
+from typing import IO, Any, Callable, Iterable, Iterator, TypeVar, Union
 
 Loader = Any
 MetaPathFinder = Any
 PathEntryFinder = Any
 
+_PathT = TypeVar("_PathT", bound=Iterable[str])
 _ModuleInfoLike = tuple[Union[MetaPathFinder, PathEntryFinder], str, bool]
 
-def extend_path(path: list[str], name: str) -> list[str]: ...
+def extend_path(path: _PathT, name: str) -> _PathT: ...
 
 class ImpImporter:
     def __init__(self, path: str | None = ...) -> None: ...

--- a/stdlib/pkgutil.pyi
+++ b/stdlib/pkgutil.pyi
@@ -1,7 +1,7 @@
 import sys
 from _typeshed import SupportsRead
 from importlib.abc import Loader, MetaPathFinder, PathEntryFinder
-from typing import IO, Any, Callable, Iterable, Iterator, NamedTuple
+from typing import IO, Any, Callable, Iterable, Iterator, NamedTuple, TypeVar
 
 __all__ = [
     "get_importer",
@@ -18,12 +18,14 @@ __all__ = [
     "ModuleInfo",
 ]
 
+_PathT = TypeVar("_PathT", bound=Iterable[str])
+
 class ModuleInfo(NamedTuple):
     module_finder: MetaPathFinder | PathEntryFinder
     name: str
     ispkg: bool
 
-def extend_path(path: list[str], name: str) -> list[str]: ...
+def extend_path(path: _PathT, name: str) -> _PathT: ...
 
 class ImpImporter:
     def __init__(self, path: str | None = ...) -> None: ...


### PR DESCRIPTION
Partial fix for #6650

According to the Python docs `pkgutil.extend_path` returns either a modified list if a list is passed or the path unchanged.
https://docs.python.org/3.10/library/pkgutil.html#pkgutil.extend_path

[cpython/pkgutil.py -> extend_path](https://github.com/python/cpython/blob/8714b6fa27271035dd6dd3514e283f92d669321d/Lib/pkgutil.py#L539-L542) 