### PR TITLE
`protobuf`: Delete some `__new__` and `__init__` methods

### DIFF
--- a/stubs/protobuf/@tests/stubtest_allowlist.txt
+++ b/stubs/protobuf/@tests/stubtest_allowlist.txt
@@ -23,3 +23,12 @@ google.protobuf.text_format.MessageToBytes
 # Stubbed as static method, but actually exists as a property that's
 # a function. Typeshed's typing is more useful
 google.protobuf.service.Service.GetDescriptor
+
+# These are deliberately omitted in the stub
+# due to the fact that these classes have conflicting signatures for __init__/__new__.
+# The classes also can't be constructed directly anyway,
+# so the signatures of their constructors are somewhat irrelevant.
+google.protobuf.descriptor.Descriptor.__init__
+google.protobuf.descriptor.Descriptor.__new__
+google.protobuf.descriptor.ServiceDescriptor.__init__
+google.protobuf.descriptor.ServiceDescriptor.__new__

--- a/stubs/protobuf/google/protobuf/descriptor.pyi
+++ b/stubs/protobuf/google/protobuf/descriptor.pyi
@@ -45,27 +45,6 @@ class _NestedDescriptorBase(DescriptorBase):
     def CopyToProto(self, proto): ...
 
 class Descriptor(_NestedDescriptorBase):
-    def __new__(
-        cls,
-        name=...,
-        full_name=...,
-        filename=...,
-        containing_type=...,
-        fields=...,
-        nested_types=...,
-        enum_types=...,
-        extensions=...,
-        options=...,
-        serialized_options=...,
-        is_extendable=...,
-        extension_ranges=...,
-        oneofs=...,
-        file=...,
-        serialized_start=...,
-        serialized_end=...,
-        syntax=...,
-        create_key=...,
-    ): ...
     fields: Any
     fields_by_number: Any
     fields_by_name: Any
@@ -81,27 +60,6 @@ class Descriptor(_NestedDescriptorBase):
     oneofs: Any
     oneofs_by_name: Any
     syntax: Any
-    def __init__(
-        self,
-        name,
-        full_name,
-        filename,
-        containing_type,
-        fields,
-        nested_types,
-        enum_types,
-        extensions,
-        options=...,
-        serialized_options=...,
-        is_extendable=...,
-        extension_ranges=...,
-        oneofs=...,
-        file=...,
-        serialized_start=...,
-        serialized_end=...,
-        syntax=...,
-        create_key=...,
-    ) -> None: ...
     def EnumValueName(self, enum, value): ...
     def CopyToProto(self, proto): ...
     def GetOptions(self) -> MessageOptions: ...
@@ -266,35 +224,9 @@ class OneofDescriptor:
     def GetOptions(self) -> OneofOptions: ...
 
 class ServiceDescriptor(_NestedDescriptorBase):
-    def __new__(
-        cls,
-        name=...,
-        full_name=...,
-        index=...,
-        methods=...,
-        options=...,
-        serialized_options=...,
-        file=...,
-        serialized_start=...,
-        serialized_end=...,
-        create_key=...,
-    ): ...
     index: Any
     methods: Any
     methods_by_name: Any
-    def __init__(
-        self,
-        name,
-        full_name,
-        index,
-        methods,
-        options=...,
-        serialized_options=...,
-        file=...,
-        serialized_start=...,
-        serialized_end=...,
-        create_key=...,
-    ) -> None: ...
     def FindMethodByName(self, name): ...
     def CopyToProto(self, proto): ...
     def GetOptions(self) -> ServiceOptions: ...


### PR DESCRIPTION
Refs #6905.

Pyright points out that two classes in the stubs for `protobuf` have `__init__` and `__new__` methods that contradict. However, neither of these classes can be directly instantiated anyway:

```python
>>> from google.protobuf.descriptor import Descriptor
>>> Descriptor()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\alexw\coding\protobuf\lib\site-packages\google\protobuf\descriptor.py", line 313, in __new__
    _message.Message._CheckCalledFromGeneratedFile()
TypeError: Descriptors cannot not be created directly.
If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
If you cannot immediately regenerate your protos, some other possible workarounds are:
 1. Downgrade the protobuf package to 3.20.x or lower.
 2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).

More information: https://developers.google.com/protocol-buffers/docs/news/2022-05-06#python-updates
```

As such, I propose that we simply delete the `__init__` and `__new__` methods for these two classes.

Cc. @nipunn1313