### PR TITLE
mypy_test.py: Fix argument-parsing for `--python-version`

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -17,7 +17,7 @@ in the `CONTRIBUTING.md` document. In particular, we recommend running with Pyth
 
 ## mypy\_test.py
 
-This test requires Python 3.7+. Run using:
+This test requires Python 3.8+. Run using:
 ```
 (.venv3)$ python3 tests/mypy_test.py
 ```

--- a/tests/mypy_test.py
+++ b/tests/mypy_test.py
@@ -36,7 +36,7 @@ parser = argparse.ArgumentParser(description="Test runner for typeshed. Patterns
 parser.add_argument("-v", "--verbose", action="count", default=0, help="More output")
 parser.add_argument("-n", "--dry-run", action="store_true", help="Don't actually run mypy")
 parser.add_argument("-x", "--exclude", type=str, nargs="*", help="Exclude pattern")
-parser.add_argument("-p", "--python-version", type=str, nargs="*", help="These versions only (major[.minor])")
+parser.add_argument("-p", "--python-version", type=str, nargs="*", action="extend", help="These versions only (major[.minor])")
 parser.add_argument("--platform", help="Run mypy for a certain OS platform (defaults to sys.platform)")
 parser.add_argument("filter", type=str, nargs="*", help="Include pattern (default all)")
 


### PR DESCRIPTION
Currently, the argument-parsing for the `--python-version` option is a little broken. If you try to pass more than one value to `--python-version` when running the test locally, it doesn't work.

This PR means that either of the following two invocations will work:

```
python tests/mypy_test.py -p3.6 -p3.7
```

```
python tests/mypy_test.py --python-version 3.6 3.7
```