### PR TITLE
Add back six.moves.http_cookies.Morsel

### DIFF
--- a/stubs/six/six/moves/http_cookies.pyi
+++ b/stubs/six/six/moves/http_cookies.pyi
@@ -1,1 +1,3 @@
+# Morsel is not included in __all__ so export it explicitly
 from http.cookies import *
+from http.cookies import Morsel as Morsel


### PR DESCRIPTION
It exists at runtime:
```
>>> import http.cookies
>>> import six.moves.http_cookies
>>> http.cookies.Morsel
<class 'http.cookies.Morsel'>
>>> six.moves.http_cookies.Morsel
<class 'http.cookies.Morsel'>
```