### PR TITLE
Use re-exports instead of TypeAliases in email.parser

### DIFF
--- a/stdlib/email/__init__.pyi
+++ b/stdlib/email/__init__.pyi
@@ -1,7 +1,7 @@
 from collections.abc import Callable
 from email.message import Message
 from email.policy import Policy
-from typing import IO, TypeVar, Union
+from typing import IO, Union
 from typing_extensions import TypeAlias
 
 # Definitions imported by multiple submodules in typeshed

--- a/stdlib/email/__init__.pyi
+++ b/stdlib/email/__init__.pyi
@@ -5,7 +5,6 @@ from typing import IO, TypeVar, Union
 from typing_extensions import TypeAlias
 
 # Definitions imported by multiple submodules in typeshed
-_MessageT = TypeVar("_MessageT", bound=Message)  # noqa: Y018
 _ParamType: TypeAlias = Union[str, tuple[str | None, str | None, str]]
 _ParamsType: TypeAlias = Union[str, None, tuple[str, str | None, str]]
 

--- a/stdlib/email/feedparser.pyi
+++ b/stdlib/email/feedparser.pyi
@@ -1,10 +1,11 @@
 from collections.abc import Callable
-from email import _MessageT
 from email.message import Message
 from email.policy import Policy
-from typing import Generic, overload
+from typing import Generic, TypeVar, overload
 
 __all__ = ["FeedParser", "BytesFeedParser"]
+
+_MessageT = TypeVar("_MessageT", bound=Message)
 
 class FeedParser(Generic[_MessageT]):
     @overload

--- a/stdlib/email/parser.pyi
+++ b/stdlib/email/parser.pyi
@@ -1,15 +1,10 @@
-import email.feedparser
 from collections.abc import Callable
-from email import _MessageT
+from email.feedparser import BytesFeedParser as BytesFeedParser, FeedParser as FeedParser
 from email.message import Message
 from email.policy import Policy
 from typing import BinaryIO, TextIO
-from typing_extensions import TypeAlias
 
 __all__ = ["Parser", "HeaderParser", "BytesParser", "BytesHeaderParser", "FeedParser", "BytesFeedParser"]
-
-FeedParser: TypeAlias = email.feedparser.FeedParser[_MessageT]
-BytesFeedParser: TypeAlias = email.feedparser.BytesFeedParser[_MessageT]
 
 class Parser:
     def __init__(self, _class: Callable[[], Message] | None = ..., *, policy: Policy = ...) -> None: ...


### PR DESCRIPTION
- Simplifies the code
- More closely matches the runtime: https://github.com/python/cpython/blob/main/Lib/email/parser.py
- Reduces the risk of issues like #7632 cropping up.