### PR TITLE
`check_new_syntax.py`: Fix bug in `visit_AnnAssign`

### DIFF
--- a/tests/check_new_syntax.py
+++ b/tests/check_new_syntax.py
@@ -44,6 +44,8 @@ def check_new_syntax(tree: ast.AST, path: Path, stub: str) -> list[str]:
     class OldSyntaxFinder(ast.NodeVisitor):
         def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
             AnnotationUnionFinder().visit(node.annotation)
+            if node.value is not None:
+                NonAnnotationUnionFinder().visit(node.value)
             self.generic_visit(node)
 
         def visit_arg(self, node: ast.arg) -> None:


### PR DESCRIPTION
There's a few places in #8013 where `check_new_syntax.py` should be complaining that the author isn't using PEP 604 syntax, but it isn't. This PR fixes that bug.