### PR TITLE
Add `http.HTTPMethod`

### DIFF
--- a/stdlib/http/__init__.pyi
+++ b/stdlib/http/__init__.pyi
@@ -2,7 +2,13 @@ import sys
 from enum import IntEnum
 from typing_extensions import Literal
 
-__all__ = ["HTTPStatus"]
+if sys.version_info >= (3, 11):
+    from enum import StrEnum
+
+if sys.version_info >= (3, 11):
+    __all__ = ["HTTPStatus", "HTTPMethod"]
+else:
+    __all__ = ["HTTPStatus"]
 
 class HTTPStatus(IntEnum):
     @property
@@ -74,3 +80,17 @@ class HTTPStatus(IntEnum):
         EARLY_HINTS: Literal[103]
         IM_A_TEAPOT: Literal[418]
         TOO_EARLY: Literal[425]
+
+if sys.version_info >= (3, 11):
+    class HTTPMethod(StrEnum):
+        @property
+        def description(self) -> str: ...
+        CONNECT: str
+        DELETE: str
+        GET: str
+        HEAD: str
+        OPTIONS: str
+        PATCH: str
+        POST: str
+        PUT: str
+        TRACE: str


### PR DESCRIPTION
https://github.com/python/cpython/pull/91997

`description` isn't actually read-only at runtime, but I don't think there's any other way of telling type checkers "this is an attribute that the members have, not a member itself". And pretending it's a property is already what we do for `HTTPStatus`, which has the same issue.