### PR TITLE
logging/handlers.pyi: atTime is datetime.time

### DIFF
--- a/stdlib/logging/handlers.pyi
+++ b/stdlib/logging/handlers.pyi
@@ -78,7 +78,7 @@ class TimedRotatingFileHandler(BaseRotatingHandler):
     when: str  # undocumented
     backupCount: int  # undocumented
     utc: bool  # undocumented
-    atTime: datetime.datetime | None  # undocumented
+    atTime: datetime.time | None  # undocumented
     interval: int  # undocumented
     suffix: str  # undocumented
     dayOfWeek: int  # undocumented
@@ -94,7 +94,7 @@ class TimedRotatingFileHandler(BaseRotatingHandler):
             encoding: str | None = ...,
             delay: bool = ...,
             utc: bool = ...,
-            atTime: datetime.datetime | None = ...,
+            atTime: datetime.time | None = ...,
             errors: str | None = ...,
         ) -> None: ...
     else:
@@ -107,7 +107,7 @@ class TimedRotatingFileHandler(BaseRotatingHandler):
             encoding: str | None = ...,
             delay: bool = ...,
             utc: bool = ...,
-            atTime: datetime.datetime | None = ...,
+            atTime: datetime.time | None = ...,
         ) -> None: ...
 
     def doRollover(self) -> None: ...


### PR DESCRIPTION
It is marked as having type `datetime.datetime` but `atTime`
refers to a time of day; only the fields on `datetime.time`
are used. The [docs](https://docs.python.org/3/library/logging.handlers.html#timedrotatingfilehandler)
clearly state that it is a `time`.

One unfortunate problem is that `datetime.datetime` only inherits
from `datetime.date`, not `datetime.time` even though it exposes
the same API as `datetime.time`.

As a result, even though it is possible to pass a `datetime.datetime`
due to duck-typing, this change will causes code that does so to
not type check.

We could use a union type to allow passing either, or even create
a protocol for a "time-like interface". I'll leave that up to reviewers.