### PR TITLE
Only run CI on pushes to main/master and pull requests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,6 +3,9 @@ name: Test
 on:
   workflow_dispatch:
   push:
+    branches:
+      - main
+      - master
   pull_request:
 
 permissions:


### PR DESCRIPTION
Currently, when a maintainer opens a pull request from a branch in the
typeshed repository (instead of a fork), CI is run twice: once for the
PR and once for the push. This not only wastes CI minutes (and it seems
we're running into some limits lately), but also makes CI output twice
as large and more difficult to process.

The disadvantage is that a PR needs to be opened to run CI.
Alternatively, CI can be triggered manually.