### PR TITLE
allow `asyncio.start_server()` to accept a Sequence of hosts

### DIFF
--- a/stdlib/asyncio/streams.pyi
+++ b/stdlib/asyncio/streams.pyi
@@ -1,6 +1,6 @@
 import sys
 from _typeshed import Self, StrPath
-from typing import Any, AsyncIterator, Awaitable, Callable, Iterable
+from typing import Any, AsyncIterator, Awaitable, Callable, Iterable, Sequence
 
 from . import events, protocols, transports
 from .base_events import Server
@@ -87,7 +87,7 @@ if sys.version_info >= (3, 10):
     ) -> tuple[StreamReader, StreamWriter]: ...
     async def start_server(
         client_connected_cb: _ClientConnectedCallback,
-        host: str | None = ...,
+        host: str | Sequence[str] | None = ...,
         port: int | str | None = ...,
         *,
         limit: int = ...,


### PR DESCRIPTION
From the asyncio [documentation](https://docs.python.org/3/library/asyncio-stream.html#asyncio.start_server), the start_server function passes the host argument directly through to the underlying `create_server()` function. Since 3.5.1, the `create_server()` function accepts a `Sequence[str]` for the host, this should be mirrored in the `start_server()` function as-well.