### PR TITLE
unittest.mock: target must be a str

### DIFF
--- a/stdlib/unittest/mock.pyi
+++ b/stdlib/unittest/mock.pyi
@@ -297,7 +297,7 @@ class _patcher:
     @overload
     def __call__(  # type: ignore[misc]
         self,
-        target: Any,
+        target: str,
         new: _T,
         spec: Any | None = ...,
         create: bool = ...,
@@ -309,7 +309,7 @@ class _patcher:
     @overload
     def __call__(
         self,
-        target: Any,
+        target: str,
         *,
         spec: Any | None = ...,
         create: bool = ...,


### PR DESCRIPTION
See [the CPython source](https://github.com/python/cpython/blob/eaa85cb22fa2d9e7cd31c2eac29a56cd3a8f2f65/Lib/unittest/mock.py#L1754). It calls `_get_target`, and [that](https://github.com/python/cpython/blob/eaa85cb22fa2d9e7cd31c2eac29a56cd3a8f2f65/Lib/unittest/mock.py#L1594) does `target.rsplit('.', 1)`.