### PR TITLE
Use PEP 585 syntax in `collections`

### DIFF
--- a/stdlib/collections/__init__.pyi
+++ b/stdlib/collections/__init__.pyi
@@ -8,7 +8,7 @@ if sys.version_info >= (3, 9):
     from types import GenericAlias
 
 if sys.version_info >= (3, 10):
-    from typing import Callable, Iterable, Iterator, Mapping, MutableMapping, MutableSequence, Reversible, Sequence
+    from collections.abc import Callable, Iterable, Iterator, Mapping, MutableMapping, MutableSequence, Reversible, Sequence
 else:
     from _collections_abc import *
 


### PR DESCRIPTION
For some reason I excluded this in the script I used in #7635. I think I remember the last time I tried refactoring typeshed to use PEP 585 syntax everwhere (#6688), it caused mypy crashes if I imported from `collections.abc` inside `collections/__init__.pyi`. But it doesn't seem to now, anyway :)