### PR TITLE
Add missing 'headers' property to urllib.error.HTTPError.

### DIFF
--- a/stdlib/urllib/error.pyi
+++ b/stdlib/urllib/error.pyi
@@ -10,6 +10,8 @@ class URLError(IOError):
 
 class HTTPError(URLError, addinfourl):
     @property
+    def headers(self) -> Message: ...
+    @property
     def reason(self) -> str: ...  # type: ignore[override]
     code: int
     def __init__(self, url: str, code: int, msg: str, hdrs: Message, fp: IO[bytes] | None) -> None: ...

--- a/stdlib/urllib/error.pyi
+++ b/stdlib/urllib/error.pyi
@@ -10,7 +10,7 @@ class URLError(IOError):
 
 class HTTPError(URLError, addinfourl):
     @property
-    def headers(self) -> Message: ...
+    def headers(self) -> Message: ...  # type: ignore[override]
     @property
     def reason(self) -> str: ...  # type: ignore[override]
     code: int


### PR DESCRIPTION
Add missing 'headers' property to urllib.error.HTTPError.

Seen here: https://docs.python.org/3/library/urllib.error.html#urllib.error.HTTPError.headers