### PR TITLE
Make test scripts pass `mypy --strict`

### DIFF
--- a/tests/check_consistent.py
+++ b/tests/check_consistent.py
@@ -10,6 +10,7 @@
 # symlinks but that doesn't always work on Windows, so now you must
 # manually update both files, and this test verifies that they are
 # identical.  The list below indicates which sets of files must match.
+from __future__ import annotations
 
 import filecmp
 import os

--- a/tests/check_consistent.py
+++ b/tests/check_consistent.py
@@ -22,7 +22,7 @@ metadata_keys = {"version", "requires", "extra_description", "obsolete_since", "
 allowed_files = {"README.md"}
 
 
-def assert_stubs_only(directory):
+def assert_stubs_only(directory: str) -> None:
     """Check that given directory contains only valid stub files."""
     top = directory.split(os.sep)[-1]
     assert top.isidentifier(), f"Bad directory name: {top}"
@@ -37,7 +37,7 @@ def assert_stubs_only(directory):
             assert subdir.isidentifier(), f"Directories must be valid packages, got: {subdir}"
 
 
-def check_stdlib():
+def check_stdlib() -> None:
     for entry in os.listdir("stdlib"):
         if os.path.isfile(os.path.join("stdlib", entry)):
             name, ext = os.path.splitext(entry)
@@ -57,7 +57,7 @@ def check_stdlib():
             assert_stubs_only(os.path.join("stdlib/@python2", entry))
 
 
-def check_stubs():
+def check_stubs() -> None:
     for distribution in os.listdir("stubs"):
         assert not os.path.isfile(distribution), f"Only directories allowed in stubs, got {distribution}"
         for entry in os.listdir(os.path.join("stubs", distribution)):
@@ -73,7 +73,7 @@ def check_stubs():
                 assert_stubs_only(os.path.join("stubs", distribution, entry))
 
 
-def check_same_files():
+def check_same_files() -> None:
     files = [os.path.join(root, file) for root, dir, files in os.walk(".") for file in files]
     no_symlink = "You cannot use symlinks in typeshed, please copy {} to its link."
     for file in files:
@@ -94,7 +94,7 @@ def check_same_files():
 _VERSIONS_RE = re.compile(r"^([a-zA-Z_][a-zA-Z0-9_.]*): [23]\.\d{1,2}-(?:[23]\.\d{1,2})?$")
 
 
-def check_versions():
+def check_versions() -> None:
     versions = set()
     with open("stdlib/VERSIONS") as f:
         data = f.read().splitlines()
@@ -131,7 +131,7 @@ def _find_stdlib_modules() -> set[str]:
     return modules
 
 
-def _strip_dep_version(dependency):
+def _strip_dep_version(dependency: str) -> tuple[str, str, str]:
     dep_version_pos = len(dependency)
     for pos, c in enumerate(dependency):
         if c in "=<>":
@@ -151,7 +151,7 @@ def _strip_dep_version(dependency):
     return stripped, relation, version
 
 
-def check_metadata():
+def check_metadata() -> None:
     for distribution in os.listdir("stubs"):
         with open(os.path.join("stubs", distribution, "METADATA.toml")) as f:
             data = tomli.loads(f.read())

--- a/tests/pytype_test.py
+++ b/tests/pytype_test.py
@@ -11,21 +11,19 @@ Option two will load the file and all the builtins, typeshed dependencies. This
 will also discover incorrect usage of imported modules.
 """
 
+from __future__ import annotations
+
 import argparse
 import os
 import sys
 import traceback
-from typing import List, Optional, Sequence
+from collections.abc import Sequence
 
 from pytype import config as pytype_config, load_pytd
 from pytype.pytd import typeshed
 
 TYPESHED_SUBDIRS = ["stdlib", "stubs"]
-
-
 TYPESHED_HOME = "TYPESHED_HOME"
-UNSET = object()  # marker for tracking the TYPESHED_HOME environment variable
-
 _LOADERS = {}
 
 
@@ -34,13 +32,13 @@ def main() -> None:
     typeshed_location = args.typeshed_location or os.getcwd()
     subdir_paths = [os.path.join(typeshed_location, d) for d in TYPESHED_SUBDIRS]
     check_subdirs_discoverable(subdir_paths)
-    old_typeshed_home = os.environ.get(TYPESHED_HOME, UNSET)
+    old_typeshed_home = os.environ.get(TYPESHED_HOME)
     os.environ[TYPESHED_HOME] = typeshed_location
     files_to_test = determine_files_to_test(typeshed_location=typeshed_location, paths=args.files or subdir_paths)
     run_all_tests(
         files_to_test=files_to_test, typeshed_location=typeshed_location, print_stderr=args.print_stderr, dry_run=args.dry_run
     )
-    if old_typeshed_home is UNSET:
+    if old_typeshed_home is None:
         del os.environ[TYPESHED_HOME]
     else:
         os.environ[TYPESHED_HOME] = old_typeshed_home
@@ -61,13 +59,14 @@ def create_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def run_pytype(*, filename: str, python_version: str, typeshed_location: str) -> Optional[str]:
+def run_pytype(*, filename: str, python_version: str, typeshed_location: str) -> str | None:
     """Runs pytype, returning the stderr if any."""
     if python_version not in _LOADERS:
         options = pytype_config.Options.create("", parse_pyi=True, python_version=python_version)
         loader = load_pytd.create_loader(options)
         _LOADERS[python_version] = (options, loader)
     options, loader = _LOADERS[python_version]
+    stderr: str | None
     try:
         with pytype_config.verbosity_from(options):
             ast = loader.load_file(_get_module_name(filename), filename)
@@ -108,13 +107,13 @@ def _is_version(path: str, version: str) -> bool:
     return any("{}{}{}".format(d, os.path.sep, version) in path for d in TYPESHED_SUBDIRS)
 
 
-def check_subdirs_discoverable(subdir_paths: List[str]) -> None:
+def check_subdirs_discoverable(subdir_paths: list[str]) -> None:
     for p in subdir_paths:
         if not os.path.isdir(p):
             raise SystemExit("Cannot find typeshed subdir at {} (specify parent dir via --typeshed-location)".format(p))
 
 
-def determine_files_to_test(*, typeshed_location: str, paths: Sequence[str]) -> List[str]:
+def determine_files_to_test(*, typeshed_location: str, paths: Sequence[str]) -> list[str]:
     """Determine all files to test, checking if it's in the exclude list and which Python versions to use.
 
     Returns a list of pairs of the file path and Python version as an int."""
@@ -130,8 +129,8 @@ def determine_files_to_test(*, typeshed_location: str, paths: Sequence[str]) -> 
     return files
 
 
-def find_stubs_in_paths(paths: Sequence[str]) -> List[str]:
-    filenames = []
+def find_stubs_in_paths(paths: Sequence[str]) -> list[str]:
+    filenames: list[str] = []
     for path in paths:
         if os.path.isdir(path):
             for root, _, fns in os.walk(path):

--- a/tests/stubtest_third_party.py
+++ b/tests/stubtest_third_party.py
@@ -16,7 +16,7 @@ import tomli
 
 
 @functools.lru_cache()
-def get_mypy_req():
+def get_mypy_req() -> str:
     with open("requirements-tests.txt") as f:
         return next(line.strip() for line in f if "mypy" in line)
 


### PR DESCRIPTION
- Add several type hints to untyped functions.
- While we're at it, upgrade several annotations to use modern syntax by using `from __future__ import annotations`. This means that the tests can't be run on Python 3.6, but 3.6 is EOL, and it is already the case that some scripts in this directory can only be run on more recent Python versions. E.g. `check_new_syntax.py` uses `ast.unparse`, which is only available in Python 3.9+.
- Fix a few pieces of code that didn't type check.