### PR TITLE
docopt.printable_usage

### DIFF
--- a/stubs/docopt/docopt.pyi
+++ b/stubs/docopt/docopt.pyi
@@ -6,6 +6,8 @@ __version__: str
 
 _Argv: TypeAlias = Iterable[str] | str
 
+def printable_usage(doc: str) -> str: ...
+
 def docopt(
     doc: str, argv: _Argv | None = ..., help: bool = ..., version: Any | None = ..., options_first: bool = ...
 ) -> dict[str, Any]: ...  # Really should be dict[str, str | bool]

--- a/stubs/docopt/docopt.pyi
+++ b/stubs/docopt/docopt.pyi
@@ -7,7 +7,6 @@ __version__: str
 _Argv: TypeAlias = Iterable[str] | str
 
 def printable_usage(doc: str) -> str: ...
-
 def docopt(
     doc: str, argv: _Argv | None = ..., help: bool = ..., version: Any | None = ..., options_first: bool = ...
 ) -> dict[str, Any]: ...  # Really should be dict[str, str | bool]


### PR DESCRIPTION
`docopt.printable_usage`: https://github.com/docopt/docopt/blob/5f08e0b412fc9fec3a73dd47bc26044dae66a013/docopt.py#L464-L471

Usage of this annotation: https://github.com/jjjake/internetarchive/blob/5897fb9d86b1321d9568600afed13b10bb137f83/internetarchive/cli/ia.py#L64