### PR TITLE
[stubsabot] Bump stripe to 3.5.*

### DIFF
--- a/stubs/stripe/METADATA.toml
+++ b/stubs/stripe/METADATA.toml
@@ -1,1 +1,1 @@
-version = "3.4.*"
+version = "3.5.*"


### PR DESCRIPTION
Release: https://pypi.org/project/stripe/3.5.0/
Homepage: https://github.com/stripe/stripe-python
Changelog: https://github.com/stripe/stripe-python/blob/master/CHANGELOG.md

If stubtest fails for this PR:
- Leave this PR open (as a reminder, and to prevent stubsabot from opening another PR)
- Fix stubtest failures in another PR, then close this PR
