### PR TITLE
Accept `mtime=None` in `linecache.cache` entries.

### DIFF
--- a/stdlib/linecache.pyi
+++ b/stdlib/linecache.pyi
@@ -7,7 +7,7 @@ else:
     __all__ = ["getline", "clearcache", "checkcache"]
 
 _ModuleGlobals = dict[str, Any]
-_ModuleMetadata = tuple[int, float, list[str], str]
+_ModuleMetadata = tuple[int, float | None, list[str], str]
 
 class _SourceLoader(Protocol):
     def __call__(self) -> str | None: ...


### PR DESCRIPTION
The mtime in linecache entries can be set to `None` fir files loaded via a `__loader__` (cf: https://github.com/python/cpython/blob/3.10/Lib/linecache.py#L70)