### PR TITLE
`mypy_test`: Add two more config options

### DIFF
--- a/tests/mypy_test.py
+++ b/tests/mypy_test.py
@@ -207,6 +207,9 @@ def get_mypy_flags(args, major: int, minor: int, temp_name: str, *, custom_types
         "--warn-incomplete-stub",
         "--show-error-codes",
         "--no-error-summary",
+        "--enable-error-code",
+        "ignore-without-code",
+        "--strict-equality"
     ]
     if custom_typeshed:
         # Setting custom typeshed dir prevents mypy from falling back to its bundled

--- a/tests/mypy_test.py
+++ b/tests/mypy_test.py
@@ -209,7 +209,7 @@ def get_mypy_flags(args, major: int, minor: int, temp_name: str, *, custom_types
         "--no-error-summary",
         "--enable-error-code",
         "ignore-without-code",
-        "--strict-equality"
+        "--strict-equality",
     ]
     if custom_typeshed:
         # Setting custom typeshed dir prevents mypy from falling back to its bundled


### PR DESCRIPTION
- `--enable-error-code ignore-without-code` means that mypy will ignore any `type: ignore` comments that don't have mypy error codes. It doesn't appear to have any effect on `type: ignore` comments that `mypy_test` doesn't use (e.g. because they're pyright- or stubtest-specific).
- `--strict-equality` means that mypy will raise errors if we do something silly like `if sys.version_info == "linux"`. flake8-pyi should also check this for us, but I don't see any reason not to have mypy check this as well.