### PR TITLE
requests: allow str and bytes for fileobj in files parameter

### DIFF
--- a/stubs/requests/requests/sessions.pyi
+++ b/stubs/requests/requests/sessions.pyi
@@ -49,10 +49,10 @@ _Data: TypeAlias = str | bytes | Mapping[str, Any] | Iterable[tuple[str, str | N
 _Auth: TypeAlias = Union[tuple[str, str], _auth.AuthBase, Callable[[PreparedRequest], PreparedRequest]]
 _Cert: TypeAlias = Union[str, tuple[str, str]]
 _Files: TypeAlias = (
-    MutableMapping[str, IO[Any]]
-    | MutableMapping[str, tuple[str | None, IO[Any]]]
-    | MutableMapping[str, tuple[str | None, IO[Any], str]]
-    | MutableMapping[str, tuple[str | None, IO[Any], str, _TextMapping]]
+    MutableMapping[str, IO[Any] | str | bytes]
+    | MutableMapping[str, tuple[str | None, IO[Any] | str | bytes]]
+    | MutableMapping[str, tuple[str | None, IO[Any] | str | bytes, str]]
+    | MutableMapping[str, tuple[str | None, IO[Any] | str | bytes, str, _TextMapping]]
 )
 _Hook: TypeAlias = Callable[[Response], Any]
 _Hooks: TypeAlias = MutableMapping[str, _Hook | list[_Hook]]

--- a/stubs/requests/requests/sessions.pyi
+++ b/stubs/requests/requests/sessions.pyi
@@ -1,4 +1,4 @@
-from _typeshed import Self, SupportsItems
+from _typeshed import Self, SupportsItems, SupportsRead
 from collections.abc import Callable, Iterable, Mapping, MutableMapping
 from typing import IO, Any, Union
 from typing_extensions import TypeAlias
@@ -49,10 +49,10 @@ _Data: TypeAlias = str | bytes | Mapping[str, Any] | Iterable[tuple[str, str | N
 _Auth: TypeAlias = Union[tuple[str, str], _auth.AuthBase, Callable[[PreparedRequest], PreparedRequest]]
 _Cert: TypeAlias = Union[str, tuple[str, str]]
 _Files: TypeAlias = (
-    MutableMapping[str, IO[Any] | str | bytes]
-    | MutableMapping[str, tuple[str | None, IO[Any] | str | bytes]]
-    | MutableMapping[str, tuple[str | None, IO[Any] | str | bytes, str]]
-    | MutableMapping[str, tuple[str | None, IO[Any] | str | bytes, str, _TextMapping]]
+    MutableMapping[str, SupportsRead[str | bytes] | str | bytes]
+    | MutableMapping[str, tuple[str | None, SupportsRead[str | bytes] | str | bytes]]
+    | MutableMapping[str, tuple[str | None, SupportsRead[str | bytes] | str | bytes, str]]
+    | MutableMapping[str, tuple[str | None, SupportsRead[str | bytes] | str | bytes, str, _TextMapping]]
 )
 _Hook: TypeAlias = Callable[[Response], Any]
 _Hooks: TypeAlias = MutableMapping[str, _Hook | list[_Hook]]


### PR DESCRIPTION
Some people are having issues with this one, see https://github.com/python/typeshed/issues/7724

[Documentation](https://docs.python-requests.org/en/latest/api/) says to pass a "file-like-object". [Implementation](https://github.com/psf/requests/blob/v2.27.1/requests/models.py#L158) allows for `str`, `bytes`, `bytearray` or anything that implements `.read()`. 
Left `bytearray` out for now because urllib3 documents `str` and `bytes` as valid in [RequestField](https://urllib3.readthedocs.io/en/latest/reference/urllib3.fields.html) in the next major version.

Resolves #7724 