### PR TITLE
CodeType.co_linetable is of type `bytes`

### DIFF
--- a/stdlib/types.pyi
+++ b/stdlib/types.pyi
@@ -308,11 +308,11 @@ class CodeType:
             co_cellvars: tuple[str, ...] = ...,
             co_filename: str = ...,
             co_name: str = ...,
-            co_linetable: object = ...,
+            co_linetable: bytes = ...,
         ) -> CodeType: ...
         def co_lines(self) -> Iterator[tuple[int, int, int | None]]: ...
         @property
-        def co_linetable(self) -> object: ...
+        def co_linetable(self) -> bytes: ...
     elif sys.version_info >= (3, 8):
         def replace(
             self,


### PR DESCRIPTION
Although the specific format of the bytes is opaque and undocumented, the fact that it will be bytes is stable.

This is necessary in order for type checkers to allow creating one code object from another, since the `lnotab`
positional argument to `__init__` is typed as bytes.