### PR TITLE
Unpin pyright-action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,14 +75,14 @@ jobs:
       PYRIGHT_VERSION: 1.1.230 # Must match pyright_test.py.
     steps:
       - uses: actions/checkout@v2
-      - uses: jakebailey/pyright-action@v1.0.4
+      - uses: jakebailey/pyright-action@v1
         with:
           version: ${{ env.PYRIGHT_VERSION }}
           python-platform: ${{ matrix.python-platform }}
           python-version: ${{ matrix.python-version }}
           no-comments: ${{ matrix.python-version != '3.9' || matrix.python-platform != 'Linux' }}  # Having each job create the same comment is too noisy.
           project: ./pyrightconfig.stricter.json
-      - uses: jakebailey/pyright-action@v1.0.4
+      - uses: jakebailey/pyright-action@v1
         with:
           version: ${{ env.PYRIGHT_VERSION }}
           python-platform: ${{ matrix.python-platform }}


### PR DESCRIPTION
The issues that broke typeshed's CI should have been fixed by https://github.com/jakebailey/pyright-action/commit/e7c2cbabca407c6ba1eecc5c2317422f8a609c2a (thanks @jakebailey!)