### PR TITLE
stubtest: use separate table in METADATA.toml

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -193,10 +193,13 @@ supported:
 * `no_longer_updated` (optional): This field is set to `true` before removing
   stubs for other reasons than the upstream library shipping with type
   information.
-* `stubtest` (default: `true`): Whether stubtest should be run against this
-  package. Please avoid setting this to `false`, and add a comment if you have
+
+In addition, we specify configuration for stubtest in the `tool.stubtest` table.
+This has the following keys:
+* `skip` (default: `false`): Whether stubtest should be run against this
+  package. Please avoid setting this to `true`, and add a comment if you have
   to.
-* `stubtest_apt_dependencies` (default: `[]`): A list of Ubuntu APT packages
+* `apt_dependencies` (default: `[]`): A list of Ubuntu APT packages
   that need to be installed for stubtest to run successfully. These are
   usually packages needed to pip install the implementation distribution.
 

--- a/stubs/JACK-Client/METADATA.toml
+++ b/stubs/JACK-Client/METADATA.toml
@@ -1,2 +1,4 @@
 version = "0.5.*"
-stubtest_apt_dependencies = ["libjack-dev"]
+
+[tool.stubtest]
+apt_dependencies = ["libjack-dev"]

--- a/stubs/gdb/METADATA.toml
+++ b/stubs/gdb/METADATA.toml
@@ -7,6 +7,7 @@ extra_description = """\
   using `pip`.\
 """
 
+[tool.stubtest]
 # Since the "gdb" Python package is available only inside GDB, it is not
 # possible to install it through pip, so stub tests cannot install it.
-stubtest = false
+skip = true

--- a/stubs/pyaudio/METADATA.toml
+++ b/stubs/pyaudio/METADATA.toml
@@ -1,2 +1,4 @@
 version = "0.2.*"
-stubtest_apt_dependencies = ["portaudio19-dev"]
+
+[tool.stubtest]
+apt_dependencies = ["portaudio19-dev"]

--- a/stubs/pycurl/METADATA.toml
+++ b/stubs/pycurl/METADATA.toml
@@ -1,2 +1,4 @@
 version = "7.44.*"
-stubtest_apt_dependencies = ["libcurl4-openssl-dev"]
+
+[tool.stubtest]
+apt_dependencies = ["libcurl4-openssl-dev"]

--- a/stubs/pynput/METADATA.toml
+++ b/stubs/pynput/METADATA.toml
@@ -1,2 +1,4 @@
 version = "1.7.*"
-stubtest = false  # A display server (e.g. X11) is required to import pynput
+
+[tool.stubtest]
+skip = true  # A display server (e.g. X11) is required to import pynput

--- a/tests/check_consistent.py
+++ b/tests/check_consistent.py
@@ -25,8 +25,11 @@ metadata_keys = {
     "extra_description",
     "obsolete_since",
     "no_longer_updated",
-    "stubtest",
-    "stubtest_apt_dependencies",
+    "tool",
+}
+stubtest_keys = {
+    "skip",
+    "apt_dependencies",
 }
 allowed_files = {"README.md"}
 
@@ -183,6 +186,10 @@ def check_metadata() -> None:
                 assert dep_version.count(".") <= 2, f"Bad version '{dep_version}' in dependency {dep}"
                 for part in dep_version.split("."):
                     assert part.isnumeric(), f"Bad version '{part}' in dependency {dep}"
+
+        assert set(data.get("tool", [])).issubset({"stubtest"}), f"Unrecognised tool for {distribution}"
+        for key in data.get("tool", {}).get("stubtest", {}):
+            assert key in stubtest_keys, f"Unrecognised stubtest key {key} for {distribution}"
 
 
 if __name__ == "__main__":

--- a/tests/check_consistent.py
+++ b/tests/check_consistent.py
@@ -20,7 +20,7 @@ import tomli
 
 consistent_files = [{"stdlib/@python2/builtins.pyi", "stdlib/@python2/__builtin__.pyi"}]
 metadata_keys = {"version", "requires", "extra_description", "obsolete_since", "no_longer_updated", "tool"}
-stubtest_keys = {"skip", "apt_dependencies"}
+tool_keys = {"stubtest": {"skip", "apt_dependencies"}}
 allowed_files = {"README.md"}
 
 
@@ -177,9 +177,10 @@ def check_metadata() -> None:
                 for part in dep_version.split("."):
                     assert part.isnumeric(), f"Bad version '{part}' in dependency {dep}"
 
-        assert set(data.get("tool", [])).issubset({"stubtest"}), f"Unrecognised tool for {distribution}"
-        for key in data.get("tool", {}).get("stubtest", {}):
-            assert key in stubtest_keys, f"Unrecognised stubtest key {key} for {distribution}"
+        assert set(data.get("tool", [])).issubset(tool_keys.keys()), f"Unrecognised tool for {distribution}"
+        for tool, tk in tool_keys.items():
+            for key in data.get("tool", {}).get(tool, {}):
+                assert key in tk, f"Unrecognised {tool} key {key} for {distribution}"
 
 
 if __name__ == "__main__":

--- a/tests/check_consistent.py
+++ b/tests/check_consistent.py
@@ -19,18 +19,8 @@ import re
 import tomli
 
 consistent_files = [{"stdlib/@python2/builtins.pyi", "stdlib/@python2/__builtin__.pyi"}]
-metadata_keys = {
-    "version",
-    "requires",
-    "extra_description",
-    "obsolete_since",
-    "no_longer_updated",
-    "tool",
-}
-stubtest_keys = {
-    "skip",
-    "apt_dependencies",
-}
+metadata_keys = {"version", "requires", "extra_description", "obsolete_since", "no_longer_updated", "tool"}
+stubtest_keys = {"skip", "apt_dependencies"}
 allowed_files = {"README.md"}
 
 

--- a/tests/get_apt_packages.py
+++ b/tests/get_apt_packages.py
@@ -10,5 +10,5 @@ if not distributions:
 
 for distribution in distributions:
     with open(f"stubs/{distribution}/METADATA.toml", "rb") as file:
-        for apt_package in tomli.load(file).get("stubtest_apt_dependencies", []):
+        for apt_package in tomli.load(file).get("tool", {}).get("stubtest", {}).get("apt_dependencies", []):
             print(apt_package)

--- a/tests/stubtest_third_party.py
+++ b/tests/stubtest_third_party.py
@@ -28,7 +28,8 @@ def run_stubtest(dist: Path, *, verbose: bool = False) -> bool:
 
     print(f"{dist.name}... ", end="")
 
-    if not metadata.get("stubtest", True):
+    stubtest_meta = metadata.get("tool", {}).get("stubtest", {})
+    if stubtest_meta.get("skip", False):
         print(colored("skipping", "yellow"))
         return True
 


### PR DESCRIPTION
I want to start enabling `--ignore-missing-stub` on third party packages, like we do for stdlib, since this helps ensure type completeness. I thought it might make sense to separate out the metadata little bit.