### PR TITLE
Add `types.FunctionType.__module__`

### DIFF
--- a/stdlib/types.pyi
+++ b/stdlib/types.pyi
@@ -200,6 +200,7 @@ class FunctionType:
         @property
         def __builtins__(self) -> dict[str, Any]: ...
 
+    __module__: str
     def __init__(
         self,
         code: CodeType,


### PR DESCRIPTION
This exists on builtins.function but not here.