### PR TITLE
Fix stdlib `subprocess.Popen.returncode` typing

### DIFF
--- a/stdlib/subprocess.pyi
+++ b/stdlib/subprocess.pyi
@@ -798,7 +798,7 @@ class Popen(Generic[AnyStr]):
     stdout: IO[AnyStr] | None
     stderr: IO[AnyStr] | None
     pid: int
-    returncode: int | None
+    returncode: int | Any
     universal_newlines: bool
 
     # Technically it is wrong that Popen provides __new__ instead of __init__

--- a/stdlib/subprocess.pyi
+++ b/stdlib/subprocess.pyi
@@ -2,7 +2,7 @@ import sys
 from _typeshed import Self, StrOrBytesPath
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from types import TracebackType
-from typing import IO, Any, AnyStr, Generic, TypeVar, overload
+from typing import IO, Any, AnyStr, Generic, Optional, TypeVar, overload
 from typing_extensions import Literal, TypeAlias
 
 if sys.version_info >= (3, 9):
@@ -798,7 +798,7 @@ class Popen(Generic[AnyStr]):
     stdout: IO[AnyStr] | None
     stderr: IO[AnyStr] | None
     pid: int
-    returncode: int
+    returncode: Optional[int]
     universal_newlines: bool
 
     # Technically it is wrong that Popen provides __new__ instead of __init__

--- a/stdlib/subprocess.pyi
+++ b/stdlib/subprocess.pyi
@@ -2,7 +2,7 @@ import sys
 from _typeshed import Self, StrOrBytesPath
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from types import TracebackType
-from typing import IO, Any, AnyStr, Generic, Optional, TypeVar, overload
+from typing import IO, Any, AnyStr, Generic, TypeVar, overload
 from typing_extensions import Literal, TypeAlias
 
 if sys.version_info >= (3, 9):
@@ -798,7 +798,7 @@ class Popen(Generic[AnyStr]):
     stdout: IO[AnyStr] | None
     stderr: IO[AnyStr] | None
     pid: int
-    returncode: Optional[int]
+    returncode: int | None
     universal_newlines: bool
 
     # Technically it is wrong that Popen provides __new__ instead of __init__


### PR DESCRIPTION
According to [the document](https://docs.python.org/3/library/subprocess.html#subprocess.Popen.returncode), the `Popen.returncode` should be `Optional[int]`:

>The child return code, set by [poll()](https://docs.python.org/3/library/subprocess.html#subprocess.Popen.poll) and [wait()](https://docs.python.org/3/library/subprocess.html#subprocess.Popen.wait) (and indirectly by [communicate()](https://docs.python.org/3/library/subprocess.html#subprocess.Popen.communicate)). **A None value indicates that the process hasn’t terminated yet.**