### PR TITLE
Import from `collections.abc` wherever possible

### DIFF
--- a/stdlib/_bisect.pyi
+++ b/stdlib/_bisect.pyi
@@ -1,6 +1,7 @@
 import sys
 from _typeshed import SupportsRichComparisonT
-from typing import Callable, MutableSequence, Sequence, TypeVar, overload
+from collections.abc import Callable, MutableSequence, Sequence
+from typing import TypeVar, overload
 
 _T = TypeVar("_T")
 

--- a/stdlib/_codecs.pyi
+++ b/stdlib/_codecs.pyi
@@ -1,6 +1,7 @@
 import codecs
 import sys
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 from typing_extensions import TypeAlias
 
 # This type is not exposed; it is defined in unicodeobject.c

--- a/stdlib/_compression.pyi
+++ b/stdlib/_compression.pyi
@@ -1,6 +1,7 @@
 from _typeshed import WriteableBuffer
+from collections.abc import Callable
 from io import DEFAULT_BUFFER_SIZE, BufferedIOBase, RawIOBase
-from typing import Any, Callable, Protocol
+from typing import Any, Protocol
 
 BUFFER_SIZE = DEFAULT_BUFFER_SIZE
 

--- a/stdlib/_csv.pyi
+++ b/stdlib/_csv.pyi
@@ -1,4 +1,5 @@
-from typing import Any, Iterable, Iterator, Protocol, Union
+from collections.abc import Iterable, Iterator
+from typing import Any, Protocol, Union
 from typing_extensions import Literal, TypeAlias
 
 __version__: str

--- a/stdlib/_decimal.pyi
+++ b/stdlib/_decimal.pyi
@@ -1,8 +1,9 @@
 import numbers
 import sys
 from _typeshed import Self
+from collections.abc import Container, Sequence
 from types import TracebackType
-from typing import Any, Container, NamedTuple, Sequence, Union, overload
+from typing import Any, NamedTuple, Union, overload
 from typing_extensions import TypeAlias
 
 _Decimal: TypeAlias = Decimal | int

--- a/stdlib/_dummy_thread.pyi
+++ b/stdlib/_dummy_thread.pyi
@@ -1,5 +1,6 @@
+from collections.abc import Callable
 from types import TracebackType
-from typing import Any, Callable, NoReturn
+from typing import Any, NoReturn
 
 TIMEOUT_MAX: int
 error = RuntimeError

--- a/stdlib/_dummy_threading.pyi
+++ b/stdlib/_dummy_threading.pyi
@@ -1,6 +1,7 @@
 import sys
+from collections.abc import Callable, Iterable, Mapping
 from types import FrameType, TracebackType
-from typing import Any, Callable, Iterable, Mapping, TypeVar
+from typing import Any, TypeVar
 from typing_extensions import TypeAlias
 
 # TODO recursive type

--- a/stdlib/_json.pyi
+++ b/stdlib/_json.pyi
@@ -1,4 +1,5 @@
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 from typing_extensions import final
 
 @final

--- a/stdlib/_operator.pyi
+++ b/stdlib/_operator.pyi
@@ -1,20 +1,6 @@
 import sys
-from typing import (
-    Any,
-    AnyStr,
-    Callable,
-    Container,
-    Generic,
-    Iterable,
-    Mapping,
-    MutableMapping,
-    MutableSequence,
-    Protocol,
-    Sequence,
-    SupportsAbs,
-    TypeVar,
-    overload,
-)
+from collections.abc import Callable, Container, Iterable, Mapping, MutableMapping, MutableSequence, Sequence
+from typing import Any, AnyStr, Generic, Protocol, SupportsAbs, TypeVar, overload
 from typing_extensions import ParamSpec, SupportsIndex, TypeAlias, final
 
 _R = TypeVar("_R")

--- a/stdlib/_osx_support.pyi
+++ b/stdlib/_osx_support.pyi
@@ -1,5 +1,6 @@
 import sys
-from typing import Iterable, Sequence, TypeVar
+from collections.abc import Iterable, Sequence
+from typing import TypeVar
 
 _T = TypeVar("_T")
 _K = TypeVar("_K")

--- a/stdlib/_posixsubprocess.pyi
+++ b/stdlib/_posixsubprocess.pyi
@@ -1,5 +1,5 @@
 import sys
-from typing import Callable, Sequence
+from collections.abc import Callable, Sequence
 
 if sys.platform != "win32":
     def cloexec_pipe() -> tuple[int, int]: ...

--- a/stdlib/_sitebuiltins.pyi
+++ b/stdlib/_sitebuiltins.pyi
@@ -1,4 +1,5 @@
-from typing import ClassVar, Iterable, NoReturn
+from collections.abc import Iterable
+from typing import ClassVar, NoReturn
 from typing_extensions import Literal
 
 class Quitter:

--- a/stdlib/_thread.pyi
+++ b/stdlib/_thread.pyi
@@ -1,8 +1,9 @@
 import sys
 from _typeshed import structseq
+from collections.abc import Callable
 from threading import Thread
 from types import TracebackType
-from typing import Any, Callable, NoReturn
+from typing import Any, NoReturn
 from typing_extensions import Final, final
 
 error = RuntimeError

--- a/stdlib/_tracemalloc.pyi
+++ b/stdlib/_tracemalloc.pyi
@@ -1,6 +1,6 @@
 import sys
+from collections.abc import Sequence
 from tracemalloc import _FrameTupleT, _TraceTupleT
-from typing import Sequence
 
 def _get_object_traceback(__obj: object) -> Sequence[_FrameTupleT] | None: ...
 def _get_traces() -> Sequence[_TraceTupleT]: ...

--- a/stdlib/_typeshed/__init__.pyi
+++ b/stdlib/_typeshed/__init__.pyi
@@ -6,10 +6,10 @@ import array
 import ctypes
 import mmap
 import sys
-from collections.abc import Awaitable, Container, Iterable
+from collections.abc import Awaitable, Container, Iterable, Set as AbstractSet
 from os import PathLike
 from types import TracebackType
-from typing import AbstractSet, Any, Generic, Protocol, TypeVar, Union
+from typing import Any, Generic, Protocol, TypeVar, Union
 from typing_extensions import Final, Literal, TypeAlias, final
 
 _KT = TypeVar("_KT")

--- a/stdlib/_typeshed/__init__.pyi
+++ b/stdlib/_typeshed/__init__.pyi
@@ -6,9 +6,10 @@ import array
 import ctypes
 import mmap
 import sys
+from collections.abc import Awaitable, Container, Iterable
 from os import PathLike
 from types import TracebackType
-from typing import AbstractSet, Any, Awaitable, Container, Generic, Iterable, Protocol, TypeVar, Union
+from typing import AbstractSet, Any, Generic, Protocol, TypeVar, Union
 from typing_extensions import Final, Literal, TypeAlias, final
 
 _KT = TypeVar("_KT")

--- a/stdlib/_typeshed/wsgi.pyi
+++ b/stdlib/_typeshed/wsgi.pyi
@@ -6,7 +6,8 @@
 
 import sys
 from _typeshed import OptExcInfo
-from typing import Any, Callable, Iterable, Protocol
+from collections.abc import Callable, Iterable
+from typing import Any, Protocol
 from typing_extensions import TypeAlias
 
 class _Readable(Protocol):

--- a/stdlib/_weakref.pyi
+++ b/stdlib/_weakref.pyi
@@ -1,5 +1,6 @@
 import sys
-from typing import Any, Callable, Generic, TypeVar, overload
+from collections.abc import Callable
+from typing import Any, Generic, TypeVar, overload
 from typing_extensions import final
 
 if sys.version_info >= (3, 9):

--- a/stdlib/_weakrefset.pyi
+++ b/stdlib/_weakrefset.pyi
@@ -1,6 +1,7 @@
 import sys
 from _typeshed import Self
-from typing import Any, Generic, Iterable, Iterator, MutableSet, TypeVar
+from collections.abc import Iterable, Iterator, MutableSet
+from typing import Any, Generic, TypeVar
 
 if sys.version_info >= (3, 9):
     from types import GenericAlias

--- a/stdlib/_winapi.pyi
+++ b/stdlib/_winapi.pyi
@@ -1,5 +1,6 @@
 import sys
-from typing import Any, NoReturn, Sequence, overload
+from collections.abc import Sequence
+from typing import Any, NoReturn, overload
 from typing_extensions import Literal, final
 
 if sys.platform == "win32":

--- a/stdlib/argparse.pyi
+++ b/stdlib/argparse.pyi
@@ -1,19 +1,6 @@
 import sys
-from typing import (
-    IO,
-    Any,
-    Callable,
-    Generator,
-    Generic,
-    Iterable,
-    NewType,
-    NoReturn,
-    Pattern,
-    Protocol,
-    Sequence,
-    TypeVar,
-    overload,
-)
+from collections.abc import Callable, Generator, Iterable, Sequence
+from typing import IO, Any, Generic, NewType, NoReturn, Pattern, Protocol, TypeVar, overload
 from typing_extensions import Literal
 
 if sys.version_info >= (3, 9):

--- a/stdlib/array.pyi
+++ b/stdlib/array.pyi
@@ -1,7 +1,7 @@
 import sys
 from _typeshed import Self
-from collections.abc import Iterable, MutableSequence
-from typing import Any, BinaryIO, Generic, TypeVar, overload
+from collections.abc import Iterable
+from typing import Any, BinaryIO, Generic, MutableSequence, TypeVar, overload
 from typing_extensions import Literal, SupportsIndex, TypeAlias
 
 _IntTypeCode: TypeAlias = Literal["b", "B", "h", "H", "i", "I", "l", "L", "q", "Q"]

--- a/stdlib/array.pyi
+++ b/stdlib/array.pyi
@@ -1,6 +1,7 @@
 import sys
 from _typeshed import Self
-from typing import Any, BinaryIO, Generic, Iterable, MutableSequence, TypeVar, overload
+from collections.abc import Iterable, MutableSequence
+from typing import Any, BinaryIO, Generic, TypeVar, overload
 from typing_extensions import Literal, SupportsIndex, TypeAlias
 
 _IntTypeCode: TypeAlias = Literal["b", "B", "h", "H", "i", "I", "l", "L", "q", "Q"]

--- a/stdlib/ast.pyi
+++ b/stdlib/ast.pyi
@@ -1,6 +1,7 @@
 import sys
 from _ast import *
-from typing import Any, Iterator, TypeVar, overload
+from collections.abc import Iterator
+from typing import Any, TypeVar, overload
 from typing_extensions import Literal
 
 if sys.version_info >= (3, 8):

--- a/stdlib/asyncio/base_events.pyi
+++ b/stdlib/asyncio/base_events.pyi
@@ -6,9 +6,9 @@ from asyncio.futures import Future
 from asyncio.protocols import BaseProtocol
 from asyncio.tasks import Task
 from asyncio.transports import BaseTransport, ReadTransport, SubprocessTransport, WriteTransport
-from collections.abc import Iterable
+from collections.abc import Awaitable, Callable, Coroutine, Generator, Iterable, Sequence
 from socket import AddressFamily, SocketKind, _Address, _RetAddress, socket
-from typing import IO, Any, Awaitable, Callable, Coroutine, Generator, Sequence, TypeVar, overload
+from typing import IO, Any, TypeVar, overload
 from typing_extensions import Literal, TypeAlias
 
 if sys.version_info >= (3, 7):

--- a/stdlib/asyncio/base_futures.pyi
+++ b/stdlib/asyncio/base_futures.pyi
@@ -1,5 +1,6 @@
 import sys
-from typing import Any, Callable, Sequence
+from collections.abc import Callable, Sequence
+from typing import Any
 from typing_extensions import Literal
 
 if sys.version_info >= (3, 7):

--- a/stdlib/asyncio/base_subprocess.pyi
+++ b/stdlib/asyncio/base_subprocess.pyi
@@ -1,6 +1,7 @@
 import subprocess
 from collections import deque
-from typing import IO, Any, Callable, Sequence
+from collections.abc import Callable, Sequence
+from typing import IO, Any
 from typing_extensions import TypeAlias
 
 from . import events, futures, protocols, transports

--- a/stdlib/asyncio/events.pyi
+++ b/stdlib/asyncio/events.pyi
@@ -2,8 +2,9 @@ import ssl
 import sys
 from _typeshed import FileDescriptorLike, Self
 from abc import ABCMeta, abstractmethod
+from collections.abc import Awaitable, Callable, Coroutine, Generator, Sequence
 from socket import AddressFamily, SocketKind, _Address, _RetAddress, socket
-from typing import IO, Any, Awaitable, Callable, Coroutine, Generator, Sequence, TypeVar, overload
+from typing import IO, Any, TypeVar, overload
 from typing_extensions import Literal, TypeAlias
 
 from .base_events import Server

--- a/stdlib/asyncio/format_helpers.pyi
+++ b/stdlib/asyncio/format_helpers.pyi
@@ -1,7 +1,8 @@
 import functools
 import traceback
+from collections.abc import Iterable
 from types import FrameType, FunctionType
-from typing import Any, Iterable, overload
+from typing import Any, overload
 from typing_extensions import TypeAlias
 
 class _HasWrapper:

--- a/stdlib/asyncio/futures.pyi
+++ b/stdlib/asyncio/futures.pyi
@@ -1,7 +1,8 @@
 import sys
 from _typeshed import Self
