### PR TITLE
asyncio.iscoroutine: fix return type (`Generator` -> `AwaitableGenerator`)

### DIFF
--- a/stdlib/asyncio/coroutines.pyi
+++ b/stdlib/asyncio/coroutines.pyi
@@ -1,7 +1,6 @@
 import sys
-import types
 from collections.abc import Coroutine
-from typing import Any
+from typing import Any, AwaitableGenerator
 from typing_extensions import TypeGuard
 
 if sys.version_info >= (3, 11):
@@ -24,4 +23,4 @@ if sys.version_info >= (3, 8):
     def iscoroutine(obj: object) -> TypeGuard[Coroutine[Any, Any, Any]]: ...
 
 else:
-    def iscoroutine(obj: object) -> TypeGuard[types.GeneratorType[Any, Any, Any] | Coroutine[Any, Any, Any]]: ...
+    def iscoroutine(obj: object) -> TypeGuard[AwaitableGenerator[Any, Any, Any] | Coroutine[Any, Any, Any]]: ...


### PR DESCRIPTION
As noted by @florimondmanca [here](https://github.com/python/typeshed/pull/6105#discussion_r901080130) the correct return type should be the sus type_check_only type `AwaitableGenerator`.