### PR TITLE
Remove mypy error codes from the `test_cases` directory

### DIFF
--- a/test_cases/stdlib/builtins/test_pow.py
+++ b/test_cases/stdlib/builtins/test_pow.py
@@ -76,16 +76,12 @@ assert_type(pow(4.7, 9.2, None), Any)
 assert_type((-95) ** 8.42, Any)
 
 # All of the following cases should fail a type-checker.
-#
-# mypy/pyright will emit errors if any of them do not fail:
-# - We use --warn-unused-ignores for mypy when checking this subdirectory;
-# - For pyright, we have reportUnnecessaryTypeIgnoreComment=true at the top of this file
-pow(1.9, 4, 6)  # type: ignore[misc]
-pow(4, 7, 4.32)  # type: ignore[misc]
-pow(6.2, 5.9, 73)  # type: ignore[misc]
-pow(complex(6), 6.2, 7)  # type: ignore[misc]
-pow(Fraction(), 5, 8)  # type: ignore[call-overload]
-Decimal("8.7") ** 3.14  # type: ignore[operator]
+pow(1.9, 4, 6)  # type: ignore
+pow(4, 7, 4.32)  # type: ignore
+pow(6.2, 5.9, 73)  # type: ignore
+pow(complex(6), 6.2, 7)  # type: ignore
+pow(Fraction(), 5, 8)  # type: ignore
+Decimal("8.7") ** 3.14  # type: ignore
 
 # TODO: This fails at runtime, but currently passes mypy and pyright:
 pow(Decimal("8.5"), 3.21)

--- a/test_cases/stdlib/builtins/test_sum.py
+++ b/test_cases/stdlib/builtins/test_sum.py
@@ -40,12 +40,12 @@ sum([5.6, 3.2])  # mypy: `float`; pyright: `float | Literal[0]`
 sum([2.5, 5.8], 5)  # mypy: `float`; pyright: `float | int`
 
 # These all fail at runtime
-sum("abcde")  # type: ignore[arg-type]
-sum([["foo"], ["bar"]])  # type: ignore[list-item]
-sum([("foo",), ("bar", "baz")])  # type: ignore[list-item]
-sum([Foo(), Foo()])  # type: ignore[list-item]
-sum([Bar(), Bar()], Bar())  # type: ignore[call-overload]
-sum([Bar(), Bar()])  # type: ignore[list-item]
+sum("abcde")  # type: ignore
+sum([["foo"], ["bar"]])  # type: ignore
+sum([("foo",), ("bar", "baz")])  # type: ignore
+sum([Foo(), Foo()])  # type: ignore
+sum([Bar(), Bar()], Bar())  # type: ignore
+sum([Bar(), Bar()])  # type: ignore
 
 # TODO: these pass pyright with the current stubs, but mypy erroneously emits an error:
 # sum([3, Fraction(7, 22), complex(8, 0), 9.83])

--- a/test_cases/stdlib/test_codecs.py
+++ b/test_cases/stdlib/test_codecs.py
@@ -7,7 +7,7 @@ assert_type(codecs.decode("x", "unicode-escape"), str)
 assert_type(codecs.decode(b"x", "unicode-escape"), str)
 
 assert_type(codecs.decode(b"x", "utf-8"), str)
-codecs.decode("x", "utf-8")  # type: ignore[call-overload]
+codecs.decode("x", "utf-8")  # type: ignore
 
 assert_type(codecs.decode("ab", "hex"), bytes)
 assert_type(codecs.decode(b"ab", "hex"), bytes)

--- a/test_cases/stdlib/test_unittest.py
+++ b/test_cases/stdlib/test_unittest.py
@@ -16,14 +16,14 @@ case.assertAlmostEqual(2.4, 2.41, places=8)
 case.assertAlmostEqual(2.4, 2.41, delta=0.02)
 case.assertAlmostEqual(2.4, 2.41, None, "foo", 0.02)
 
