### PR TITLE
pytype_test: Don't mix up stdlib and stub packages starting with stdlib.

### DIFF
--- a/tests/pytype_test.py
+++ b/tests/pytype_test.py
@@ -83,7 +83,7 @@ def _get_relative(filename: str) -> str:
     top = 0
     for d in TYPESHED_SUBDIRS:
         try:
-            top = filename.index(d)
+            top = filename.index(d + os.path.sep)
         except ValueError:
             continue
         else:


### PR DESCRIPTION
This should fix the pytype_test failure in
https://github.com/python/typeshed/pull/7608.