### PR TITLE
[stubsabot] Bump requests to 2.28.*

### DIFF
--- a/stubs/requests/METADATA.toml
+++ b/stubs/requests/METADATA.toml
@@ -1,2 +1,2 @@
-version = "2.27.*"
+version = "2.28.*"
 requires = ["types-urllib3<1.27"] # keep in sync with requests's setup.py


### PR DESCRIPTION
If stubtest fails for this PR:
- Leave this PR open (as a reminder, and to prevent stubsabot from opening another PR)
- Fix stubtest failures in another PR, then close this PR
