### PR TITLE
subprocess: Add _USE_VFORK and _USE_POSIX_SPAWN

### DIFF
--- a/stdlib/subprocess.pyi
+++ b/stdlib/subprocess.pyi
@@ -118,6 +118,12 @@ else:
 
 _T = TypeVar("_T")
 
+# These two are private but documented
+if sys.version_info >= (3, 11):
+    _USE_VFORK: bool
+if sys.version_info >= (3, 8):
+    _USE_POSIX_SPAWN: bool
+
 class CompletedProcess(Generic[_T]):
     # morally: _CMD
     args: Any


### PR DESCRIPTION
Debatable whether to include these, but they are now documented: python/cpython#91490