### PR TITLE
Remove explicit inheritance from `object`

### DIFF
--- a/stubs/protobuf/google/protobuf/internal/message_listener.pyi
+++ b/stubs/protobuf/google/protobuf/internal/message_listener.pyi
@@ -1,4 +1,4 @@
-class MessageListener(object):
+class MessageListener:
     def Modified(self) -> None: ...
 
 class NullMessageListener(MessageListener):


### PR DESCRIPTION
These stubs no longer support Python 2, and explicit inheritance from `object` is never necessary in Python 3.

Unblocks https://github.com/PyCQA/flake8-pyi/pull/217