### PR TITLE
mypy_primer: mention if output is truncated

### DIFF
--- a/.github/workflows/mypy_primer_comment.yml
+++ b/.github/workflows/mypy_primer_comment.yml
@@ -38,9 +38,8 @@ jobs:
             fs.writeFileSync("diff.zip", Buffer.from(download.data));
 
       - run: unzip diff.zip
-      # 30000 bytes is about 300 lines, posting comment fails if too long
       - run: |
-          cat diff_*.txt | head -c 30000 | tee fulldiff.txt
+          cat diff_*.txt | tee fulldiff.txt
 
       - name: Post comment
         id: post-comment
@@ -49,7 +48,11 @@ jobs:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             const fs = require('fs')
-            const data = fs.readFileSync('fulldiff.txt', { encoding: 'utf8' })
+            let data = fs.readFileSync('fulldiff.txt', { encoding: 'utf8' })
+            // posting comment fails if too long, so truncate
+            if (data.length > 30000) {
+                data = data.substring(0, 30000) + `\n\n... (truncated ${diff.length - 30000} chars) ...\n`
+            }
 
             let body
             if (data.trim()) {

--- a/.github/workflows/mypy_primer_comment.yml
+++ b/.github/workflows/mypy_primer_comment.yml
@@ -51,7 +51,7 @@ jobs:
             let data = fs.readFileSync('fulldiff.txt', { encoding: 'utf8' })
             // posting comment fails if too long, so truncate
             if (data.length > 30000) {
-                data = data.substring(0, 30000) + `\n\n... (truncated ${diff.length - 30000} chars) ...\n`
+              data = data.substring(0, 30000) + `\n\n... (truncated ${diff.length - 30000} chars) ...\n`
             }
 
             let body


### PR DESCRIPTION
When changes are really disruptive, like #7430, we truncate output.
Mention this, so that it's known that the change is even more disruptive
than it might appear.