### PR TITLE
flake8 config: Ignore more error codes in `.py` files

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,8 +1,8 @@
 # The following rules are incompatible with or enforced by black:
 #       E203 whitespace before ':' -- scripts only
-#       E301 expected 1 blank line -- stubs only
-#       E302 expected 2 blank lines -- stubs only
-#       E305 expected 2 blank lines -- stubs only
+#       E301 expected 1 blank line
+#       E302 expected 2 blank lines
+#       E305 expected 2 blank lines
 #       E501 line too long
 
 # Some rules are considered irrelevant to stub files:
@@ -27,7 +27,7 @@
 
 [flake8]
 per-file-ignores =
-  *.py: E203, E501
+  *.py: E203, E301, E302, E305, E501
   *.pyi: E301, E302, E305, E501, E701, E741, F401, F403, F405, F822, Y037
   # Since typing.pyi defines "overload" this is not recognized by flake8 as typing.overload.
   # Unfortunately, flake8 does not allow to "noqa" just a specific error inside the file itself.


### PR DESCRIPTION
black fixes these for us in `pre-commit.ci`. See #8064 for an example.