### PR TITLE
pyright: turn off reportPropertyTypeMismatch

### DIFF
--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -40,7 +40,7 @@
     "reportUnboundVariable": "error",
     "reportInvalidStubStatement": "error",
     "reportInvalidTypeVarUse": "error",
-    "reportPropertyTypeMismatch": "error",
+    "reportPropertyTypeMismatch": "none",
     "reportSelfClsParameterName": "error",
     "reportUnsupportedDunderAll": "error",
     // Incompatible overrides are out of typeshed's control as they are

--- a/pyrightconfig.stricter.json
+++ b/pyrightconfig.stricter.json
@@ -110,7 +110,7 @@
     "reportUnboundVariable": "error",
     "reportInvalidStubStatement": "error",
     "reportInvalidTypeVarUse": "error",
-    "reportPropertyTypeMismatch": "error",
+    "reportPropertyTypeMismatch": "none",
     "reportSelfClsParameterName": "error",
     "reportUnsupportedDunderAll": "error",
     // Incompatible overrides are out of typeshed's control as they are


### PR DESCRIPTION
It doesn't usually find real issues in stubs.

https://github.com/python/typeshed/pull/7964#discussion_r884106104
