### PR TITLE
requests: allow immutable headers

### DIFF
--- a/stubs/requests/requests/sessions.pyi
+++ b/stubs/requests/requests/sessions.pyi
@@ -66,16 +66,8 @@ _Params: TypeAlias = Union[
     str | bytes,
 ]
 _TextMapping: TypeAlias = MutableMapping[str, str]
-_HeadersMapping: TypeAlias = MutableMapping[str, str] | MutableMapping[str, bytes] | MutableMapping[str, str | bytes]
-_HeadersUpdateMapping: TypeAlias = (
-    MutableMapping[str, str]
-    | MutableMapping[str, bytes]
-    | MutableMapping[str, None]
-    | MutableMapping[str, str | bytes]
-    | MutableMapping[str, str | None]
-    | MutableMapping[str, bytes | None]
-    | MutableMapping[str, str | bytes | None]
-)
+_HeadersMapping: TypeAlias = Mapping[str, str | bytes]
+_HeadersUpdateMapping: TypeAlias = Mapping[str, str | bytes | None]
 _Timeout: TypeAlias = Union[float, tuple[float, float], tuple[float, None]]
 _Verify: TypeAlias = bool | str
 


### PR DESCRIPTION
Fixes a problem reported by @rpdelaney in  https://github.com/python/typeshed/pull/7773#issuecomment-1134888216

I spent a while looking at requests source code, and I'm quite convinced that the headers can't be mutated. Each request is prepared before auth etc headers are applied, and the headers are copied when preparing.