### PR TITLE
Add back six.moves.configparser.Error

### DIFF
--- a/stubs/six/six/moves/configparser.pyi
+++ b/stubs/six/six/moves/configparser.pyi
@@ -1,1 +1,3 @@
+# Error is not included in __all__ so export it explicitly
 from configparser import *
+from configparser import Error as Error


### PR DESCRIPTION
It got removed as an unintended side effect of #7300.

It's available at runtime:
```
>>> import configparser
>>> configparser.Error
<class 'configparser.Error'>
>>> import six.moves
>>> six.moves.configparser.Error
<class 'configparser.Error'>
```