-case.assertAlmostEqual(2.4, 2.41, places=9, delta=0.02)  # type: ignore[call-overload]
-case.assertAlmostEqual("foo", "bar")  # type: ignore[call-overload]
-case.assertAlmostEqual(datetime(1999, 1, 2), datetime(1999, 1, 2, microsecond=1))  # type: ignore[arg-type]
+case.assertAlmostEqual(2.4, 2.41, places=9, delta=0.02)  # type: ignore
+case.assertAlmostEqual("foo", "bar")  # type: ignore
+case.assertAlmostEqual(datetime(1999, 1, 2), datetime(1999, 1, 2, microsecond=1))  # type: ignore
 
 case.assertNotAlmostEqual(Fraction(49, 50), Fraction(48, 50))
 case.assertNotAlmostEqual(datetime(1999, 1, 2), datetime(1999, 1, 2, microsecond=1), delta=timedelta(hours=1))
 case.assertNotAlmostEqual(datetime(1999, 1, 2), datetime(1999, 1, 2, microsecond=1), None, "foo", timedelta(hours=1))
 
-case.assertNotAlmostEqual(2.4, 2.41, places=9, delta=0.02)  # type: ignore[call-overload]
-case.assertNotAlmostEqual("foo", "bar")  # type: ignore[call-overload]
-case.assertNotAlmostEqual(datetime(1999, 1, 2), datetime(1999, 1, 2, microsecond=1))  # type: ignore[arg-type]
+case.assertNotAlmostEqual(2.4, 2.41, places=9, delta=0.02)  # type: ignore
+case.assertNotAlmostEqual("foo", "bar")  # type: ignore
+case.assertNotAlmostEqual(datetime(1999, 1, 2), datetime(1999, 1, 2, microsecond=1))  # type: ignore

--- a/tests/mypy_test.py
+++ b/tests/mypy_test.py
@@ -229,6 +229,7 @@ def get_mypy_flags(
     custom_typeshed: bool = False,
     strict: bool = False,
     test_suite_run: bool = False,
+    enforce_error_codes: bool = True,
 ) -> list[str]:
     flags = [
         "--python-version",
@@ -240,8 +241,6 @@ def get_mypy_flags(
         "--warn-incomplete-stub",
         "--show-error-codes",
         "--no-error-summary",
-        "--enable-error-code",
-        "ignore-without-code",
         "--strict-equality",
     ]
     if temp_name is not None:
@@ -260,6 +259,8 @@ def get_mypy_flags(
             flags.extend(["--exclude", "tests/pytype_test.py"])
     else:
         flags.append("--no-site-packages")
+    if enforce_error_codes:
+        flags.extend(["--enable-error-code", "ignore-without-code"])
     return flags
 
 
@@ -406,7 +407,7 @@ def test_the_test_scripts(code: int, major: int, minor: int, args: argparse.Name
 def test_the_test_cases(code: int, major: int, minor: int, args: argparse.Namespace) -> TestResults:
     test_case_files = list(map(str, Path("test_cases").rglob("*.py")))
     num_test_case_files = len(test_case_files)
-    flags = get_mypy_flags(args, major, minor, None, strict=True, custom_typeshed=True)
+    flags = get_mypy_flags(args, major, minor, None, strict=True, custom_typeshed=True, enforce_error_codes=False)
     print(f"Running mypy on the test_cases directory ({num_test_case_files} files)...")
     print("Running mypy " + " ".join(flags))
     if args.dry_run:


### PR DESCRIPTION
This PR removes mypy error codes from the `test_cases` directory, and alters `mypy_test` so that it no longer enforces that `type: ignore`s in the `test_cases` directory have mypy error codes.

When I created the first test cases, it seemed like a good idea to enforce mypy error codes, as we use mypy error codes in most of the rest of typeshed. But `type: ignore`s in the `test_cases` directory serve a different purpose to those in the rest of typeshed -- whereas in the rest of typeshed we use them to stop a type checker complaining where we're doing something it doesn't quite understand, in the `test_cases` directory we use them to signify "this code is meant to fail a type checker". As a result, whereas the error codes in the rest of typeshed help make the stubs more self-documenting, it feels like the error codes in the `test_cases` directory just end up adding noise. They're also mypy-specific, and, in general, we should probably aim to have as little stuff in typeshed as possible that's specific to one type checker.

More discussion here: https://github.com/python/typeshed/pull/8066#discussion_r896969019