### PR TITLE
Update pyVmomi stubs

### DIFF
--- a/stubs/pyvmomi/pyVmomi/vim/option.pyi
+++ b/stubs/pyvmomi/pyVmomi/vim/option.pyi
@@ -7,3 +7,4 @@ class OptionManager:
 
 class OptionValue:
     value: Any
+    key: str

--- a/stubs/pyvmomi/pyVmomi/vmodl/__init__.pyi
+++ b/stubs/pyvmomi/pyVmomi/vmodl/__init__.pyi
@@ -3,6 +3,8 @@ from typing import Any
 from .fault import *
 from .query import *
 
+class DynamicData: ...
+
 class DynamicProperty:
     def __init__(self, *, name: str = ..., val: Any = ...) -> None: ...
     name: str
@@ -10,16 +12,16 @@ class DynamicProperty:
 
 class ManagedObject: ...
 
-class KeyAnyValue:
+class KeyAnyValue(DynamicData):
     key: str
     value: Any
 
-class LocalizableMessage:
+class LocalizableMessage(DynamicData):
     key: str
     arg: list[KeyAnyValue] | None
     message: str | None
 
-class MethodFault(Exception):
+class MethodFault(DynamicData, Exception):
     msg: str | None
     faultCause: MethodFault | None
     faultMessage: list[LocalizableMessage] | None

--- a/stubs/pyvmomi/pyVmomi/vmodl/__init__.pyi
+++ b/stubs/pyvmomi/pyVmomi/vmodl/__init__.pyi
@@ -19,7 +19,7 @@ class LocalizableMessage:
     arg: list[KeyAnyValue] | None
     message: str | None
 
-class MethodFault:
+class MethodFault(Exception):
     msg: str | None
     faultCause: MethodFault | None
     faultMessage: list[LocalizableMessage] | None

--- a/stubs/pyvmomi/pyVmomi/vmodl/query.pyi
+++ b/stubs/pyvmomi/pyVmomi/vmodl/query.pyi
@@ -21,8 +21,8 @@ class PropertyCollector:
         def __getattr__(self, name: str) -> Any: ...  # incomplete
 
     class RetrieveOptions:
-        def __init__(self, *, maxObjects: int) -> None: ...
-        maxObjects: int
+        def __init__(self, *, maxObjects: int | None = ...) -> None: ...
+        maxObjects: int | None
 
     class ObjectSpec:
         def __init__(


### PR DESCRIPTION
- Add generic base class `DynamicData`
- Add missing `key` prop to `OptionValue` 
- Fix `MethodFault` not inheriting from `Exception`
- Fix `RetrieveOptions` default `maxObjects` type and default