### PR TITLE
errno: fix typo

### DIFF
--- a/stdlib/errno.pyi
+++ b/stdlib/errno.pyi
@@ -37,7 +37,7 @@ EPIPE: int
 EDOM: int
 ERANGE: int
 EDEADLK: int
-EDEADLCK: int
+EDEADLOCK: int
 ENAMETOOLONG: int
 ENOLCK: int
 ENOSYS: int


### PR DESCRIPTION
In case you're wondering, they're aliases for each other, at least on my system. See https://github.com/python/cpython/blob/main/Modules/errnomodule.c (I checked main and 3.6 and it's the same).

Noticed this while looking at #7551

```
In [17]: errno.EDEADLOCK
Out[17]: 35

In [18]: errno.EDEADLK
Out[18]: 35
```