### PR TITLE
`parsimonious`: `re.Match` does not exist in Python 3.6

### DIFF
--- a/stubs/parsimonious/parsimonious/nodes.pyi
+++ b/stubs/parsimonious/parsimonious/nodes.pyi
@@ -1,5 +1,4 @@
-from re import Match
-from typing import Any, Callable, Iterator, NoReturn, Sequence, TypeVar
+from typing import Any, Callable, Iterator, Match, NoReturn, Sequence, TypeVar
 
 from parsimonious.exceptions import VisitationError as VisitationError
 from parsimonious.expressions import Expression


### PR DESCRIPTION
It has to be imported from `typing` in <3.7. Refs https://github.com/python/typeshed/pull/7478.