### PR TITLE
Update `property.fget`, `property.fset`, and `property.fdel`

### DIFF
--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -1021,9 +1021,9 @@ class range(Sequence[int]):
     def __reversed__(self) -> Iterator[int]: ...
 
 class property:
-    fget: Callable[[Any], Any] | None
-    fset: Callable[[Any, Any], None] | None
-    fdel: Callable[[Any], None] | None
+    fget: Callable[[property, Any], Any] | None
+    fset: Callable[[property, Any, Any], None] | None
+    fdel: Callable[[property, Any], None] | None
     __isabstractmethod__: bool
     def __init__(
         self,


### PR DESCRIPTION
Closes #7516.

```python
class A:
    def __init__(self, foo: int) -> None:
        self._foo = foo

    @property
    def foo(self) -> int:
        return self._foo
    
    @foo.setter
    def foo(self, foo: int) -> None:
        self._foo = foo
    
    @foo.deleter
    def foo(self) -> None:
        del self._foo

a = A(1)
print(A.foo.fget(a))

A.foo.fset(a, 2)
print(a.foo)

A.foo.fdel(a)
```
These property methods take `property` type as first arg and then the desired instance.