### PR TITLE
Update adapters.pyi

### DIFF
--- a/stubs/requests/requests/adapters.pyi
+++ b/stubs/requests/requests/adapters.pyi
@@ -1,4 +1,4 @@
-from typing import Any, Container, Mapping, Text
+from typing import Any, Mapping, Text
 
 from urllib3 import exceptions as urllib3_exceptions, poolmanager, response
 from urllib3.util import retry

--- a/stubs/requests/requests/adapters.pyi
+++ b/stubs/requests/requests/adapters.pyi
@@ -43,7 +43,7 @@ class BaseAdapter:
         stream: bool = ...,
         timeout: None | float | tuple[float, float] | tuple[float, None] = ...,
         verify: bool | str = ...,
-        cert: None | bytes | Text | Container[bytes | Text] = ...,
+        cert: None | bytes | Text | tuple[bytes | Text, bytes | Text] = ...,
         proxies: Mapping[str, str] | None = ...,
     ) -> Response: ...
     def close(self) -> None: ...

--- a/stubs/requests/requests/adapters.pyi
+++ b/stubs/requests/requests/adapters.pyi
@@ -72,6 +72,6 @@ class HTTPAdapter(BaseAdapter):
         stream: bool = ...,
         timeout: None | float | tuple[float, float] | tuple[float, None] = ...,
         verify: bool | str = ...,
-        cert: None | bytes | Text | Container[bytes | Text] = ...,
+        cert: None | bytes | Text | tuple[bytes | Text, bytes | Text] = ...,
         proxies: Mapping[str, str] | None = ...,
     ) -> Response: ...


### PR DESCRIPTION
The cert can be
* A string / bytes which is a path to a certfile
* A tuple with two string / bytes, where the first is the certfile and the second is a keyfile
* None (optional)

The tuple could be anything indexable, but there are strict requirement to actualle have two items, don't know if there is something more generic

See https://github.com/psf/requests/blob/main/requests/adapters.py#L242-L248