### PR TITLE
[stubsabot] Bump entrypoints to 0.4.*

### DIFF
--- a/stubs/entrypoints/METADATA.toml
+++ b/stubs/entrypoints/METADATA.toml
@@ -1,1 +1,1 @@
-version = "0.3.*"
+version = "0.4.*"


### PR DESCRIPTION
Release: https://pypi.org/project/entrypoints/0.4/
Homepage: https://github.com/takluyver/entrypoints

If stubtest fails for this PR:
- Leave this PR open (as a reminder, and to prevent stubsabot from opening another PR)
- Fix stubtest failures in another PR, then close this PR
