### PR TITLE
Fix jsonschema exception str|int containers

### DIFF
--- a/stubs/jsonschema/jsonschema/exceptions.pyi
+++ b/stubs/jsonschema/jsonschema/exceptions.pyi
@@ -14,8 +14,8 @@ class _Error(Exception):
     message: str
     path: deque[str | int]
     relative_path: deque[str | int]
-    schema_path: deque[str]
-    relative_schema_path: deque[str]
+    schema_path: deque[str | int]
+    relative_schema_path: deque[str | int]
     context: list[ValidationError] | None
     cause: Exception | None
     validator: protocols.Validator | None
@@ -33,7 +33,7 @@ class _Error(Exception):
         validator_value=...,
         instance: Any = ...,
         schema: Any = ...,
-        schema_path: Sequence[str] = ...,
+        schema_path: Sequence[str | int] = ...,
         parent: _Error | None = ...,
     ) -> None: ...
     @classmethod
@@ -41,7 +41,7 @@ class _Error(Exception):
     @property
     def absolute_path(self) -> Sequence[str | int]: ...
     @property
-    def absolute_schema_path(self) -> Sequence[str]: ...
+    def absolute_schema_path(self) -> Sequence[str | int]: ...
     @property
     def json_path(self) -> str: ...
     # TODO: this type could be made more precise using TypedDict to


### PR DESCRIPTION
Related to #7980, I checked for more attributes where I had made the mistake of introducing a `<container>[str]` annotation which should read `<container>[str | int]`

I didn't have an example usage in mind, so I tried adding a `for x in schema_path: assert isinstance(x, str)` to the error init and running jsonschema's tests. It failed (as expected) on ints, so I'm certain that the original annotation I added has an error in it and I'm reasonably confident that `str | int` is the correct form.

schema_path, relative_schema_path, and absolute_schema_path are all (related) attributes of `jsonschema` errors which contain `str | int` but were accidentally annotated as containing `str`. Fix them for accuracy.