### PR TITLE
`csv.pyi`: minor cleanup

### DIFF
--- a/stdlib/csv.pyi
+++ b/stdlib/csv.pyi
@@ -1,4 +1,6 @@
 import sys
+
+# actually csv.Dialect is a different class to _csv.Dialect at runtime, but for typing purposes, they're identical
 from _csv import (
     QUOTE_ALL as QUOTE_ALL,
     QUOTE_MINIMAL as QUOTE_MINIMAL,
@@ -18,9 +20,10 @@ from _csv import (
     unregister_dialect as unregister_dialect,
     writer as writer,
 )
-from _typeshed import Self
+from _typeshed import Self, SupportsWrite
 from collections.abc import Collection, Iterable, Iterator, Mapping, Sequence
 from typing import Any, Generic, TypeVar, overload
+from typing_extensions import Literal
 
 if sys.version_info >= (3, 8):
     from builtins import dict as _DictReadMapping
@@ -107,14 +110,14 @@ class DictReader(Generic[_T], Iterator[_DictReadMapping[_T, str]]):
 class DictWriter(Generic[_T]):
     fieldnames: Collection[_T]
     restval: Any | None
-    extrasaction: str
+    extrasaction: Literal["raise", "ignore"]
     writer: _writer
     def __init__(
         self,
-        f: Any,
+        f: SupportsWrite[str],
         fieldnames: Collection[_T],
         restval: Any | None = ...,
-        extrasaction: str = ...,
+        extrasaction: Literal["raise", "ignore"] = ...,
         dialect: _DialectLike = ...,
         *args: Any,
         **kwds: Any,


### PR DESCRIPTION
- Add a comment about `_csv.Dialect` and `csv.Dialect` (they're two different classes at runtime, but in the stub we re-export for simplicity).
- Instantiating a `DictWriter` fails at runtime if the object passed to the `f` parameter doesn't have a `write()` method.
- Instantiating a `DictWriter` fails at runtime if the string passed to the `extrasaction` parameter is not either "raise" or "ignore".