### PR TITLE
[stubsabot] Bump aws-xray-sdk to 2.10.*

### DIFF
--- a/stubs/aws-xray-sdk/METADATA.toml
+++ b/stubs/aws-xray-sdk/METADATA.toml
@@ -1,1 +1,1 @@
-version = "2.9.*"
+version = "2.10.*"


### PR DESCRIPTION
Release: https://pypi.org/project/aws-xray-sdk/2.10.0/
Homepage: https://github.com/aws/aws-xray-sdk-python

If stubtest fails for this PR:
- Leave this PR open (as a reminder, and to prevent stubsabot from opening another PR)
- Fix stubtest failures in another PR, then close this PR
