### PR TITLE
`typing_extensions`: harmonise `__all__` with `__all__` at runtime

### DIFF
--- a/stdlib/typing_extensions.pyi
+++ b/stdlib/typing_extensions.pyi
@@ -37,6 +37,8 @@ __all__ = [
     "Final",
     "LiteralString",
     "ParamSpec",
+    "ParamSpecArgs",
+    "ParamSpecKwargs",
     "Self",
     "Type",
     "TypeVarTuple",
@@ -158,6 +160,8 @@ if sys.version_info >= (3, 10):
     from typing import (
         Concatenate as Concatenate,
         ParamSpec as ParamSpec,
+        ParamSpecArgs as ParamSpecArgs,
+        ParamSpecKwargs as ParamSpecKwargs,
         TypeAlias as TypeAlias,
         TypeGuard as TypeGuard,
         is_typeddict as is_typeddict,


### PR DESCRIPTION
This wasn't possible prior to https://github.com/google/pytype/commit/6b1fee04f8e040be59b9787228abaa4bb48cd407