### PR TITLE
Improve `host` parameter of `socket.getaddrinfo()`

### DIFF
--- a/stdlib/socket.pyi
+++ b/stdlib/socket.pyi
@@ -619,10 +619,5 @@ if sys.version_info >= (3, 8):
 
 # the 5th tuple item is an address
 def getaddrinfo(
-    host: bytes | str | None,
-    port: str | int | None,
-    family: int = ...,
-    type: int = ...,
-    proto: int = ...,
-    flags: int = ...,
+    host: bytes | str | None, port: str | int | None, family: int = ..., type: int = ..., proto: int = ..., flags: int = ...
 ) -> list[tuple[AddressFamily, SocketKind, int, str, tuple[str, int] | tuple[str, int, int, int]]]: ...

--- a/stdlib/socket.pyi
+++ b/stdlib/socket.pyi
@@ -619,7 +619,7 @@ if sys.version_info >= (3, 8):
 
 # the 5th tuple item is an address
 def getaddrinfo(
-    host: bytearray | bytes | str | None,
+    host: bytes | str | None,
     port: str | int | None,
     family: int = ...,
     type: int = ...,


### PR DESCRIPTION
As pointed out by @srittau in #7517, `bytearray` [is redundant](https://docs.python.org/3/library/typing.html#typing.ByteString) in a union where `bytes` is also in the union.