+from collections.abc import Awaitable, Callable, Generator, Iterable
 from concurrent.futures._base import Error, Future as _ConcurrentFuture
-from typing import Any, Awaitable, Callable, Generator, Iterable, TypeVar
+from typing import Any, TypeVar
 from typing_extensions import Literal, TypeGuard
 
 from .events import AbstractEventLoop

--- a/stdlib/asyncio/locks.pyi
+++ b/stdlib/asyncio/locks.pyi
@@ -1,7 +1,8 @@
 import sys
 from collections import deque
+from collections.abc import Callable, Generator
 from types import TracebackType
-from typing import Any, Callable, Generator, TypeVar
+from typing import Any, TypeVar
 from typing_extensions import Literal
 
 from .events import AbstractEventLoop

--- a/stdlib/asyncio/proactor_events.pyi
+++ b/stdlib/asyncio/proactor_events.pyi
@@ -1,6 +1,7 @@
 import sys
+from collections.abc import Mapping
 from socket import socket
-from typing import Any, Mapping, Protocol
+from typing import Any, Protocol
 from typing_extensions import Literal
 
 from . import base_events, constants, events, futures, streams, transports

--- a/stdlib/asyncio/runners.pyi
+++ b/stdlib/asyncio/runners.pyi
@@ -1,5 +1,6 @@
 import sys
-from typing import Awaitable, TypeVar
+from collections.abc import Awaitable
+from typing import TypeVar
 
 __all__ = ("run",)
 _T = TypeVar("_T")

--- a/stdlib/asyncio/sslproto.pyi
+++ b/stdlib/asyncio/sslproto.pyi
@@ -1,7 +1,8 @@
 import ssl
 import sys
 from collections import deque
-from typing import Any, Callable, ClassVar
+from collections.abc import Callable
+from typing import Any, ClassVar
 from typing_extensions import Literal
 
 from . import constants, events, futures, protocols, transports

--- a/stdlib/asyncio/staggered.pyi
+++ b/stdlib/asyncio/staggered.pyi
@@ -1,4 +1,5 @@
-from typing import Any, Awaitable, Callable, Iterable
+from collections.abc import Awaitable, Callable, Iterable
+from typing import Any
 
 from . import events
 

--- a/stdlib/asyncio/streams.pyi
+++ b/stdlib/asyncio/streams.pyi
@@ -1,6 +1,7 @@
 import sys
 from _typeshed import Self, StrPath
-from typing import Any, AsyncIterator, Awaitable, Callable, Iterable, Sequence
+from collections.abc import AsyncIterator, Awaitable, Callable, Iterable, Sequence
+from typing import Any
 from typing_extensions import TypeAlias
 
 from . import events, protocols, transports

--- a/stdlib/asyncio/subprocess.pyi
+++ b/stdlib/asyncio/subprocess.pyi
@@ -2,7 +2,8 @@ import subprocess
 import sys
 from _typeshed import StrOrBytesPath
 from asyncio import events, protocols, streams, transports
-from typing import IO, Any, Callable
+from collections.abc import Callable
+from typing import IO, Any
 from typing_extensions import Literal, TypeAlias
 
 if sys.version_info >= (3, 7):

--- a/stdlib/asyncio/taskgroups.pyi
+++ b/stdlib/asyncio/taskgroups.pyi
@@ -1,8 +1,9 @@
 # This only exists in 3.11+. See VERSIONS.
 
 from _typeshed import Self
+from collections.abc import Coroutine, Generator
 from types import TracebackType
-from typing import Any, Coroutine, Generator, TypeVar
+from typing import Any, TypeVar
 
 from .tasks import Task
 

--- a/stdlib/asyncio/tasks.pyi
+++ b/stdlib/asyncio/tasks.pyi
@@ -1,8 +1,8 @@
 import concurrent.futures
 import sys
-from collections.abc import Awaitable, Generator, Iterable, Iterator
+from collections.abc import Awaitable, Coroutine, Generator, Iterable, Iterator
 from types import FrameType
-from typing import Any, Coroutine, Generic, TextIO, TypeVar, overload
+from typing import Any, Generic, TextIO, TypeVar, overload
 from typing_extensions import Literal, TypeAlias
 
 from .events import AbstractEventLoop

--- a/stdlib/asyncio/threads.pyi
+++ b/stdlib/asyncio/threads.pyi
@@ -1,4 +1,5 @@
-from typing import Callable, TypeVar
+from collections.abc import Callable
+from typing import TypeVar
 from typing_extensions import ParamSpec
 
 __all__ = ("to_thread",)

--- a/stdlib/asyncio/transports.pyi
+++ b/stdlib/asyncio/transports.pyi
@@ -1,8 +1,9 @@
 import sys
 from asyncio.events import AbstractEventLoop
 from asyncio.protocols import BaseProtocol
+from collections.abc import Mapping
 from socket import _Address
-from typing import Any, Mapping
+from typing import Any
 
 if sys.version_info >= (3, 7):
     __all__ = ("BaseTransport", "ReadTransport", "WriteTransport", "Transport", "DatagramTransport", "SubprocessTransport")

--- a/stdlib/asyncio/trsock.pyi
+++ b/stdlib/asyncio/trsock.pyi
@@ -1,8 +1,9 @@
 import socket
 import sys
 from builtins import type as Type  # alias to avoid name clashes with property named "type"
+from collections.abc import Iterable
 from types import TracebackType
-from typing import Any, BinaryIO, Iterable, NoReturn, overload
+from typing import Any, BinaryIO, NoReturn, overload
 from typing_extensions import TypeAlias
 
 # These are based in socket, maybe move them out into _typeshed.pyi or such

--- a/stdlib/asyncio/unix_events.pyi
+++ b/stdlib/asyncio/unix_events.pyi
@@ -2,8 +2,9 @@ import sys
 import types
 from _typeshed import Self
 from abc import ABCMeta, abstractmethod
+from collections.abc import Callable
 from socket import socket
-from typing import Any, Callable
+from typing import Any
 from typing_extensions import Literal
 
 from .base_events import Server

--- a/stdlib/asyncio/windows_events.pyi
+++ b/stdlib/asyncio/windows_events.pyi
@@ -1,7 +1,8 @@
 import socket
 import sys
 from _typeshed import WriteableBuffer
-from typing import IO, Any, Callable, ClassVar, NoReturn
+from collections.abc import Callable
+from typing import IO, Any, ClassVar, NoReturn
 from typing_extensions import Literal
 
 from . import events, futures, proactor_events, selector_events, streams, windows_utils

--- a/stdlib/asyncio/windows_utils.pyi
+++ b/stdlib/asyncio/windows_utils.pyi
@@ -1,8 +1,9 @@
 import subprocess
 import sys
 from _typeshed import Self
+from collections.abc import Callable
 from types import TracebackType
-from typing import Any, AnyStr, Callable, Protocol
+from typing import Any, AnyStr, Protocol
 from typing_extensions import Literal
 
 if sys.platform == "win32":

--- a/stdlib/atexit.pyi
+++ b/stdlib/atexit.pyi
@@ -1,4 +1,5 @@
-from typing import Any, Callable, TypeVar
+from collections.abc import Callable
+from typing import Any, TypeVar
 from typing_extensions import ParamSpec
 
 _T = TypeVar("_T")

--- a/stdlib/bdb.pyi
+++ b/stdlib/bdb.pyi
@@ -1,6 +1,7 @@
 from _typeshed import ExcInfo
+from collections.abc import Callable, Iterable, Mapping
 from types import CodeType, FrameType, TracebackType
-from typing import IO, Any, Callable, Iterable, Mapping, SupportsInt, TypeVar
+from typing import IO, Any, SupportsInt, TypeVar
 from typing_extensions import Literal, ParamSpec, TypeAlias
 
 __all__ = ["BdbQuit", "Bdb", "Breakpoint"]

--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -22,12 +22,11 @@ from _typeshed import (
     SupportsTrunc,
     SupportsWrite,
 )
