### PR TITLE
Add `NoReturn` overload to `builtins.sum`

### DIFF
--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -1487,6 +1487,7 @@ _SumS = TypeVar("_SumS", bound=_SupportsSum)
 if sys.version_info >= (3, 8):
     @overload
     def sum(__iterable: Iterable[str], start: _SupportsSum = ...) -> NoReturn: ...
+
 else:
     @overload
     def sum(__iterable: Iterable[str], __start: _SupportsSum = ...) -> NoReturn: ...

--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -1484,6 +1484,13 @@ class _SupportsSum(Protocol):
 _SumT = TypeVar("_SumT", bound=_SupportsSum)
 _SumS = TypeVar("_SumS", bound=_SupportsSum)
 
+if sys.version_info >= (3, 8):
+    @overload
+    def sum(__iterable: Iterable[str], start: _SupportsSum = ...) -> NoReturn: ...
+else:
+    @overload
+    def sum(__iterable: Iterable[str], __start: _SupportsSum = ...) -> NoReturn: ...
+
 @overload
 def sum(__iterable: Iterable[_SumT]) -> _SumT | Literal[0]: ...
 


### PR DESCRIPTION
`sum` fails if you try to pass an iterable of strings to it:

```python
>>> sum(('a', 'b', 'c'), start='d')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: sum() can't sum strings [use ''.join(seq) instead]
```

As pointed out by @Akuli, there's no ideal way to describe this in the stubs without https://github.com/python/typing/issues/1043. However, a `NoReturn` overload is better than nothing.

Helps with #7574