### PR TITLE
Bump xmltodict to 0.13.*

### DIFF
--- a/stubs/xmltodict/METADATA.toml
+++ b/stubs/xmltodict/METADATA.toml
@@ -1,4 +1,4 @@
-version = "0.12.*"
+version = "0.13.*"
 
 [tool.stubtest]
 ignore_missing_stub = false

--- a/stubs/xmltodict/xmltodict.pyi
+++ b/stubs/xmltodict/xmltodict.pyi
@@ -14,6 +14,7 @@ def parse(
     process_namespaces: bool = ...,
     namespace_separator: str = ...,
     disable_entities: bool = ...,
+    process_comments: bool = ...,
     **kwargs: Any,
 ) -> OrderedDict[str, Any]: ...
 @overload


### PR DESCRIPTION
Release: https://pypi.org/project/xmltodict/0.13.0/
Homepage: https://github.com/martinblech/xmltodict

If stubtest fails for this PR:
- Leave this PR open (as a reminder, and to prevent stubsabot from opening another PR)
- Fix stubtest failures in another PR, then close this PR
