### PR TITLE
socket: consistency between constants and enums

### DIFF
--- a/stdlib/socket.pyi
+++ b/stdlib/socket.pyi
@@ -425,7 +425,7 @@ class AddressFamily(IntEnum):
         if sys.version_info >= (3, 8):
             AF_QIPCRTR: AddressFamily
     AF_LINK: AddressFamily  # availability: BSD, macOS
-    if sys.platform != "win32" and sys.platform != "darwin":
+    if sys.platform != "darwin":
         AF_BLUETOOTH: AddressFamily
 
 AF_UNIX: AddressFamily
@@ -467,7 +467,7 @@ if sys.platform == "linux":
     if sys.version_info >= (3, 8):
         AF_QIPCRTR: AddressFamily
 AF_LINK: AddressFamily  # availability: BSD, macOS
-if sys.platform != "win32" and sys.platform != "darwin":
+if sys.platform != "darwin":
     AF_BLUETOOTH: AddressFamily
 
 class SocketKind(IntEnum):

--- a/stdlib/socket.pyi
+++ b/stdlib/socket.pyi
@@ -390,39 +390,43 @@ class AddressFamily(IntEnum):
     AF_INET: int
     AF_INET6: int
     AF_AAL5: int
-    AF_ALG: int
     AF_APPLETALK: int
     AF_ASH: int
     AF_ATMPVC: int
     AF_ATMSVC: int
     AF_AX25: int
-    AF_BLUETOOTH: int
     AF_BRIDGE: int
-    AF_CAN: int
     AF_DECnet: int
     AF_ECONET: int
     AF_IPX: int
     AF_IRDA: int
     AF_KEY: int
-    AF_LINK: int
     AF_LLC: int
     AF_NETBEUI: int
-    AF_NETLINK: int
     AF_NETROM: int
-    AF_PACKET: int
     AF_PPPOX: int
-    AF_QIPCRTR: int
-    AF_RDS: int
     AF_ROSE: int
     AF_ROUTE: int
     AF_SECURITY: int
     AF_SNA: int
     AF_SYSTEM: int
-    AF_TIPC: int
     AF_UNSPEC: int
-    AF_VSOCK: int
     AF_WANPIPE: int
     AF_X25: int
+    if sys.platform == "linux":
+        AF_CAN: AddressFamily
+        AF_PACKET: AddressFamily
+        AF_RDS: AddressFamily
+        AF_TIPC: AddressFamily
+        AF_ALG: AddressFamily
+        AF_NETLINK: AddressFamily
+        if sys.version_info >= (3, 7):
+            AF_VSOCK: AddressFamily
+        if sys.version_info >= (3, 8):
+            AF_QIPCRTR: AddressFamily
+    AF_LINK: AddressFamily  # availability: BSD, macOS
+    if sys.platform != "win32" and sys.platform != "darwin":
+        AF_BLUETOOTH: AddressFamily
 
 AF_UNIX: AddressFamily
 AF_INET: AddressFamily
@@ -472,8 +476,9 @@ class SocketKind(IntEnum):
     SOCK_RAW: int
     SOCK_RDM: int
     SOCK_SEQPACKET: int
-    SOCK_CLOEXEC: int
-    SOCK_NONBLOCK: int
+    if sys.platform == "linux":
+        SOCK_CLOEXEC: int
+        SOCK_NONBLOCK: int
 
 SOCK_STREAM: SocketKind
 SOCK_DGRAM: SocketKind
@@ -485,10 +490,22 @@ if sys.platform == "linux":
     SOCK_NONBLOCK: SocketKind
 
 class MsgFlag(IntFlag):
+    MSG_BCAST: int
+    MSG_BTAG: int
+    MSG_CMSG_CLOEXEC: int
+    MSG_CONFIRM: int
     MSG_CTRUNC: int
     MSG_DONTROUTE: int
     MSG_DONTWAIT: int
+    MSG_EOF: int
     MSG_EOR: int
+    MSG_ERRQUEUE: int
+    MSG_ETAG: int
+    MSG_FASTOPEN: int
+    MSG_MCAST: int
+    MSG_MORE: int
+    MSG_NOSIGNAL: int
+    MSG_NOTIFICATION: int
     MSG_OOB: int
     MSG_PEEK: int
     MSG_TRUNC: int
@@ -519,10 +536,13 @@ class AddressInfo(IntFlag):
     AI_ADDRCONFIG: int
     AI_ALL: int
     AI_CANONNAME: int
+    AI_DEFAULT: int
+    AI_MASK: int
     AI_NUMERICHOST: int
     AI_NUMERICSERV: int
     AI_PASSIVE: int
     AI_V4MAPPED: int
+    AI_V4MAPPED_CFG: int
 
 AI_ADDRCONFIG: AddressInfo
 AI_ALL: AddressInfo

--- a/stdlib/socket.pyi
+++ b/stdlib/socket.pyi
@@ -414,19 +414,19 @@ class AddressFamily(IntEnum):
     AF_WANPIPE: int
     AF_X25: int
     if sys.platform == "linux":
-        AF_CAN: AddressFamily
-        AF_PACKET: AddressFamily
-        AF_RDS: AddressFamily
-        AF_TIPC: AddressFamily
-        AF_ALG: AddressFamily
-        AF_NETLINK: AddressFamily
+        AF_CAN: int
+        AF_PACKET: int
+        AF_RDS: int
+        AF_TIPC: int
+        AF_ALG: int
+        AF_NETLINK: int
         if sys.version_info >= (3, 7):
