### PR TITLE
filelock: mark as obsolete since 3.3.0

### DIFF
--- a/stubs/filelock/METADATA.toml
+++ b/stubs/filelock/METADATA.toml
@@ -1,1 +1,2 @@
 version = "3.2.*"
+obsolete_since = "3.3.0"


### PR DESCRIPTION
Release on 2021-10-03, so we can remove these.