### PR TITLE
[stubsabot] Bump pycurl to 7.45.*

### DIFF
--- a/stubs/pycurl/METADATA.toml
+++ b/stubs/pycurl/METADATA.toml
@@ -1,4 +1,4 @@
-version = "7.44.*"
+version = "7.45.*"
 
 [tool.stubtest]
 apt_dependencies = ["libcurl4-openssl-dev"]


### PR DESCRIPTION
Release: https://pypi.org/project/pycurl/7.45.1/
Homepage: http://pycurl.io/

If stubtest fails for this PR:
- Leave this PR open (as a reminder, and to prevent stubsabot from opening another PR)
- Fix stubtest failures in another PR, then close this PR
