### PR TITLE
certifi: mark as obsolete since 2022.5.18.1

### DIFF
--- a/stubs/certifi/METADATA.toml
+++ b/stubs/certifi/METADATA.toml
@@ -1,1 +1,2 @@
 version = "2021.10.8"
+obsolete_since = "2022.5.18.1"


### PR DESCRIPTION
Looks like technically the released sdist doesn't have py.typed, but the
wheel does:
https://github.com/certifi/python-certifi/commit/4151e8849481f396537c34812068e89b32731e52 (not yet released)
https://github.com/certifi/python-certifi/commit/5f09ea84b97202a41430fed5bb3cbd489d04c18e

Removable in November, as you may have guessed