### PR TITLE
fix: type-hints for imaplib exceptions

### DIFF
--- a/stdlib/imaplib.pyi
+++ b/stdlib/imaplib.pyi
@@ -19,9 +19,9 @@ _CommandResults: TypeAlias = tuple[str, list[Any]]
 _AnyResponseData: TypeAlias = list[None] | list[bytes | tuple[bytes, bytes]]
 
 class IMAP4:
-    error: type[Exception]
-    abort: type[Exception]
-    readonly: type[Exception]
+    class error(Exception): ...
+    class abort(error): ...
+    class readonly(abort): ...
     mustquote: Pattern[str]
     debug: int
     state: str


### PR DESCRIPTION
`mypy` would complain when trying to sub-class the `imaplib`
exceptions.

Change the exceptions from a `type` to a `class`

Closes: #8094