### PR TITLE
Pillow: change `_Mode` type alias to `str` in `Image.pyi` stub

### DIFF
--- a/stubs/Pillow/PIL/Image.pyi
+++ b/stubs/Pillow/PIL/Image.pyi
@@ -14,32 +14,7 @@ from ._imaging import (
 from .ImageFilter import Filter
 from .ImagePalette import ImagePalette
 
-_Mode: TypeAlias = Literal[
-    "1",
-    "BGR;15",
-    "BGR;16",
-    "BGR;24",
-    "BGR;32",
-    "CMYK",
-    "F",
-    "HSV",
-    "I",
-    "I;16",
-    "I;16B",
-    "I;16L",
-    "I;16N",
-    "L",
-    "LA",
-    "LAB",
-    "La",
-    "P",
-    "PA",
-    "RGB",
-    "RGBA",
-    "RGBX",
-    "RGBa",
-    "YCbCr",
-]
+_Mode: TypeAlias = str
 _Resample: TypeAlias = Literal[0, 1, 2, 3, 4, 5]
 _Size: TypeAlias = tuple[int, int]
 _Box: TypeAlias = tuple[int, int, int, int]


### PR DESCRIPTION
As mentioned by @Julian-O in [their comment](https://github.com/python/typeshed/pull/7960#issuecomment-1139252724) on the previous PR, support for various image types is inconsistent.

This PR changes the `_Mode` type alias to simply be `str`