### PR TITLE
Use Self return type for the 'replace()' methods in datetime classes

### DIFF
--- a/stdlib/datetime.pyi
+++ b/stdlib/datetime.pyi
@@ -65,7 +65,12 @@ class date:
     def isoformat(self) -> str: ...
     def timetuple(self) -> struct_time: ...
     def toordinal(self) -> int: ...
-    def replace(self, year: int = ..., month: int = ..., day: int = ...) -> date: ...
+    if sys.version_info >= (3, 6):
+        def replace(self: Self, year: int = ..., month: int = ..., day: int = ...) -> Self: ...
+    else:
+        # Prior to Python 3.6, the `replace` method always returned `date`, even in subclasses
+        def replace(self, year: int = ..., month: int = ..., day: int = ...) -> date: ...
+
     def __le__(self, __other: date) -> bool: ...
     def __lt__(self, __other: date) -> bool: ...
     def __ge__(self, __other: date) -> bool: ...
@@ -139,16 +144,29 @@ class time:
     def utcoffset(self) -> timedelta | None: ...
     def tzname(self) -> str | None: ...
     def dst(self) -> timedelta | None: ...
-    def replace(
-        self,
-        hour: int = ...,
-        minute: int = ...,
-        second: int = ...,
-        microsecond: int = ...,
-        tzinfo: _tzinfo | None = ...,
-        *,
-        fold: int = ...,
-    ) -> time: ...
+    if sys.version_info >= (3, 6):
+        def replace(
+            self: Self,
+            hour: int = ...,
+            minute: int = ...,
+            second: int = ...,
+            microsecond: int = ...,
+            tzinfo: _tzinfo | None = ...,
+            *,
+            fold: int = ...,
+        ) -> Self: ...
+    else:
+        # Prior to Python 3.6, the `replace` method always returned `time`, even in subclasses
+        def replace(
+            self,
+            hour: int = ...,
+            minute: int = ...,
+            second: int = ...,
+            microsecond: int = ...,
+            tzinfo: _tzinfo | None = ...,
+            *,
+            fold: int = ...,
+        ) -> time: ...
 
 _date = date
 _time = time
@@ -260,19 +278,35 @@ class datetime(date):
     def date(self) -> _date: ...
     def time(self) -> _time: ...
     def timetz(self) -> _time: ...
-    def replace(
-        self,
-        year: int = ...,
-        month: int = ...,
-        day: int = ...,
-        hour: int = ...,
-        minute: int = ...,
-        second: int = ...,
-        microsecond: int = ...,
-        tzinfo: _tzinfo | None = ...,
-        *,
-        fold: int = ...,
-    ) -> datetime: ...
+    if sys.version_info >= (3, 6):
+        def replace(
+            self: Self,
+            year: int = ...,
+            month: int = ...,
+            day: int = ...,
+            hour: int = ...,
+            minute: int = ...,
+            second: int = ...,
+            microsecond: int = ...,
+            tzinfo: _tzinfo | None = ...,
+            *,
+            fold: int = ...,
+        ) -> Self: ...
+    else:
+        # Prior to Python 3.6, the `replace` method always returned `datetime`, even in subclasses
+        def replace(
+            self,
+            year: int = ...,
+            month: int = ...,
+            day: int = ...,
+            hour: int = ...,
+            minute: int = ...,
+            second: int = ...,
+            microsecond: int = ...,
+            tzinfo: _tzinfo | None = ...,
+            *,
+            fold: int = ...,
+        ) -> datetime: ...
     if sys.version_info >= (3, 8):
         def astimezone(self: Self, tz: _tzinfo | None = ...) -> Self: ...
     else:


### PR DESCRIPTION
Since Python 3.6, the `replace()` methods support subclasses - the return
type is the subclass being replaced.

Link to Python issue: https://bugs.python.org/issue31222