### PR TITLE
Exclude the Python-2 stdlib from the flake8 CI check

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -35,10 +35,8 @@ per-file-ignores =
   # https://github.com/PyCQA/flake8/issues/1079
   #     F811 redefinition of unused '...'
   stubs/*.pyi: E301, E302, E305, E501, E701, E741, F401, F403, F405, F822, Y026, Y027
-  stdlib/@python2/*.pyi: E301, E302, E305, E501, E701, E741, F401, F403, F405, F822, Y026, Y027
-  stdlib/@python2/typing.pyi: E301, E302, E305, E501, E701, E741, F401, F403, F405, F811, F822, Y026, Y027
   stdlib/typing.pyi: E301, E302, E305, E501, E701, E741, F401, F403, F405, F811, F822, Y026, Y034
 
 # We are checking with Python 3 but many of the stubs are Python 2 stubs.
 builtins = buffer,file,long,raw_input,unicode,xrange
-exclude = .venv*,.git,*_pb2.pyi
+exclude = .venv*,.git,*_pb2.pyi,stdlib/@python2/*


### PR DESCRIPTION
We should hopefully be getting rid of this entire subdirectory soon anyway (#7367). This will make PRs to flake8-pyi a lot easier.