-            AF_VSOCK: AddressFamily
+            AF_VSOCK: int
         if sys.version_info >= (3, 8):
-            AF_QIPCRTR: AddressFamily
+            AF_QIPCRTR: int
     AF_LINK: AddressFamily  # availability: BSD, macOS
     if sys.platform != "darwin":
-        AF_BLUETOOTH: AddressFamily
+        AF_BLUETOOTH: int
 
 AF_UNIX: AddressFamily
 AF_INET: AddressFamily

--- a/tests/stubtest_allowlists/darwin.txt
+++ b/tests/stubtest_allowlists/darwin.txt
@@ -16,10 +16,6 @@ distutils.msvccompiler.MSVCCompiler.set_path_env_var
 distutils.msvccompiler.MacroExpander
 mimetypes.MimeTypes.read_windows_registry
 selectors.DefaultSelector.fileno
-socket.AddressInfo.AI_DEFAULT
-socket.AddressInfo.AI_MASK
-socket.AddressInfo.AI_V4MAPPED_CFG
-socket.MsgFlag.MSG_EOF
 
 posix.NGROUPS_MAX
 posix.error.characters_written

--- a/tests/stubtest_allowlists/linux.txt
+++ b/tests/stubtest_allowlists/linux.txt
@@ -17,12 +17,6 @@ distutils.msvccompiler.MSVCCompiler.set_path_env_var
 distutils.msvccompiler.MacroExpander
 mimetypes.MimeTypes.read_windows_registry
 selectors.DefaultSelector.fileno
-socket.MsgFlag.MSG_CMSG_CLOEXEC
-socket.MsgFlag.MSG_CONFIRM
-socket.MsgFlag.MSG_ERRQUEUE
-socket.MsgFlag.MSG_FASTOPEN
-socket.MsgFlag.MSG_MORE
-socket.MsgFlag.MSG_NOSIGNAL
 spwd.struct_spwd.sp_nam
 spwd.struct_spwd.sp_pwd
 

--- a/tests/stubtest_allowlists/win32-py310.txt
+++ b/tests/stubtest_allowlists/win32-py310.txt
@@ -9,7 +9,6 @@ asyncio.windows_events.IocpProactor.recvfrom
 asyncio.windows_events.IocpProactor.sendto
 distutils.command.build_ext.__warningregistry__
 msvcrt.GetErrorMode
-socket.MsgFlag.MSG_ERRQUEUE
 subprocess.STARTUPINFO.copy
 
 # ==========

--- a/tests/stubtest_allowlists/win32-py311.txt
+++ b/tests/stubtest_allowlists/win32-py311.txt
@@ -12,7 +12,6 @@ asyncio.windows_events.IocpProactor.sendto
 distutils.command.build_ext.__warningregistry__
 msvcrt.GetErrorMode
 os.EX_OK
-socket.MsgFlag.MSG_ERRQUEUE
 subprocess.STARTUPINFO.copy
 
 # ==========

--- a/tests/stubtest_allowlists/win32-py37.txt
+++ b/tests/stubtest_allowlists/win32-py37.txt
@@ -10,9 +10,6 @@ urllib.parse.parse_qsl
 
 os.startfile
 
-# Exists at runtime, but missing from stubs
-socket.MsgFlag.MSG_ERRQUEUE
-
 # ==========
 # Allowlist entries that cannot or should not be fixed
 # ==========

--- a/tests/stubtest_allowlists/win32-py38.txt
+++ b/tests/stubtest_allowlists/win32-py38.txt
@@ -7,7 +7,6 @@ asyncio.IocpProactor.recvfrom
 asyncio.IocpProactor.sendto
 asyncio.windows_events.IocpProactor.recvfrom
 asyncio.windows_events.IocpProactor.sendto
-socket.MsgFlag.MSG_ERRQUEUE
 subprocess.STARTUPINFO.copy
 
 # ==========

--- a/tests/stubtest_allowlists/win32-py39.txt
+++ b/tests/stubtest_allowlists/win32-py39.txt
@@ -7,7 +7,6 @@ asyncio.IocpProactor.recvfrom
 asyncio.IocpProactor.sendto
 asyncio.windows_events.IocpProactor.recvfrom
 asyncio.windows_events.IocpProactor.sendto
-socket.MsgFlag.MSG_ERRQUEUE
 subprocess.STARTUPINFO.copy
 
 # ==========

--- a/tests/stubtest_allowlists/win32.txt
+++ b/tests/stubtest_allowlists/win32.txt
@@ -27,8 +27,6 @@ distutils.msvccompiler.MSVCCompiler.manifest_get_embed_info
 distutils.msvccompiler.MSVCCompiler.manifest_setup_ldargs
 distutils.msvccompiler.OldMSVCCompiler
 msvcrt.SetErrorMode
-socket.MsgFlag.MSG_BCAST
-socket.MsgFlag.MSG_MCAST
 ssl.SSLSocket.recvmsg
 ssl.SSLSocket.recvmsg_into
 ssl.SSLSocket.sendmsg


### PR DESCRIPTION
This matches what happens at runtime, from `Enum._convert_`
Helps with #8098. Fixes #5696.