### PR TITLE
Further improve `mypy_test.py`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       matrix:
         platform: ["linux", "win32", "darwin"]
-        python-version: ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/tests/mypy_test.py
+++ b/tests/mypy_test.py
@@ -274,9 +274,9 @@ def test_third_party_distribution(distribution: str, major: int, minor: int, arg
     return code, len(files)
 
 
-def is_probably_stubs_folder(dist_path: Path) -> bool:
+def is_probably_stubs_folder(distribution: str, distribution_path: Path) -> bool:
     """Validate that `dist_path` is a folder containing stubs"""
-    return (dist_path / "METADATA.toml").exists()
+    return distribution != ".mypy_cache" and distribution_path.is_dir()
 
 
 def main():
@@ -330,7 +330,7 @@ def main():
 
             distribution_path = Path("stubs", distribution)
 
-            if not is_probably_stubs_folder(distribution_path):
+            if not is_probably_stubs_folder(distribution, distribution_path):
                 continue
 
             if not is_supported(distribution_path, major):


### PR DESCRIPTION
- Run mypy on the 3.11 stdlib in CI, as a regression test for https://github.com/python/mypy/issues/12220
- Correct the docstring at the top of the file following the changes made in https://github.com/python/typeshed/pull/7478
- Stop the test from crashing when run locally if there's an extra file/folder in the `stubs` directory. (I had a few `.mypy_cache` folders and extra codemodding scripts in various places, which meant that the test was crashing. The `dist_path / "METADATA.toml"` call in the `is_supported` function was evaluating to a nonexistent filepath.)