### PR TITLE
create_baseline_stubs: check all defs by default

### DIFF
--- a/scripts/create_baseline_stubs.py
+++ b/scripts/create_baseline_stubs.py
@@ -85,7 +85,14 @@ def create_metadata(stub_dir: str, version: str) -> None:
     assert not os.path.exists(fnam)
     print(f"Writing {fnam}")
     with open(fnam, "w") as f:
-        f.write(f'version = "{version}.*"\n')
+        f.write(
+            f"""\
+version = "{version}.*"
+
+[tool.stubtest]
+ignore_missing_stub = false
+"""
+        )
 
 
 def add_pyright_exclusion(stub_dir: str) -> None:


### PR DESCRIPTION
Since stubgen will usually create definition complete stubs, we should have
stubtest check missing definitions so we can know to reflect any future
additions.