### PR TITLE
`builtins.sum`: Items in the iterable must support addition with `int` if no `start` value is given

### DIFF
--- a/stdlib/_typeshed/__init__.pyi
+++ b/stdlib/_typeshed/__init__.pyi
@@ -72,6 +72,9 @@ SupportsRichComparisonT = TypeVar("SupportsRichComparisonT", bound=SupportsRichC
 class SupportsAdd(Protocol[_T_contra, _T_co]):
     def __add__(self, __x: _T_contra) -> _T_co: ...
 
+class SupportsRAdd(Protocol[_T_contra, _T_co]):
+    def __radd__(self, __x: _T_contra) -> _T_co: ...
+
 class SupportsDivMod(Protocol[_T_contra, _T_co]):
     def __divmod__(self, __other: _T_contra) -> _T_co: ...
 

--- a/stdlib/_typeshed/__init__.pyi
+++ b/stdlib/_typeshed/__init__.pyi
@@ -69,11 +69,8 @@ SupportsRichComparisonT = TypeVar("SupportsRichComparisonT", bound=SupportsRichC
 
 # Dunder protocols
 
-class SupportsAdd(Protocol):
-    def __add__(self, __x: Any) -> Any: ...
-
-class SupportsAddWithInt(Protocol):
-    def __add__(self, __x: int) -> Any: ...
+class SupportsAdd(Protocol[_T_contra, _T_co]):
+    def __add__(self, __x: _T_contra) -> _T_co: ...
 
 class SupportsDivMod(Protocol[_T_contra, _T_co]):
     def __divmod__(self, __other: _T_contra) -> _T_co: ...

--- a/stdlib/_typeshed/__init__.pyi
+++ b/stdlib/_typeshed/__init__.pyi
@@ -69,8 +69,11 @@ SupportsRichComparisonT = TypeVar("SupportsRichComparisonT", bound=SupportsRichC
 
 # Dunder protocols
 
-class SupportsAdd(Protocol):
+class SupportsAddition(Protocol):
     def __add__(self, __x: Any) -> Any: ...
+
+class SupportsAdditionWithInt(Protocol):
+    def __add__(self, __x: int) -> Any: ...
 
 class SupportsDivMod(Protocol[_T_contra, _T_co]):
     def __divmod__(self, __other: _T_contra) -> _T_co: ...

--- a/stdlib/_typeshed/__init__.pyi
+++ b/stdlib/_typeshed/__init__.pyi
@@ -69,10 +69,10 @@ SupportsRichComparisonT = TypeVar("SupportsRichComparisonT", bound=SupportsRichC
 
 # Dunder protocols
 
-class SupportsAddition(Protocol):
+class SupportsAdd(Protocol):
     def __add__(self, __x: Any) -> Any: ...
 
-class SupportsAdditionWithInt(Protocol):
+class SupportsAddWithInt(Protocol):
     def __add__(self, __x: int) -> Any: ...
 
 class SupportsDivMod(Protocol[_T_contra, _T_co]):

--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -12,7 +12,8 @@ from _typeshed import (
     ReadableBuffer,
     Self,
     StrOrBytesPath,
-    SupportsAdd,
+    SupportsAddition,
+    SupportsAdditionWithInt,
     SupportsAiter,
     SupportsAnext,
     SupportsDivMod,
@@ -1545,8 +1546,9 @@ def sorted(
 @overload
 def sorted(__iterable: Iterable[_T], *, key: Callable[[_T], SupportsRichComparison], reverse: bool = ...) -> list[_T]: ...
 
-_SumT = TypeVar("_SumT", bound=SupportsAdd)
-_SumS = TypeVar("_SumS", bound=SupportsAdd)
+_SupportsAdditionT_1 = TypeVar("_SupportsAdditionT_1", bound=SupportsAddition)
+_SupportsAdditionT_2 = TypeVar("_SupportsAdditionT_2", bound=SupportsAddition)
+_SupportsAdditionWithIntT = TypeVar("_SupportsAdditionWithIntT", bound=SupportsAdditionWithInt)
 
 # In general, the return type of `x + x` is *not* guaranteed to be the same type as x.
 # However, we can't express that in the stub for `sum()`
@@ -1561,15 +1563,19 @@ else:
     def sum(__iterable: Iterable[bool], __start: int = ...) -> int: ...  # type: ignore[misc]
 
 @overload
-def sum(__iterable: Iterable[_SumT]) -> _SumT | Literal[0]: ...
+def sum(__iterable: Iterable[_SupportsAdditionWithIntT]) -> _SupportsAdditionWithIntT | Literal[0]: ...
 
 if sys.version_info >= (3, 8):
     @overload
-    def sum(__iterable: Iterable[_SumT], start: _SumS) -> _SumT | _SumS: ...
+    def sum(
+        __iterable: Iterable[_SupportsAdditionT_1], start: _SupportsAdditionT_2
+    ) -> _SupportsAdditionT_1 | _SupportsAdditionT_2: ...
 
 else:
     @overload
-    def sum(__iterable: Iterable[_SumT], __start: _SumS) -> _SumT | _SumS: ...
+    def sum(
+        __iterable: Iterable[_SupportsAdditionT_1], __start: _SupportsAdditionT_2
+    ) -> _SupportsAdditionT_1 | _SupportsAdditionT_2: ...
 
 # The argument to `vars()` has to have a `__dict__` attribute, so can't be annotated with `object`
 # (A "SupportsDunderDict" protocol doesn't work)

--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -12,8 +12,8 @@ from _typeshed import (
     ReadableBuffer,
     Self,
     StrOrBytesPath,
-    SupportsAddition,
-    SupportsAdditionWithInt,
+    SupportsAdd,
+    SupportsAddWithInt,
     SupportsAiter,
     SupportsAnext,
     SupportsDivMod,
@@ -1546,9 +1546,9 @@ def sorted(
 @overload
 def sorted(__iterable: Iterable[_T], *, key: Callable[[_T], SupportsRichComparison], reverse: bool = ...) -> list[_T]: ...
 
-_SupportsAdditionT_1 = TypeVar("_SupportsAdditionT_1", bound=SupportsAddition)
-_SupportsAdditionT_2 = TypeVar("_SupportsAdditionT_2", bound=SupportsAddition)
-_SupportsAdditionWithIntT = TypeVar("_SupportsAdditionWithIntT", bound=SupportsAdditionWithInt)
+_AddableT1 = TypeVar("_AddableT1", bound=SupportsAdd)
+_AddableT2 = TypeVar("_AddableT2", bound=SupportsAdd)
+_AddableWithIntT = TypeVar("_AddableWithIntT", bound=SupportsAddWithInt)
 
 # In general, the return type of `x + x` is *not* guaranteed to be the same type as x.
 # However, we can't express that in the stub for `sum()`
@@ -1563,19 +1563,15 @@ else:
     def sum(__iterable: Iterable[bool], __start: int = ...) -> int: ...  # type: ignore[misc]
 
 @overload
-def sum(__iterable: Iterable[_SupportsAdditionWithIntT]) -> _SupportsAdditionWithIntT | Literal[0]: ...
+def sum(__iterable: Iterable[_AddableWithIntT]) -> _AddableWithIntT | Literal[0]: ...
 
 if sys.version_info >= (3, 8):
     @overload
-    def sum(
-        __iterable: Iterable[_SupportsAdditionT_1], start: _SupportsAdditionT_2
-    ) -> _SupportsAdditionT_1 | _SupportsAdditionT_2: ...
+    def sum(__iterable: Iterable[_AddableT1], start: _AddableT2) -> _AddableT1 | _AddableT2: ...
 
 else:
     @overload
-    def sum(
-        __iterable: Iterable[_SupportsAdditionT_1], __start: _SupportsAdditionT_2
-    ) -> _SupportsAdditionT_1 | _SupportsAdditionT_2: ...
+    def sum(__iterable: Iterable[_AddableT1], __start: _AddableT2) -> _AddableT1 | _AddableT2: ...
 
 # The argument to `vars()` has to have a `__dict__` attribute, so can't be annotated with `object`
 # (A "SupportsDunderDict" protocol doesn't work)

--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -20,6 +20,7 @@ from _typeshed import (
     SupportsKeysAndGetItem,
     SupportsLenAndGetItem,
     SupportsNext,
+    SupportsRAdd,
     SupportsRDivMod,
     SupportsRichComparison,
     SupportsRichComparisonT,
@@ -1547,7 +1548,10 @@ def sorted(__iterable: Iterable[_T], *, key: Callable[[_T], SupportsRichComparis
 
 _AddableT1 = TypeVar("_AddableT1", bound=SupportsAdd[Any, Any])
 _AddableT2 = TypeVar("_AddableT2", bound=SupportsAdd[Any, Any])
-_AddableWithIntT = TypeVar("_AddableWithIntT", bound=SupportsAdd[int, Any])
+
+class _SupportsSumWithNoDefaultGiven(SupportsAdd[Any, Any], SupportsRAdd[int, Any], Protocol): ...
+
+_SupportsSumNoDefaultT = TypeVar("_SupportsSumNoDefaultT", bound=_SupportsSumWithNoDefaultGiven)
 
 # In general, the return type of `x + x` is *not* guaranteed to be the same type as x.
 # However, we can't express that in the stub for `sum()`
@@ -1562,7 +1566,7 @@ else:
     def sum(__iterable: Iterable[bool], __start: int = ...) -> int: ...  # type: ignore[misc]
 
 @overload
-def sum(__iterable: Iterable[_AddableWithIntT]) -> _AddableWithIntT | Literal[0]: ...
+def sum(__iterable: Iterable[_SupportsSumNoDefaultT]) -> _SupportsSumNoDefaultT | Literal[0]: ...
 
 if sys.version_info >= (3, 8):
     @overload

--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -13,7 +13,6 @@ from _typeshed import (
     Self,
     StrOrBytesPath,
     SupportsAdd,
-    SupportsAddWithInt,
     SupportsAiter,
     SupportsAnext,
     SupportsDivMod,
@@ -1546,9 +1545,9 @@ def sorted(
 @overload
 def sorted(__iterable: Iterable[_T], *, key: Callable[[_T], SupportsRichComparison], reverse: bool = ...) -> list[_T]: ...
 
-_AddableT1 = TypeVar("_AddableT1", bound=SupportsAdd)
-_AddableT2 = TypeVar("_AddableT2", bound=SupportsAdd)
-_AddableWithIntT = TypeVar("_AddableWithIntT", bound=SupportsAddWithInt)
+_AddableT1 = TypeVar("_AddableT1", bound=SupportsAdd[Any, Any])
+_AddableT2 = TypeVar("_AddableT2", bound=SupportsAdd[Any, Any])
+_AddableWithIntT = TypeVar("_AddableWithIntT", bound=SupportsAdd[int, Any])
 
 # In general, the return type of `x + x` is *not* guaranteed to be the same type as x.
 # However, we can't express that in the stub for `sum()`

--- a/test_cases/stdlib/builtins/test_sum.py
+++ b/test_cases/stdlib/builtins/test_sum.py
@@ -5,20 +5,20 @@ from typing_extensions import Literal, assert_type
 
 
 class Foo:
-    def __add__(self, other: Any) -> Foo:
+    def __add__(self, other: Any) -> "Foo":
         return Foo()
 
 
 class Bar:
-    def __radd__(self, other: Any) -> Bar:
+    def __radd__(self, other: Any) -> "Bar":
         return Bar()
 
 
 class Baz:
-    def __add__(self, other: Any) -> Baz:
+    def __add__(self, other: Any) -> "Baz":
         return Baz()
 
-    def __radd__(self, other: Any) -> Baz:
+    def __radd__(self, other: Any) -> "Baz":
         return Baz()
 
 
@@ -30,7 +30,7 @@ assert_type(sum([True, False], True), int)
 
 assert_type(sum([["foo"], ["bar"]], ["baz"]), List[str])
 
-assert_type(sum([Foo(), Foo()], start=Foo()), Foo)
+assert_type(sum([Foo(), Foo()], Foo()), Foo)
 assert_type(sum([Baz(), Baz()]), Union[Baz, Literal[0]])
 
 # mypy and pyright infer the types differently for these, so we can't use assert_type
@@ -44,7 +44,7 @@ sum("abcde")  # type: ignore[arg-type]
 sum([["foo"], ["bar"]])  # type: ignore[list-item]
 sum([("foo",), ("bar", "baz")])  # type: ignore[list-item]
 sum([Foo(), Foo()])  # type: ignore[list-item]
-sum([Bar(), Bar()], start=Bar())  # type: ignore[call-overload]
+sum([Bar(), Bar()], Bar())  # type: ignore[call-overload]
 sum([Bar(), Bar()])  # type: ignore[list-item]
 
 # TODO: these pass pyright with the current stubs, but mypy erroneously emits an error:

--- a/test_cases/stdlib/builtins/test_sum.py
+++ b/test_cases/stdlib/builtins/test_sum.py
@@ -9,18 +9,18 @@ assert_type(sum([3, 5], 4), int)
 assert_type(sum([True, False]), int)
 assert_type(sum([True, False], True), int)
 
-assert_type(sum([['foo'], ['bar']], ['baz']), List[str])
+assert_type(sum([["foo"], ["bar"]], ["baz"]), List[str])
 
 # mypy and pyright infer the types differently for these, so we can't use assert_type
 # Just test that no error is emitted for any of these
-sum([('foo',), ('bar', 'baz')], ())  # mypy: `tuple[str, ...]`; pyright: `tuple[()] | tuple[str] | tuple[str, str]`
+sum([("foo",), ("bar", "baz")], ())  # mypy: `tuple[str, ...]`; pyright: `tuple[()] | tuple[str] | tuple[str, str]`
 sum([5.6, 3.2])  # mypy: `float`; pyright: `float | Literal[0]`
 sum([2.5, 5.8], 5)  # mypy: `float`; pyright: `float | int`
 
 # These all fail at runtime
-sum('abcde')  # type: ignore[arg-type]
-sum([['foo'], ['bar']])  # type: ignore[list-item]
-sum([('foo',), ('bar', 'baz')])  # type: ignore[list-item]
+sum("abcde")  # type: ignore[arg-type]
+sum([["foo"], ["bar"]])  # type: ignore[list-item]
+sum([("foo",), ("bar", "baz")])  # type: ignore[list-item]
 
 # TODO: these pass pyright with the current stubs, but mypy erroneously emits an error:
 # sum([3, Fraction(7, 22), complex(8, 0), 9.83])

--- a/test_cases/stdlib/builtins/test_sum.py
+++ b/test_cases/stdlib/builtins/test_sum.py
@@ -1,0 +1,27 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=true
+
+from typing import List
+from typing_extensions import assert_type
+
+assert_type(sum([2, 4]), int)
+assert_type(sum([3, 5], 4), int)
+
+assert_type(sum([True, False]), int)
+assert_type(sum([True, False], True), int)
+
+assert_type(sum([['foo'], ['bar']], ['baz']), List[str])
+
+# mypy and pyright infer the types differently for these, so we can't use assert_type
+# Just test that no error is emitted for any of these
+sum([('foo',), ('bar', 'baz')], ())  # mypy: `tuple[str, ...]`; pyright: `tuple[()] | tuple[str] | tuple[str, str]`
+sum([5.6, 3.2])  # mypy: `float`; pyright: `float | Literal[0]`
+sum([2.5, 5.8], 5)  # mypy: `float`; pyright: `float | int`
+
+# These all fail at runtime
+sum('abcde')  # type: ignore[arg-type]
+sum([['foo'], ['bar']])  # type: ignore[list-item]
+sum([('foo',), ('bar', 'baz')])  # type: ignore[list-item]
+
+# TODO: these pass pyright with the current stubs, but mypy erroneously emits an error:
+# sum([3, Fraction(7, 22), complex(8, 0), 9.83])
+# sum([3, Decimal('0.98')])

--- a/test_cases/stdlib/builtins/test_sum.py
+++ b/test_cases/stdlib/builtins/test_sum.py
@@ -1,7 +1,26 @@
 # pyright: reportUnnecessaryTypeIgnoreComment=true
 
-from typing import List
-from typing_extensions import assert_type
+from typing import Any, List, Union
+from typing_extensions import Literal, assert_type
+
+
+class Foo:
+    def __add__(self, other: Any) -> Foo:
+        return Foo()
+
+
+class Bar:
+    def __radd__(self, other: Any) -> Bar:
+        return Bar()
+
+
+class Baz:
+    def __add__(self, other: Any) -> Baz:
+        return Baz()
+
+    def __radd__(self, other: Any) -> Baz:
+        return Baz()
+
 
 assert_type(sum([2, 4]), int)
 assert_type(sum([3, 5], 4), int)
@@ -10,6 +29,9 @@ assert_type(sum([True, False]), int)
 assert_type(sum([True, False], True), int)
 
 assert_type(sum([["foo"], ["bar"]], ["baz"]), List[str])
+
+assert_type(sum([Foo(), Foo()], start=Foo()), Foo)
+assert_type(sum([Baz(), Baz()]), Union[Baz, Literal[0]])
 
 # mypy and pyright infer the types differently for these, so we can't use assert_type
 # Just test that no error is emitted for any of these
@@ -21,6 +43,9 @@ sum([2.5, 5.8], 5)  # mypy: `float`; pyright: `float | int`
 sum("abcde")  # type: ignore[arg-type]
 sum([["foo"], ["bar"]])  # type: ignore[list-item]
 sum([("foo",), ("bar", "baz")])  # type: ignore[list-item]
+sum([Foo(), Foo()])  # type: ignore[list-item]
+sum([Bar(), Bar()], start=Bar())  # type: ignore[call-overload]
+sum([Bar(), Bar()])  # type: ignore[list-item]
 
 # TODO: these pass pyright with the current stubs, but mypy erroneously emits an error:
 # sum([3, Fraction(7, 22), complex(8, 0), 9.83])


### PR DESCRIPTION
Closes #7574 (cc. @jpy-git). I think this is just about the best we can do without introducing many false-positive errors.