### PR TITLE
Fix crash when running mypy master against typeshed master

### DIFF
--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -22,22 +22,11 @@ from _typeshed import (
     SupportsTrunc,
     SupportsWrite,
 )
-from collections.abc import (
-    Awaitable,
-    Callable,
-    Iterable,
-    Iterator,
-    Mapping,
-    MutableMapping,
-    MutableSet,
-    Reversible,
-    Set as AbstractSet,
-    Sized,
-)
+from collections.abc import Awaitable, Callable, Iterable, Iterator, MutableSet, Reversible, Set as AbstractSet, Sized
 from io import BufferedRandom, BufferedReader, BufferedWriter, FileIO, TextIOWrapper
 from types import CodeType, TracebackType, _Cell
 
-# mypy crashes if any of {ByteString, Sequence, MutableSequence} are imported from collections.abc in builtins.pyi
+# mypy crashes if any of {ByteString, Sequence, MutableSequence, Mapping, MutableMapping} are imported from collections.abc in builtins.pyi
 from typing import (  # noqa: Y027
     IO,
     Any,
@@ -45,6 +34,8 @@ from typing import (  # noqa: Y027
     ByteString,
     ClassVar,
     Generic,
+    Mapping,
+    MutableMapping,
     MutableSequence,
     NoReturn,
     Protocol,


### PR DESCRIPTION
I appear to have accidentally broken mypy.

When running mypy 0.942 against typeshed master, there are no problems.

But I have just (accidentally) discovered that if you run mypy master with `--custom-typeshed-dir` set to typeshed master, you get this:

```
C:\Users\alexw\coding\typeshed\stdlib\abc.pyi: error: INTERNAL ERROR -- Please try using mypy master on Github:
https://mypy.readthedocs.io/en/stable/common_issues.html#using-a-development-mypy-build
Please report a bug at https://github.com/python/mypy/issues
version: 0.960+dev.9cab2964a186d7e71567a1528fcc956f9eecebac
Traceback (most recent call last):
  File "C:\Users\alexw\AppData\Local\Programs\Python\Python310\lib\runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "C:\Users\alexw\AppData\Local\Programs\Python\Python310\lib\runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "C:\Users\alexw\coding\mypy\mypy\__main__.py", line 34, in <module>
    console_entry()
  File "C:\Users\alexw\coding\mypy\mypy\__main__.py", line 12, in console_entry
    main(None, sys.stdout, sys.stderr)
  File "C:\Users\alexw\coding\mypy\mypy\main.py", line 96, in main
    res, messages, blockers = run_build(sources, options, fscache, t0, stdout, stderr)
  File "C:\Users\alexw\coding\mypy\mypy\main.py", line 173, in run_build
    res = build.build(sources, options, None, flush_errors, fscache, stdout, stderr)
  File "C:\Users\alexw\coding\mypy\mypy\build.py", line 180, in build
    result = _build(
  File "C:\Users\alexw\coding\mypy\mypy\build.py", line 256, in _build
    graph = dispatch(sources, manager, stdout)
  File "C:\Users\alexw\coding\mypy\mypy\build.py", line 2733, in dispatch
    process_graph(graph, manager)
  File "C:\Users\alexw\coding\mypy\mypy\build.py", line 3081, in process_graph
    process_stale_scc(graph, scc, manager)
  File "C:\Users\alexw\coding\mypy\mypy\build.py", line 3173, in process_stale_scc
    mypy.semanal_main.semantic_analysis_for_scc(graph, scc, manager.errors)
  File "C:\Users\alexw\coding\mypy\mypy\semanal_main.py", line 78, in semantic_analysis_for_scc
    process_top_levels(graph, scc, patches)
  File "C:\Users\alexw\coding\mypy\mypy\semanal_main.py", line 199, in process_top_levels
    deferred, incomplete, progress = semantic_analyze_target(next_id, state,
  File "C:\Users\alexw\coding\mypy\mypy\semanal_main.py", line 321, in semantic_analyze_target
    with state.wrap_context(check_blockers=False):
  File "C:\Users\alexw\AppData\Local\Programs\Python\Python310\lib\contextlib.py", line 153, in __exit__
    self.gen.throw(typ, value, traceback)
  File "C:\Users\alexw\coding\mypy\mypy\build.py", line 1976, in wrap_context
    yield
  File "C:\Users\alexw\coding\mypy\mypy\semanal_main.py", line 326, in semantic_analyze_target
    analyzer.refresh_partial(refresh_node,
  File "C:\Users\alexw\coding\mypy\mypy\semanal.py", line 414, in refresh_partial
    self.refresh_top_level(node)
  File "C:\Users\alexw\coding\mypy\mypy\semanal.py", line 423, in refresh_top_level
    self.add_implicit_module_attrs(file_node)
  File "C:\Users\alexw\coding\mypy\mypy\semanal.py", line 460, in add_implicit_module_attrs
    assert isinstance(node, TypeInfo)
AssertionError:
C:\Users\alexw\coding\typeshed\stdlib\abc.pyi: : note: use --pdb to drop into pdb
```

I'm pretty sure that this is because of this recently merged mypy PR:
- https://github.com/python/mypy/pull/10969

I don't want to cause problems for mypy unnecessarily, and importing `(Mutable)Mapping` from `typing` in builtins fixes it, so let's just do that for now.