### PR TITLE
mock: Fix unconstrained TypeVar

### DIFF
--- a/stubs/mock/mock/mock.pyi
+++ b/stubs/mock/mock/mock.pyi
@@ -230,7 +230,7 @@ class _patcher:
         self,
         target: Any,
         attribute: str,
-        new: _T = ...,
+        new: _T,
         spec: Any | None = ...,
         create: bool = ...,
         spec_set: Any | None = ...,


### PR DESCRIPTION
The first overload covers the case where `new` is not given.

Part of #7928