### PR TITLE
re-exporting `HTTPError` in `urllib.request`

### DIFF
--- a/stdlib/urllib/request.pyi
+++ b/stdlib/urllib/request.pyi
@@ -7,7 +7,7 @@ from http.client import HTTPMessage, HTTPResponse, _HTTPConnectionProtocol
 from http.cookiejar import CookieJar
 from typing import IO, Any, ClassVar, NoReturn, Pattern, TypeVar, overload
 from typing_extensions import TypeAlias
-from urllib.error import HTTPError
+from urllib.error import HTTPError as HTTPError
 from urllib.response import addclosehook, addinfourl
 
 __all__ = [


### PR DESCRIPTION
to mitigate typechecker complains about unknown module members. [cpython/#94204](https://github.com/python/cpython/issues/94204)