### PR TITLE
Add pre-commit config for flake8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: isort
         name: isort (python)
   - repo: https://github.com/pycqa/flake8
-    rev: 4.0.1
+    rev: 4.0.1  # must match requirements-tests.txt
     hooks:
       - id: flake8
         additional_dependencies:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,7 @@ repos:
     hooks:
       - id: flake8
         additional_dependencies:
+          # must match requirements-tests.txt
           - 'flake8-bugbear==21.11.29'
           - 'flake8-pyi==22.5.1'
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,11 +9,18 @@ repos:
     hooks:
       - id: isort
         name: isort (python)
+  - repo: https://github.com/pycqa/flake8
+    rev: 4.0.1
+    hooks:
+      - id: flake8
+        additional_dependencies:
+          - 'flake8-bugbear==21.11.29'
+          - 'flake8-pyi==22.5.1'
 
 ci:
     autofix_commit_msg: '[pre-commit.ci] auto fixes from pre-commit.com hooks'
     autofix_prs: true
     autoupdate_commit_msg: '[pre-commit.ci] pre-commit autoupdate'
     autoupdate_schedule: weekly
-    skip: []
+    skip: [flake8]
     submodules: false

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -2,6 +2,7 @@ mypy==0.960
 pytype==2022.5.10; platform_system != "Windows"
 # must match .pre-commit-config.yaml
 black==22.3.0
+# must match .pre-commit-config.yaml
 flake8==4.0.1
 flake8-bugbear==21.11.29
 flake8-pyi==22.5.1


### PR DESCRIPTION
This makes it easier to lint your own work with `pre-commit`, but doesn't change the CI config by adding this to the pre-commit.ci skip list.

There's no way to automatically reflect the additional dependencies from the requirements file, so the flake8 plugin list needs to be a verbatim copy.

resolves #7991

---

Two asides:
- Sorry this took me so long to put in. I meant to do it right away and got distracted.
- If there's any discomfort about copying the requirements data, let's just nix this and close #7991 as a wontfix (at least for now). I think it's worth keeping the copy, but I also understand not wanting duplicate configs.