### PR TITLE
Add the missing fields to dj-database-url config type

### DIFF
--- a/stubs/dj-database-url/dj_database_url.pyi
+++ b/stubs/dj-database-url/dj_database_url.pyi
@@ -13,7 +13,7 @@ class _DBConfig(TypedDict, total=False):
     ENGINE: str
     HOST: str
     NAME: str
-    OPTIONS: dict[str, Any]
+    OPTIONS: dict[str, Any] | None
     PASSWORD: str
     PORT: str
     TEST: dict[str, Any]


### PR DESCRIPTION
Corrects issues from https://github.com/python/typeshed/pull/7972#issuecomment-1143473923