### PR TITLE
Add a `getattr` overload for `BaseException.__notes__`

### DIFF
--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -1192,6 +1192,8 @@ class filter(Iterator[_T], Generic[_T]):
 
 def format(__value: object, __format_spec: str = ...) -> str: ...  # TODO unicode
 @overload
+def getattr(__o: BaseException, __name: Literal["__notes__"], __default: list[str] = ...) -> list[str]: ...
+@overload
 def getattr(__o: object, __name: str) -> Any: ...
 
 # While technically covered by the last overload, spelling out the types for None, bool


### PR DESCRIPTION
This change means that type checkers can easily infer that the type of `getattr(base_exception_obj, "__notes__", [])` will be `list[str]`, without requiring an explicit annotation.

As suggested by @Akuli in https://github.com/python/typeshed/pull/7860#discussion_r876692941