### PR TITLE
[stubsabot] Bump aws-xray-sdk to 2.9.*

### DIFF
--- a/stubs/aws-xray-sdk/METADATA.toml
+++ b/stubs/aws-xray-sdk/METADATA.toml
@@ -1,1 +1,1 @@
-version = "2.8.*"
+version = "2.9.*"

--- a/stubs/aws-xray-sdk/aws_xray_sdk/core/recorder.pyi
+++ b/stubs/aws-xray-sdk/aws_xray_sdk/core/recorder.pyi
@@ -19,8 +19,8 @@ from .models.dummy_entities import DummySegment as DummySegment, DummySubsegment
 from .models.segment import Segment as Segment, SegmentContextManager as SegmentContextManager
 from .models.subsegment import Subsegment as Subsegment, SubsegmentContextManager as SubsegmentContextManager
 from .plugins.utils import get_plugin_modules as get_plugin_modules
-from .sampling.local.sampler import LocalSampler as LocalSampler
-from .sampling.sampler import DefaultSampler as DefaultSampler
+from .sampling.local.sampler import LocalSampler
+from .sampling.sampler import DefaultSampler
 from .streaming.default_streaming import DefaultStreaming as DefaultStreaming
 from .utils import stacktrace as stacktrace
 from .utils.compat import string_types as string_types


### PR DESCRIPTION
Release: https://pypi.org/project/aws-xray-sdk/2.9.0/
Homepage: https://github.com/aws/aws-xray-sdk-python

If stubtest fails for this PR:
- Leave this PR open (as a reminder, and to prevent stubsabot from opening another PR)
- Fix stubtest failures in another PR, then close this PR