-from collections.abc import Callable
+from collections.abc import Callable, Set as AbstractSet
 from io import BufferedRandom, BufferedReader, BufferedWriter, FileIO, TextIOWrapper
 from types import CodeType, TracebackType, _Cell
 from typing import (
     IO,
-    AbstractSet,
     Any,
     Awaitable,
     BinaryIO,

--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -22,28 +22,31 @@ from _typeshed import (
     SupportsTrunc,
     SupportsWrite,
 )
-from collections.abc import Callable, Set as AbstractSet
+from collections.abc import (
+    Awaitable,
+    Callable,
+    Iterable,
+    Iterator,
+    Mapping,
+    MutableMapping,
+    MutableSet,
+    Reversible,
+    Set as AbstractSet,
+    Sized,
+)
 from io import BufferedRandom, BufferedReader, BufferedWriter, FileIO, TextIOWrapper
 from types import CodeType, TracebackType, _Cell
 from typing import (
     IO,
     Any,
-    Awaitable,
     BinaryIO,
     ByteString,
     ClassVar,
     Generic,
-    Iterable,
-    Iterator,
-    Mapping,
-    MutableMapping,
     MutableSequence,
-    MutableSet,
     NoReturn,
     Protocol,
-    Reversible,
     Sequence,
-    Sized,
     SupportsAbs,
     SupportsBytes,
     SupportsComplex,

--- a/stdlib/bz2.pyi
+++ b/stdlib/bz2.pyi
@@ -2,7 +2,8 @@ import _compression
 import sys
 from _compression import BaseStream
 from _typeshed import ReadableBuffer, Self, StrOrBytesPath, WriteableBuffer
-from typing import IO, Any, Iterable, Protocol, TextIO, overload
+from collections.abc import Iterable
+from typing import IO, Any, Protocol, TextIO, overload
 from typing_extensions import Literal, SupportsIndex, TypeAlias, final
 
 __all__ = ["BZ2File", "BZ2Compressor", "BZ2Decompressor", "open", "compress", "decompress"]

--- a/stdlib/cProfile.pyi
+++ b/stdlib/cProfile.pyi
@@ -1,7 +1,8 @@
 import sys
 from _typeshed import Self, StrOrBytesPath
+from collections.abc import Callable
 from types import CodeType
-from typing import Any, Callable, TypeVar
+from typing import Any, TypeVar
 from typing_extensions import ParamSpec, TypeAlias
 
 __all__ = ["run", "runctx", "Profile"]

--- a/stdlib/cgitb.pyi
+++ b/stdlib/cgitb.pyi
@@ -1,6 +1,7 @@
 from _typeshed import OptExcInfo, StrOrBytesPath
+from collections.abc import Callable
 from types import FrameType, TracebackType
-from typing import IO, Any, Callable
+from typing import IO, Any
 
 __UNDEF__: object  # undocumented sentinel
 

--- a/stdlib/cmd.pyi
+++ b/stdlib/cmd.pyi
@@ -1,4 +1,5 @@
-from typing import IO, Any, Callable
+from collections.abc import Callable
+from typing import IO, Any
 from typing_extensions import Literal
 
 __all__ = ["Cmd"]

--- a/stdlib/code.pyi
+++ b/stdlib/code.pyi
@@ -1,6 +1,7 @@
 from codeop import CommandCompiler
+from collections.abc import Callable, Mapping
 from types import CodeType
-from typing import Any, Callable, Mapping
+from typing import Any
 
 __all__ = ["InteractiveInterpreter", "InteractiveConsole", "interact", "compile_command"]
 

--- a/stdlib/codecs.pyi
+++ b/stdlib/codecs.pyi
@@ -2,7 +2,8 @@ import sys
 import types
 from _typeshed import Self
 from abc import abstractmethod
-from typing import IO, Any, BinaryIO, Callable, Generator, Iterable, Iterator, Protocol, TextIO, overload
+from collections.abc import Callable, Generator, Iterable, Iterator
+from typing import IO, Any, BinaryIO, Protocol, TextIO, overload
 from typing_extensions import Literal, TypeAlias
 
 __all__ = [

--- a/stdlib/concurrent/futures/_base.pyi
+++ b/stdlib/concurrent/futures/_base.pyi
@@ -2,10 +2,10 @@ import sys
 import threading
 from _typeshed import Self
 from abc import abstractmethod
-from collections.abc import Container, Iterable, Iterator, Sequence
+from collections.abc import Callable, Container, Iterable, Iterator, Sequence
 from logging import Logger
 from types import TracebackType
-from typing import Any, Callable, Generic, Protocol, TypeVar, overload
+from typing import Any, Generic, Protocol, TypeVar, overload
 from typing_extensions import Literal, ParamSpec, SupportsIndex
 
 if sys.version_info >= (3, 9):

--- a/stdlib/concurrent/futures/process.pyi
+++ b/stdlib/concurrent/futures/process.pyi
@@ -1,11 +1,11 @@
 import sys
-from collections.abc import Generator, Iterable, Mapping, MutableMapping, MutableSequence
+from collections.abc import Callable, Generator, Iterable, Mapping, MutableMapping, MutableSequence
 from multiprocessing.connection import Connection
 from multiprocessing.context import BaseContext, Process
 from multiprocessing.queues import Queue, SimpleQueue
 from threading import Lock, Semaphore, Thread
 from types import TracebackType
-from typing import Any, Callable, Generic, TypeVar
+from typing import Any, Generic, TypeVar
 from weakref import ref
 
 from ._base import Executor, Future

--- a/stdlib/concurrent/futures/thread.pyi
+++ b/stdlib/concurrent/futures/thread.pyi
@@ -1,8 +1,8 @@
 import queue
 import sys
-from collections.abc import Iterable, Mapping, Set as AbstractSet
+from collections.abc import Callable, Iterable, Mapping, Set as AbstractSet
 from threading import Lock, Semaphore, Thread
-from typing import Any, Callable, Generic, TypeVar
+from typing import Any, Generic, TypeVar
 from weakref import ref
 
 from ._base import Executor, Future

--- a/stdlib/contextlib.pyi
+++ b/stdlib/contextlib.pyi
@@ -1,21 +1,8 @@
 import sys
 from _typeshed import Self, StrOrBytesPath
+from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable, Generator, Iterator
 from types import TracebackType
-from typing import (  # noqa: Y027
-    IO,
-    Any,
-    AsyncGenerator,
-    AsyncIterator,
-    Awaitable,
-    Callable,
-    ContextManager,
-    Generator,
-    Generic,
-    Iterator,
-    Protocol,
-    TypeVar,
-    overload,
-)
+from typing import IO, Any, ContextManager, Generic, Protocol, TypeVar, overload  # noqa: Y027
 from typing_extensions import ParamSpec, TypeAlias
 
 if sys.version_info >= (3, 11):

--- a/stdlib/contextvars.pyi
+++ b/stdlib/contextvars.pyi
@@ -1,5 +1,6 @@
 import sys
-from typing import Any, Callable, ClassVar, Generic, Iterator, Mapping, TypeVar, overload
+from collections.abc import Callable, Iterator, Mapping
+from typing import Any, ClassVar, Generic, TypeVar, overload
 from typing_extensions import ParamSpec, final
 
 if sys.version_info >= (3, 9):

--- a/stdlib/copyreg.pyi
+++ b/stdlib/copyreg.pyi
@@ -1,4 +1,5 @@
-from typing import Any, Callable, Hashable, SupportsInt, TypeVar, Union
+from collections.abc import Callable, Hashable
+from typing import Any, SupportsInt, TypeVar, Union
 from typing_extensions import TypeAlias
 
 _T = TypeVar("_T")

--- a/stdlib/ctypes/__init__.pyi
+++ b/stdlib/ctypes/__init__.pyi
@@ -1,7 +1,8 @@
 import sys
 from _typeshed import ReadableBuffer, Self, WriteableBuffer
 from abc import abstractmethod
-from typing import Any, Callable, ClassVar, Generic, Iterable, Iterator, Mapping, Sequence, TypeVar, Union as _UnionT, overload
+from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
+from typing import Any, ClassVar, Generic, TypeVar, Union as _UnionT, overload
 from typing_extensions import TypeAlias
 
 if sys.version_info >= (3, 9):

--- a/stdlib/curses/__init__.pyi
+++ b/stdlib/curses/__init__.pyi
@@ -1,5 +1,6 @@
 import sys
-from typing import Any, Callable, TypeVar
+from collections.abc import Callable
+from typing import Any, TypeVar
 
 if sys.platform != "win32":
     from _curses import *

--- a/stdlib/curses/textpad.pyi
+++ b/stdlib/curses/textpad.pyi
@@ -1,5 +1,5 @@
 import sys
-from typing import Callable
+from collections.abc import Callable
 
 if sys.platform != "win32":
     from _curses import _CursesWindow

--- a/stdlib/dataclasses.pyi
+++ b/stdlib/dataclasses.pyi
@@ -2,7 +2,8 @@ import enum
 import sys
 import types
 from builtins import type as Type  # alias to avoid name clashes with fields named "type"
-from typing import Any, Callable, Generic, Iterable, Mapping, Protocol, TypeVar, overload
+from collections.abc import Callable, Iterable, Mapping
+from typing import Any, Generic, Protocol, TypeVar, overload
 from typing_extensions import Literal
 
 if sys.version_info >= (3, 9):

--- a/stdlib/dbm/__init__.pyi
+++ b/stdlib/dbm/__init__.pyi
@@ -1,6 +1,6 @@
 from _typeshed import Self
+from collections.abc import Iterator, MutableMapping
 from types import TracebackType
-from typing import Iterator, MutableMapping
 from typing_extensions import Literal, TypeAlias
 
 __all__ = ["open", "whichdb", "error"]

--- a/stdlib/dbm/dumb.pyi
+++ b/stdlib/dbm/dumb.pyi
@@ -1,6 +1,6 @@
 from _typeshed import Self
+from collections.abc import Iterator, MutableMapping
 from types import TracebackType
-from typing import Iterator, MutableMapping
 from typing_extensions import TypeAlias
 
 __all__ = ["error", "open"]

--- a/stdlib/difflib.pyi
+++ b/stdlib/difflib.pyi
@@ -1,5 +1,6 @@
 import sys
-from typing import Any, AnyStr, Callable, Generic, Iterable, Iterator, NamedTuple, Sequence, TypeVar, overload
+from collections.abc import Callable, Iterable, Iterator, Sequence
+from typing import Any, AnyStr, Generic, NamedTuple, TypeVar, overload
 
 if sys.version_info >= (3, 9):
     from types import GenericAlias

--- a/stdlib/dis.pyi
+++ b/stdlib/dis.pyi
@@ -1,8 +1,9 @@
 import sys
 import types
 from _typeshed import Self
+from collections.abc import Callable, Iterator
 from opcode import *  # `dis` re-exports it as a part of public API
-from typing import IO, Any, Callable, Iterator, NamedTuple
+from typing import IO, Any, NamedTuple
 from typing_extensions import TypeAlias
 
 __all__ = [

--- a/stdlib/distutils/ccompiler.pyi
+++ b/stdlib/distutils/ccompiler.pyi
@@ -1,4 +1,5 @@
-from typing import Any, Callable, Union
+from collections.abc import Callable
+from typing import Any, Union
 from typing_extensions import TypeAlias
 
 _Macro: TypeAlias = Union[tuple[str], tuple[str, str | None]]

--- a/stdlib/distutils/cmd.pyi
+++ b/stdlib/distutils/cmd.pyi
@@ -1,6 +1,7 @@
 from abc import abstractmethod
+from collections.abc import Callable, Iterable
 from distutils.dist import Distribution
-from typing import Any, Callable, Iterable
+from typing import Any
 
 class Command:
     sub_commands: list[tuple[str, Callable[[Command], bool] | None]]

--- a/stdlib/distutils/core.pyi
+++ b/stdlib/distutils/core.pyi
@@ -1,7 +1,8 @@
+from collections.abc import Mapping
 from distutils.cmd import Command as Command
 from distutils.dist import Distribution as Distribution
 from distutils.extension import Extension as Extension
-from typing import Any, Mapping
+from typing import Any
 
 def setup(
     *,

--- a/stdlib/distutils/dist.pyi
+++ b/stdlib/distutils/dist.pyi
@@ -1,6 +1,7 @@
 from _typeshed import StrOrBytesPath, SupportsWrite
+from collections.abc import Iterable, Mapping
 from distutils.cmd import Command
-from typing import IO, Any, Iterable, Mapping
+from typing import IO, Any
 
 class DistributionMetadata:
     def __init__(self, path: int | StrOrBytesPath | None = ...) -> None: ...

--- a/stdlib/distutils/fancy_getopt.pyi
+++ b/stdlib/distutils/fancy_getopt.pyi
@@ -1,4 +1,5 @@
-from typing import Any, Iterable, Mapping, overload
+from collections.abc import Iterable, Mapping
+from typing import Any, overload
 from typing_extensions import TypeAlias
 
 _Option: TypeAlias = tuple[str, str | None, str]

--- a/stdlib/distutils/file_util.pyi
+++ b/stdlib/distutils/file_util.pyi
@@ -1,4 +1,4 @@
-from typing import Sequence
+from collections.abc import Sequence
 
 def copy_file(
     src: str,

--- a/stdlib/distutils/filelist.pyi
+++ b/stdlib/distutils/filelist.pyi
@@ -1,4 +1,5 @@
-from typing import Iterable, Pattern, overload
+from collections.abc import Iterable
+from typing import Pattern, overload
 from typing_extensions import Literal
 
 # class is entirely undocumented

--- a/stdlib/distutils/sysconfig.pyi
+++ b/stdlib/distutils/sysconfig.pyi
@@ -1,5 +1,5 @@
+from collections.abc import Mapping
 from distutils.ccompiler import CCompiler
-from typing import Mapping
 
 PREFIX: str
 EXEC_PREFIX: str

--- a/stdlib/doctest.pyi
+++ b/stdlib/doctest.pyi
@@ -1,7 +1,8 @@
 import types
 import unittest
 from _typeshed import ExcInfo
-from typing import Any, Callable, NamedTuple
+from collections.abc import Callable
+from typing import Any, NamedTuple
 from typing_extensions import TypeAlias
 
 __all__ = [

--- a/stdlib/email/__init__.pyi
+++ b/stdlib/email/__init__.pyi
@@ -1,6 +1,7 @@
+from collections.abc import Callable
 from email.message import Message
 from email.policy import Policy
-from typing import IO, Callable, TypeVar, Union
+from typing import IO, TypeVar, Union
 from typing_extensions import TypeAlias
 
 # Definitions imported by multiple submodules in typeshed

--- a/stdlib/email/_header_value_parser.pyi
+++ b/stdlib/email/_header_value_parser.pyi
@@ -1,8 +1,9 @@
 import sys
 from _typeshed import Self
+from collections.abc import Iterable, Iterator
 from email.errors import HeaderParseError, MessageDefect
 from email.policy import Policy
-from typing import Any, Iterable, Iterator, Pattern
+from typing import Any, Pattern
 from typing_extensions import Final
 
 WSP: Final[set[str]]

--- a/stdlib/email/charset.pyi
+++ b/stdlib/email/charset.pyi
@@ -1,4 +1,4 @@
-from typing import Iterator
+from collections.abc import Iterator
 
 __all__ = ["Charset", "add_alias", "add_charset", "add_codec"]
 

--- a/stdlib/email/contentmanager.pyi
+++ b/stdlib/email/contentmanager.pyi
@@ -1,5 +1,6 @@
+from collections.abc import Callable
 from email.message import Message
-from typing import Any, Callable
+from typing import Any
 
 class ContentManager:
     def __init__(self) -> None: ...

--- a/stdlib/email/feedparser.pyi
+++ b/stdlib/email/feedparser.pyi
@@ -1,7 +1,8 @@
+from collections.abc import Callable
 from email import _MessageT
 from email.message import Message
 from email.policy import Policy
-from typing import Callable, Generic, overload
+from typing import Generic, overload
 
 __all__ = ["FeedParser", "BytesFeedParser"]
 

--- a/stdlib/email/iterators.pyi
+++ b/stdlib/email/iterators.pyi
@@ -1,6 +1,6 @@
 from _typeshed import SupportsWrite
+from collections.abc import Iterator
 from email.message import Message
-from typing import Iterator
 
 __all__ = ["body_line_iterator", "typed_subpart_iterator", "walk"]
 

--- a/stdlib/email/message.pyi
+++ b/stdlib/email/message.pyi
@@ -1,9 +1,10 @@
+from collections.abc import Generator, Iterator, Sequence
 from email import _ParamsType, _ParamType
 from email.charset import Charset
 from email.contentmanager import ContentManager
 from email.errors import MessageDefect
 from email.policy import Policy
-from typing import Any, Generator, Iterator, Sequence, TypeVar
+from typing import Any, TypeVar
 from typing_extensions import TypeAlias
 
 __all__ = ["Message", "EmailMessage"]

--- a/stdlib/email/parser.pyi
+++ b/stdlib/email/parser.pyi
@@ -1,8 +1,9 @@
 import email.feedparser
+from collections.abc import Callable
 from email import _MessageT
 from email.message import Message
 from email.policy import Policy
-from typing import BinaryIO, Callable, TextIO
+from typing import BinaryIO, TextIO
 from typing_extensions import TypeAlias
 
 __all__ = ["Parser", "HeaderParser", "BytesParser", "BytesHeaderParser", "FeedParser", "BytesFeedParser"]

--- a/stdlib/email/policy.pyi
+++ b/stdlib/email/policy.pyi
@@ -1,9 +1,10 @@
 from abc import ABCMeta, abstractmethod
+from collections.abc import Callable
 from email.contentmanager import ContentManager
 from email.errors import MessageDefect
 from email.header import Header
 from email.message import Message
-from typing import Any, Callable
+from typing import Any
 
 __all__ = ["Compat32", "compat32", "Policy", "EmailPolicy", "default", "strict", "SMTP", "HTTP"]
 

--- a/stdlib/errno.pyi
+++ b/stdlib/errno.pyi
@@ -1,4 +1,4 @@
-from typing import Mapping
+from collections.abc import Mapping
 
 errorcode: Mapping[int, str]
 

--- a/stdlib/filecmp.pyi
+++ b/stdlib/filecmp.pyi
@@ -1,7 +1,8 @@
 import sys
 from _typeshed import StrOrBytesPath
+from collections.abc import Callable, Iterable, Sequence
 from os import PathLike
-from typing import Any, AnyStr, Callable, Generic, Iterable, Sequence
+from typing import Any, AnyStr, Generic
 from typing_extensions import Literal
 
 if sys.version_info >= (3, 9):

--- a/stdlib/fileinput.pyi
+++ b/stdlib/fileinput.pyi
@@ -1,7 +1,8 @@
 import sys
 from _typeshed import Self, StrOrBytesPath
+from collections.abc import Callable, Iterable, Iterator
 from types import TracebackType
-from typing import IO, Any, AnyStr, Callable, Generic, Iterable, Iterator
+from typing import IO, Any, AnyStr, Generic
 
 __all__ = [
     "input",

--- a/stdlib/fnmatch.pyi
+++ b/stdlib/fnmatch.pyi
@@ -1,4 +1,5 @@
-from typing import AnyStr, Iterable
+from collections.abc import Iterable
+from typing import AnyStr
 
 __all__ = ["filter", "fnmatch", "fnmatchcase", "translate"]
 

--- a/stdlib/formatter.pyi
+++ b/stdlib/formatter.pyi
@@ -1,4 +1,5 @@
-from typing import IO, Any, Iterable
+from collections.abc import Iterable
+from typing import IO, Any
 from typing_extensions import TypeAlias
 
 AS_IS: None

--- a/stdlib/ftplib.pyi
+++ b/stdlib/ftplib.pyi
@@ -1,9 +1,10 @@
 import sys
 from _typeshed import Self, SupportsRead, SupportsReadline
+from collections.abc import Callable, Iterable, Iterator
 from socket import socket
 from ssl import SSLContext
 from types import TracebackType
-from typing import Any, Callable, Iterable, Iterator, TextIO
+from typing import Any, TextIO
 from typing_extensions import Literal
 
 __all__ = ["FTP", "error_reply", "error_temp", "error_perm", "error_proto", "all_errors", "FTP_TLS"]

--- a/stdlib/functools.pyi
+++ b/stdlib/functools.pyi
@@ -1,7 +1,8 @@
 import sys
 import types
 from _typeshed import Self, SupportsAllComparisons, SupportsItems
-from typing import Any, Callable, Generic, Hashable, Iterable, NamedTuple, Sequence, Sized, TypeVar, overload
+from collections.abc import Callable, Hashable, Iterable, Sequence, Sized
+from typing import Any, Generic, NamedTuple, TypeVar, overload
 from typing_extensions import Literal, TypeAlias, final
 
 if sys.version_info >= (3, 9):

--- a/stdlib/gc.pyi
+++ b/stdlib/gc.pyi
@@ -1,5 +1,6 @@
 import sys
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 from typing_extensions import Literal, TypeAlias
 
 DEBUG_COLLECTABLE: Literal[2]

--- a/stdlib/genericpath.pyi
+++ b/stdlib/genericpath.pyi
@@ -1,6 +1,7 @@
 import os
 from _typeshed import BytesPath, StrOrBytesPath, StrPath, SupportsRichComparisonT
-from typing import Sequence, overload
+from collections.abc import Sequence
+from typing import overload
 from typing_extensions import Literal
 
 __all__ = [

--- a/stdlib/glob.pyi
+++ b/stdlib/glob.pyi
@@ -1,6 +1,7 @@
 import sys
 from _typeshed import StrOrBytesPath
-from typing import AnyStr, Iterator
+from collections.abc import Iterator
+from typing import AnyStr
 
 __all__ = ["escape", "glob", "iglob"]
 

--- a/stdlib/graphlib.pyi
+++ b/stdlib/graphlib.pyi
@@ -1,6 +1,7 @@
 import sys
 from _typeshed import SupportsItems
-from typing import Any, Generic, Iterable, TypeVar
+from collections.abc import Iterable
+from typing import Any, Generic, TypeVar
 
 __all__ = ["TopologicalSorter", "CycleError"]
 

--- a/stdlib/hashlib.pyi
+++ b/stdlib/hashlib.pyi
@@ -1,6 +1,6 @@
 import sys
 from _typeshed import ReadableBuffer, Self
-from typing import AbstractSet
+from collections.abc import Set as AbstractSet
 from typing_extensions import final
 
 __all__ = (

--- a/stdlib/heapq.pyi
+++ b/stdlib/heapq.pyi
@@ -1,6 +1,7 @@
 from _heapq import *
 from _typeshed import SupportsRichComparison
-from typing import Any, Callable, Iterable, TypeVar
+from collections.abc import Callable, Iterable
+from typing import Any, TypeVar
 
 __all__ = ["heappush", "heappop", "heapify", "heapreplace", "merge", "nlargest", "nsmallest", "heappushpop"]
 

--- a/stdlib/hmac.pyi
+++ b/stdlib/hmac.pyi
@@ -1,7 +1,8 @@
 import sys
 from _typeshed import ReadableBuffer
+from collections.abc import Callable
 from types import ModuleType
-from typing import Any, AnyStr, Callable, overload
+from typing import Any, AnyStr, overload
 from typing_extensions import TypeAlias
 
 # TODO more precise type for object of hashlib

--- a/stdlib/http/client.pyi
+++ b/stdlib/http/client.pyi
@@ -4,8 +4,9 @@ import ssl
 import sys
 import types
 from _typeshed import Self, WriteableBuffer
+from collections.abc import Callable, Iterable, Iterator, Mapping
 from socket import socket
-from typing import IO, Any, BinaryIO, Callable, Iterable, Iterator, Mapping, Protocol, TypeVar, overload
+from typing import IO, Any, BinaryIO, Protocol, TypeVar, overload
 from typing_extensions import TypeAlias
 
 __all__ = [

--- a/stdlib/http/cookiejar.pyi
+++ b/stdlib/http/cookiejar.pyi
@@ -1,7 +1,8 @@
 import sys
 from _typeshed import StrPath
+from collections.abc import Iterable, Iterator, Sequence
 from http.client import HTTPResponse
-from typing import ClassVar, Iterable, Iterator, Pattern, Sequence, TypeVar, overload
+from typing import ClassVar, Pattern, TypeVar, overload
 from urllib.request import Request
 
 __all__ = [

--- a/stdlib/http/cookies.pyi
+++ b/stdlib/http/cookies.pyi
@@ -1,5 +1,6 @@
 import sys
-from typing import Any, Generic, Iterable, Mapping, TypeVar, overload
+from collections.abc import Iterable, Mapping
+from typing import Any, Generic, TypeVar, overload
 from typing_extensions import TypeAlias
 
 if sys.version_info >= (3, 9):

--- a/stdlib/http/server.pyi
+++ b/stdlib/http/server.pyi
@@ -3,7 +3,8 @@ import io
 import socketserver
 import sys
 from _typeshed import StrPath, SupportsRead, SupportsWrite
-from typing import Any, AnyStr, BinaryIO, ClassVar, Mapping, Sequence
+from collections.abc import Mapping, Sequence
+from typing import Any, AnyStr, BinaryIO, ClassVar
 
 if sys.version_info >= (3, 7):
     __all__ = ["HTTPServer", "ThreadingHTTPServer", "BaseHTTPRequestHandler", "SimpleHTTPRequestHandler", "CGIHTTPRequestHandler"]

--- a/stdlib/imaplib.pyi
+++ b/stdlib/imaplib.pyi
@@ -3,10 +3,11 @@ import sys
 import time
 from _typeshed import Self
 from builtins import list as _list  # conflicts with a method named "list"
+from collections.abc import Callable
 from socket import socket as _socket
 from ssl import SSLContext, SSLSocket
 from types import TracebackType
-from typing import IO, Any, Callable, Pattern
+from typing import IO, Any, Pattern
 from typing_extensions import Literal, TypeAlias
 
 __all__ = ["IMAP4", "IMAP4_stream", "Internaldate2tuple", "Int2AP", "ParseFlags", "Time2Internaldate", "IMAP4_SSL"]

--- a/stdlib/imghdr.pyi
+++ b/stdlib/imghdr.pyi
@@ -1,5 +1,6 @@
 from _typeshed import StrPath
-from typing import Any, BinaryIO, Callable, Protocol, overload
+from collections.abc import Callable
+from typing import Any, BinaryIO, Protocol, overload
 
 __all__ = ["what"]
 

--- a/stdlib/importlib/__init__.pyi
+++ b/stdlib/importlib/__init__.pyi
@@ -1,6 +1,6 @@
+from collections.abc import Mapping, Sequence
 from importlib.abc import Loader
 from types import ModuleType
-from typing import Mapping, Sequence
 
 __all__ = ["__import__", "import_module", "invalidate_caches", "reload"]
 

--- a/stdlib/importlib/abc.pyi
+++ b/stdlib/importlib/abc.pyi
@@ -10,9 +10,10 @@ from _typeshed import (
     StrPath,
 )
 from abc import ABCMeta, abstractmethod
+from collections.abc import Iterator, Mapping, Sequence
 from importlib.machinery import ModuleSpec
 from io import BufferedRandom, BufferedReader, BufferedWriter, FileIO, TextIOWrapper
-from typing import IO, Any, BinaryIO, Iterator, Mapping, NoReturn, Protocol, Sequence, overload, runtime_checkable
+from typing import IO, Any, BinaryIO, NoReturn, Protocol, overload, runtime_checkable
 from typing_extensions import Literal, TypeAlias
 
 _Path: TypeAlias = bytes | str

--- a/stdlib/importlib/machinery.pyi
+++ b/stdlib/importlib/machinery.pyi
@@ -1,7 +1,8 @@
 import importlib.abc
 import sys
 import types
-from typing import Any, Callable, Iterable, Sequence
+from collections.abc import Callable, Iterable, Sequence
+from typing import Any
 
 if sys.version_info >= (3, 8):
     from importlib.metadata import DistributionFinder, PathDistribution

--- a/stdlib/importlib/metadata/__init__.pyi
+++ b/stdlib/importlib/metadata/__init__.pyi
@@ -2,12 +2,12 @@ import abc
 import pathlib
 import sys
 from _typeshed import Self, StrPath
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from email.message import Message
 from importlib.abc import MetaPathFinder
 from os import PathLike
 from pathlib import Path
-from typing import Any, ClassVar, Iterable, NamedTuple, Pattern, overload
+from typing import Any, ClassVar, NamedTuple, Pattern, overload
 
 if sys.version_info >= (3, 10):
     __all__ = [

--- a/stdlib/importlib/metadata/_meta.pyi
+++ b/stdlib/importlib/metadata/_meta.pyi
@@ -1,4 +1,5 @@
-from typing import Any, Iterator, Protocol, TypeVar
+from collections.abc import Iterator
+from typing import Any, Protocol, TypeVar
 
 _T = TypeVar("_T")
 

--- a/stdlib/importlib/resources.pyi
+++ b/stdlib/importlib/resources.pyi
@@ -1,9 +1,10 @@
 import os
 import sys
+from collections.abc import Iterator
 from contextlib import AbstractContextManager
 from pathlib import Path
 from types import ModuleType
-from typing import Any, BinaryIO, Iterator, TextIO
+from typing import Any, BinaryIO, TextIO
 from typing_extensions import TypeAlias
 
 if sys.version_info >= (3, 10):

--- a/stdlib/importlib/util.pyi
+++ b/stdlib/importlib/util.pyi
@@ -3,7 +3,8 @@ import importlib.machinery
 import sys
 import types
 from _typeshed import StrOrBytesPath
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 from typing_extensions import ParamSpec
 
 _P = ParamSpec("_P")

--- a/stdlib/inspect.pyi
+++ b/stdlib/inspect.pyi
@@ -3,7 +3,7 @@ import sys
 import types
 from _typeshed import Self
 from collections import OrderedDict
-from collections.abc import Awaitable, Callable, Generator, Mapping, Sequence, Set as AbstractSet
+from collections.abc import Awaitable, Callable, Coroutine, Generator, Mapping, Sequence, Set as AbstractSet
 from types import (
     AsyncGeneratorType,
     BuiltinFunctionType,
@@ -30,7 +30,7 @@ if sys.version_info >= (3, 7):
         MethodWrapperType,
     )
 
-from typing import Any, ClassVar, Coroutine, NamedTuple, Protocol, TypeVar, Union
+from typing import Any, ClassVar, NamedTuple, Protocol, TypeVar, Union
 from typing_extensions import Literal, ParamSpec, TypeGuard
 
 if sys.version_info >= (3, 11):

--- a/stdlib/io.pyi
+++ b/stdlib/io.pyi
@@ -2,9 +2,10 @@ import builtins
 import codecs
 import sys
 from _typeshed import ReadableBuffer, Self, StrOrBytesPath, WriteableBuffer
+from collections.abc import Callable, Iterable, Iterator
 from os import _Opener
 from types import TracebackType
-from typing import IO, Any, BinaryIO, Callable, Iterable, Iterator, TextIO
+from typing import IO, Any, BinaryIO, TextIO
 from typing_extensions import Literal
 
 if sys.version_info >= (3, 8):

--- a/stdlib/ipaddress.pyi
+++ b/stdlib/ipaddress.pyi
@@ -1,6 +1,7 @@
 import sys
 from _typeshed import Self
-from typing import Any, Container, Generic, Iterable, Iterator, SupportsInt, TypeVar, overload
+from collections.abc import Container, Iterable, Iterator
+from typing import Any, Generic, SupportsInt, TypeVar, overload
 from typing_extensions import Literal, TypeAlias
 
 # Undocumented length constants

--- a/stdlib/itertools.pyi
+++ b/stdlib/itertools.pyi
@@ -1,6 +1,7 @@
 import sys
 from _typeshed import Self
-from typing import Any, Callable, Generic, Iterable, Iterator, SupportsComplex, SupportsFloat, SupportsInt, TypeVar, overload
+from collections.abc import Callable, Iterable, Iterator
+from typing import Any, Generic, SupportsComplex, SupportsFloat, SupportsInt, TypeVar, overload
 from typing_extensions import Literal, SupportsIndex, TypeAlias
 
 if sys.version_info >= (3, 9):

--- a/stdlib/json/__init__.pyi
+++ b/stdlib/json/__init__.pyi
@@ -1,5 +1,6 @@
 from _typeshed import SupportsRead
-from typing import IO, Any, Callable
+from collections.abc import Callable
+from typing import IO, Any
 
 from .decoder import JSONDecodeError as JSONDecodeError, JSONDecoder as JSONDecoder
 from .encoder import JSONEncoder as JSONEncoder

--- a/stdlib/json/decoder.pyi
+++ b/stdlib/json/decoder.pyi
@@ -1,4 +1,5 @@
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 __all__ = ["JSONDecoder", "JSONDecodeError"]
 

--- a/stdlib/json/encoder.pyi
+++ b/stdlib/json/encoder.pyi
@@ -1,4 +1,5 @@
-from typing import Any, Callable, Iterator, Pattern
+from collections.abc import Callable, Iterator
+from typing import Any, Pattern
 
 ESCAPE: Pattern[str]
 ESCAPE_ASCII: Pattern[str]

--- a/stdlib/keyword.pyi
+++ b/stdlib/keyword.pyi
@@ -1,5 +1,5 @@
 import sys
-from typing import Sequence
+from collections.abc import Sequence
 
 if sys.version_info >= (3, 9):
     __all__ = ["iskeyword", "issoftkeyword", "kwlist", "softkwlist"]

--- a/stdlib/lib2to3/pgen2/driver.pyi
+++ b/stdlib/lib2to3/pgen2/driver.pyi
@@ -1,8 +1,9 @@
 from _typeshed import StrPath
+from collections.abc import Iterable
 from lib2to3.pgen2.grammar import Grammar
 from lib2to3.pytree import _NL, _Convert
 from logging import Logger
-from typing import IO, Any, Iterable
+from typing import IO, Any
 
 __all__ = ["Driver", "load_grammar"]
 

--- a/stdlib/lib2to3/pgen2/parse.pyi
+++ b/stdlib/lib2to3/pgen2/parse.pyi
@@ -1,6 +1,7 @@
+from collections.abc import Sequence
 from lib2to3.pgen2.grammar import _DFAS, Grammar
 from lib2to3.pytree import _NL, _Convert, _RawNode
-from typing import Any, Sequence
+from typing import Any
 from typing_extensions import TypeAlias
 
 _Context: TypeAlias = Sequence[Any]

--- a/stdlib/lib2to3/pgen2/pgen.pyi
+++ b/stdlib/lib2to3/pgen2/pgen.pyi
@@ -1,7 +1,8 @@
 from _typeshed import StrPath
+from collections.abc import Iterable, Iterator
 from lib2to3.pgen2 import grammar
 from lib2to3.pgen2.tokenize import _TokenInfo
-from typing import IO, Any, Iterable, Iterator, NoReturn
+from typing import IO, Any, NoReturn
 
 class PgenGrammar(grammar.Grammar): ...
 

--- a/stdlib/lib2to3/pgen2/tokenize.pyi
+++ b/stdlib/lib2to3/pgen2/tokenize.pyi
@@ -1,6 +1,6 @@
 import sys
+from collections.abc import Callable, Iterable, Iterator
 from lib2to3.pgen2.token import *
-from typing import Callable, Iterable, Iterator
 from typing_extensions import TypeAlias
 
 if sys.version_info >= (3, 8):

--- a/stdlib/lib2to3/pytree.pyi
+++ b/stdlib/lib2to3/pytree.pyi
@@ -1,6 +1,7 @@
 from _typeshed import Self
+from collections.abc import Callable, Iterator
 from lib2to3.pgen2.grammar import Grammar
-from typing import Any, Callable, Iterator
+from typing import Any
 from typing_extensions import TypeAlias
 
 _NL: TypeAlias = Node | Leaf

--- a/stdlib/locale.pyi
+++ b/stdlib/locale.pyi
@@ -1,5 +1,6 @@
 import sys
 from _typeshed import StrPath
+from collections.abc import Callable, Iterable, Mapping
 
 __all__ = [
     "getlocale",
@@ -32,7 +33,7 @@ __all__ = [
 # as a type annotation or type alias.
 from builtins import str as _str
 from decimal import Decimal
-from typing import Any, Callable, Iterable, Mapping
+from typing import Any
 
 CODESET: int
 D_T_FMT: int

--- a/stdlib/logging/config.pyi
+++ b/stdlib/logging/config.pyi
@@ -1,9 +1,9 @@
 import sys
 from _typeshed import StrOrBytesPath, StrPath
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from configparser import RawConfigParser
 from threading import Thread
-from typing import IO, Any, Pattern, Sequence
+from typing import IO, Any, Pattern
 
 from . import _Level
 

--- a/stdlib/lzma.pyi
+++ b/stdlib/lzma.pyi
@@ -1,6 +1,7 @@
 import io
 from _typeshed import ReadableBuffer, Self, StrOrBytesPath
-from typing import IO, Any, Mapping, Sequence, TextIO, overload
+from collections.abc import Mapping, Sequence
+from typing import IO, Any, TextIO, overload
 from typing_extensions import Literal, TypeAlias, final
 
 __all__ = [

--- a/stdlib/mailbox.pyi
+++ b/stdlib/mailbox.pyi
@@ -2,8 +2,9 @@ import email.message
 import sys
 from _typeshed import Self, StrOrBytesPath
 from abc import ABCMeta, abstractmethod
+from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from types import TracebackType
-from typing import IO, Any, AnyStr, Callable, Generic, Iterable, Iterator, Mapping, Protocol, Sequence, TypeVar, overload
+from typing import IO, Any, AnyStr, Generic, Protocol, TypeVar, overload
 from typing_extensions import Literal, TypeAlias
 
 if sys.version_info >= (3, 9):

--- a/stdlib/mailcap.pyi
+++ b/stdlib/mailcap.pyi
@@ -1,4 +1,4 @@
-from typing import Mapping, Sequence
+from collections.abc import Mapping, Sequence
 from typing_extensions import TypeAlias
 
 _Cap: TypeAlias = dict[str, str | int]

--- a/stdlib/math.pyi
+++ b/stdlib/math.pyi
@@ -1,6 +1,7 @@
 import sys
 from _typeshed import SupportsTrunc
-from typing import Iterable, SupportsFloat, overload
+from collections.abc import Iterable
+from typing import SupportsFloat, overload
 from typing_extensions import SupportsIndex, TypeAlias
 
 if sys.version_info >= (3, 8):

--- a/stdlib/mimetypes.pyi
+++ b/stdlib/mimetypes.pyi
@@ -1,6 +1,7 @@
 import sys
 from _typeshed import StrPath
-from typing import IO, Sequence
+from collections.abc import Sequence
+from typing import IO
 
 __all__ = [
     "knownfiles",

--- a/stdlib/mmap.pyi
+++ b/stdlib/mmap.pyi
@@ -1,6 +1,7 @@
 import sys
 from _typeshed import ReadableBuffer, Self
-from typing import Iterable, Iterator, NoReturn, Sized, overload
+from collections.abc import Iterable, Iterator, Sized
+from typing import NoReturn, overload
 
 ACCESS_DEFAULT: int
 ACCESS_READ: int

--- a/stdlib/modulefinder.pyi
+++ b/stdlib/modulefinder.pyi
@@ -1,6 +1,7 @@
 import sys
+from collections.abc import Container, Iterable, Iterator, Sequence
 from types import CodeType
-from typing import IO, Any, Container, Iterable, Iterator, Sequence
+from typing import IO, Any
 
 LOAD_CONST: int  # undocumented
 IMPORT_NAME: int  # undocumented

--- a/stdlib/msilib/__init__.pyi
+++ b/stdlib/msilib/__init__.pyi
@@ -1,6 +1,7 @@
 import sys
+from collections.abc import Container, Iterable, Sequence
 from types import ModuleType
-from typing import Any, Container, Iterable, Sequence
+from typing import Any
 from typing_extensions import Literal
 
 if sys.platform == "win32":

--- a/stdlib/multiprocessing/connection.pyi
+++ b/stdlib/multiprocessing/connection.pyi
@@ -2,7 +2,8 @@ import socket
 import sys
 import types
 from _typeshed import Self
-from typing import Any, Iterable, Union
+from collections.abc import Iterable
+from typing import Any, Union
 from typing_extensions import SupportsIndex, TypeAlias
 
 __all__ = ["Client", "Listener", "Pipe", "wait"]

--- a/stdlib/multiprocessing/dummy/__init__.pyi
+++ b/stdlib/multiprocessing/dummy/__init__.pyi
@@ -1,8 +1,9 @@
 import array
 import threading
 import weakref
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from queue import Queue as Queue
-from typing import Any, Callable, Iterable, Mapping, Sequence
+from typing import Any
 from typing_extensions import Literal
 
 from .connection import Pipe as Pipe

--- a/stdlib/multiprocessing/managers.pyi
+++ b/stdlib/multiprocessing/managers.pyi
@@ -2,8 +2,9 @@ import queue
 import sys
 import threading
 from _typeshed import Self
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from types import TracebackType
-from typing import Any, AnyStr, Callable, Generic, Iterable, Mapping, Sequence, TypeVar
+from typing import Any, AnyStr, Generic, TypeVar
 
 from .connection import Connection
 from .context import BaseContext

--- a/stdlib/multiprocessing/pool.pyi
+++ b/stdlib/multiprocessing/pool.pyi
@@ -1,7 +1,8 @@
 import sys
 from _typeshed import Self
+from collections.abc import Callable, Iterable, Iterator, Mapping
 from types import TracebackType
-from typing import Any, Callable, Generic, Iterable, Iterator, Mapping, TypeVar
+from typing import Any, Generic, TypeVar
 from typing_extensions import Literal
 
 if sys.version_info >= (3, 9):

--- a/stdlib/multiprocessing/shared_memory.pyi
+++ b/stdlib/multiprocessing/shared_memory.pyi
@@ -1,6 +1,7 @@
 import sys
 from _typeshed import Self
-from typing import Any, Generic, Iterable, TypeVar
+from collections.abc import Iterable
+from typing import Any, Generic, TypeVar
 
 if sys.version_info >= (3, 9):
     from types import GenericAlias

--- a/stdlib/multiprocessing/spawn.pyi
+++ b/stdlib/multiprocessing/spawn.pyi
@@ -1,5 +1,6 @@
+from collections.abc import Mapping, Sequence
 from types import ModuleType
-from typing import Any, Mapping, Sequence
+from typing import Any
 
 __all__ = [
     "_main",

--- a/stdlib/multiprocessing/synchronize.pyi
+++ b/stdlib/multiprocessing/synchronize.pyi
@@ -1,9 +1,10 @@
 import sys
 import threading
+from collections.abc import Callable
 from contextlib import AbstractContextManager
 from multiprocessing.context import BaseContext
 from types import TracebackType
-from typing import Any, Callable
+from typing import Any
 from typing_extensions import TypeAlias
 
 __all__ = ["Lock", "RLock", "Semaphore", "BoundedSemaphore", "Condition", "Event"]

--- a/stdlib/nntplib.pyi
+++ b/stdlib/nntplib.pyi
@@ -3,7 +3,8 @@ import socket
 import ssl
 import sys
 from _typeshed import Self
-from typing import IO, Any, Iterable, NamedTuple
+from collections.abc import Iterable
+from typing import IO, Any, NamedTuple
 from typing_extensions import Literal, TypeAlias
 
 __all__ = [

--- a/stdlib/optparse.pyi
+++ b/stdlib/optparse.pyi
@@ -1,5 +1,6 @@
 from abc import abstractmethod
-from typing import IO, Any, AnyStr, Callable, Iterable, Mapping, Sequence, overload
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from typing import IO, Any, AnyStr, overload
 
 __all__ = [
     "Option",

--- a/stdlib/os/__init__.pyi
+++ b/stdlib/os/__init__.pyi
@@ -14,27 +14,11 @@ from _typeshed import (
 )
 from abc import abstractmethod
 from builtins import OSError
+from collections.abc import Callable, Iterable, Iterator, Mapping, MutableMapping, Sequence
 from contextlib import AbstractContextManager
 from io import BufferedRandom, BufferedReader, BufferedWriter, FileIO, TextIOWrapper as _TextIOWrapper
 from subprocess import Popen
-from typing import (
-    IO,
-    Any,
-    AnyStr,
-    BinaryIO,
-    Callable,
-    Generic,
-    Iterable,
-    Iterator,
-    Mapping,
-    MutableMapping,
-    NoReturn,
-    Protocol,
-    Sequence,
-    TypeVar,
-    overload,
-    runtime_checkable,
-)
+from typing import IO, Any, AnyStr, BinaryIO, Generic, NoReturn, Protocol, TypeVar, overload, runtime_checkable
 from typing_extensions import Final, Literal, TypeAlias, final
 
 from . import path as _path

--- a/stdlib/parser.pyi
+++ b/stdlib/parser.pyi
@@ -1,6 +1,7 @@
 from _typeshed import StrOrBytesPath
+from collections.abc import Sequence
 from types import CodeType
-from typing import Any, Sequence
+from typing import Any
 from typing_extensions import final
 
 def expr(source: str) -> STType: ...

--- a/stdlib/pathlib.pyi
+++ b/stdlib/pathlib.pyi
@@ -8,10 +8,11 @@ from _typeshed import (
     Self,
     StrPath,
 )
+from collections.abc import Generator, Sequence
 from io import BufferedRandom, BufferedReader, BufferedWriter, FileIO, TextIOWrapper
 from os import PathLike, stat_result
 from types import TracebackType
-from typing import IO, Any, BinaryIO, Generator, Sequence, overload
+from typing import IO, Any, BinaryIO, overload
 from typing_extensions import Literal
 
 if sys.version_info >= (3, 9):

--- a/stdlib/pdb.pyi
+++ b/stdlib/pdb.pyi
@@ -3,9 +3,10 @@ import sys
 from _typeshed import Self
 from bdb import Bdb
 from cmd import Cmd
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from inspect import _SourceObjectType
 from types import CodeType, FrameType, TracebackType
-from typing import IO, Any, Callable, ClassVar, Iterable, Mapping, Sequence, TypeVar
+from typing import IO, Any, ClassVar, TypeVar
 from typing_extensions import ParamSpec
 
 __all__ = ["run", "pm", "Pdb", "runeval", "runctx", "runcall", "set_trace", "post_mortem", "help"]

--- a/stdlib/pickle.pyi
+++ b/stdlib/pickle.pyi
@@ -1,5 +1,6 @@
 import sys
-from typing import Any, Callable, ClassVar, Iterable, Iterator, Mapping, Protocol, Union
+from collections.abc import Callable, Iterable, Iterator, Mapping
+from typing import Any, ClassVar, Protocol, Union
 from typing_extensions import TypeAlias, final
 
 if sys.version_info >= (3, 8):

--- a/stdlib/pickletools.pyi
+++ b/stdlib/pickletools.pyi
@@ -1,4 +1,5 @@
-from typing import IO, Any, Callable, Iterator, MutableMapping
+from collections.abc import Callable, Iterator, MutableMapping
+from typing import IO, Any
 from typing_extensions import TypeAlias
 
 __all__ = ["dis", "genops", "optimize"]

--- a/stdlib/pkgutil.pyi
+++ b/stdlib/pkgutil.pyi
@@ -1,7 +1,8 @@
 import sys
 from _typeshed import SupportsRead
+from collections.abc import Callable, Iterable, Iterator
 from importlib.abc import Loader, MetaPathFinder, PathEntryFinder
-from typing import IO, Any, Callable, Iterable, Iterator, NamedTuple, TypeVar
+from typing import IO, Any, NamedTuple, TypeVar
 
 __all__ = [
     "get_importer",

--- a/stdlib/plistlib.pyi
+++ b/stdlib/plistlib.pyi
@@ -1,8 +1,9 @@
 import sys
 from _typeshed import Self
+from collections.abc import Mapping, MutableMapping
 from datetime import datetime
 from enum import Enum
-from typing import IO, Any, Mapping, MutableMapping
+from typing import IO, Any
 
 if sys.version_info >= (3, 9):
     __all__ = ["InvalidFileException", "FMT_XML", "FMT_BINARY", "load", "dump", "loads", "dumps", "UID"]

--- a/stdlib/posixpath.pyi
+++ b/stdlib/posixpath.pyi
@@ -1,5 +1,6 @@
 import sys
 from _typeshed import BytesPath, StrOrBytesPath, StrPath
+from collections.abc import Sequence
 from genericpath import (
     commonprefix as commonprefix,
     exists as exists,
@@ -14,7 +15,7 @@ from genericpath import (
     samestat as samestat,
 )
 from os import PathLike
-from typing import AnyStr, Sequence, overload
+from typing import AnyStr, overload
 
 __all__ = [
     "normcase",

--- a/stdlib/profile.pyi
+++ b/stdlib/profile.pyi
@@ -1,5 +1,6 @@
 from _typeshed import Self, StrOrBytesPath
-from typing import Any, Callable, TypeVar
+from collections.abc import Callable
+from typing import Any, TypeVar
 from typing_extensions import ParamSpec, TypeAlias
 
 __all__ = ["run", "runctx", "Profile"]

--- a/stdlib/pstats.pyi
+++ b/stdlib/pstats.pyi
@@ -1,8 +1,9 @@
 import sys
 from _typeshed import Self, StrOrBytesPath
+from collections.abc import Iterable
 from cProfile import Profile as _cProfile
 from profile import Profile
-from typing import IO, Any, Iterable, overload
+from typing import IO, Any, overload
 from typing_extensions import Literal, TypeAlias
 
 if sys.version_info >= (3, 9):

--- a/stdlib/pty.pyi
+++ b/stdlib/pty.pyi
@@ -1,5 +1,5 @@
 import sys
-from typing import Callable, Iterable
+from collections.abc import Callable, Iterable
 from typing_extensions import Literal, TypeAlias
 
 if sys.platform != "win32":

--- a/stdlib/pydoc.pyi
+++ b/stdlib/pydoc.pyi
@@ -1,8 +1,9 @@
 from _typeshed import SupportsWrite
 from abc import abstractmethod
+from collections.abc import Callable, Container, Mapping, MutableMapping
 from reprlib import Repr
 from types import MethodType, ModuleType, TracebackType
-from typing import IO, Any, AnyStr, Callable, Container, Mapping, MutableMapping, NoReturn, TypeVar
+from typing import IO, Any, AnyStr, NoReturn, TypeVar
 from typing_extensions import TypeAlias
 
 __all__ = ["help"]

--- a/stdlib/pyexpat/__init__.pyi
+++ b/stdlib/pyexpat/__init__.pyi
@@ -1,7 +1,8 @@
 import pyexpat.errors as errors
 import pyexpat.model as model
 from _typeshed import SupportsRead
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 from typing_extensions import TypeAlias, final
 
 EXPAT_VERSION: str  # undocumented

--- a/stdlib/re.pyi
+++ b/stdlib/re.pyi
@@ -1,8 +1,9 @@
 import enum
 import sre_compile
 import sys
+from collections.abc import Callable, Iterator
 from sre_constants import error as error
-from typing import Any, AnyStr, Callable, Iterator, overload
+from typing import Any, AnyStr, overload
 from typing_extensions import TypeAlias
 
 # ----- re variables and constants -----

--- a/stdlib/readline.pyi
+++ b/stdlib/readline.pyi
@@ -1,6 +1,6 @@
 import sys
 from _typeshed import StrOrBytesPath
-from typing import Callable, Sequence
+from collections.abc import Callable, Sequence
 from typing_extensions import TypeAlias
 
 if sys.platform != "win32":

--- a/stdlib/reprlib.pyi
+++ b/stdlib/reprlib.pyi
@@ -1,6 +1,7 @@
 from array import array
 from collections import deque
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 from typing_extensions import TypeAlias
 
 __all__ = ["Repr", "repr", "recursive_repr"]

--- a/stdlib/sched.pyi
+++ b/stdlib/sched.pyi
@@ -1,5 +1,6 @@
 import sys
-from typing import Any, Callable, NamedTuple
+from collections.abc import Callable
+from typing import Any, NamedTuple
 
 __all__ = ["scheduler"]
 

--- a/stdlib/select.pyi
+++ b/stdlib/select.pyi
@@ -1,7 +1,8 @@
 import sys
 from _typeshed import FileDescriptorLike, Self
+from collections.abc import Iterable
 from types import TracebackType
-from typing import Any, Iterable
+from typing import Any
 from typing_extensions import final
 
 if sys.platform != "win32":

--- a/stdlib/selectors.pyi
+++ b/stdlib/selectors.pyi
@@ -1,7 +1,8 @@
 import sys
 from _typeshed import FileDescriptor, FileDescriptorLike, Self
 from abc import ABCMeta, abstractmethod
-from typing import Any, Mapping, NamedTuple
+from collections.abc import Mapping
+from typing import Any, NamedTuple
 
 _EventMask = int
 

--- a/stdlib/shlex.pyi
+++ b/stdlib/shlex.pyi
@@ -1,6 +1,7 @@
 import sys
 from _typeshed import Self
-from typing import Iterable, TextIO
+from collections.abc import Iterable
+from typing import TextIO
 
 if sys.version_info >= (3, 8):
     __all__ = ["shlex", "split", "quote", "join"]

--- a/stdlib/shutil.pyi
+++ b/stdlib/shutil.pyi
@@ -1,7 +1,8 @@
 import os
 import sys
 from _typeshed import BytesPath, StrOrBytesPath, StrPath, SupportsRead, SupportsWrite
-from typing import Any, AnyStr, Callable, Iterable, NamedTuple, Sequence, TypeVar, overload
+from collections.abc import Callable, Iterable, Sequence
+from typing import Any, AnyStr, NamedTuple, TypeVar, overload
 from typing_extensions import TypeAlias
 
 __all__ = [

--- a/stdlib/signal.pyi
+++ b/stdlib/signal.pyi
@@ -1,8 +1,9 @@
 import sys
 from _typeshed import structseq
+from collections.abc import Callable, Iterable
 from enum import IntEnum
 from types import FrameType
-from typing import Any, Callable, Iterable, Union
+from typing import Any, Union
 from typing_extensions import Final, TypeAlias, final
 
 NSIG: int

--- a/stdlib/site.pyi
+++ b/stdlib/site.pyi
@@ -1,5 +1,5 @@
 from _typeshed import StrPath
-from typing import Iterable
+from collections.abc import Iterable
 
 PREFIXES: list[str]
 ENABLE_USER_SITE: bool | None

--- a/stdlib/smtplib.pyi
+++ b/stdlib/smtplib.pyi
@@ -1,10 +1,11 @@
 import sys
 from _typeshed import Self
+from collections.abc import Sequence
 from email.message import Message as _Message
 from socket import socket
 from ssl import SSLContext
 from types import TracebackType
-from typing import Any, Pattern, Protocol, Sequence, overload
+from typing import Any, Pattern, Protocol, overload
 from typing_extensions import TypeAlias
 
 if sys.version_info >= (3, 7):

--- a/stdlib/socketserver.pyi
+++ b/stdlib/socketserver.pyi
@@ -1,8 +1,9 @@
 import sys
 import types
 from _typeshed import Self
+from collections.abc import Callable
 from socket import socket as _socket
-from typing import Any, BinaryIO, Callable, ClassVar, Union
+from typing import Any, BinaryIO, ClassVar, Union
 from typing_extensions import TypeAlias
 
 if sys.platform == "win32":

--- a/stdlib/sre_parse.pyi
+++ b/stdlib/sre_parse.pyi
@@ -1,7 +1,8 @@
 import sys
+from collections.abc import Iterable
 from sre_constants import *
 from sre_constants import _NamedIntConstant as _NIC, error as _Error
-from typing import Any, Iterable, Match, Pattern as _Pattern, overload
+from typing import Any, Match, Pattern as _Pattern, overload
 from typing_extensions import TypeAlias
 
 SPECIAL_CHARS: str

--- a/stdlib/ssl.pyi
+++ b/stdlib/ssl.pyi
@@ -2,7 +2,8 @@ import enum
 import socket
 import sys
 from _typeshed import ReadableBuffer, Self, StrOrBytesPath, WriteableBuffer
-from typing import Any, Callable, Iterable, NamedTuple, Union, overload
+from collections.abc import Callable, Iterable
+from typing import Any, NamedTuple, Union, overload
 from typing_extensions import Literal, TypeAlias, TypedDict, final
 
 _PCTRTT: TypeAlias = tuple[tuple[str, str], ...]

--- a/stdlib/statistics.pyi
+++ b/stdlib/statistics.pyi
@@ -1,8 +1,9 @@
 import sys
 from _typeshed import Self, SupportsRichComparisonT
+from collections.abc import Hashable, Iterable, Sequence
 from decimal import Decimal
 from fractions import Fraction
-from typing import Any, Hashable, Iterable, NamedTuple, Sequence, SupportsFloat, TypeVar
+from typing import Any, NamedTuple, SupportsFloat, TypeVar
 from typing_extensions import Literal, TypeAlias
 
 if sys.version_info >= (3, 10):

--- a/stdlib/string.pyi
+++ b/stdlib/string.pyi
@@ -1,6 +1,7 @@
 import sys
+from collections.abc import Iterable, Mapping, Sequence
 from re import RegexFlag
-from typing import Any, Iterable, Mapping, Sequence
+from typing import Any
 
 if sys.version_info >= (3, 8):
     from re import Pattern

--- a/stdlib/struct.pyi
+++ b/stdlib/struct.pyi
@@ -1,6 +1,7 @@
 import sys
 from _typeshed import ReadableBuffer, WriteableBuffer
-from typing import Any, Iterator
+from collections.abc import Iterator
+from typing import Any
 
 __all__ = ["calcsize", "pack", "pack_into", "unpack", "unpack_from", "iter_unpack", "Struct", "error"]
 

--- a/stdlib/subprocess.pyi
+++ b/stdlib/subprocess.pyi
@@ -1,7 +1,8 @@
 import sys
 from _typeshed import Self, StrOrBytesPath
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from types import TracebackType
-from typing import IO, Any, AnyStr, Callable, Generic, Iterable, Mapping, Sequence, TypeVar, overload
+from typing import IO, Any, AnyStr, Generic, TypeVar, overload
 from typing_extensions import Literal, TypeAlias
 
 if sys.version_info >= (3, 9):

--- a/stdlib/symtable.pyi
+++ b/stdlib/symtable.pyi
@@ -1,5 +1,6 @@
 import sys
-from typing import Any, Sequence
+from collections.abc import Sequence
+from typing import Any
 
 __all__ = ["symtable", "SymbolTable", "Class", "Function", "Symbol"]
 

--- a/stdlib/sys.pyi
+++ b/stdlib/sys.pyi
@@ -1,11 +1,12 @@
 import sys
 from _typeshed import OptExcInfo, structseq
 from builtins import object as _object
+from collections.abc import AsyncGenerator, Callable, Coroutine, Sequence
 from importlib.abc import PathEntryFinder
 from importlib.machinery import ModuleSpec
 from io import TextIOWrapper
 from types import FrameType, ModuleType, TracebackType
-from typing import Any, AsyncGenerator, Callable, Coroutine, NoReturn, Protocol, Sequence, TextIO, TypeVar, overload
+from typing import Any, NoReturn, Protocol, TextIO, TypeVar, overload
 from typing_extensions import Literal, TypeAlias, final
 
 _T = TypeVar("_T")

--- a/stdlib/tabnanny.pyi
+++ b/stdlib/tabnanny.pyi
@@ -1,5 +1,5 @@
 from _typeshed import StrOrBytesPath
-from typing import Iterable
+from collections.abc import Iterable
 
 __all__ = ["check", "NannyNag", "process_tokens"]
 

--- a/stdlib/telnetlib.pyi
+++ b/stdlib/telnetlib.pyi
@@ -1,7 +1,8 @@
 import socket
 from _typeshed import Self
+from collections.abc import Callable, Sequence
 from types import TracebackType
-from typing import Any, Callable, Match, Pattern, Sequence
+from typing import Any, Match, Pattern
 
 __all__ = ["Telnet"]
 

--- a/stdlib/tempfile.pyi
+++ b/stdlib/tempfile.pyi
@@ -1,8 +1,9 @@
 import os
 import sys
 from _typeshed import Self
+from collections.abc import Iterable, Iterator
 from types import TracebackType
-from typing import IO, Any, AnyStr, Generic, Iterable, Iterator, overload
+from typing import IO, Any, AnyStr, Generic, overload
 from typing_extensions import Literal, TypeAlias
 
 if sys.version_info >= (3, 9):

--- a/stdlib/textwrap.pyi
+++ b/stdlib/textwrap.pyi
@@ -1,4 +1,5 @@
-from typing import Callable, Pattern
+from collections.abc import Callable
+from typing import Pattern
 
 __all__ = ["TextWrapper", "wrap", "fill", "dedent", "indent", "shorten"]
 

--- a/stdlib/threading.pyi
+++ b/stdlib/threading.pyi
@@ -1,6 +1,7 @@
 import sys
+from collections.abc import Callable, Iterable, Mapping
 from types import FrameType, TracebackType
-from typing import Any, Callable, Iterable, Mapping, TypeVar
+from typing import Any, TypeVar
 from typing_extensions import TypeAlias
 
 # TODO recursive type

--- a/stdlib/timeit.pyi
+++ b/stdlib/timeit.pyi
@@ -1,4 +1,5 @@
-from typing import IO, Any, Callable, Sequence
+from collections.abc import Callable, Sequence
+from typing import IO, Any
 from typing_extensions import TypeAlias
 
 __all__ = ["Timer", "timeit", "repeat", "default_timer"]

--- a/stdlib/tkinter/__init__.pyi
+++ b/stdlib/tkinter/__init__.pyi
@@ -1,11 +1,12 @@
 import _tkinter
 import sys
 from _typeshed import StrOrBytesPath
+from collections.abc import Callable, Mapping, Sequence
 from enum import Enum
 from tkinter.constants import *
 from tkinter.font import _FontDescription
 from types import TracebackType
-from typing import Any, Callable, Generic, Mapping, Protocol, Sequence, TypeVar, Union, overload
+from typing import Any, Generic, Protocol, TypeVar, Union, overload
 from typing_extensions import Literal, TypeAlias, TypedDict
 
 if sys.version_info >= (3, 9):

--- a/stdlib/tkinter/commondialog.pyi
+++ b/stdlib/tkinter/commondialog.pyi
@@ -1,5 +1,6 @@
 import sys
-from typing import Any, ClassVar, Mapping
+from collections.abc import Mapping
+from typing import Any, ClassVar
 
 if sys.version_info >= (3, 9):
     __all__ = ["Dialog"]

--- a/stdlib/tkinter/dialog.pyi
+++ b/stdlib/tkinter/dialog.pyi
@@ -1,6 +1,7 @@
 import sys
+from collections.abc import Mapping
 from tkinter import Widget
-from typing import Any, Mapping
+from typing import Any
 
 if sys.version_info >= (3, 9):
     __all__ = ["Dialog"]

--- a/stdlib/tkinter/filedialog.pyi
+++ b/stdlib/tkinter/filedialog.pyi
@@ -1,7 +1,8 @@
 import sys
 from _typeshed import StrOrBytesPath
+from collections.abc import Iterable
 from tkinter import Button, Entry, Frame, Listbox, Misc, Scrollbar, StringVar, Toplevel, commondialog
-from typing import IO, Any, ClassVar, Iterable
+from typing import IO, Any, ClassVar
 from typing_extensions import Literal
 
 if sys.version_info >= (3, 9):

--- a/stdlib/tkinter/ttk.pyi
+++ b/stdlib/tkinter/ttk.pyi
@@ -1,8 +1,9 @@
 import _tkinter
 import sys
 import tkinter
+from collections.abc import Callable
 from tkinter.font import _FontDescription
-from typing import Any, Callable, overload
+from typing import Any, overload
 from typing_extensions import Literal, TypeAlias, TypedDict
 
 if sys.version_info >= (3, 7):

--- a/stdlib/tokenize.pyi
+++ b/stdlib/tokenize.pyi
@@ -1,8 +1,9 @@
 import sys
 from _typeshed import StrOrBytesPath
 from builtins import open as _builtin_open
+from collections.abc import Callable, Generator, Iterable, Sequence
 from token import *
-from typing import Any, Callable, Generator, Iterable, NamedTuple, Pattern, Sequence, TextIO
+from typing import Any, NamedTuple, Pattern, TextIO
 from typing_extensions import TypeAlias
 
 if sys.version_info >= (3, 10):

--- a/stdlib/trace.pyi
+++ b/stdlib/trace.pyi
@@ -1,7 +1,8 @@
 import sys
 import types
 from _typeshed import StrPath
-from typing import Any, Callable, Mapping, Sequence, TypeVar
+from collections.abc import Callable, Mapping, Sequence
+from typing import Any, TypeVar
 from typing_extensions import ParamSpec, TypeAlias
 
 __all__ = ["Trace", "CoverageResults"]

--- a/stdlib/traceback.pyi
+++ b/stdlib/traceback.pyi
@@ -1,7 +1,8 @@
 import sys
 from _typeshed import Self, SupportsWrite
+from collections.abc import Generator, Iterable, Iterator, Mapping
 from types import FrameType, TracebackType
-from typing import IO, Any, Generator, Iterable, Iterator, Mapping, overload
+from typing import IO, Any, overload
 from typing_extensions import Literal, TypeAlias
 
 __all__ = [

--- a/stdlib/tracemalloc.pyi
+++ b/stdlib/tracemalloc.pyi
@@ -1,6 +1,7 @@
 import sys
 from _tracemalloc import *
-from typing import Any, Sequence, Union, overload
+from collections.abc import Sequence
+from typing import Any, Union, overload
 from typing_extensions import SupportsIndex, TypeAlias
 
 def get_object_traceback(obj: object) -> Traceback | None: ...

--- a/stdlib/turtle.pyi
+++ b/stdlib/turtle.pyi
@@ -1,6 +1,7 @@
 from _typeshed import Self
+from collections.abc import Callable, Sequence
 from tkinter import Canvas, Frame, Misc, PhotoImage, Scrollbar
-from typing import Any, Callable, ClassVar, Sequence, Union, overload
+from typing import Any, ClassVar, Union, overload
 from typing_extensions import TypeAlias
 
 __all__ = [

--- a/stdlib/types.pyi
+++ b/stdlib/types.pyi
@@ -10,13 +10,12 @@ from collections.abc import (
     Iterable,
     Iterator,
     KeysView,
-    Mapping,
     MutableSequence,
     ValuesView,
 )
 from importlib.abc import _LoaderProtocol
 from importlib.machinery import ModuleSpec
-from typing import Any, ClassVar, Generic, TypeVar, overload
+from typing import Any, ClassVar, Generic, Mapping, TypeVar, overload
 from typing_extensions import Literal, ParamSpec, final
 
 if sys.version_info >= (3, 10):

--- a/stdlib/types.pyi
+++ b/stdlib/types.pyi
@@ -1,26 +1,22 @@
 import sys
 from _typeshed import SupportsKeysAndGetItem
-from importlib.abc import _LoaderProtocol
-from importlib.machinery import ModuleSpec
-from typing import (
-    Any,
+from collections.abc import (
     AsyncGenerator,
     Awaitable,
     Callable,
-    ClassVar,
     Coroutine,
     Generator,
-    Generic,
     ItemsView,
     Iterable,
     Iterator,
     KeysView,
     Mapping,
     MutableSequence,
-    TypeVar,
     ValuesView,
-    overload,
 )
+from importlib.abc import _LoaderProtocol
+from importlib.machinery import ModuleSpec
+from typing import Any, ClassVar, Generic, TypeVar, overload
 from typing_extensions import Literal, ParamSpec, final
 
 if sys.version_info >= (3, 10):

--- a/stdlib/unittest/async_case.pyi
+++ b/stdlib/unittest/async_case.pyi
@@ -1,4 +1,4 @@
-from typing import Awaitable, Callable
+from collections.abc import Awaitable, Callable
 from typing_extensions import ParamSpec
 
 from .case import TestCase

--- a/stdlib/unittest/case.pyi
+++ b/stdlib/unittest/case.pyi
@@ -3,25 +3,10 @@ import logging
 import sys
 import unittest.result
 from _typeshed import Self
-from collections.abc import Set as AbstractSet
+from collections.abc import Callable, Container, Iterable, Mapping, Sequence, Set as AbstractSet
 from contextlib import AbstractContextManager
 from types import TracebackType
-from typing import (
-    Any,
-    AnyStr,
-    Callable,
-    ClassVar,
-    Container,
-    Generic,
-    Iterable,
-    Mapping,
-    NamedTuple,
-    NoReturn,
-    Pattern,
-    Sequence,
-    TypeVar,
-    overload,
-)
+from typing import Any, AnyStr, ClassVar, Generic, NamedTuple, NoReturn, Pattern, TypeVar, overload
 from typing_extensions import ParamSpec
 from warnings import WarningMessage
 

--- a/stdlib/unittest/loader.pyi
+++ b/stdlib/unittest/loader.pyi
@@ -2,8 +2,9 @@ import sys
 import unittest.case
 import unittest.result
 import unittest.suite
+from collections.abc import Callable, Sequence
 from types import ModuleType
-from typing import Any, Callable, Pattern, Sequence
+from typing import Any, Pattern
 from typing_extensions import TypeAlias
 
 _SortComparisonMethod: TypeAlias = Callable[[str, str], int]

--- a/stdlib/unittest/main.pyi
+++ b/stdlib/unittest/main.pyi
@@ -3,8 +3,9 @@ import unittest.case
 import unittest.loader
 import unittest.result
 import unittest.suite
+from collections.abc import Iterable
 from types import ModuleType
-from typing import Any, Iterable, Protocol
+from typing import Any, Protocol
 
 MAIN_EXAMPLES: str
 MODULE_EXAMPLES: str

--- a/stdlib/unittest/mock.pyi
+++ b/stdlib/unittest/mock.pyi
@@ -1,8 +1,9 @@
 import sys
 from _typeshed import Self
+from collections.abc import Awaitable, Callable, Iterable, Mapping, Sequence
 from contextlib import _GeneratorContextManager
 from types import TracebackType
-from typing import Any, Awaitable, Callable, Generic, Iterable, Mapping, Sequence, TypeVar, overload
+from typing import Any, Generic, TypeVar, overload
 from typing_extensions import Literal, TypeAlias
 
 _T = TypeVar("_T")

--- a/stdlib/unittest/result.pyi
+++ b/stdlib/unittest/result.pyi
@@ -1,6 +1,7 @@
 import unittest.case
+from collections.abc import Callable
 from types import TracebackType
-from typing import Any, Callable, TextIO, TypeVar, Union
+from typing import Any, TextIO, TypeVar, Union
 from typing_extensions import TypeAlias
 
 _SysExcInfoType: TypeAlias = Union[tuple[type[BaseException], BaseException, TracebackType], tuple[None, None, None]]

--- a/stdlib/unittest/runner.pyi
+++ b/stdlib/unittest/runner.pyi
@@ -1,7 +1,8 @@
 import unittest.case
 import unittest.result
 import unittest.suite
-from typing import Callable, Iterable, TextIO
+from collections.abc import Callable, Iterable
+from typing import TextIO
 from typing_extensions import TypeAlias
 
 _ResultClassType: TypeAlias = Callable[[TextIO, bool, int], unittest.result.TestResult]

--- a/stdlib/unittest/signals.pyi
+++ b/stdlib/unittest/signals.pyi
@@ -1,5 +1,6 @@
 import unittest.result
-from typing import Callable, TypeVar, overload
+from collections.abc import Callable
+from typing import TypeVar, overload
 from typing_extensions import ParamSpec
 
 _P = ParamSpec("_P")

--- a/stdlib/unittest/suite.pyi
+++ b/stdlib/unittest/suite.pyi
@@ -1,6 +1,6 @@
 import unittest.case
 import unittest.result
-from typing import Iterable, Iterator
+from collections.abc import Iterable, Iterator
 from typing_extensions import TypeAlias
 
 _TestType: TypeAlias = unittest.case.TestCase | TestSuite

--- a/stdlib/unittest/util.pyi
+++ b/stdlib/unittest/util.pyi
@@ -1,4 +1,5 @@
-from typing import Any, Sequence, TypeVar
+from collections.abc import Sequence
+from typing import Any, TypeVar
 from typing_extensions import TypeAlias
 
 _T = TypeVar("_T")

--- a/stdlib/urllib/parse.pyi
+++ b/stdlib/urllib/parse.pyi
@@ -1,5 +1,6 @@
 import sys
-from typing import Any, AnyStr, Callable, Generic, Mapping, NamedTuple, Sequence, overload
+from collections.abc import Callable, Mapping, Sequence
+from typing import Any, AnyStr, Generic, NamedTuple, overload
 from typing_extensions import TypeAlias
 
 if sys.version_info >= (3, 9):

--- a/stdlib/urllib/request.pyi
+++ b/stdlib/urllib/request.pyi
@@ -1,10 +1,11 @@
 import ssl
 import sys
 from _typeshed import StrOrBytesPath, SupportsRead
+from collections.abc import Callable, Iterable, Mapping, MutableMapping, Sequence
 from email.message import Message
 from http.client import HTTPMessage, HTTPResponse, _HTTPConnectionProtocol
 from http.cookiejar import CookieJar
-from typing import IO, Any, Callable, ClassVar, Iterable, Mapping, MutableMapping, NoReturn, Pattern, Sequence, TypeVar, overload
+from typing import IO, Any, ClassVar, NoReturn, Pattern, TypeVar, overload
 from typing_extensions import TypeAlias
 from urllib.error import HTTPError
 from urllib.response import addclosehook, addinfourl

--- a/stdlib/urllib/response.pyi
+++ b/stdlib/urllib/response.pyi
@@ -1,8 +1,9 @@
 import sys
 from _typeshed import Self
+from collections.abc import Callable, Iterable
 from email.message import Message
 from types import TracebackType
-from typing import IO, Any, BinaryIO, Callable, Iterable
+from typing import IO, Any, BinaryIO
 
 __all__ = ["addbase", "addclosehook", "addinfo", "addinfourl"]
 

--- a/stdlib/urllib/robotparser.pyi
+++ b/stdlib/urllib/robotparser.pyi
@@ -1,5 +1,6 @@
 import sys
-from typing import Iterable, NamedTuple
+from collections.abc import Iterable
+from typing import NamedTuple
 
 __all__ = ["RobotFileParser"]
 

--- a/stdlib/venv/__init__.pyi
+++ b/stdlib/venv/__init__.pyi
@@ -1,7 +1,8 @@
+from collections.abc import Sequence
 import sys
 from _typeshed import StrOrBytesPath
 from types import SimpleNamespace
-from typing import Sequence
+
 
 if sys.version_info >= (3, 9):
     CORE_VENV_DEPS: tuple[str, ...]

--- a/stdlib/warnings.pyi
+++ b/stdlib/warnings.pyi
@@ -1,6 +1,7 @@
 from _warnings import warn as warn, warn_explicit as warn_explicit
+from collections.abc import Sequence
 from types import ModuleType, TracebackType
-from typing import Any, Sequence, TextIO, overload
+from typing import Any, TextIO, overload
 from typing_extensions import Literal, TypeAlias
 
 __all__ = [

--- a/stdlib/weakref.pyi
+++ b/stdlib/weakref.pyi
@@ -1,7 +1,8 @@
 import sys
 from _typeshed import Self, SupportsKeysAndGetItem
 from _weakrefset import WeakSet as WeakSet
-from typing import Any, Callable, Generic, Iterable, Iterator, Mapping, MutableMapping, TypeVar, overload
+from collections.abc import Callable, Iterable, Iterator, Mapping, MutableMapping
+from typing import Any, Generic, TypeVar, overload
 from typing_extensions import ParamSpec
 
 from _weakref import (

--- a/stdlib/webbrowser.pyi
+++ b/stdlib/webbrowser.pyi
@@ -1,6 +1,6 @@
 import sys
 from abc import abstractmethod
-from typing import Callable, Sequence
+from collections.abc import Callable, Sequence
 from typing_extensions import Literal
 
 __all__ = ["Error", "open", "open_new", "open_new_tab", "get", "register"]

--- a/stdlib/wsgiref/handlers.pyi
+++ b/stdlib/wsgiref/handlers.pyi
@@ -1,7 +1,8 @@
 from _typeshed import OptExcInfo
 from _typeshed.wsgi import ErrorStream, InputStream, StartResponse, WSGIApplication, WSGIEnvironment
 from abc import abstractmethod
-from typing import IO, Callable, MutableMapping
+from collections.abc import Callable, MutableMapping
+from typing import IO
 
 from .headers import Headers
 from .util import FileWrapper

--- a/stdlib/wsgiref/util.pyi
+++ b/stdlib/wsgiref/util.pyi
@@ -1,6 +1,7 @@
 import sys
 from _typeshed.wsgi import WSGIEnvironment
-from typing import IO, Any, Callable
+from collections.abc import Callable
+from typing import IO, Any
 
 __all__ = ["FileWrapper", "guess_scheme", "application_uri", "request_uri", "shift_path_info", "setup_testing_defaults"]
 

--- a/stdlib/wsgiref/validate.pyi
+++ b/stdlib/wsgiref/validate.pyi
@@ -1,5 +1,6 @@
 from _typeshed.wsgi import ErrorStream, InputStream, WSGIApplication
-from typing import Any, Callable, Iterable, Iterator, NoReturn
+from collections.abc import Callable, Iterable, Iterator
+from typing import Any, NoReturn
 
 __all__ = ["validator"]
 

--- a/stdlib/xdrlib.pyi
+++ b/stdlib/xdrlib.pyi
@@ -1,4 +1,5 @@
-from typing import Callable, Sequence, TypeVar
+from collections.abc import Callable, Sequence
+from typing import TypeVar
 
 __all__ = ["Error", "Packer", "Unpacker", "ConversionError"]
 

--- a/stdlib/xml/dom/domreg.pyi
+++ b/stdlib/xml/dom/domreg.pyi
@@ -1,5 +1,5 @@
 from _typeshed.xml import DOMImplementation
-from typing import Callable, Iterable
+from collections.abc import Callable, Iterable
 
 well_known_implementations: dict[str, str]
 registered: dict[str, Callable[[], DOMImplementation]]

--- a/stdlib/xml/dom/minicompat.pyi
+++ b/stdlib/xml/dom/minicompat.pyi
@@ -1,4 +1,5 @@
-from typing import Any, Iterable, TypeVar
+from collections.abc import Iterable
+from typing import Any, TypeVar
 
 __all__ = ["NodeList", "EmptyNodeList", "StringTypes", "defproperty"]
 

--- a/stdlib/xml/dom/pulldom.pyi
+++ b/stdlib/xml/dom/pulldom.pyi
@@ -1,6 +1,7 @@
 import sys
 from _typeshed import SupportsRead
-from typing import Any, Sequence
+from collections.abc import Sequence
+from typing import Any
 from typing_extensions import Literal, TypeAlias
 from xml.dom.minidom import Document, DOMImplementation, Element, Text
 from xml.sax.handler import ContentHandler

--- a/stdlib/xml/etree/ElementInclude.pyi
+++ b/stdlib/xml/etree/ElementInclude.pyi
@@ -1,5 +1,5 @@
 import sys
-from typing import Callable
+from collections.abc import Callable
 from xml.etree.ElementTree import Element
 
 XINCLUDE: str

--- a/stdlib/xml/etree/ElementPath.pyi
+++ b/stdlib/xml/etree/ElementPath.pyi
@@ -1,4 +1,5 @@
-from typing import Callable, Generator, Pattern, TypeVar
+from collections.abc import Callable, Generator
+from typing import Pattern, TypeVar
 from typing_extensions import TypeAlias
 from xml.etree.ElementTree import Element
 

--- a/stdlib/xml/etree/ElementTree.pyi
+++ b/stdlib/xml/etree/ElementTree.pyi
@@ -1,19 +1,7 @@
 import sys
 from _typeshed import FileDescriptor, StrOrBytesPath, SupportsRead, SupportsWrite
-from typing import (
-    Any,
-    Callable,
-    Generator,
-    ItemsView,
-    Iterable,
-    Iterator,
-    KeysView,
-    Mapping,
-    MutableSequence,
-    Sequence,
-    TypeVar,
-    overload,
-)
+from collections.abc import Callable, Generator, ItemsView, Iterable, Iterator, KeysView, Mapping, MutableSequence, Sequence
+from typing import Any, TypeVar, overload
 from typing_extensions import Literal, SupportsIndex, TypeAlias, TypeGuard
 
 if sys.version_info >= (3, 9):

--- a/stdlib/xml/sax/__init__.pyi
+++ b/stdlib/xml/sax/__init__.pyi
@@ -1,6 +1,7 @@
 import sys
 from _typeshed import SupportsRead, _T_co
-from typing import Any, Iterable, NoReturn, Protocol
+from collections.abc import Iterable
+from typing import Any, NoReturn, Protocol
 from xml.sax.handler import ContentHandler, ErrorHandler
 from xml.sax.xmlreader import Locator, XMLReader
 

--- a/stdlib/xml/sax/saxutils.pyi
+++ b/stdlib/xml/sax/saxutils.pyi
@@ -1,7 +1,7 @@
 from _typeshed import SupportsWrite
 from codecs import StreamReaderWriter, StreamWriter
+from collections.abc import Mapping
 from io import RawIOBase, TextIOBase
-from typing import Mapping
 from xml.sax import handler, xmlreader
 
 def escape(data: str, entities: Mapping[str, str] = ...) -> str: ...

--- a/stdlib/xml/sax/xmlreader.pyi
+++ b/stdlib/xml/sax/xmlreader.pyi
@@ -1,4 +1,4 @@
-from typing import Mapping
+from collections.abc import Mapping
 
 class XMLReader:
     def __init__(self) -> None: ...

--- a/stdlib/xmlrpc/client.pyi
+++ b/stdlib/xmlrpc/client.pyi
@@ -3,10 +3,11 @@ import http.client
 import sys
 import time
 from _typeshed import Self, SupportsRead, SupportsWrite
+from collections.abc import Callable, Iterable, Mapping
 from datetime import datetime
 from io import BytesIO
 from types import TracebackType
-from typing import Any, Callable, Iterable, Mapping, Protocol, Union, overload
+from typing import Any, Protocol, Union, overload
 from typing_extensions import Literal, TypeAlias
 
 class _SupportsTimeTuple(Protocol):

--- a/stdlib/xmlrpc/server.pyi
+++ b/stdlib/xmlrpc/server.pyi
@@ -2,8 +2,9 @@ import http.server
 import pydoc
 import socketserver
 import sys
+from collections.abc import Callable, Iterable, Mapping
 from datetime import datetime
-from typing import Any, Callable, Iterable, Mapping, Pattern, Protocol
+from typing import Any, Pattern, Protocol
 from typing_extensions import TypeAlias
 from xmlrpc.client import Fault
 

--- a/stdlib/zipapp.pyi
+++ b/stdlib/zipapp.pyi
@@ -1,6 +1,7 @@
 import sys
+from collections.abc import Callable
 from pathlib import Path
-from typing import BinaryIO, Callable
+from typing import BinaryIO
 from typing_extensions import TypeAlias
 
 __all__ = ["ZipAppError", "create_archive", "get_interpreter"]

--- a/stdlib/zipfile.pyi
+++ b/stdlib/zipfile.pyi
@@ -1,9 +1,10 @@
 import io
 import sys
 from _typeshed import Self, StrOrBytesPath, StrPath
+from collections.abc import Callable, Iterable, Iterator, Sequence
 from os import PathLike
 from types import TracebackType
-from typing import IO, Any, Callable, Iterable, Iterator, Protocol, Sequence, overload
+from typing import IO, Any, Protocol, overload
 from typing_extensions import Literal, TypeAlias
 
 if sys.version_info >= (3, 8):

--- a/stdlib/zoneinfo/__init__.pyi
+++ b/stdlib/zoneinfo/__init__.pyi
@@ -1,6 +1,7 @@
 from _typeshed import Self, StrPath
+from collections.abc import Iterable, Sequence
 from datetime import tzinfo
-from typing import Any, Iterable, Protocol, Sequence
+from typing import Any, Protocol
 
 __all__ = ["ZoneInfo", "reset_tzpath", "available_timezones", "TZPATH", "ZoneInfoNotFoundError", "InvalidTZPathWarning"]
 


### PR DESCRIPTION
We still can't do `collections.abc` imports in `builtins` (it still causes mypy crashes).

Also, there were lots of pytype crashes the last time I tried doing this (https://github.com/python/typeshed/pull/6688). I'm not sure where pytype stands on this now.