### PR TITLE
frozendict: mark as obsolete since 2.2.0

### DIFF
--- a/stubs/frozendict/METADATA.toml
+++ b/stubs/frozendict/METADATA.toml
@@ -1,1 +1,2 @@
 version = "2.0.*"
+obsolete_since = "2.2.0"


### PR DESCRIPTION
No changelog kept, but https://github.com/Marco-Sulla/python-frozendict/commit/7fcdd3aa990aa323fbcecea4b33733468c97cc27

So removable come July 15