### PR TITLE
requests: allow non-mutable Mapping for files/hooks parameters

### DIFF
--- a/stubs/requests/requests/sessions.pyi
+++ b/stubs/requests/requests/sessions.pyi
@@ -49,14 +49,14 @@ _Data: TypeAlias = str | bytes | Mapping[str, Any] | Iterable[tuple[str, str | N
 _Auth: TypeAlias = Union[tuple[str, str], _auth.AuthBase, Callable[[PreparedRequest], PreparedRequest]]
 _Cert: TypeAlias = Union[str, tuple[str, str]]
 _Files: TypeAlias = (
-    MutableMapping[str, SupportsRead[str | bytes] | str | bytes]
-    | MutableMapping[str, tuple[str | None, SupportsRead[str | bytes] | str | bytes]]
-    | MutableMapping[str, tuple[str | None, SupportsRead[str | bytes] | str | bytes, str]]
-    | MutableMapping[str, tuple[str | None, SupportsRead[str | bytes] | str | bytes, str, _TextMapping]]
+    Mapping[str, SupportsRead[str | bytes] | str | bytes]
+    | Mapping[str, tuple[str | None, SupportsRead[str | bytes] | str | bytes]]
+    | Mapping[str, tuple[str | None, SupportsRead[str | bytes] | str | bytes, str]]
+    | Mapping[str, tuple[str | None, SupportsRead[str | bytes] | str | bytes, str, _TextMapping]]
 )
 _Hook: TypeAlias = Callable[[Response], Any]
-_Hooks: TypeAlias = MutableMapping[str, _Hook | list[_Hook]]
-_HooksInput: TypeAlias = MutableMapping[str, Iterable[_Hook] | _Hook]
+_Hooks: TypeAlias = Mapping[str, _Hook | list[_Hook]]
+_HooksInput: TypeAlias = Mapping[str, Iterable[_Hook] | _Hook]
 
 _ParamsMappingKeyType: TypeAlias = str | bytes | int | float
 _ParamsMappingValueType: TypeAlias = str | bytes | int | float | Iterable[str | bytes | int | float] | None


### PR DESCRIPTION
Another one 😒 still an issue with #7724 . Problem is `MutableMapping` is invariant, so the union type will actually never match.
Changed it to `Mapping` (which is covariant in the value type) now. It doesn't seem to be mutated anywhere, I also passed `frozendict` to try. Also tried assigning a `dict[str, BufferedReader]` to it as in the issue, which passes the type check now.

Same problem would occur in `_Hooks`, so changed that one too. Kept `_TextMapping` as-is because it requires `str` (would still fail on a subtype of `str`).