### PR TITLE
Fix requests files typealias stub

### DIFF
--- a/stubs/requests/requests/sessions.pyi
+++ b/stubs/requests/requests/sessions.pyi
@@ -50,9 +50,9 @@ _Auth: TypeAlias = Union[tuple[str, str], _auth.AuthBase, Callable[[PreparedRequ
 _Cert: TypeAlias = Union[str, tuple[str, str]]
 _Files: TypeAlias = (
     MutableMapping[str, IO[Any]]
-    | MutableMapping[str, tuple[str, IO[Any]]]
-    | MutableMapping[str, tuple[str, IO[Any], str]]
-    | MutableMapping[str, tuple[str, IO[Any], str, _TextMapping]]
+    | MutableMapping[str, tuple[str | None, IO[Any]]]
+    | MutableMapping[str, tuple[str | None, IO[Any], str]]
+    | MutableMapping[str, tuple[str | None, IO[Any], str, _TextMapping]]
 )
 _Hook: TypeAlias = Callable[[Response], Any]
 _Hooks: TypeAlias = MutableMapping[str, _Hook | list[_Hook]]


### PR DESCRIPTION
Resolves https://github.com/python/typeshed/issues/7720

As noted in the issue, the first argument of the tuple here should be optional.