### PR TITLE
[stubsabot] Bump tzlocal to 4.2

### DIFF
--- a/stubs/tzlocal/METADATA.toml
+++ b/stubs/tzlocal/METADATA.toml
@@ -1,4 +1,4 @@
-version = "4.1"
+version = "4.2"
 requires = ["types-pytz"]
 
 [tool.stubtest]


### PR DESCRIPTION
Release: https://pypi.org/project/tzlocal/4.2/

If stubtest fails for this PR:
- Leave this PR open (as a reminder, and to prevent stubsabot from opening another PR)
- Fix stubtest failures in another PR, then close this PR
