### PR TITLE
urllib3: stubs are not Python 2 compatible

### DIFF
--- a/stubs/urllib3/METADATA.toml
+++ b/stubs/urllib3/METADATA.toml
@@ -1,2 +1,1 @@
 version = "1.26.*"
-python2 = true


### PR DESCRIPTION
They use http.client, which is Python 3-only. Another catch from #7478.