### PR TITLE
`typing.TextIO`: add `write_through` and `reconfigure`.

### DIFF
--- a/stdlib/typing.pyi
+++ b/stdlib/typing.pyi
@@ -706,6 +706,18 @@ class TextIO(IO[str]):
     def newlines(self) -> Any: ...  # None, str or tuple
     @abstractmethod
     def __enter__(self) -> TextIO: ...
+    if sys.version_info >= (3, 7):
+        @property
+        def write_through(self) -> bool: ...
+        def reconfigure(
+            self,
+            *,
+            encoding: str | None = ...,
+            errors: str | None = ...,
+            newline: str | None = ...,
+            line_buffering: bool | None = ...,
+            write_through: bool | None = ...,
+        ) -> None: ...
 
 class ByteString(Sequence[int], metaclass=ABCMeta): ...
 


### PR DESCRIPTION
Hi,

Thanks a lot for taking care of typeshed, mypy, and the related projects!

What do you think about the attached trivial patch that makes it possible to use e.g. `sys.stdin.reconfigure(encoding="UTF-8")` in cases when it is needed?

Thanks again, and keep up the great work!

G'luck,
Peter
