### PR TITLE
Don't run mypy_primer on changes to test files

### DIFF
--- a/.github/workflows/mypy_primer.yml
+++ b/.github/workflows/mypy_primer.yml
@@ -3,6 +3,10 @@ name: Run mypy_primer
 on:
   # Only run on PR, since we diff against master
   pull_request:
+    paths:
+    - 'stdlib/**'
+    - 'stubs/**'
+    - '.github/workflows/**'
 
 jobs:
   mypy_primer:


### PR DESCRIPTION
Only changes to files in `stdlib` or `stubs` will ever have any effect on the checked open-source code. But also run primer on changes to files in `.github/workflows` so that we can see the effect of changes to the `mypy_primer.yml` file itself.