### PR TITLE
flake8 config: remove line that exists only for Python-2 checking

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -37,6 +37,4 @@ per-file-ignores =
   stubs/*.pyi: E301, E302, E305, E501, E701, E741, F401, F403, F405, F822, Y026, Y027
   stdlib/typing.pyi: E301, E302, E305, E501, E701, E741, F401, F403, F405, F811, F822, Y026, Y034
 
-# We are checking with Python 3 but many of the stubs are Python 2 stubs.
-builtins = buffer,file,long,raw_input,unicode,xrange
 exclude = .venv*,.git,*_pb2.pyi,stdlib/@python2/*

--- a/stubs/humanfriendly/humanfriendly/compat.pyi
+++ b/stubs/humanfriendly/humanfriendly/compat.pyi
@@ -11,7 +11,7 @@ else:
     unicode = unicode
     unichr = unichr
     basestring = basestring
-    interactive_prompt = raw_input
+    interactive_prompt = raw_input  # noqa: F821  # exists as a builtin in Python 2, but not in Python 3
     from StringIO import StringIO as StringIO
 
     from HTMLParser import HTMLParser as HTMLParser


### PR DESCRIPTION
flake8 no longer runs on the Python-2 stdlib in CI