### PR TITLE
Add undocumented _mapping to collections.abc MappingView, KeysView, ValuesView, ItemsView

### DIFF
--- a/stdlib/_collections_abc.pyi
+++ b/stdlib/_collections_abc.pyi
@@ -14,12 +14,12 @@ from typing import (
     Generator as Generator,
     Generic,
     Hashable as Hashable,
-    ItemsView as ItemsView,
+    ItemsView as _ItemsView,
     Iterable as Iterable,
     Iterator as Iterator,
-    KeysView as KeysView,
+    KeysView as _KeysView,
     Mapping as Mapping,
-    MappingView as MappingView,
+    MappingView as _MappingView,
     MutableMapping as MutableMapping,
     MutableSequence as MutableSequence,
     MutableSet as MutableSet,
@@ -27,7 +27,8 @@ from typing import (
     Sequence as Sequence,
     Sized as Sized,
     TypeVar,
-    ValuesView as ValuesView,
+    ValuesView as _ValuesView,
+    Any as _Any,
 )
 from typing_extensions import final
 
@@ -63,19 +64,31 @@ _KT_co = TypeVar("_KT_co", covariant=True)  # Key type covariant containers.
 _VT_co = TypeVar("_VT_co", covariant=True)  # Value type covariant containers.
 
 @final
-class dict_keys(KeysView[_KT_co], Generic[_KT_co, _VT_co]):  # undocumented
+class dict_keys(_KeysView[_KT_co], Generic[_KT_co, _VT_co]):  # undocumented
     if sys.version_info >= (3, 10):
         @property
         def mapping(self) -> MappingProxyType[_KT_co, _VT_co]: ...
 
 @final
-class dict_values(ValuesView[_VT_co], Generic[_KT_co, _VT_co]):  # undocumented
+class dict_values(_ValuesView[_VT_co], Generic[_KT_co, _VT_co]):  # undocumented
     if sys.version_info >= (3, 10):
         @property
         def mapping(self) -> MappingProxyType[_KT_co, _VT_co]: ...
 
 @final
-class dict_items(ItemsView[_KT_co, _VT_co], Generic[_KT_co, _VT_co]):  # undocumented
+class dict_items(_ItemsView[_KT_co, _VT_co], Generic[_KT_co, _VT_co]):  # undocumented
     if sys.version_info >= (3, 10):
         @property
         def mapping(self) -> MappingProxyType[_KT_co, _VT_co]: ...
+
+class MappingView(_MappingView):
+    _mapping: Mapping[_Any, _Any]  # undocumented
+
+class KeysView(_KeysView[_KT_co], Generic[_KT_co, _VT_co]):
+    _mapping: Mapping[_KT_co, _VT_co]  # undocumented
+
+class ValuesView(_KeysView[_VT_co], Generic[_KT_co, _VT_co]):
+    _mapping: Mapping[_KT_co, _VT_co]  # undocumented
+
+class ItemsView(_ItemsView[_KT_co, _VT_co], Generic[_KT_co, _VT_co]):
+    _mapping: Mapping[_KT_co, _VT_co]  # undocumented

--- a/stdlib/_collections_abc.pyi
+++ b/stdlib/_collections_abc.pyi
@@ -28,7 +28,7 @@ from typing import (
     Sized as Sized,
     TypeVar,
     ValuesView as _ValuesView,
-    Any as _Any,
+    Any,
 )
 from typing_extensions import final
 
@@ -82,13 +82,13 @@ class dict_items(_ItemsView[_KT_co, _VT_co], Generic[_KT_co, _VT_co]):  # undocu
         def mapping(self) -> MappingProxyType[_KT_co, _VT_co]: ...
 
 class MappingView(_MappingView):
-    _mapping: Mapping[_Any, _Any]  # undocumented
+    _mapping: Mapping[Any, Any]  # undocumented
 
-class KeysView(_KeysView[_KT_co], Generic[_KT_co, _VT_co]):
-    _mapping: Mapping[_KT_co, _VT_co]  # undocumented
+class KeysView(_KeysView[_KT_co], Generic[_KT_co]):
+    _mapping: Mapping[_KT_co, Any]  # undocumented
 
-class ValuesView(_KeysView[_VT_co], Generic[_KT_co, _VT_co]):
-    _mapping: Mapping[_KT_co, _VT_co]  # undocumented
+class ValuesView(_ValuesView[_VT_co], Generic[_VT_co]):
+    _mapping: Mapping[Any, _VT_co]  # undocumented
 
 class ItemsView(_ItemsView[_KT_co, _VT_co], Generic[_KT_co, _VT_co]):
     _mapping: Mapping[_KT_co, _VT_co]  # undocumented

--- a/tests/stubtest_allowlists/py310.txt
+++ b/tests/stubtest_allowlists/py310.txt
@@ -3,9 +3,6 @@ _collections_abc.AsyncGenerator.ag_await
 _collections_abc.AsyncGenerator.ag_code
 _collections_abc.AsyncGenerator.ag_frame
 _collections_abc.AsyncGenerator.ag_running
-_collections_abc.ItemsView.__reversed__
-_collections_abc.KeysView.__reversed__
-_collections_abc.ValuesView.__reversed__
 
 # These are not positional-only at runtime, but we treat them
 # as positional-only to match dict.

--- a/tests/stubtest_allowlists/py38.txt
+++ b/tests/stubtest_allowlists/py38.txt
@@ -25,9 +25,6 @@ collections.AsyncGenerator.ag_code
 collections.AsyncGenerator.ag_frame
 collections.AsyncGenerator.ag_running
 collections.Callable
-collections.ItemsView.__reversed__
-collections.KeysView.__reversed__
-collections.ValuesView.__reversed__
 collections.Mapping.__reversed__  # Set to None at runtime for a better error message
 # Adding these reflected dunders to `typing.AbstractSet` causes a large number of false-positives. See #7414.
 collections.Set.__rand__

--- a/tests/stubtest_allowlists/py38.txt
+++ b/tests/stubtest_allowlists/py38.txt
@@ -2,9 +2,6 @@ _collections_abc.AsyncGenerator.ag_await
 _collections_abc.AsyncGenerator.ag_code
 _collections_abc.AsyncGenerator.ag_frame
 _collections_abc.AsyncGenerator.ag_running
-_collections_abc.ItemsView.__reversed__
-_collections_abc.KeysView.__reversed__
-_collections_abc.ValuesView.__reversed__
 _dummy_threading
 ast.Bytes.__new__
 ast.Ellipsis.__new__

--- a/tests/stubtest_allowlists/py39.txt
+++ b/tests/stubtest_allowlists/py39.txt
@@ -30,9 +30,6 @@ collections.AsyncGenerator.ag_frame
 collections.AsyncGenerator.ag_running
 collections.Callable
 collections.Mapping.__reversed__  # Set to None at runtime for a better error message
-collections.ItemsView.__reversed__
-collections.KeysView.__reversed__
-collections.ValuesView.__reversed__
 # Adding these reflected dunders to `typing.AbstractSet` causes a large number of false-positives. See #7414.
 collections.Set.__rand__
 collections.Set.__ror__

--- a/tests/stubtest_allowlists/py39.txt
+++ b/tests/stubtest_allowlists/py39.txt
@@ -3,9 +3,6 @@ _collections_abc.AsyncGenerator.ag_await
 _collections_abc.AsyncGenerator.ag_code
 _collections_abc.AsyncGenerator.ag_frame
 _collections_abc.AsyncGenerator.ag_running
-_collections_abc.ItemsView.__reversed__
-_collections_abc.KeysView.__reversed__
-_collections_abc.ValuesView.__reversed__
 _weakref.ProxyType.__reversed__  # Doesn't really exist
 ast.Bytes.__new__
 ast.Ellipsis.__new__


### PR DESCRIPTION
Added self._mapping attribute which was missing from collections.abc.MappingView and subclasses.

fixes: #7576