### PR TITLE
`tempfile.pyi`: readability improvements

### DIFF
--- a/stdlib/tempfile.pyi
+++ b/stdlib/tempfile.pyi
@@ -32,11 +32,13 @@ tempdir: str | None
 template: str
 
 _Dir: TypeAlias = AnyStr | os.PathLike[AnyStr]
+_StrMode: TypeAlias = Literal["r", "w", "a", "x", "r+", "w+", "a+", "x+", "rt", "wt", "at", "xt", "r+t", "w+t", "a+t", "x+t"]
+_BytesMode: TypeAlias = Literal["rb", "wb", "ab", "xb", "r+b", "w+b", "a+b", "x+b"]
 
 if sys.version_info >= (3, 8):
     @overload
     def NamedTemporaryFile(
-        mode: Literal["r", "w", "a", "x", "r+", "w+", "a+", "x+", "rt", "wt", "at", "xt", "r+t", "w+t", "a+t", "x+t"],
+        mode: _StrMode,
         buffering: int = ...,
         encoding: str | None = ...,
         newline: str | None = ...,
@@ -49,7 +51,7 @@ if sys.version_info >= (3, 8):
     ) -> _TemporaryFileWrapper[str]: ...
     @overload
     def NamedTemporaryFile(
-        mode: Literal["rb", "wb", "ab", "xb", "r+b", "w+b", "a+b", "x+b"] = ...,
+        mode: _BytesMode = ...,
         buffering: int = ...,
         encoding: str | None = ...,
         newline: str | None = ...,
@@ -77,7 +79,7 @@ if sys.version_info >= (3, 8):
 else:
     @overload
     def NamedTemporaryFile(
-        mode: Literal["r", "w", "a", "x", "r+", "w+", "a+", "x+", "rt", "wt", "at", "xt", "r+t", "w+t", "a+t", "x+t"],
+        mode: _StrMode,
         buffering: int = ...,
         encoding: str | None = ...,
         newline: str | None = ...,
@@ -88,7 +90,7 @@ else:
     ) -> _TemporaryFileWrapper[str]: ...
     @overload
     def NamedTemporaryFile(
-        mode: Literal["rb", "wb", "ab", "xb", "r+b", "w+b", "a+b", "x+b"] = ...,
+        mode: _BytesMode = ...,
         buffering: int = ...,
         encoding: str | None = ...,
         newline: str | None = ...,
@@ -115,7 +117,7 @@ else:
     if sys.version_info >= (3, 8):
         @overload
         def TemporaryFile(
-            mode: Literal["r", "w", "a", "x", "r+", "w+", "a+", "x+", "rt", "wt", "at", "xt", "r+t", "w+t", "a+t", "x+t"],
+            mode: _StrMode,
             buffering: int = ...,
             encoding: str | None = ...,
             newline: str | None = ...,
@@ -127,7 +129,7 @@ else:
         ) -> IO[str]: ...
         @overload
         def TemporaryFile(
-            mode: Literal["rb", "wb", "ab", "xb", "r+b", "w+b", "a+b", "x+b"] = ...,
+            mode: _BytesMode = ...,
             buffering: int = ...,
             encoding: str | None = ...,
             newline: str | None = ...,
@@ -152,7 +154,7 @@ else:
     else:
         @overload
         def TemporaryFile(
-            mode: Literal["r", "w", "a", "x", "r+", "w+", "a+", "x+", "rt", "wt", "at", "xt", "r+t", "w+t", "a+t", "x+t"],
+            mode: _StrMode,
             buffering: int = ...,
             encoding: str | None = ...,
             newline: str | None = ...,
@@ -162,7 +164,7 @@ else:
         ) -> IO[str]: ...
         @overload
         def TemporaryFile(
-            mode: Literal["rb", "wb", "ab", "xb", "r+b", "w+b", "a+b", "x+b"] = ...,
+            mode: _BytesMode = ...,
             buffering: int = ...,
             encoding: str | None = ...,
             newline: str | None = ...,
@@ -236,7 +238,7 @@ class SpooledTemporaryFile(IO[AnyStr], _SpooledTemporaryFileBase):
         def __init__(
             self: SpooledTemporaryFile[bytes],
             max_size: int = ...,
-            mode: Literal["rb", "wb", "ab", "xb", "r+b", "w+b", "a+b", "x+b"] = ...,
+            mode: _BytesMode = ...,
             buffering: int = ...,
             encoding: str | None = ...,
             newline: str | None = ...,
@@ -250,7 +252,7 @@ class SpooledTemporaryFile(IO[AnyStr], _SpooledTemporaryFileBase):
         def __init__(
             self: SpooledTemporaryFile[str],
             max_size: int = ...,
-            mode: Literal["r", "w", "a", "x", "r+", "w+", "a+", "x+", "rt", "wt", "at", "xt", "r+t", "w+t", "a+t", "x+t"] = ...,
+            mode: _StrMode = ...,
             buffering: int = ...,
             encoding: str | None = ...,
             newline: str | None = ...,
@@ -281,7 +283,7 @@ class SpooledTemporaryFile(IO[AnyStr], _SpooledTemporaryFileBase):
         def __init__(
             self: SpooledTemporaryFile[bytes],
             max_size: int = ...,
-            mode: Literal["rb", "wb", "ab", "xb", "r+b", "w+b", "a+b", "x+b"] = ...,
+            mode: _BytesMode = ...,
             buffering: int = ...,
             encoding: str | None = ...,
             newline: str | None = ...,
@@ -293,7 +295,7 @@ class SpooledTemporaryFile(IO[AnyStr], _SpooledTemporaryFileBase):
         def __init__(
             self: SpooledTemporaryFile[str],
             max_size: int = ...,
-            mode: Literal["r", "w", "a", "x", "r+", "w+", "a+", "x+", "rt", "wt", "at", "xt", "r+t", "w+t", "a+t", "x+t"] = ...,
+            mode: _StrMode = ...,
             buffering: int = ...,
             encoding: str | None = ...,
             newline: str | None = ...,

--- a/stdlib/tempfile.pyi
+++ b/stdlib/tempfile.pyi
@@ -32,30 +32,58 @@ tempdir: str | None
 template: str
 
 _Dir: TypeAlias = AnyStr | os.PathLike[AnyStr]
+_StrMode: TypeAlias = Literal["r", "w", "a", "x", "r+", "w+", "a+", "x+", "rt", "wt", "at", "xt", "r+t", "w+t", "a+t", "x+t"]
+_BytesMode: TypeAlias = Literal["rb", "wb", "ab", "xb", "r+b", "w+b", "a+b", "x+b"]
 
 if sys.version_info >= (3, 8):
     @overload
     def NamedTemporaryFile(
-        mode: Literal["r", "w", "a", "x", "r+", "w+", "a+", "x+", "rt", "wt", "at", "xt", "r+t", "w+t", "a+t", "x+t"],
+        mode: _StrMode,
         buffering: int = ...,
         encoding: str | None = ...,
         newline: str | None = ...,
-        suffix: AnyStr | None = ...,
-        prefix: AnyStr | None = ...,
-        dir: _Dir[AnyStr] | None = ...,
+        suffix: str | None = ...,
+        prefix: str | None = ...,
+        dir: _Dir[str] | None = ...,
         delete: bool = ...,
         *,
         errors: str | None = ...,
     ) -> _TemporaryFileWrapper[str]: ...
     @overload
     def NamedTemporaryFile(
-        mode: Literal["rb", "wb", "ab", "xb", "r+b", "w+b", "a+b", "x+b"] = ...,
+        mode: _StrMode,
         buffering: int = ...,
         encoding: str | None = ...,
         newline: str | None = ...,
-        suffix: AnyStr | None = ...,
-        prefix: AnyStr | None = ...,
-        dir: _Dir[AnyStr] | None = ...,
+        suffix: bytes | None = ...,
+        prefix: bytes | None = ...,
+        dir: _Dir[bytes] | None = ...,
+        delete: bool = ...,
+        *,
+        errors: str | None = ...,
+    ) -> _TemporaryFileWrapper[str]: ...
+    @overload
+    def NamedTemporaryFile(
+        mode: _BytesMode = ...,
+        buffering: int = ...,
+        encoding: str | None = ...,
+        newline: str | None = ...,
+        suffix: str | None = ...,
+        prefix: str | None = ...,
+        dir: _Dir[str] | None = ...,
+        delete: bool = ...,
+        *,
+        errors: str | None = ...,
+    ) -> _TemporaryFileWrapper[bytes]: ...
+    @overload
+    def NamedTemporaryFile(
+        mode: _BytesMode = ...,
+        buffering: int = ...,
+        encoding: str | None = ...,
+        newline: str | None = ...,
+        suffix: bytes | None = ...,
+        prefix: bytes | None = ...,
+        dir: _Dir[bytes] | None = ...,
         delete: bool = ...,
         *,
         errors: str | None = ...,
@@ -66,9 +94,22 @@ if sys.version_info >= (3, 8):
         buffering: int = ...,
         encoding: str | None = ...,
         newline: str | None = ...,
-        suffix: AnyStr | None = ...,
-        prefix: AnyStr | None = ...,
-        dir: _Dir[AnyStr] | None = ...,
+        suffix: str | None = ...,
+        prefix: str | None = ...,
+        dir: _Dir[str] | None = ...,
+        delete: bool = ...,
+        *,
+        errors: str | None = ...,
+    ) -> _TemporaryFileWrapper[Any]: ...
+    @overload
+    def NamedTemporaryFile(
+        mode: str = ...,
+        buffering: int = ...,
+        encoding: str | None = ...,
+        newline: str | None = ...,
+        suffix: bytes | None = ...,
+        prefix: bytes | None = ...,
+        dir: _Dir[bytes] | None = ...,
         delete: bool = ...,
         *,
         errors: str | None = ...,
@@ -77,24 +118,46 @@ if sys.version_info >= (3, 8):
 else:
     @overload
     def NamedTemporaryFile(
-        mode: Literal["r", "w", "a", "x", "r+", "w+", "a+", "x+", "rt", "wt", "at", "xt", "r+t", "w+t", "a+t", "x+t"],
+        mode: _StrMode,
         buffering: int = ...,
         encoding: str | None = ...,
         newline: str | None = ...,
-        suffix: AnyStr | None = ...,
-        prefix: AnyStr | None = ...,
-        dir: _Dir[AnyStr] | None = ...,
+        suffix: str | None = ...,
+        prefix: str | None = ...,
+        dir: _Dir[str] | None = ...,
         delete: bool = ...,
     ) -> _TemporaryFileWrapper[str]: ...
     @overload
     def NamedTemporaryFile(
-        mode: Literal["rb", "wb", "ab", "xb", "r+b", "w+b", "a+b", "x+b"] = ...,
+        mode: _StrMode,
         buffering: int = ...,
         encoding: str | None = ...,
         newline: str | None = ...,
-        suffix: AnyStr | None = ...,
-        prefix: AnyStr | None = ...,
-        dir: _Dir[AnyStr] | None = ...,
+        suffix: bytes | None = ...,
+        prefix: bytes | None = ...,
+        dir: _Dir[bytes] | None = ...,
+        delete: bool = ...,
+    ) -> _TemporaryFileWrapper[str]: ...
+    @overload
+    def NamedTemporaryFile(
+        mode: _BytesMode = ...,
+        buffering: int = ...,
+        encoding: str | None = ...,
+        newline: str | None = ...,
+        suffix: str | None = ...,
+        prefix: str | None = ...,
+        dir: _Dir[str] | None = ...,
+        delete: bool = ...,
+    ) -> _TemporaryFileWrapper[bytes]: ...
+    @overload
+    def NamedTemporaryFile(
+        mode: _BytesMode = ...,
+        buffering: int = ...,
+        encoding: str | None = ...,
+        newline: str | None = ...,
+        suffix: bytes | None = ...,
+        prefix: bytes | None = ...,
+        dir: _Dir[bytes] | None = ...,
         delete: bool = ...,
     ) -> _TemporaryFileWrapper[bytes]: ...
     @overload
@@ -103,9 +166,20 @@ else:
         buffering: int = ...,
         encoding: str | None = ...,
         newline: str | None = ...,
-        suffix: AnyStr | None = ...,
-        prefix: AnyStr | None = ...,
-        dir: _Dir[AnyStr] | None = ...,
+        suffix: str | None = ...,
+        prefix: str | None = ...,
+        dir: _Dir[str] | None = ...,
+        delete: bool = ...,
+    ) -> _TemporaryFileWrapper[Any]: ...
+    @overload
+    def NamedTemporaryFile(
+        mode: str = ...,
+        buffering: int = ...,
+        encoding: str | None = ...,
+        newline: str | None = ...,
+        suffix: bytes | None = ...,
+        prefix: bytes | None = ...,
+        dir: _Dir[bytes] | None = ...,
         delete: bool = ...,
     ) -> _TemporaryFileWrapper[Any]: ...
 
@@ -115,25 +189,49 @@ else:
     if sys.version_info >= (3, 8):
         @overload
         def TemporaryFile(
-            mode: Literal["r", "w", "a", "x", "r+", "w+", "a+", "x+", "rt", "wt", "at", "xt", "r+t", "w+t", "a+t", "x+t"],
+            mode: _StrMode,
             buffering: int = ...,
             encoding: str | None = ...,
             newline: str | None = ...,
-            suffix: AnyStr | None = ...,
-            prefix: AnyStr | None = ...,
-            dir: _Dir[AnyStr] | None = ...,
+            suffix: str | None = ...,
+            prefix: str | None = ...,
+            dir: _Dir[str] | None = ...,
             *,
             errors: str | None = ...,
         ) -> IO[str]: ...
         @overload
         def TemporaryFile(
-            mode: Literal["rb", "wb", "ab", "xb", "r+b", "w+b", "a+b", "x+b"] = ...,
+            mode: _StrMode,
             buffering: int = ...,
             encoding: str | None = ...,
             newline: str | None = ...,
-            suffix: AnyStr | None = ...,
-            prefix: AnyStr | None = ...,
-            dir: _Dir[AnyStr] | None = ...,
+            suffix: bytes | None = ...,
+            prefix: bytes | None = ...,
+            dir: _Dir[bytes] | None = ...,
+            *,
+            errors: str | None = ...,
+        ) -> IO[str]: ...
+        @overload
+        def TemporaryFile(
+            mode: _BytesMode = ...,
+            buffering: int = ...,
+            encoding: str | None = ...,
+            newline: str | None = ...,
+            suffix: str | None = ...,
+            prefix: str | None = ...,
+            dir: _Dir[str] | None = ...,
+            *,
+            errors: str | None = ...,
+        ) -> IO[bytes]: ...
+        @overload
+        def TemporaryFile(
+            mode: _BytesMode = ...,
+            buffering: int = ...,
+            encoding: str | None = ...,
+            newline: str | None = ...,
+            suffix: bytes | None = ...,
+            prefix: bytes | None = ...,
+            dir: _Dir[bytes] | None = ...,
             *,
             errors: str | None = ...,
         ) -> IO[bytes]: ...
@@ -143,32 +241,64 @@ else:
             buffering: int = ...,
             encoding: str | None = ...,
             newline: str | None = ...,
-            suffix: AnyStr | None = ...,
-            prefix: AnyStr | None = ...,
-            dir: _Dir[AnyStr] | None = ...,
+            suffix: str | None = ...,
+            prefix: str | None = ...,
+            dir: _Dir[str] | None = ...,
+            *,
+            errors: str | None = ...,
+        ) -> IO[Any]: ...
+        @overload
+        def TemporaryFile(
+            mode: str = ...,
+            buffering: int = ...,
+            encoding: str | None = ...,
+            newline: str | None = ...,
+            suffix: bytes | None = ...,
+            prefix: bytes | None = ...,
+            dir: _Dir[bytes] | None = ...,
             *,
             errors: str | None = ...,
         ) -> IO[Any]: ...
     else:
         @overload
         def TemporaryFile(
-            mode: Literal["r", "w", "a", "x", "r+", "w+", "a+", "x+", "rt", "wt", "at", "xt", "r+t", "w+t", "a+t", "x+t"],
+            mode: _StrMode,
             buffering: int = ...,
             encoding: str | None = ...,
             newline: str | None = ...,
-            suffix: AnyStr | None = ...,
-            prefix: AnyStr | None = ...,
-            dir: _Dir[AnyStr] | None = ...,
+            suffix: str | None = ...,
+            prefix: str | None = ...,
+            dir: _Dir[str] | None = ...,
         ) -> IO[str]: ...
         @overload
         def TemporaryFile(
-            mode: Literal["rb", "wb", "ab", "xb", "r+b", "w+b", "a+b", "x+b"] = ...,
+            mode: _StrMode,
             buffering: int = ...,
             encoding: str | None = ...,
             newline: str | None = ...,
-            suffix: AnyStr | None = ...,
-            prefix: AnyStr | None = ...,
-            dir: _Dir[AnyStr] | None = ...,
+            suffix: bytes | None = ...,
+            prefix: bytes | None = ...,
+            dir: _Dir[bytes] | None = ...,
+        ) -> IO[str]: ...
+        @overload
+        def TemporaryFile(
+            mode: _BytesMode = ...,
+            buffering: int = ...,
+            encoding: str | None = ...,
+            newline: str | None = ...,
+            suffix: str | None = ...,
+            prefix: str | None = ...,
+            dir: _Dir[str] | None = ...,
+        ) -> IO[bytes]: ...
+        @overload
+        def TemporaryFile(
+            mode: _BytesMode = ...,
+            buffering: int = ...,
+            encoding: str | None = ...,
+            newline: str | None = ...,
+            suffix: bytes | None = ...,
+            prefix: bytes | None = ...,
+            dir: _Dir[bytes] | None = ...,
         ) -> IO[bytes]: ...
         @overload
         def TemporaryFile(
@@ -176,9 +306,19 @@ else:
             buffering: int = ...,
             encoding: str | None = ...,
             newline: str | None = ...,
-            suffix: AnyStr | None = ...,
-            prefix: AnyStr | None = ...,
-            dir: _Dir[AnyStr] | None = ...,
+            suffix: str | None = ...,
+            prefix: str | None = ...,
+            dir: _Dir[str] | None = ...,
+        ) -> IO[Any]: ...
+        @overload
+        def TemporaryFile(
+            mode: str = ...,
+            buffering: int = ...,
+            encoding: str | None = ...,
+            newline: str | None = ...,
+            suffix: bytes | None = ...,
+            prefix: bytes | None = ...,
+            dir: _Dir[bytes] | None = ...,
         ) -> IO[Any]: ...
 
 class _TemporaryFileWrapper(Generic[AnyStr], IO[AnyStr]):
@@ -236,7 +376,7 @@ class SpooledTemporaryFile(IO[AnyStr], _SpooledTemporaryFileBase):
         def __init__(
             self: SpooledTemporaryFile[bytes],
             max_size: int = ...,
-            mode: Literal["rb", "wb", "ab", "xb", "r+b", "w+b", "a+b", "x+b"] = ...,
+            mode: _BytesMode = ...,
             buffering: int = ...,
             encoding: str | None = ...,
             newline: str | None = ...,
@@ -250,7 +390,7 @@ class SpooledTemporaryFile(IO[AnyStr], _SpooledTemporaryFileBase):
         def __init__(
             self: SpooledTemporaryFile[str],
             max_size: int = ...,
-            mode: Literal["r", "w", "a", "x", "r+", "w+", "a+", "x+", "rt", "wt", "at", "xt", "r+t", "w+t", "a+t", "x+t"] = ...,
+            mode: _StrMode = ...,
             buffering: int = ...,
             encoding: str | None = ...,
             newline: str | None = ...,
@@ -281,7 +421,7 @@ class SpooledTemporaryFile(IO[AnyStr], _SpooledTemporaryFileBase):
         def __init__(
             self: SpooledTemporaryFile[bytes],
             max_size: int = ...,
-            mode: Literal["rb", "wb", "ab", "xb", "r+b", "w+b", "a+b", "x+b"] = ...,
+            mode: _BytesMode = ...,
             buffering: int = ...,
             encoding: str | None = ...,
             newline: str | None = ...,
@@ -293,7 +433,7 @@ class SpooledTemporaryFile(IO[AnyStr], _SpooledTemporaryFileBase):
         def __init__(
             self: SpooledTemporaryFile[str],
             max_size: int = ...,
-            mode: Literal["r", "w", "a", "x", "r+", "w+", "a+", "x+", "rt", "wt", "at", "xt", "r+t", "w+t", "a+t", "x+t"] = ...,
+            mode: _StrMode = ...,
             buffering: int = ...,
             encoding: str | None = ...,
             newline: str | None = ...,

--- a/stdlib/tempfile.pyi
+++ b/stdlib/tempfile.pyi
@@ -31,7 +31,7 @@ TMP_MAX: int
 tempdir: str | None
 template: str
 
-_DirT: TypeAlias = AnyStr | os.PathLike[AnyStr]
+_Dir: TypeAlias = AnyStr | os.PathLike[AnyStr]
 
 if sys.version_info >= (3, 8):
     @overload
@@ -42,7 +42,7 @@ if sys.version_info >= (3, 8):
         newline: str | None = ...,
         suffix: AnyStr | None = ...,
         prefix: AnyStr | None = ...,
-        dir: _DirT[AnyStr] | None = ...,
+        dir: _Dir[AnyStr] | None = ...,
         delete: bool = ...,
         *,
         errors: str | None = ...,
@@ -55,7 +55,7 @@ if sys.version_info >= (3, 8):
         newline: str | None = ...,
         suffix: AnyStr | None = ...,
         prefix: AnyStr | None = ...,
-        dir: _DirT[AnyStr] | None = ...,
+        dir: _Dir[AnyStr] | None = ...,
         delete: bool = ...,
         *,
         errors: str | None = ...,
@@ -68,7 +68,7 @@ if sys.version_info >= (3, 8):
         newline: str | None = ...,
         suffix: AnyStr | None = ...,
         prefix: AnyStr | None = ...,
-        dir: _DirT[AnyStr] | None = ...,
+        dir: _Dir[AnyStr] | None = ...,
         delete: bool = ...,
         *,
         errors: str | None = ...,
@@ -83,7 +83,7 @@ else:
         newline: str | None = ...,
         suffix: AnyStr | None = ...,
         prefix: AnyStr | None = ...,
-        dir: _DirT[AnyStr] | None = ...,
+        dir: _Dir[AnyStr] | None = ...,
         delete: bool = ...,
     ) -> _TemporaryFileWrapper[str]: ...
     @overload
@@ -94,7 +94,7 @@ else:
         newline: str | None = ...,
         suffix: AnyStr | None = ...,
         prefix: AnyStr | None = ...,
-        dir: _DirT[AnyStr] | None = ...,
+        dir: _Dir[AnyStr] | None = ...,
         delete: bool = ...,
     ) -> _TemporaryFileWrapper[bytes]: ...
     @overload
@@ -105,7 +105,7 @@ else:
         newline: str | None = ...,
         suffix: AnyStr | None = ...,
         prefix: AnyStr | None = ...,
-        dir: _DirT[AnyStr] | None = ...,
+        dir: _Dir[AnyStr] | None = ...,
         delete: bool = ...,
     ) -> _TemporaryFileWrapper[Any]: ...
 
@@ -121,7 +121,7 @@ else:
             newline: str | None = ...,
             suffix: AnyStr | None = ...,
             prefix: AnyStr | None = ...,
-            dir: _DirT[AnyStr] | None = ...,
+            dir: _Dir[AnyStr] | None = ...,
             *,
             errors: str | None = ...,
         ) -> IO[str]: ...
@@ -133,7 +133,7 @@ else:
             newline: str | None = ...,
             suffix: AnyStr | None = ...,
             prefix: AnyStr | None = ...,
-            dir: _DirT[AnyStr] | None = ...,
+            dir: _Dir[AnyStr] | None = ...,
             *,
             errors: str | None = ...,
         ) -> IO[bytes]: ...
@@ -145,7 +145,7 @@ else:
             newline: str | None = ...,
             suffix: AnyStr | None = ...,
             prefix: AnyStr | None = ...,
-            dir: _DirT[AnyStr] | None = ...,
+            dir: _Dir[AnyStr] | None = ...,
             *,
             errors: str | None = ...,
         ) -> IO[Any]: ...
@@ -158,7 +158,7 @@ else:
             newline: str | None = ...,
             suffix: AnyStr | None = ...,
             prefix: AnyStr | None = ...,
-            dir: _DirT[AnyStr] | None = ...,
+            dir: _Dir[AnyStr] | None = ...,
         ) -> IO[str]: ...
         @overload
         def TemporaryFile(
@@ -168,7 +168,7 @@ else:
             newline: str | None = ...,
             suffix: AnyStr | None = ...,
             prefix: AnyStr | None = ...,
-            dir: _DirT[AnyStr] | None = ...,
+            dir: _Dir[AnyStr] | None = ...,
         ) -> IO[bytes]: ...
         @overload
         def TemporaryFile(
@@ -178,7 +178,7 @@ else:
             newline: str | None = ...,
             suffix: AnyStr | None = ...,
             prefix: AnyStr | None = ...,
-            dir: _DirT[AnyStr] | None = ...,
+            dir: _Dir[AnyStr] | None = ...,
         ) -> IO[Any]: ...
 
 class _TemporaryFileWrapper(Generic[AnyStr], IO[AnyStr]):
@@ -365,14 +365,14 @@ class TemporaryDirectory(Generic[AnyStr]):
             self,
             suffix: AnyStr | None = ...,
             prefix: AnyStr | None = ...,
-            dir: _DirT[AnyStr] | None = ...,
+            dir: _Dir[AnyStr] | None = ...,
             ignore_cleanup_errors: bool = ...,
         ) -> None: ...
     else:
         @overload
         def __init__(self: TemporaryDirectory[str], suffix: None = ..., prefix: None = ..., dir: None = ...) -> None: ...
         @overload
-        def __init__(self, suffix: AnyStr | None = ..., prefix: AnyStr | None = ..., dir: _DirT[AnyStr] | None = ...) -> None: ...
+        def __init__(self, suffix: AnyStr | None = ..., prefix: AnyStr | None = ..., dir: _Dir[AnyStr] | None = ...) -> None: ...
 
     def cleanup(self) -> None: ...
     def __enter__(self) -> AnyStr: ...
@@ -383,18 +383,18 @@ class TemporaryDirectory(Generic[AnyStr]):
 # The overloads overlap, but they should still work fine.
 @overload
 def mkstemp(  # type: ignore[misc]
-    suffix: str | None = ..., prefix: str | None = ..., dir: _DirT[str] | None = ..., text: bool = ...
+    suffix: str | None = ..., prefix: str | None = ..., dir: _Dir[str] | None = ..., text: bool = ...
 ) -> tuple[int, str]: ...
 @overload
 def mkstemp(
-    suffix: bytes | None = ..., prefix: bytes | None = ..., dir: _DirT[bytes] | None = ..., text: bool = ...
+    suffix: bytes | None = ..., prefix: bytes | None = ..., dir: _Dir[bytes] | None = ..., text: bool = ...
 ) -> tuple[int, bytes]: ...
 
 # The overloads overlap, but they should still work fine.
 @overload
-def mkdtemp(suffix: str | None = ..., prefix: str | None = ..., dir: _DirT[str] | None = ...) -> str: ...  # type: ignore[misc]
+def mkdtemp(suffix: str | None = ..., prefix: str | None = ..., dir: _Dir[str] | None = ...) -> str: ...  # type: ignore[misc]
 @overload
-def mkdtemp(suffix: bytes | None = ..., prefix: bytes | None = ..., dir: _DirT[bytes] | None = ...) -> bytes: ...
+def mkdtemp(suffix: bytes | None = ..., prefix: bytes | None = ..., dir: _Dir[bytes] | None = ...) -> bytes: ...
 def mktemp(suffix: str = ..., prefix: str = ..., dir: StrPath | None = ...) -> str: ...
 def gettempdirb() -> bytes: ...
 def gettempprefixb() -> bytes: ...

--- a/stdlib/tempfile.pyi
+++ b/stdlib/tempfile.pyi
@@ -32,58 +32,30 @@ tempdir: str | None
 template: str
 
 _Dir: TypeAlias = AnyStr | os.PathLike[AnyStr]
-_StrMode: TypeAlias = Literal["r", "w", "a", "x", "r+", "w+", "a+", "x+", "rt", "wt", "at", "xt", "r+t", "w+t", "a+t", "x+t"]
-_BytesMode: TypeAlias = Literal["rb", "wb", "ab", "xb", "r+b", "w+b", "a+b", "x+b"]
 
 if sys.version_info >= (3, 8):
     @overload
     def NamedTemporaryFile(
-        mode: _StrMode,
+        mode: Literal["r", "w", "a", "x", "r+", "w+", "a+", "x+", "rt", "wt", "at", "xt", "r+t", "w+t", "a+t", "x+t"],
         buffering: int = ...,
         encoding: str | None = ...,
         newline: str | None = ...,
-        suffix: str | None = ...,
-        prefix: str | None = ...,
-        dir: _Dir[str] | None = ...,
+        suffix: AnyStr | None = ...,
+        prefix: AnyStr | None = ...,
+        dir: _Dir[AnyStr] | None = ...,
         delete: bool = ...,
         *,
         errors: str | None = ...,
     ) -> _TemporaryFileWrapper[str]: ...
     @overload
     def NamedTemporaryFile(
-        mode: _StrMode,
+        mode: Literal["rb", "wb", "ab", "xb", "r+b", "w+b", "a+b", "x+b"] = ...,
         buffering: int = ...,
         encoding: str | None = ...,
         newline: str | None = ...,
-        suffix: bytes | None = ...,
-        prefix: bytes | None = ...,
-        dir: _Dir[bytes] | None = ...,
-        delete: bool = ...,
-        *,
-        errors: str | None = ...,
-    ) -> _TemporaryFileWrapper[str]: ...
-    @overload
-    def NamedTemporaryFile(
-        mode: _BytesMode = ...,
-        buffering: int = ...,
-        encoding: str | None = ...,
-        newline: str | None = ...,
-        suffix: str | None = ...,
-        prefix: str | None = ...,
-        dir: _Dir[str] | None = ...,
-        delete: bool = ...,
-        *,
-        errors: str | None = ...,
-    ) -> _TemporaryFileWrapper[bytes]: ...
-    @overload
-    def NamedTemporaryFile(
-        mode: _BytesMode = ...,
-        buffering: int = ...,
-        encoding: str | None = ...,
-        newline: str | None = ...,
-        suffix: bytes | None = ...,
-        prefix: bytes | None = ...,
-        dir: _Dir[bytes] | None = ...,
+        suffix: AnyStr | None = ...,
+        prefix: AnyStr | None = ...,
+        dir: _Dir[AnyStr] | None = ...,
         delete: bool = ...,
         *,
         errors: str | None = ...,
@@ -94,22 +66,9 @@ if sys.version_info >= (3, 8):
         buffering: int = ...,
         encoding: str | None = ...,
         newline: str | None = ...,
-        suffix: str | None = ...,
-        prefix: str | None = ...,
-        dir: _Dir[str] | None = ...,
-        delete: bool = ...,
-        *,
-        errors: str | None = ...,
-    ) -> _TemporaryFileWrapper[Any]: ...
-    @overload
-    def NamedTemporaryFile(
-        mode: str = ...,
-        buffering: int = ...,
-        encoding: str | None = ...,
-        newline: str | None = ...,
-        suffix: bytes | None = ...,
-        prefix: bytes | None = ...,
-        dir: _Dir[bytes] | None = ...,
+        suffix: AnyStr | None = ...,
+        prefix: AnyStr | None = ...,
+        dir: _Dir[AnyStr] | None = ...,
         delete: bool = ...,
         *,
         errors: str | None = ...,
@@ -118,46 +77,24 @@ if sys.version_info >= (3, 8):
 else:
     @overload
     def NamedTemporaryFile(
-        mode: _StrMode,
+        mode: Literal["r", "w", "a", "x", "r+", "w+", "a+", "x+", "rt", "wt", "at", "xt", "r+t", "w+t", "a+t", "x+t"],
         buffering: int = ...,
         encoding: str | None = ...,
         newline: str | None = ...,
-        suffix: str | None = ...,
-        prefix: str | None = ...,
-        dir: _Dir[str] | None = ...,
+        suffix: AnyStr | None = ...,
+        prefix: AnyStr | None = ...,
+        dir: _Dir[AnyStr] | None = ...,
         delete: bool = ...,
     ) -> _TemporaryFileWrapper[str]: ...
     @overload
     def NamedTemporaryFile(
-        mode: _StrMode,
+        mode: Literal["rb", "wb", "ab", "xb", "r+b", "w+b", "a+b", "x+b"] = ...,
         buffering: int = ...,
         encoding: str | None = ...,
         newline: str | None = ...,
-        suffix: bytes | None = ...,
-        prefix: bytes | None = ...,
-        dir: _Dir[bytes] | None = ...,
-        delete: bool = ...,
-    ) -> _TemporaryFileWrapper[str]: ...
-    @overload
-    def NamedTemporaryFile(
-        mode: _BytesMode = ...,
-        buffering: int = ...,
-        encoding: str | None = ...,
-        newline: str | None = ...,
-        suffix: str | None = ...,
-        prefix: str | None = ...,
-        dir: _Dir[str] | None = ...,
-        delete: bool = ...,
-    ) -> _TemporaryFileWrapper[bytes]: ...
-    @overload
-    def NamedTemporaryFile(
-        mode: _BytesMode = ...,
-        buffering: int = ...,
-        encoding: str | None = ...,
-        newline: str | None = ...,
-        suffix: bytes | None = ...,
-        prefix: bytes | None = ...,
-        dir: _Dir[bytes] | None = ...,
+        suffix: AnyStr | None = ...,
+        prefix: AnyStr | None = ...,
+        dir: _Dir[AnyStr] | None = ...,
         delete: bool = ...,
     ) -> _TemporaryFileWrapper[bytes]: ...
     @overload
@@ -166,20 +103,9 @@ else:
         buffering: int = ...,
         encoding: str | None = ...,
         newline: str | None = ...,
-        suffix: str | None = ...,
-        prefix: str | None = ...,
-        dir: _Dir[str] | None = ...,
-        delete: bool = ...,
-    ) -> _TemporaryFileWrapper[Any]: ...
-    @overload
-    def NamedTemporaryFile(
-        mode: str = ...,
-        buffering: int = ...,
-        encoding: str | None = ...,
-        newline: str | None = ...,
-        suffix: bytes | None = ...,
-        prefix: bytes | None = ...,
-        dir: _Dir[bytes] | None = ...,
+        suffix: AnyStr | None = ...,
+        prefix: AnyStr | None = ...,
+        dir: _Dir[AnyStr] | None = ...,
         delete: bool = ...,
     ) -> _TemporaryFileWrapper[Any]: ...
 
@@ -189,49 +115,25 @@ else:
     if sys.version_info >= (3, 8):
         @overload
         def TemporaryFile(
-            mode: _StrMode,
+            mode: Literal["r", "w", "a", "x", "r+", "w+", "a+", "x+", "rt", "wt", "at", "xt", "r+t", "w+t", "a+t", "x+t"],
             buffering: int = ...,
             encoding: str | None = ...,
             newline: str | None = ...,
-            suffix: str | None = ...,
-            prefix: str | None = ...,
-            dir: _Dir[str] | None = ...,
+            suffix: AnyStr | None = ...,
+            prefix: AnyStr | None = ...,
+            dir: _Dir[AnyStr] | None = ...,
             *,
             errors: str | None = ...,
         ) -> IO[str]: ...
         @overload
         def TemporaryFile(
-            mode: _StrMode,
+            mode: Literal["rb", "wb", "ab", "xb", "r+b", "w+b", "a+b", "x+b"] = ...,
             buffering: int = ...,
             encoding: str | None = ...,
             newline: str | None = ...,
-            suffix: bytes | None = ...,
-            prefix: bytes | None = ...,
-            dir: _Dir[bytes] | None = ...,
-            *,
-            errors: str | None = ...,
-        ) -> IO[str]: ...
-        @overload
-        def TemporaryFile(
-            mode: _BytesMode = ...,
-            buffering: int = ...,
-            encoding: str | None = ...,
-            newline: str | None = ...,
-            suffix: str | None = ...,
-            prefix: str | None = ...,
-            dir: _Dir[str] | None = ...,
-            *,
-            errors: str | None = ...,
-        ) -> IO[bytes]: ...
-        @overload
-        def TemporaryFile(
-            mode: _BytesMode = ...,
-            buffering: int = ...,
-            encoding: str | None = ...,
-            newline: str | None = ...,
-            suffix: bytes | None = ...,
-            prefix: bytes | None = ...,
-            dir: _Dir[bytes] | None = ...,
+            suffix: AnyStr | None = ...,
+            prefix: AnyStr | None = ...,
+            dir: _Dir[AnyStr] | None = ...,
             *,
             errors: str | None = ...,
         ) -> IO[bytes]: ...
@@ -241,64 +143,32 @@ else:
             buffering: int = ...,
             encoding: str | None = ...,
             newline: str | None = ...,
-            suffix: str | None = ...,
-            prefix: str | None = ...,
-            dir: _Dir[str] | None = ...,
-            *,
-            errors: str | None = ...,
-        ) -> IO[Any]: ...
-        @overload
-        def TemporaryFile(
-            mode: str = ...,
-            buffering: int = ...,
-            encoding: str | None = ...,
-            newline: str | None = ...,
-            suffix: bytes | None = ...,
-            prefix: bytes | None = ...,
-            dir: _Dir[bytes] | None = ...,
+            suffix: AnyStr | None = ...,
+            prefix: AnyStr | None = ...,
+            dir: _Dir[AnyStr] | None = ...,
             *,
             errors: str | None = ...,
         ) -> IO[Any]: ...
     else:
         @overload
         def TemporaryFile(
-            mode: _StrMode,
+            mode: Literal["r", "w", "a", "x", "r+", "w+", "a+", "x+", "rt", "wt", "at", "xt", "r+t", "w+t", "a+t", "x+t"],
             buffering: int = ...,
             encoding: str | None = ...,
             newline: str | None = ...,
-            suffix: str | None = ...,
-            prefix: str | None = ...,
-            dir: _Dir[str] | None = ...,
+            suffix: AnyStr | None = ...,
+            prefix: AnyStr | None = ...,
+            dir: _Dir[AnyStr] | None = ...,
         ) -> IO[str]: ...
         @overload
         def TemporaryFile(
-            mode: _StrMode,
+            mode: Literal["rb", "wb", "ab", "xb", "r+b", "w+b", "a+b", "x+b"] = ...,
             buffering: int = ...,
             encoding: str | None = ...,
             newline: str | None = ...,
-            suffix: bytes | None = ...,
-            prefix: bytes | None = ...,
-            dir: _Dir[bytes] | None = ...,
-        ) -> IO[str]: ...
-        @overload
-        def TemporaryFile(
-            mode: _BytesMode = ...,
-            buffering: int = ...,
-            encoding: str | None = ...,
-            newline: str | None = ...,
-            suffix: str | None = ...,
-            prefix: str | None = ...,
-            dir: _Dir[str] | None = ...,
-        ) -> IO[bytes]: ...
-        @overload
-        def TemporaryFile(
-            mode: _BytesMode = ...,
-            buffering: int = ...,
-            encoding: str | None = ...,
-            newline: str | None = ...,
-            suffix: bytes | None = ...,
-            prefix: bytes | None = ...,
-            dir: _Dir[bytes] | None = ...,
+            suffix: AnyStr | None = ...,
+            prefix: AnyStr | None = ...,
+            dir: _Dir[AnyStr] | None = ...,
         ) -> IO[bytes]: ...
         @overload
         def TemporaryFile(
@@ -306,19 +176,9 @@ else:
             buffering: int = ...,
             encoding: str | None = ...,
             newline: str | None = ...,
-            suffix: str | None = ...,
-            prefix: str | None = ...,
-            dir: _Dir[str] | None = ...,
-        ) -> IO[Any]: ...
-        @overload
-        def TemporaryFile(
-            mode: str = ...,
-            buffering: int = ...,
-            encoding: str | None = ...,
-            newline: str | None = ...,
-            suffix: bytes | None = ...,
-            prefix: bytes | None = ...,
-            dir: _Dir[bytes] | None = ...,
+            suffix: AnyStr | None = ...,
+            prefix: AnyStr | None = ...,
+            dir: _Dir[AnyStr] | None = ...,
         ) -> IO[Any]: ...
 
 class _TemporaryFileWrapper(Generic[AnyStr], IO[AnyStr]):
@@ -376,7 +236,7 @@ class SpooledTemporaryFile(IO[AnyStr], _SpooledTemporaryFileBase):
         def __init__(
             self: SpooledTemporaryFile[bytes],
             max_size: int = ...,
-            mode: _BytesMode = ...,
+            mode: Literal["rb", "wb", "ab", "xb", "r+b", "w+b", "a+b", "x+b"] = ...,
             buffering: int = ...,
             encoding: str | None = ...,
             newline: str | None = ...,
@@ -390,7 +250,7 @@ class SpooledTemporaryFile(IO[AnyStr], _SpooledTemporaryFileBase):
         def __init__(
             self: SpooledTemporaryFile[str],
             max_size: int = ...,
-            mode: _StrMode = ...,
+            mode: Literal["r", "w", "a", "x", "r+", "w+", "a+", "x+", "rt", "wt", "at", "xt", "r+t", "w+t", "a+t", "x+t"] = ...,
             buffering: int = ...,
             encoding: str | None = ...,
             newline: str | None = ...,
@@ -421,7 +281,7 @@ class SpooledTemporaryFile(IO[AnyStr], _SpooledTemporaryFileBase):
         def __init__(
             self: SpooledTemporaryFile[bytes],
             max_size: int = ...,
-            mode: _BytesMode = ...,
+            mode: Literal["rb", "wb", "ab", "xb", "r+b", "w+b", "a+b", "x+b"] = ...,
             buffering: int = ...,
             encoding: str | None = ...,
             newline: str | None = ...,
@@ -433,7 +293,7 @@ class SpooledTemporaryFile(IO[AnyStr], _SpooledTemporaryFileBase):
         def __init__(
             self: SpooledTemporaryFile[str],
             max_size: int = ...,
-            mode: _StrMode = ...,
+            mode: Literal["r", "w", "a", "x", "r+", "w+", "a+", "x+", "rt", "wt", "at", "xt", "r+t", "w+t", "a+t", "x+t"] = ...,
             buffering: int = ...,
             encoding: str | None = ...,
             newline: str | None = ...,


### PR DESCRIPTION
The name `_DirT` implies that it is a `TypeVar`, but it isn't; it's a generic `TypeAlias` that can be parameterised with a `TypeVar`. Rename it to just `_Dir` instead.

Also, use aliases instead of repeating incredibly long `Literal` annotations six times.