### PR TITLE
[stubsabot] Bump jmespath to 1.0.*

### DIFF
--- a/stubs/jmespath/METADATA.toml
+++ b/stubs/jmespath/METADATA.toml
@@ -1,4 +1,4 @@
-version = "0.10.*"
+version = "1.0.*"
 
 [tool.stubtest]
 ignore_missing_stub = false


### PR DESCRIPTION
Release: https://pypi.org/project/jmespath/1.0.1/
Homepage: https://github.com/jmespath/jmespath.py

If stubtest fails for this PR:
- Leave this PR open (as a reminder, and to prevent stubsabot from opening another PR)
- Fix stubtest failures in another PR, then close this PR
