### PR TITLE
[stubsabot] Bump python-nmap to 0.7.*

### DIFF
--- a/stubs/python-nmap/METADATA.toml
+++ b/stubs/python-nmap/METADATA.toml
@@ -1,1 +1,1 @@
-version = "0.6.*"
+version = "0.7.*"


### PR DESCRIPTION
Release: https://pypi.org/project/python-nmap/0.7.1/
Homepage: http://xael.org/pages/python-nmap-en.html

If stubtest fails for this PR:
- Leave this PR open (as a reminder, and to prevent stubsabot from opening another PR)
- Fix stubtest failures in another PR, then close this PR
