### PR TITLE
`asyncio.gather`: Remove default values for `return_exceptions: bool` overloads

### DIFF
--- a/stdlib/asyncio/tasks.pyi
+++ b/stdlib/asyncio/tasks.pyi
@@ -131,10 +131,10 @@ if sys.version_info >= (3, 10):
         return_exceptions: bool = ...,
     ) -> Future[list[Any]]: ...
     @overload
-    def gather(__coro_or_future1: _FutureT[_T1], *, return_exceptions: bool = ...) -> Future[tuple[_T1 | BaseException]]: ...
+    def gather(__coro_or_future1: _FutureT[_T1], *, return_exceptions: bool) -> Future[tuple[_T1 | BaseException]]: ...
     @overload
     def gather(
-        __coro_or_future1: _FutureT[_T1], __coro_or_future2: _FutureT[_T2], *, return_exceptions: bool = ...
+        __coro_or_future1: _FutureT[_T1], __coro_or_future2: _FutureT[_T2], *, return_exceptions: bool
     ) -> Future[tuple[_T1 | BaseException, _T2 | BaseException]]: ...
     @overload
     def gather(
@@ -142,7 +142,7 @@ if sys.version_info >= (3, 10):
         __coro_or_future2: _FutureT[_T2],
         __coro_or_future3: _FutureT[_T3],
         *,
-        return_exceptions: bool = ...,
+        return_exceptions: bool,
     ) -> Future[tuple[_T1 | BaseException, _T2 | BaseException, _T3 | BaseException]]: ...
     @overload
     def gather(
@@ -151,7 +151,7 @@ if sys.version_info >= (3, 10):
         __coro_or_future3: _FutureT[_T3],
         __coro_or_future4: _FutureT[_T4],
         *,
-        return_exceptions: bool = ...,
+        return_exceptions: bool,
     ) -> Future[tuple[_T1 | BaseException, _T2 | BaseException, _T3 | BaseException, _T4 | BaseException]]: ...
     @overload
     def gather(
@@ -161,7 +161,7 @@ if sys.version_info >= (3, 10):
         __coro_or_future4: _FutureT[_T4],
         __coro_or_future5: _FutureT[_T5],
         *,
-        return_exceptions: bool = ...,
+        return_exceptions: bool,
     ) -> Future[
         tuple[_T1 | BaseException, _T2 | BaseException, _T3 | BaseException, _T4 | BaseException, _T5 | BaseException]
     ]: ...
@@ -223,7 +223,7 @@ else:
     ) -> Future[list[Any]]: ...
     @overload
     def gather(
-        __coro_or_future1: _FutureT[_T1], *, loop: AbstractEventLoop | None = ..., return_exceptions: bool = ...
+        __coro_or_future1: _FutureT[_T1], *, loop: AbstractEventLoop | None = ..., return_exceptions: bool
     ) -> Future[tuple[_T1 | BaseException]]: ...
     @overload
     def gather(
@@ -231,7 +231,7 @@ else:
         __coro_or_future2: _FutureT[_T2],
         *,
         loop: AbstractEventLoop | None = ...,
-        return_exceptions: bool = ...,
+        return_exceptions: bool,
     ) -> Future[tuple[_T1 | BaseException, _T2 | BaseException]]: ...
     @overload
     def gather(
@@ -240,7 +240,7 @@ else:
         __coro_or_future3: _FutureT[_T3],
         *,
         loop: AbstractEventLoop | None = ...,
-        return_exceptions: bool = ...,
+        return_exceptions: bool,
     ) -> Future[tuple[_T1 | BaseException, _T2 | BaseException, _T3 | BaseException]]: ...
     @overload
     def gather(
@@ -250,7 +250,7 @@ else:
         __coro_or_future4: _FutureT[_T4],
         *,
         loop: AbstractEventLoop | None = ...,
-        return_exceptions: bool = ...,
+        return_exceptions: bool,
     ) -> Future[tuple[_T1 | BaseException, _T2 | BaseException, _T3 | BaseException, _T4 | BaseException]]: ...
     @overload
     def gather(
@@ -261,7 +261,7 @@ else:
         __coro_or_future5: _FutureT[_T5],
         *,
         loop: AbstractEventLoop | None = ...,
-        return_exceptions: bool = ...,
+        return_exceptions: bool,
     ) -> Future[
         tuple[_T1 | BaseException, _T2 | BaseException, _T3 | BaseException, _T4 | BaseException, _T5 | BaseException]
     ]: ...


### PR DESCRIPTION
At runtime, the signature for `asyncio.gather()` has `return_exceptions=False` as the default. As such, the `asyncio.gather()` overloads with `return_exceptions: bool` should only be chosen if a user actually specifies a value for `return_exceptions`. The `= ...` isn't needed for these overloads.