### PR TITLE
Revert "Use import instead of type alias in `email/message.pyi`"

### DIFF
--- a/stdlib/email/message.pyi
+++ b/stdlib/email/message.pyi
@@ -2,9 +2,7 @@ from email.charset import Charset
 from email.contentmanager import ContentManager
 from email.errors import MessageDefect
 from email.policy import Policy
-
-# using a type alias ("_HeaderType = Any") breaks mypy, who knows why
-from typing import Any, Any as _HeaderType, Generator, Iterator, Sequence, TypeVar, Union
+from typing import Any, Generator, Iterator, Sequence, TypeVar, Union
 
 __all__ = ["Message", "EmailMessage"]
 
@@ -14,6 +12,7 @@ _PayloadType = list[Message] | str | bytes
 _CharsetType = Charset | str | None
 _ParamsType = Union[str, None, tuple[str, str | None, str]]
 _ParamType = Union[str, tuple[str | None, str | None, str]]
+_HeaderType = Any
 
 class Message:
     policy: Policy  # undocumented


### PR DESCRIPTION
Let's see if this is fixed in mypy 0.942.

This reverts the changes made in #7022, which was a hack to fix #7019