### PR TITLE
Use type alias to simplify overloads in `unittest.mock`

### DIFF
--- a/stdlib/unittest/mock.pyi
+++ b/stdlib/unittest/mock.pyi
@@ -279,117 +279,67 @@ class _patch_dict:
     start: Any
     stop: Any
 
+if sys.version_info >= (3, 8):
+    _Mock = MagicMock | AsyncMock
+else:
+    _Mock = MagicMock
+
 class _patcher:
     TEST_PREFIX: str
     dict: type[_patch_dict]
-    if sys.version_info >= (3, 8):
-        # This overload also covers the case, where new==DEFAULT. In this case, the return type is _patch[Any].
-        # Ideally we'd be able to add an overload for it so that the return type is _patch[MagicMock],
-        # but that's impossible with the current type system.
-        @overload
-        def __call__(  # type: ignore[misc]
-            self,
-            target: Any,
-            new: _T,
-            spec: Any | None = ...,
-            create: bool = ...,
-            spec_set: Any | None = ...,
-            autospec: Any | None = ...,
-            new_callable: Any | None = ...,
-            **kwargs: Any,
-        ) -> _patch[_T]: ...
-        @overload
-        def __call__(
-            self,
-            target: Any,
-            *,
-            spec: Any | None = ...,
-            create: bool = ...,
-            spec_set: Any | None = ...,
-            autospec: Any | None = ...,
-            new_callable: Any | None = ...,
-            **kwargs: Any,
-        ) -> _patch[MagicMock | AsyncMock]: ...
-    else:
-        @overload
-        def __call__(  # type: ignore[misc]
-            self,
-            target: Any,
-            new: _T,
-            spec: Any | None = ...,
-            create: bool = ...,
-            spec_set: Any | None = ...,
-            autospec: Any | None = ...,
-            new_callable: Any | None = ...,
-            **kwargs: Any,
-        ) -> _patch[_T]: ...
-        @overload
-        def __call__(
-            self,
-            target: Any,
-            *,
-            spec: Any | None = ...,
-            create: bool = ...,
-            spec_set: Any | None = ...,
-            autospec: Any | None = ...,
-            new_callable: Any | None = ...,
-            **kwargs: Any,
-        ) -> _patch[MagicMock]: ...
-    if sys.version_info >= (3, 8):
-        @overload
-        def object(  # type: ignore[misc]
-            self,
-            target: Any,
-            attribute: str,
-            new: _T,
-            spec: Any | None = ...,
-            create: bool = ...,
-            spec_set: Any | None = ...,
-            autospec: Any | None = ...,
-            new_callable: Any | None = ...,
-            **kwargs: Any,
-        ) -> _patch[_T]: ...
-        @overload
-        def object(
-            self,
-            target: Any,
-            attribute: str,
-            *,
-            spec: Any | None = ...,
-            create: bool = ...,
-            spec_set: Any | None = ...,
-            autospec: Any | None = ...,
-            new_callable: Any | None = ...,
-            **kwargs: Any,
-        ) -> _patch[MagicMock | AsyncMock]: ...
-    else:
-        @overload
-        def object(  # type: ignore[misc]
-            self,
-            target: Any,
-            attribute: str,
-            new: _T,
-            spec: Any | None = ...,
-            create: bool = ...,
-            spec_set: Any | None = ...,
-            autospec: Any | None = ...,
-            new_callable: Any | None = ...,
-            **kwargs: Any,
-        ) -> _patch[_T]: ...
-        @overload
-        def object(
-            self,
-            target: Any,
-            attribute: str,
-            *,
-            spec: Any | None = ...,
-            create: bool = ...,
-            spec_set: Any | None = ...,
-            autospec: Any | None = ...,
-            new_callable: Any | None = ...,
-            **kwargs: Any,
-        ) -> _patch[MagicMock]: ...
-
+    # This overload also covers the case, where new==DEFAULT. In this case, the return type is _patch[Any].
+    # Ideally we'd be able to add an overload for it so that the return type is _patch[MagicMock],
+    # but that's impossible with the current type system.
+    @overload
+    def __call__(  # type: ignore[misc]
+        self,
+        target: Any,
+        new: _T,
+        spec: Any | None = ...,
+        create: bool = ...,
+        spec_set: Any | None = ...,
+        autospec: Any | None = ...,
+        new_callable: Any | None = ...,
+        **kwargs: Any,
+    ) -> _patch[_T]: ...
+    @overload
+    def __call__(
+        self,
+        target: Any,
+        *,
+        spec: Any | None = ...,
+        create: bool = ...,
+        spec_set: Any | None = ...,
+        autospec: Any | None = ...,
+        new_callable: Any | None = ...,
+        **kwargs: Any,
+    ) -> _patch[_Mock]: ...
+    @overload
+    def object(  # type: ignore[misc]
+        self,
+        target: Any,
+        attribute: str,
+        new: _T,
+        spec: Any | None = ...,
+        create: bool = ...,
+        spec_set: Any | None = ...,
+        autospec: Any | None = ...,
+        new_callable: Any | None = ...,
+        **kwargs: Any,
+    ) -> _patch[_T]: ...
+    @overload
+    def object(
+        self,
+        target: Any,
+        attribute: str,
+        *,
+        spec: Any | None = ...,
+        create: bool = ...,
+        spec_set: Any | None = ...,
+        autospec: Any | None = ...,
+        new_callable: Any | None = ...,
+        **kwargs: Any,
+    ) -> _patch[_Mock]: ...
     def multiple(
         self,
         target: Any,


### PR DESCRIPTION
The signatures of `_patcher.__call__` and `_patcher.object` are identical in Python 3.7 and Python 3.8, except for the return type of the second overload in both functions.