### PR TITLE
`dateparser`: Remove redundant import of `_typeshed.Self`

### DIFF
--- a/stubs/dateparser/dateparser/date.pyi
+++ b/stubs/dateparser/dateparser/date.pyi
@@ -1,5 +1,4 @@
 import collections
-from _typeshed import Self as Self
 from collections.abc import Callable, Iterable, Iterator
 from datetime import datetime
 from typing import ClassVar, Pattern, overload


### PR DESCRIPTION
It doesn't exist at runtime:

```python
>>> import dateparser.date
>>> dateparser.date.Self
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'dateparser.date' has no attribute 'Self'
```

...and it's not used in the stub either.

I'm not sure why stubtest didn't pick it up. My stubtest patch over at https://github.com/python/mypy/pull/12214 _does_ pick it up (and I'm not sure why that is, either... but it's a true positive!)