### PR TITLE
`_csv.pyi`: minor cleanup

### DIFF
--- a/stdlib/_csv.pyi
+++ b/stdlib/_csv.pyi
@@ -1,5 +1,6 @@
+from _typeshed import SupportsWrite
 from collections.abc import Iterable, Iterator
-from typing import Any, Protocol, Union
+from typing import Any, Union
 from typing_extensions import Literal, TypeAlias
 
 __version__: str
@@ -8,6 +9,10 @@ QUOTE_ALL: Literal[1]
 QUOTE_MINIMAL: Literal[0]
 QUOTE_NONE: Literal[3]
 QUOTE_NONNUMERIC: Literal[2]
+
+# Ideally this would be `QUOTE_ALL | QUOTE_MINIMAL | QUOTE_NONE | QUOTE_NONNUMERIC`
+# However, using literals in situations like these can cause false-positives (see #7258)
+_QuotingType: TypeAlias = int
 
 class Error(Exception): ...
 
@@ -18,26 +23,25 @@ class Dialect:
     doublequote: bool
     skipinitialspace: bool
     lineterminator: str
-    quoting: int
-    strict: int
+    quoting: _QuotingType
+    strict: bool
     def __init__(self) -> None: ...
 
 _DialectLike: TypeAlias = Union[str, Dialect, type[Dialect]]
 
 class _reader(Iterator[list[str]]):
-    dialect: Dialect
+    @property
+    def dialect(self) -> Dialect: ...
     line_num: int
     def __next__(self) -> list[str]: ...
 
 class _writer:
-    dialect: Dialect
+    @property
+    def dialect(self) -> Dialect: ...
     def writerow(self, row: Iterable[Any]) -> Any: ...
     def writerows(self, rows: Iterable[Iterable[Any]]) -> None: ...
 
-class _Writer(Protocol):
-    def write(self, __s: str) -> object: ...
-
-def writer(csvfile: _Writer, dialect: _DialectLike = ..., **fmtparams: Any) -> _writer: ...
+def writer(csvfile: SupportsWrite[str], dialect: _DialectLike = ..., **fmtparams: Any) -> _writer: ...
 def reader(csvfile: Iterable[str], dialect: _DialectLike = ..., **fmtparams: Any) -> _reader: ...
 def register_dialect(name: str, dialect: Any = ..., **fmtparams: Any) -> None: ...
 def unregister_dialect(name: str) -> None: ...

--- a/stdlib/csv.pyi
+++ b/stdlib/csv.pyi
@@ -8,6 +8,7 @@ from _csv import (
     Error as Error,
     __version__ as __version__,
     _DialectLike,
+    _QuotingType,
     _reader,
     _writer,
     field_size_limit as field_size_limit,
@@ -59,7 +60,7 @@ class excel(Dialect):
     doublequote: bool
     skipinitialspace: bool
     lineterminator: str
-    quoting: int
+    quoting: _QuotingType
 
 class excel_tab(excel):
     delimiter: str
@@ -70,7 +71,7 @@ class unix_dialect(Dialect):
     doublequote: bool
     skipinitialspace: bool
     lineterminator: str
-    quoting: int
+    quoting: _QuotingType
 
 class DictReader(Generic[_T], Iterator[_DictReadMapping[_T, str]]):
     fieldnames: Sequence[_T] | None


### PR DESCRIPTION
- `_csv._Writer` is a confusing name for a protocol, given that there's also `_csv._writer` and `_csv.writer`. It's exactly the same as `_typeshed.SupportsWrite[str]`, so we may as well just use that.
- The `strict` field of a `_csv.Dialect` object is documented as being a `bool`, not an `int`: https://docs.python.org/3/library/csv.html#csv.Dialect.strict
- `_QuotingType` should really be a union of literal types: the runtime raises an exception if we pass in anything that's not `QUOTE_ALL`, `QUOTE_MINIMAL`, `QUOTE_NONE` or `QUOTE_NONNUMERIC`. It's probably unwise to use a union of literals here right now due to #7258, but we should use a type alias to indicate that `int` isn't really the correct type here.
- `_csv._reader.dialect` and `_csv._writer.dialect` are read-only properties at runtime.