### PR TITLE
Fix cryptography WithSerialization aliases

### DIFF
--- a/stubs/cryptography/cryptography/hazmat/primitives/asymmetric/dsa.pyi
+++ b/stubs/cryptography/cryptography/hazmat/primitives/asymmetric/dsa.pyi
@@ -34,14 +34,14 @@ class DSAPrivateKey(metaclass=ABCMeta):
     def public_key(self) -> DSAPublicKey: ...
     @abstractmethod
     def sign(self, data: bytes, algorithm: HashAlgorithm | Prehashed) -> bytes: ...
-
-class DSAPrivateKeyWithSerialization(DSAPrivateKey):
     @abstractmethod
     def private_bytes(
         self, encoding: Encoding, format: PrivateFormat, encryption_algorithm: KeySerializationEncryption
     ) -> bytes: ...
     @abstractmethod
     def private_numbers(self) -> DSAPrivateNumbers: ...
+
+DSAPrivateKeyWithSerialization = DSAPrivateKey
 
 class DSAPrivateNumbers:
     @property

--- a/stubs/cryptography/cryptography/hazmat/primitives/asymmetric/ec.pyi
+++ b/stubs/cryptography/cryptography/hazmat/primitives/asymmetric/ec.pyi
@@ -127,14 +127,14 @@ class EllipticCurvePrivateKey(metaclass=ABCMeta):
     def public_key(self) -> EllipticCurvePublicKey: ...
     @abstractmethod
     def sign(self, data: bytes, signature_algorithm: EllipticCurveSignatureAlgorithm) -> bytes: ...
-
-class EllipticCurvePrivateKeyWithSerialization(EllipticCurvePrivateKey):
     @abstractmethod
     def private_bytes(
         self, encoding: Encoding, format: PrivateFormat, encryption_algorithm: KeySerializationEncryption
     ) -> bytes: ...
     @abstractmethod
     def private_numbers(self) -> EllipticCurvePrivateNumbers: ...
+
+EllipticCurvePrivateKeyWithSerialization = EllipticCurvePrivateKey
 
 class EllipticCurvePrivateNumbers:
     @property

--- a/stubs/cryptography/cryptography/hazmat/primitives/asymmetric/rsa.pyi
+++ b/stubs/cryptography/cryptography/hazmat/primitives/asymmetric/rsa.pyi
@@ -17,14 +17,14 @@ class RSAPrivateKey(metaclass=ABCMeta):
     def public_key(self) -> RSAPublicKey: ...
     @abstractmethod
     def sign(self, data: bytes, padding: AsymmetricPadding, algorithm: HashAlgorithm | Prehashed) -> bytes: ...
-
-class RSAPrivateKeyWithSerialization(RSAPrivateKey):
     @abstractmethod
     def private_bytes(
         self, encoding: Encoding, format: PrivateFormat, encryption_algorithm: KeySerializationEncryption
     ) -> bytes: ...
     @abstractmethod
     def private_numbers(self) -> RSAPrivateNumbers: ...
+
+RSAPrivateKeyWithSerialization = RSAPrivateKey
 
 class RSAPublicKey(metaclass=ABCMeta):
     @property


### PR DESCRIPTION
Align with changes in https://github.com/pyca/cryptography/commit/6a8c0b55b99f95e1fcc8bb9c2b03fd9158d2081e, still present in [latest commit in main](https://github.com/pyca/cryptography/tree/86d9e39db80726e2dabd55ddde1699cc7b689374/src/cryptography/hazmat/primitives/asymmetric).