### PR TITLE
fix(`stdlib.xml`): re-export ContentHandler

### DIFF
--- a/stdlib/xml/sax/__init__.pyi
+++ b/stdlib/xml/sax/__init__.pyi
@@ -2,7 +2,7 @@ import sys
 from _typeshed import SupportsRead, _T_co
 from collections.abc import Iterable
 from typing import Any, NoReturn, Protocol
-from xml.sax.handler import ContentHandler as ContentHandler, ErrorHandler
+from xml.sax.handler import ContentHandler as ContentHandler, ErrorHandler as ErrorHandler
 from xml.sax.xmlreader import Locator, XMLReader
 
 class _SupportsReadClose(SupportsRead[_T_co], Protocol[_T_co]):

--- a/stdlib/xml/sax/__init__.pyi
+++ b/stdlib/xml/sax/__init__.pyi
@@ -2,7 +2,7 @@ import sys
 from _typeshed import SupportsRead, _T_co
 from collections.abc import Iterable
 from typing import Any, NoReturn, Protocol
-from xml.sax.handler import ContentHandler, ErrorHandler
+from xml.sax.handler import ContentHandler as ContentHandler, ErrorHandler
 from xml.sax.xmlreader import Locator, XMLReader
 
 class _SupportsReadClose(SupportsRead[_T_co], Protocol[_T_co]):


### PR DESCRIPTION
fixes python/typeshed#8107