### PR TITLE
Fix dj_database_url required key

### DIFF
--- a/stubs/dj-database-url/dj_database_url.pyi
+++ b/stubs/dj-database-url/dj_database_url.pyi
@@ -5,16 +5,16 @@ DEFAULT_ENV: str
 SCHEMES: dict[str, str]
 
 class _DBConfigBase(TypedDict):
-    NAME: str
+    ENGINE: str
 
 class _DBConfig(_DBConfigBase, total=False):
+    NAME: str
     USER: str
     PASSWORD: str
     HOST: str
     PORT: str
     CONN_MAX_AGE: int
     OPTIONS: dict[str, Any]
-    ENGINE: str
 
 def parse(url: str, engine: str | None = ..., conn_max_age: int = ..., ssl_require: bool = ...) -> _DBConfig: ...
 def config(

--- a/stubs/dj-database-url/dj_database_url.pyi
+++ b/stubs/dj-database-url/dj_database_url.pyi
@@ -4,10 +4,8 @@ from typing_extensions import TypedDict
 DEFAULT_ENV: str
 SCHEMES: dict[str, str]
 
-class _DBConfigBase(TypedDict):
+class _DBConfig(TypedDict, total=False):
     ENGINE: str
-
-class _DBConfig(_DBConfigBase, total=False):
     NAME: str
     USER: str
     PASSWORD: str


### PR DESCRIPTION
Hey. It's me again.

I've happily installed `types-dj-database-url`, but it seems I've made a small mistake with the PR from earlier. For reference: #7972 .

Required key is ENGINE and not NAME. This fixes that issue.

A question, I have, you might be able to answer me: I have a project that uses dj-database-url. If I wanted to test these stubs against my project, how would I go about doing so? 

Thanks.