### PR TITLE
Fix `assertAlmostEqual` regression on mixed numeric types

### DIFF
--- a/stdlib/_typeshed/__init__.pyi
+++ b/stdlib/_typeshed/__init__.pyi
@@ -80,6 +80,9 @@ class SupportsRAdd(Protocol[_T_contra, _T_co]):
 class SupportsSub(Protocol[_T_contra, _T_co]):
     def __sub__(self, __x: _T_contra) -> _T_co: ...
 
+class SupportsRSub(Protocol[_T_contra, _T_co]):
+    def __rsub__(self, __x: _T_contra) -> _T_co: ...
+
 class SupportsDivMod(Protocol[_T_contra, _T_co]):
     def __divmod__(self, __other: _T_contra) -> _T_co: ...
 

--- a/stdlib/unittest/case.pyi
+++ b/stdlib/unittest/case.pyi
@@ -1,7 +1,7 @@
 import logging
 import sys
 import unittest.result
-from _typeshed import Self, SupportsDunderGE, SupportsDunderGT, SupportsDunderLE, SupportsDunderLT, SupportsSub
+from _typeshed import Self, SupportsDunderGE, SupportsDunderGT, SupportsDunderLE, SupportsDunderLT, SupportsRSub, SupportsSub
 from collections.abc import Callable, Container, Iterable, Mapping, Sequence, Set as AbstractSet
 from contextlib import AbstractContextManager
 from types import TracebackType
@@ -217,6 +217,15 @@ class TestCase:
         delta: None = ...,
     ) -> None: ...
     @overload
+    def assertAlmostEqual(
+        self,
+        first: _T,
+        second: SupportsRSub[_T, SupportsAbs[SupportsRound[object]]],
+        places: int | None = ...,
+        msg: Any = ...,
+        delta: None = ...,
+    ) -> None: ...
+    @overload
     def assertNotAlmostEqual(self, first: _S, second: _S, places: None, msg: Any, delta: _SupportsAbsAndDunderGE) -> None: ...
     @overload
     def assertNotAlmostEqual(
@@ -227,6 +236,15 @@ class TestCase:
         self,
         first: SupportsSub[_T, SupportsAbs[SupportsRound[object]]],
         second: _T,
+        places: int | None = ...,
+        msg: Any = ...,
+        delta: None = ...,
+    ) -> None: ...
+    @overload
+    def assertNotAlmostEqual(
+        self,
+        first: _T,
+        second: SupportsRSub[_T, SupportsAbs[SupportsRound[object]]],
         places: int | None = ...,
         msg: Any = ...,
         delta: None = ...,

--- a/test_cases/stdlib/test_unittest.py
+++ b/test_cases/stdlib/test_unittest.py
@@ -11,8 +11,10 @@ case = unittest.TestCase()
 # Tests for assertAlmostEqual
 ###
 
+case.assertAlmostEqual(1, 2.4)
 case.assertAlmostEqual(2.4, 2.41)
 case.assertAlmostEqual(Fraction(49, 50), Fraction(48, 50))
+case.assertAlmostEqual(3.14, complex(5, 6))
 case.assertAlmostEqual(datetime(1999, 1, 2), datetime(1999, 1, 2, microsecond=1), delta=timedelta(hours=1))
 case.assertAlmostEqual(datetime(1999, 1, 2), datetime(1999, 1, 2, microsecond=1), None, "foo", timedelta(hours=1))
 case.assertAlmostEqual(Decimal("1.1"), Decimal("1.11"))
@@ -23,18 +25,24 @@ case.assertAlmostEqual(2.4, 2.41, None, "foo", 0.02)
 case.assertAlmostEqual(2.4, 2.41, places=9, delta=0.02)  # type: ignore
 case.assertAlmostEqual("foo", "bar")  # type: ignore
 case.assertAlmostEqual(datetime(1999, 1, 2), datetime(1999, 1, 2, microsecond=1))  # type: ignore
+case.assertAlmostEqual(Decimal("0.4"), Fraction(1, 2))  # type: ignore
+case.assertAlmostEqual(complex(2, 3), Decimal("0.9"))  # type: ignore
 
 ###
 # Tests for assertNotAlmostEqual
 ###
 
+case.assertAlmostEqual(1, 2.4)
 case.assertNotAlmostEqual(Fraction(49, 50), Fraction(48, 50))
+case.assertAlmostEqual(3.14, complex(5, 6))
 case.assertNotAlmostEqual(datetime(1999, 1, 2), datetime(1999, 1, 2, microsecond=1), delta=timedelta(hours=1))
 case.assertNotAlmostEqual(datetime(1999, 1, 2), datetime(1999, 1, 2, microsecond=1), None, "foo", timedelta(hours=1))
 
 case.assertNotAlmostEqual(2.4, 2.41, places=9, delta=0.02)  # type: ignore
 case.assertNotAlmostEqual("foo", "bar")  # type: ignore
 case.assertNotAlmostEqual(datetime(1999, 1, 2), datetime(1999, 1, 2, microsecond=1))  # type: ignore
+case.assertNotAlmostEqual(Decimal("0.4"), Fraction(1, 2))  # type: ignore
+case.assertNotAlmostEqual(complex(2, 3), Decimal("0.9"))  # type: ignore
 
 ###
 # Tests for assertGreater


### PR DESCRIPTION
Fixes #8136