### PR TITLE
pyright: Don't report incompatible overrides

### DIFF
--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -31,8 +31,6 @@
     "reportUntypedNamedTuple": "error",
     "reportPrivateUsage": "none",
     "reportConstantRedefinition": "error",
-    "reportIncompatibleMethodOverride": "error",
-    "reportIncompatibleVariableOverride": "error",
     "reportInvalidStringEscapeSequence": "error",
     "reportUnknownArgumentType": "error",
     "reportUnknownLambdaType": "error",
@@ -44,6 +42,10 @@
     "reportPropertyTypeMismatch": "error",
     "reportSelfClsParameterName": "error",
     "reportUnsupportedDunderAll": "error",
+    // Incompatible overrides are out of typeshed's control as they are
+    // inherited from the implementation.
+    "reportIncompatibleMethodOverride": "none",
+    "reportIncompatibleVariableOverride": "none",
     // Overlapping overloads cannot be enabled at this time because
     // of the "fractions.Fraction.__pow__" method and "tasks.gather" function.
     // Mypy's overlapping overload logic misses these issues (see mypy

--- a/pyrightconfig.stricter.json
+++ b/pyrightconfig.stricter.json
@@ -97,8 +97,6 @@
     "reportUntypedNamedTuple": "error",
     "reportPrivateUsage": "none",
     "reportConstantRedefinition": "error",
-    "reportIncompatibleMethodOverride": "error",
-    "reportIncompatibleVariableOverride": "error",
     "reportInvalidStringEscapeSequence": "error",
     "reportUnknownParameterType": "error",
     "reportUnknownArgumentType": "error",
@@ -113,6 +111,10 @@
     "reportPropertyTypeMismatch": "error",
     "reportSelfClsParameterName": "error",
     "reportUnsupportedDunderAll": "error",
+    // Incompatible overrides are out of typeshed's control as they are
+    // inherited from the implementation.
+    "reportIncompatibleMethodOverride": "none",
+    "reportIncompatibleVariableOverride": "none",
     // Overlapping overloads cannot be enabled at this time because
     // of the "fractions.Fraction.__pow__" method and "tasks.gather" function.
     // Mypy's overlapping overload logic misses these issues (see mypy

--- a/stubs/SQLAlchemy/sqlalchemy/dialects/mssql/pyodbc.pyi
+++ b/stubs/SQLAlchemy/sqlalchemy/dialects/mssql/pyodbc.pyi
@@ -29,9 +29,7 @@ class MSExecutionContext_pyodbc(MSExecutionContext):
     def pre_exec(self) -> None: ...
     def post_exec(self) -> None: ...
 
-# pyright complains about incompatible definitions of "supports_sane_rowcount_returning" in the base classes,
-# hence the type: ignore
-class MSDialect_pyodbc(PyODBCConnector, MSDialect):  # type: ignore
+class MSDialect_pyodbc(PyODBCConnector, MSDialect):
     supports_statement_cache: bool
     supports_sane_rowcount_returning: bool
     colspecs: Any

--- a/stubs/SQLAlchemy/sqlalchemy/dialects/mysql/pyodbc.pyi
+++ b/stubs/SQLAlchemy/sqlalchemy/dialects/mysql/pyodbc.pyi
@@ -10,9 +10,7 @@ class _pyodbcTIME(TIME):
 class MySQLExecutionContext_pyodbc(MySQLExecutionContext):
     def get_lastrowid(self): ...
 
-# pyright complains about incompatible definitions of "supports_sane_rowcount_returning" variable in the base classes,
-# hence the type: ignore
-class MySQLDialect_pyodbc(PyODBCConnector, MySQLDialect):  # type: ignore
+class MySQLDialect_pyodbc(PyODBCConnector, MySQLDialect):
     supports_statement_cache: bool
     colspecs: Any
     supports_unicode_statements: bool

--- a/stubs/SQLAlchemy/sqlalchemy/dialects/postgresql/hstore.pyi
+++ b/stubs/SQLAlchemy/sqlalchemy/dialects/postgresql/hstore.pyi
@@ -4,9 +4,7 @@ import sqlalchemy.types as sqltypes
 
 from ...sql import functions as sqlfunc
 
-# pyright complains that "Comparator" is defined incompatibly in the base classes,
-# hence the type: ignore
-class HSTORE(sqltypes.Indexable, sqltypes.Concatenable, sqltypes.TypeEngine):  # type: ignore
+class HSTORE(sqltypes.Indexable, sqltypes.Concatenable, sqltypes.TypeEngine):
     __visit_name__: str
     hashable: bool
     text_type: Any

