### PR TITLE
jsonschema: {relative,absolute}_path can hold ints

### DIFF
--- a/stubs/jsonschema/jsonschema/exceptions.pyi
+++ b/stubs/jsonschema/jsonschema/exceptions.pyi
@@ -1,7 +1,7 @@
 from _typeshed import Self, SupportsRichComparison
 from collections import deque
 from collections.abc import Callable, Container, Iterable, Sequence
-from typing import Any, Union
+from typing import Any
 
 from jsonschema import _utils, protocols
 
@@ -39,7 +39,7 @@ class _Error(Exception):
     @classmethod
     def create_from(cls: type[Self], other: _Error) -> Self: ...
     @property
-    def absolute_path(self) -> Sequence[Union[str | int]]: ...
+    def absolute_path(self) -> Sequence[str | int]: ...
     @property
     def absolute_schema_path(self) -> Sequence[str]: ...
     @property

--- a/stubs/jsonschema/jsonschema/exceptions.pyi
+++ b/stubs/jsonschema/jsonschema/exceptions.pyi
@@ -12,8 +12,8 @@ STRONG_MATCHES: frozenset[str]
 
 class _Error(Exception):
     message: str
-    path: deque[str|int]
-    relative_path: deque[str|int]
+    path: deque[str | int]
+    relative_path: deque[str | int]
     schema_path: deque[str]
     relative_schema_path: deque[str]
     context: list[ValidationError] | None
@@ -27,7 +27,7 @@ class _Error(Exception):
         self,
         message: str,
         validator: _utils.Unset | None | protocols.Validator = ...,
-        path: Sequence[str|int] = ...,
+        path: Sequence[str | int] = ...,
         cause: Any | None = ...,
         context: Sequence[ValidationError] = ...,
         validator_value=...,
@@ -39,7 +39,7 @@ class _Error(Exception):
     @classmethod
     def create_from(cls: type[Self], other: _Error) -> Self: ...
     @property
-    def absolute_path(self) -> Sequence[Union[str|int]]: ...
+    def absolute_path(self) -> Sequence[Union[str | int]]: ...
     @property
     def absolute_schema_path(self) -> Sequence[str]: ...
     @property

--- a/stubs/jsonschema/jsonschema/exceptions.pyi
+++ b/stubs/jsonschema/jsonschema/exceptions.pyi
@@ -1,7 +1,7 @@
 from _typeshed import Self, SupportsRichComparison
 from collections import deque
 from collections.abc import Callable, Container, Iterable, Sequence
-from typing import Any
+from typing import Any, Union
 
 from jsonschema import _utils, protocols
 
@@ -12,8 +12,8 @@ STRONG_MATCHES: frozenset[str]
 
 class _Error(Exception):
     message: str
-    path: deque[str]
-    relative_path: deque[str]
+    path: deque[str|int]
+    relative_path: deque[str|int]
     schema_path: deque[str]
     relative_schema_path: deque[str]
     context: list[ValidationError] | None
@@ -27,7 +27,7 @@ class _Error(Exception):
         self,
         message: str,
         validator: _utils.Unset | None | protocols.Validator = ...,
-        path: Sequence[str] = ...,
+        path: Sequence[str|int] = ...,
         cause: Any | None = ...,
         context: Sequence[ValidationError] = ...,
         validator_value=...,
@@ -39,7 +39,7 @@ class _Error(Exception):
     @classmethod
     def create_from(cls: type[Self], other: _Error) -> Self: ...
     @property
-    def absolute_path(self) -> Sequence[str]: ...
+    def absolute_path(self) -> Sequence[Union[str|int]]: ...
     @property
     def absolute_schema_path(self) -> Sequence[str]: ...
     @property


### PR DESCRIPTION
In https://github.com/matrix-org/synapse/issues/12901 I noticed an problem with the changes to the jsonschema stubs in #7950.

This change remedies that by teaching mypy that paths, relative paths and absolute paths on Error objects can hold strings, ints, or a mixture of the two. For evidence that this is the case, see e.g. https://github.com/python-jsonschema/jsonschema/blob/2e2832463e8de7977217d377ca0553c10f6fb48c/jsonschema/tests/test_exceptions.py#L246-L247 or the test case I provided in https://github.com/python/typeshed/pull/7950#discussion_r884279863.