### PR TITLE
[stubsabot] Bump jsonschema to 4.6.*

### DIFF
--- a/stubs/jsonschema/METADATA.toml
+++ b/stubs/jsonschema/METADATA.toml
@@ -1,1 +1,1 @@
-version = "4.4.*"
+version = "4.6.*"

--- a/stubs/jsonschema/jsonschema/protocols.pyi
+++ b/stubs/jsonschema/jsonschema/protocols.pyi
@@ -10,6 +10,7 @@ class Validator(Protocol):
     META_SCHEMA: ClassVar[dict[Any, Any]]
     VALIDATORS: ClassVar[dict[Any, Any]]
     TYPE_CHECKER: ClassVar[TypeChecker]
+    FORMAT_CHECKER: ClassVar[FormatChecker]
     schema: dict[Any, Any] | bool
     def __init__(
         self, schema: dict[Any, Any] | bool, resolver: RefResolver | None = ..., format_checker: FormatChecker | None = ...

--- a/stubs/jsonschema/jsonschema/validators.pyi
+++ b/stubs/jsonschema/jsonschema/validators.pyi
@@ -12,7 +12,8 @@ _Schema: TypeAlias = Mapping[str, Any]
 class _Validator:
     VALIDATORS: ClassVar[dict[Any, Any]]
     META_SCHEMA: ClassVar[dict[Any, Any]]
-    TYPE_CHECKER: Any
+    TYPE_CHECKER: ClassVar[Any]
+    FORMAT_CHECKER: ClassVar[Any]
     @staticmethod
     def ID_OF(schema: _Schema) -> str: ...
     schema: _Schema
@@ -32,9 +33,17 @@ class _Validator:
 
 def validates(version: str) -> Callable[..., Any]: ...
 def create(
-    meta_schema, validators=..., version: Any | None = ..., type_checker=..., id_of=..., applicable_validators=...
+    meta_schema,
+    validators=...,
+    version: Any | None = ...,
+    type_checker=...,
+    format_checker=...,
+    id_of=...,
+    applicable_validators=...,
 ) -> type[_Validator]: ...
-def extend(validator, validators=..., version: Any | None = ..., type_checker: Any | None = ...): ...
+def extend(
+    validator, validators=..., version: Any | None = ..., type_checker: Any | None = ..., format_checker: Any | None = ...
+): ...
 
 # At runtime these are fields that are assigned the return values of create() calls.
 class Draft3Validator(_Validator): ...


### PR DESCRIPTION
Release: https://pypi.org/project/jsonschema/4.6.0/

If stubtest fails for this PR:
- Leave this PR open (as a reminder, and to prevent stubsabot from opening another PR)
- Fix stubtest failures in another PR, then close this PR