--- a/stubs/SQLAlchemy/sqlalchemy/sql/sqltypes.pyi
+++ b/stubs/SQLAlchemy/sqlalchemy/sql/sqltypes.pyi
@@ -1,7 +1,3 @@
-# pyright complains that several classes in this file
-# have incompatible definitions of the "Comparator" variable in their bases,
-# meaning there are several type: ignores
-
 from typing import Any
 
 from .base import SchemaEventTarget
@@ -28,7 +24,7 @@ class Indexable:
         def __getitem__(self, index): ...
     comparator_factory: Any
 
-class String(Concatenable, TypeEngine):  # type: ignore
+class String(Concatenable, TypeEngine):
     __visit_name__: str
     RETURNS_UNICODE: Any
     RETURNS_BYTES: Any
@@ -63,7 +59,7 @@ class UnicodeText(Text):
     __visit_name__: str
     def __init__(self, length: Any | None = ..., **kwargs) -> None: ...
 
-class Integer(_LookupExpressionAdapter, TypeEngine):  # type: ignore
+class Integer(_LookupExpressionAdapter, TypeEngine):
     __visit_name__: str
     def get_dbapi_type(self, dbapi): ...
     @property
@@ -76,7 +72,7 @@ class SmallInteger(Integer):
 class BigInteger(Integer):
     __visit_name__: str
 
-class Numeric(_LookupExpressionAdapter, TypeEngine):  # type: ignore
+class Numeric(_LookupExpressionAdapter, TypeEngine):
     __visit_name__: str
     precision: Any
     scale: Any
@@ -101,7 +97,7 @@ class Float(Numeric):
     def __init__(self, precision: Any | None = ..., asdecimal: bool = ..., decimal_return_scale: Any | None = ...) -> None: ...
     def result_processor(self, dialect, coltype): ...
 
-class DateTime(_LookupExpressionAdapter, TypeEngine):  # type: ignore
+class DateTime(_LookupExpressionAdapter, TypeEngine):
     __visit_name__: str
     timezone: Any
     def __init__(self, timezone: bool = ...) -> None: ...
@@ -109,13 +105,13 @@ class DateTime(_LookupExpressionAdapter, TypeEngine):  # type: ignore
     @property
     def python_type(self): ...
 
-class Date(_LookupExpressionAdapter, TypeEngine):  # type: ignore
+class Date(_LookupExpressionAdapter, TypeEngine):
     __visit_name__: str
     def get_dbapi_type(self, dbapi): ...
     @property
     def python_type(self): ...
 
-class Time(_LookupExpressionAdapter, TypeEngine):  # type: ignore
+class Time(_LookupExpressionAdapter, TypeEngine):
     __visit_name__: str
     timezone: Any
     def __init__(self, timezone: bool = ...) -> None: ...
@@ -203,7 +199,7 @@ class Boolean(Emulated, TypeEngine, SchemaType):  # type: ignore[misc]
     def bind_processor(self, dialect): ...
     def result_processor(self, dialect, coltype): ...
 
-class _AbstractInterval(_LookupExpressionAdapter, TypeEngine):  # type: ignore
+class _AbstractInterval(_LookupExpressionAdapter, TypeEngine):
     def coerce_compared_value(self, op, value): ...
 
 class Interval(Emulated, _AbstractInterval, TypeDecorator):  # type: ignore[misc]
@@ -220,7 +216,7 @@ class Interval(Emulated, _AbstractInterval, TypeDecorator):  # type: ignore[misc
     def bind_processor(self, dialect): ...
     def result_processor(self, dialect, coltype): ...
 
-class JSON(Indexable, TypeEngine):  # type: ignore
+class JSON(Indexable, TypeEngine):
     __visit_name__: str
     hashable: bool
     NULL: Any
@@ -255,7 +251,7 @@ class JSON(Indexable, TypeEngine):  # type: ignore
     def bind_processor(self, dialect): ...
     def result_processor(self, dialect, coltype): ...
 
-class ARRAY(SchemaEventTarget, Indexable, Concatenable, TypeEngine):  # type: ignore
+class ARRAY(SchemaEventTarget, Indexable, Concatenable, TypeEngine):
     __visit_name__: str
     zero_indexes: bool
 


### PR DESCRIPTION
These overrides are inherited from the implementation and are out of
typeshed's control.