### PR TITLE
gettext: Make GNUTranslations.CONTEXT not final

### DIFF
--- a/stdlib/gettext.pyi
+++ b/stdlib/gettext.pyi
@@ -96,7 +96,7 @@ class NullTranslations:
 class GNUTranslations(NullTranslations):
     LE_MAGIC: Final[int]
     BE_MAGIC: Final[int]
-    CONTEXT: Final[str]
+    CONTEXT: str
     VERSIONS: Sequence[int]
 
 @overload  # ignores incompatible overloads


### PR DESCRIPTION
I saw an override of CONTEXT in an internal library, so maybe it
makes sense to modify it.