### PR TITLE
`requests` stubs are not Python 2-compatible

### DIFF
--- a/stubs/requests/METADATA.toml
+++ b/stubs/requests/METADATA.toml
@@ -1,3 +1,2 @@
 version = "2.27.*"
 requires = ["types-urllib3<1.27"] # keep in sync with requests's setup.py
-python2 = true


### PR DESCRIPTION
See https://github.com/python/typeshed/pull/7478#issuecomment-1066083307: `types-requests` imports `types-urllib3`, and `types-urllib3` is incompatible with Python 2.