### PR TITLE
third-party stubtest: run apt update before installing packages

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Install dependencies
         run: pip install $(grep tomli== requirements-tests.txt)
       - name: Install apt packages
-        run: sudo apt install -y $(python tests/get_apt_packages.py)
+        run: sudo apt update && sudo apt install -y $(python tests/get_apt_packages.py)
       - name: Run stubtest
         run: python tests/stubtest_third_party.py --num-shards 4 --shard-index ${{ matrix.shard-index }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -138,6 +138,7 @@ jobs:
             APT_PACKAGES=$(python tests/get_apt_packages.py $STUBS)
             if test -n "$APT_PACKAGES"; then
               echo "Installing apt packages: $APT_PACKAGES"
+              sudo apt update
               sudo apt install -y $APT_PACKAGES
             fi
             python tests/stubtest_third_party.py $STUBS


### PR DESCRIPTION
Fixes #7743.

In the past, I had a similar problem in a different project: https://github.com/Akuli/3d-game-experiment/pull/39

Untested. For some reason, I couldn't test this on my fork even after removing `if: github.repository == 'python/typeshed'` on both master and this PR's branch.