### PR TITLE
[stubsabot] Bump dataclasses to 0.8

### DIFF
--- a/stubs/dataclasses/METADATA.toml
+++ b/stubs/dataclasses/METADATA.toml
@@ -1,1 +1,1 @@
-version = "0.6"
+version = "0.8"


### PR DESCRIPTION
Release: https://pypi.org/project/dataclasses/0.8/
Homepage: https://github.com/ericvsmith/dataclasses

If stubtest fails for this PR:
- Leave this PR open (as a reminder, and to prevent stubsabot from opening another PR)
- Fix stubtest failures in another PR, then close this PR
