### PR TITLE
ast: FormattedValue.conversion cannot be None

### DIFF
--- a/stdlib/_ast.pyi
+++ b/stdlib/_ast.pyi
@@ -319,7 +319,7 @@ class FormattedValue(expr):
     if sys.version_info >= (3, 10):
         __match_args__ = ("value", "conversion", "format_spec")
     value: expr
-    conversion: int | None
+    conversion: int
     format_spec: expr | None
 
 class JoinedStr(expr):

--- a/tests/stubtest_allowlists/py39.txt
+++ b/tests/stubtest_allowlists/py39.txt
@@ -164,3 +164,7 @@ typing._SpecialForm.__mro_entries__
 unicodedata.UCD.is_normalized
 xml.parsers.expat.XMLParserType.SkippedEntityHandler
 xml.parsers.expat.XMLParserType.intern
+
+# None on the class, but never None on instances
+ast.FormattedValue.conversion
+_ast.FormattedValue.conversion

--- a/tests/stubtest_allowlists/py3_common.txt
+++ b/tests/stubtest_allowlists/py3_common.txt
@@ -685,6 +685,9 @@ pkgutil.ImpLoader.is_package
 pkgutil.ImpLoader.load_module
 pkgutil.ImpLoader.source
 
+# None on the class, but never None on instances
+_ast.FormattedValue.conversion
+
 # ==========
 # Exists at runtime, but missing from stubs
 # ==========

--- a/tests/stubtest_allowlists/py3_common.txt
+++ b/tests/stubtest_allowlists/py3_common.txt
@@ -687,6 +687,7 @@ pkgutil.ImpLoader.source
 
 # None on the class, but never None on instances
 ast.FormattedValue.conversion
+_ast.FormattedValue.conversion
 
 # ==========
 # Exists at runtime, but missing from stubs

--- a/tests/stubtest_allowlists/py3_common.txt
+++ b/tests/stubtest_allowlists/py3_common.txt
@@ -685,10 +685,6 @@ pkgutil.ImpLoader.is_package
 pkgutil.ImpLoader.load_module
 pkgutil.ImpLoader.source
 
-# None on the class, but never None on instances
-ast.FormattedValue.conversion
-_ast.FormattedValue.conversion
-
 # ==========
 # Exists at runtime, but missing from stubs
 # ==========

--- a/tests/stubtest_allowlists/py3_common.txt
+++ b/tests/stubtest_allowlists/py3_common.txt
@@ -686,7 +686,7 @@ pkgutil.ImpLoader.load_module
 pkgutil.ImpLoader.source
 
 # None on the class, but never None on instances
-_ast.FormattedValue.conversion
+ast.FormattedValue.conversion
 
 # ==========
 # Exists at runtime, but missing from stubs


### PR DESCRIPTION
```
In [4]: ast.dump(ast.parse('f"{x!r}"'))
Out[4]: "Module(body=[Expr(value=JoinedStr(values=[FormattedValue(value=Name(id='x', ctx=Load()), conversion=114)]))], type_ignores=[])"

In [5]: ast.dump(ast.parse('f"{x}"'))
Out[5]: "Module(body=[Expr(value=JoinedStr(values=[FormattedValue(value=Name(id='x', ctx=Load()), conversion=-1)]))], type_ignores=[])"
```
(On 3.9 but I don't think this has changed since 3.6.)

The stdlib also assumes this: https://github.com/python/cpython/blob/main/Lib/ast.py#L1211 (`chr(None)` doesn't work).