### PR TITLE
`mypy_test.py`: Skip `Flask-SQLAlchemy`

### DIFF
--- a/tests/mypy_test.py
+++ b/tests/mypy_test.py
@@ -369,8 +369,9 @@ def test_third_party_stubs(code: int, major: int, minor: int, args: argparse.Nam
     files_checked = 0
 
     for distribution in sorted(os.listdir("stubs")):
-        if distribution == "SQLAlchemy":
-            continue  # Crashes
+        if distribution in {"SQLAlchemy", "Flask-SQLAlchemy"}:
+            print(colored(f"Skipping {distribution} due to mypy crashes", "yellow"))
+            continue
 
         distribution_path = Path("stubs", distribution)
 


### PR DESCRIPTION
Ever since we upgraded to mypy 0.960, I've hit https://github.com/python/mypy/issues/11899 every second time I run `mypy_test.py` locally. Mypy always crashes on `Flask-SQLAlchemy`, so I propose we skip `mypy_test` on those stubs for now, unless and until https://github.com/python/mypy/pull/12324 is merged.