### PR TITLE
[stubsabot] Bump protobuf to 4.21.*

### DIFF
--- a/.github/workflows/stubsabot.yml
+++ b/.github/workflows/stubsabot.yml
@@ -20,6 +20,10 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.10"
+      - name: git config
+        run: |
+          git config --global user.name stubsabot
+          git config --global user.email '<>'
       - name: Install dependencies
         run: pip install aiohttp packaging termcolor tomli tomlkit
       - name: Run stubsabot

--- a/.github/workflows/stubsabot.yml
+++ b/.github/workflows/stubsabot.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   stubsabot:
     name: Upgrade stubs with stubsabot
-    if: github.repository == 'python/typeshed'
+    # if: github.repository == 'python/typeshed'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -26,19 +26,19 @@ jobs:
         run: GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} python scripts/stubsabot.py --action-level everything
 
   # https://github.community/t/run-github-actions-job-only-if-previous-job-has-failed/174786/2
-  create-issue-on-failure:
-    name: Create an issue if stubsabot failed
-    runs-on: ubuntu-latest
-    needs: [stubsabot]
-    if: ${{ github.repository == 'python/typeshed' && always() && (needs.stubsabot.result == 'failure') }}
-    steps:
-      - uses: actions/github-script@v6
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            await github.rest.issues.create({
-              owner: "python",
-              repo: "typeshed",
-              title: `Stubsabot failed on ${new Date().toDateString()}`,
-              body: "Stubsabot runs are listed here: https://github.com/python/typeshed/actions/workflows/stubsabot.yml",
-            })
+  # create-issue-on-failure:
+  #   name: Create an issue if stubsabot failed
+  #   runs-on: ubuntu-latest
+  #   needs: [stubsabot]
+  #   if: ${{ github.repository == 'python/typeshed' && always() && (needs.stubsabot.result == 'failure') }}
+  #   steps:
+  #     - uses: actions/github-script@v6
+  #       with:
+  #         github-token: ${{ secrets.GITHUB_TOKEN }}
+  #         script: |
+  #           await github.rest.issues.create({
+  #             owner: "python",
+  #             repo: "typeshed",
+  #             title: `Stubsabot failed on ${new Date().toDateString()}`,
+  #             body: "Stubsabot runs are listed here: https://github.com/python/typeshed/actions/workflows/stubsabot.yml",
+  #           })

--- a/.github/workflows/stubsabot.yml
+++ b/.github/workflows/stubsabot.yml
@@ -1,0 +1,44 @@
+name: Run stubsabot weekly
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * 5"
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  stubsabot:
+    name: Upgrade stubs with stubsabot
+    if: github.repository == 'python/typeshed'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: pip install aiohttp packaging termcolor tomli tomlkit
+      - name: Run stubsabot
+        run: GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} python scripts/stubsabot.py --action-level everything
+
+  # https://github.community/t/run-github-actions-job-only-if-previous-job-has-failed/174786/2
+  create-issue-on-failure:
+    name: Create an issue if stubsabot failed
+    runs-on: ubuntu-latest
+    needs: [stubsabot]
+    if: ${{ github.repository == 'python/typeshed' && always() && (needs.stubsabot.result == 'failure') }}
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.issues.create({
+              owner: "python",
+              repo: "typeshed",
+              title: `Stubsabot failed on ${new Date().toDateString()}`,
+              body: "Stubsabot runs are listed here: https://github.com/python/typeshed/actions/workflows/stubsabot.yml",
+            })

--- a/scripts/stubsabot.py
+++ b/scripts/stubsabot.py
@@ -210,7 +210,7 @@ TYPESHED_OWNER = "python"
 def get_origin_owner() -> str:
     output = subprocess.check_output(["git", "remote", "get-url", "origin"], text=True)
     match = re.search(r"(git@github.com:|https://github.com/)(?P<owner>[^/]+)/(?P<repo>[^/]+).git", output)
-    assert match is not None
+    assert match is not None, f"Couldn't identify origin's owner: {output}"
     assert match.group("repo") == "typeshed"
     return match.group("owner")
 

--- a/scripts/stubsabot.py
+++ b/scripts/stubsabot.py
@@ -288,6 +288,7 @@ async def suggest_typeshed_update(update: Update, session: aiohttp.ClientSession
 If stubtest fails for this PR:
 - Leave this PR open (as a reminder, and to prevent stubsabot from opening another PR)
 - Fix stubtest failures in another PR, then close this PR
+- Note that the stubsabot action may force push to this PR
 """
     await create_or_update_pull_request(title=title, body=body, branch_name=branch_name, session=session)
 

--- a/scripts/stubsabot.py
+++ b/scripts/stubsabot.py
@@ -280,7 +280,7 @@ async def suggest_typeshed_update(update: Update, session: aiohttp.ClientSession
         subprocess.check_call(["git", "commit", "--all", "-m", title])
         if action_level <= ActionLevel.local:
             return
-        subprocess.check_call(["git", "push", "origin", branch_name, "--force-with-lease"])
+        subprocess.check_call(["git", "push", "origin", branch_name, "--force"])
 
     body = "\n".join(f"{k}: {v}" for k, v in update.links.items())
     body += """
@@ -310,7 +310,7 @@ async def suggest_typeshed_obsolete(obsolete: Obsolete, session: aiohttp.ClientS
         subprocess.check_call(["git", "commit", "--all", "-m", title])
         if action_level <= ActionLevel.local:
             return
-        subprocess.check_call(["git", "push", "origin", branch_name, "--force-with-lease"])
+        subprocess.check_call(["git", "push", "origin", branch_name, "--force"])
 
     body = "\n".join(f"{k}: {v}" for k, v in obsolete.links.items())
     await create_or_update_pull_request(title=title, body=body, branch_name=branch_name, session=session)

--- a/stubs/protobuf/METADATA.toml
+++ b/stubs/protobuf/METADATA.toml
@@ -1,2 +1,2 @@
-version = "3.19.*"
+version = "4.21.*"
 extra_description = "Generated with aid from mypy-protobuf v3.2.0"


### PR DESCRIPTION
Release: https://pypi.org/project/protobuf/4.21.2/
Homepage: https://developers.google.com/protocol-buffers/

If stubtest fails for this PR:
- Leave this PR open (as a reminder, and to prevent stubsabot from opening another PR)
- Fix stubtest failures in another PR, then close this PR
