### PR TITLE
Upgrade `black` version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 22.1.0 # must match requirements-tests.txt
+    rev: 22.3.0 # must match requirements-tests.txt
     hooks:
       - id: black
         language_version: python3.9

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,7 +1,7 @@
 mypy==0.942
 pytype==2022.03.29; platform_system != "Windows" and python_version < "3.10"
 # must match .pre-commit-config.yaml
-black==22.1.0
+black==22.3.0
 flake8==4.0.1
 flake8-bugbear==21.11.29
 flake8-pyi==22.3.0


### PR DESCRIPTION
black 22.3.0 contains [a patch](https://github.com/psf/black/pull/2966) by somebody called "Jelle Zijlstra", which should fix the CI failure in #7558