### PR TITLE
[stubsabot] Bump python-slugify to 6.1.*

### DIFF
--- a/stubs/python-slugify/METADATA.toml
+++ b/stubs/python-slugify/METADATA.toml
@@ -1,1 +1,1 @@
-version = "5.0.*"
+version = "6.1.*"

--- a/stubs/python-slugify/slugify/slugify.pyi
+++ b/stubs/python-slugify/slugify/slugify.pyi
@@ -16,4 +16,5 @@ def slugify(
     regex_pattern: str | None = ...,
     lowercase: bool = ...,
     replacements: Iterable[Iterable[str]] = ...,
+    allow_unicode: bool = ...,
 ) -> str: ...


### PR DESCRIPTION
Release: https://pypi.org/project/python-slugify/6.1.2/
Homepage: https://github.com/un33k/python-slugify

If stubtest fails for this PR:
- Leave this PR open (as a reminder, and to prevent stubsabot from opening another PR)
- Fix stubtest failures in another PR, then close this PR
