### PR TITLE
`tqdm`: Improve a few `__init__` methods

### DIFF
--- a/stubs/tqdm/tqdm/contrib/discord.pyi
+++ b/stubs/tqdm/tqdm/contrib/discord.pyi
@@ -1,5 +1,6 @@
-from _typeshed import Incomplete
-from typing import Generic, TypeVar
+from _typeshed import Incomplete, SupportsWrite
+from collections.abc import Iterable, Mapping
+from typing import Generic, NoReturn, TypeVar, overload
 
 from ..auto import tqdm as tqdm_auto
 from .utils_worker import MonoWorker
@@ -14,7 +15,68 @@ _T = TypeVar("_T")
 
 class tqdm_discord(Generic[_T], tqdm_auto[_T]):
     dio: Incomplete
-    def __init__(self, *args, **kwargs) -> None: ...
+    @overload
+    def __init__(
+        self,
+        iterable: Iterable[_T],
+        desc: str | None = ...,
+        total: float | None = ...,
+        leave: bool = ...,
+        file: SupportsWrite[str] | None = ...,
+        ncols: int | None = ...,
+        mininterval: float = ...,
+        maxinterval: float = ...,
+        miniters: float | None = ...,
+        ascii: bool | str | None = ...,
+        disable: bool = ...,
+        unit: str = ...,
+        unit_scale: bool | float = ...,
+        dynamic_ncols: bool = ...,
+        smoothing: float = ...,
+        bar_format: str | None = ...,
+        initial: float = ...,
+        position: int | None = ...,
+        postfix: Mapping[str, object] | str | None = ...,
+        unit_divisor: float = ...,
+        write_bytes: bool | None = ...,
+        lock_args: tuple[bool | None, float | None] | tuple[bool | None] | None = ...,
+        nrows: int | None = ...,
+        colour: str | None = ...,
+        delay: float | None = ...,
+        gui: bool = ...,
+        **kwargs,
+    ) -> None: ...
+    @overload
+    def __init__(
+        self: tqdm_discord[NoReturn],
+        iterable: None = ...,
+        desc: str | None = ...,
+        total: float | None = ...,
+        leave: bool = ...,
+        file: SupportsWrite[str] | None = ...,
+        ncols: int | None = ...,
+        mininterval: float = ...,
+        maxinterval: float = ...,
+        miniters: float | None = ...,
+        ascii: bool | str | None = ...,
+        disable: bool = ...,
+        unit: str = ...,
+        unit_scale: bool | float = ...,
+        dynamic_ncols: bool = ...,
+        smoothing: float = ...,
+        bar_format: str | None = ...,
+        initial: float = ...,
+        position: int | None = ...,
+        postfix: Mapping[str, object] | str | None = ...,
+        unit_divisor: float = ...,
+        write_bytes: bool | None = ...,
+        lock_args: tuple[bool | None, float | None] | tuple[bool | None] | None = ...,
+        nrows: int | None = ...,
+        colour: str | None = ...,
+        delay: float | None = ...,
+        gui: bool = ...,
+        **kwargs,
+    ) -> None: ...
     def display(
         self,
         msg: str | None = ...,

--- a/stubs/tqdm/tqdm/contrib/slack.pyi
+++ b/stubs/tqdm/tqdm/contrib/slack.pyi
@@ -1,5 +1,6 @@
-from _typeshed import Incomplete
-from typing import Generic, TypeVar
+from _typeshed import Incomplete, SupportsWrite
+from collections.abc import Iterable, Mapping
+from typing import Generic, NoReturn, TypeVar, overload
 
 from ..auto import tqdm as tqdm_auto
 from .utils_worker import MonoWorker
@@ -15,7 +16,72 @@ _T = TypeVar("_T")
 
 class tqdm_slack(Generic[_T], tqdm_auto[_T]):
     sio: Incomplete
-    def __init__(self, *args, **kwargs) -> None: ...
+    @overload
+    def __init__(
+        self,
+        iterable: Iterable[_T],
+        desc: str | None = ...,
+        total: float | None = ...,
+        leave: bool = ...,
+        file: SupportsWrite[str] | None = ...,
+        ncols: int | None = ...,
+        mininterval: float = ...,
+        maxinterval: float = ...,
+        miniters: float | None = ...,
+        ascii: bool | str | None = ...,
+        disable: bool = ...,
+        unit: str = ...,
+        unit_scale: bool | float = ...,
+        dynamic_ncols: bool = ...,
+        smoothing: float = ...,
+        bar_format: str | None = ...,
+        initial: float = ...,
+        position: int | None = ...,
+        postfix: Mapping[str, object] | str | None = ...,
+        unit_divisor: float = ...,
+        write_bytes: bool | None = ...,
+        lock_args: tuple[bool | None, float | None] | tuple[bool | None] | None = ...,
+        nrows: int | None = ...,
+        colour: str | None = ...,
+        delay: float | None = ...,
+        gui: bool = ...,
+        token: str = ...,
+        channel: int = ...,
+        **kwargs,
+    ) -> None: ...
+    @overload
+    def __init__(
+        self: tqdm_slack[NoReturn],
+        iterable: None = ...,
+        desc: str | None = ...,
+        total: float | None = ...,
+        leave: bool = ...,
+        file: SupportsWrite[str] | None = ...,
+        ncols: int | None = ...,
+        mininterval: float = ...,
+        maxinterval: float = ...,
+        miniters: float | None = ...,
+        ascii: bool | str | None = ...,
+        disable: bool = ...,
+        unit: str = ...,
+        unit_scale: bool | float = ...,
+        dynamic_ncols: bool = ...,
+        smoothing: float = ...,
+        bar_format: str | None = ...,
+        initial: float = ...,
+        position: int | None = ...,
+        postfix: Mapping[str, object] | str | None = ...,
+        unit_divisor: float = ...,
+        write_bytes: bool | None = ...,
+        lock_args: tuple[bool | None, float | None] | tuple[bool | None] | None = ...,
+        nrows: int | None = ...,
+        colour: str | None = ...,
+        delay: float | None = ...,
+        gui: bool = ...,
+        token: str = ...,
+        channel: int = ...,
+        **kwargs,
+    ) -> None: ...
     def display(self, *, msg: str | None = ..., pos: int | None = ..., close: bool = ..., bar_style: Incomplete = ..., check_delay: bool = ...) -> None: ...  # type: ignore[override]
     def clear(self, *args, **kwargs) -> None: ...
 

--- a/stubs/tqdm/tqdm/contrib/telegram.pyi
+++ b/stubs/tqdm/tqdm/contrib/telegram.pyi
@@ -1,5 +1,6 @@
-from _typeshed import Incomplete
-from typing import Generic, TypeVar
+from _typeshed import Incomplete, SupportsWrite
+from collections.abc import Iterable, Mapping
+from typing import Generic, NoReturn, TypeVar, overload
 
 from ..auto import tqdm as tqdm_auto
 from .utils_worker import MonoWorker
@@ -20,7 +21,72 @@ _T = TypeVar("_T")
 
 class tqdm_telegram(Generic[_T], tqdm_auto[_T]):
     tgio: Incomplete
-    def __init__(self, *args, **kwargs) -> None: ...
+    @overload
+    def __init__(
+        self,
+        iterable: Iterable[_T],
+        desc: str | None = ...,
+        total: float | None = ...,
+        leave: bool = ...,
+        file: SupportsWrite[str] | None = ...,
+        ncols: int | None = ...,
+        mininterval: float = ...,
+        maxinterval: float = ...,
+        miniters: float | None = ...,
+        ascii: bool | str | None = ...,
+        disable: bool = ...,
+        unit: str = ...,
+        unit_scale: bool | float = ...,
+        dynamic_ncols: bool = ...,
+        smoothing: float = ...,
+        bar_format: str | None = ...,
+        initial: float = ...,
+        position: int | None = ...,
+        postfix: Mapping[str, object] | str | None = ...,
+        unit_divisor: float = ...,
+        write_bytes: bool | None = ...,
+        lock_args: tuple[bool | None, float | None] | tuple[bool | None] | None = ...,
+        nrows: int | None = ...,
+        colour: str | None = ...,
+        delay: float | None = ...,
+        gui: bool = ...,
+        token: str = ...,
+        chat_id: str = ...,
+        **kwargs,
+    ) -> None: ...
+    @overload
+    def __init__(
+        self: tqdm_telegram[NoReturn],
+        iterable: None = ...,
+        desc: str | None = ...,
+        total: float | None = ...,
+        leave: bool = ...,
+        file: SupportsWrite[str] | None = ...,
+        ncols: int | None = ...,
+        mininterval: float = ...,
+        maxinterval: float = ...,
+        miniters: float | None = ...,
+        ascii: bool | str | None = ...,
+        disable: bool = ...,
+        unit: str = ...,
+        unit_scale: bool | float = ...,
+        dynamic_ncols: bool = ...,
+        smoothing: float = ...,
+        bar_format: str | None = ...,
+        initial: float = ...,
+        position: int | None = ...,
+        postfix: Mapping[str, object] | str | None = ...,
+        unit_divisor: float = ...,
+        write_bytes: bool | None = ...,
+        lock_args: tuple[bool | None, float | None] | tuple[bool | None] | None = ...,
+        nrows: int | None = ...,
+        colour: str | None = ...,
+        delay: float | None = ...,
+        gui: bool = ...,
+        token: str = ...,
+        chat_id: str = ...,
+        **kwargs,
+    ) -> None: ...
     def display(self, *, msg: str | None = ..., pos: int | None = ..., close: bool = ..., bar_style: Incomplete = ..., check_delay: bool = ...) -> None: ...  # type: ignore[override]
     def clear(self, *args, **kwargs) -> None: ...
     def close(self) -> None: ...

--- a/stubs/tqdm/tqdm/notebook.pyi
+++ b/stubs/tqdm/tqdm/notebook.pyi
@@ -1,6 +1,6 @@
 from _typeshed import Incomplete, SupportsWrite
 from collections.abc import Iterable, Iterator, Mapping
-from typing import Generic, TypeVar, overload
+from typing import Generic, NoReturn, TypeVar, overload
 
 from .std import tqdm as std_tqdm, trange as trange
 
@@ -30,7 +30,7 @@ class tqdm_notebook(Generic[_T], std_tqdm[_T]):
     @overload
     def __init__(
         self,
-        iterable: Iterable[_T] | None,
+        iterable: Iterable[_T],
         desc: str | None = ...,
         total: float | None = ...,
         leave: bool = ...,
@@ -55,10 +55,13 @@ class tqdm_notebook(Generic[_T], std_tqdm[_T]):
         nrows: int | None = ...,
         colour: str | None = ...,
         delay: float | None = ...,
+        display: bool = ...,
+        **kwargs,
     ) -> None: ...
     @overload
     def __init__(
-        self,
+        self: tqdm_notebook[NoReturn],
+        iterable: None = ...,
         desc: str | None = ...,
         total: float | None = ...,
         leave: bool = ...,
@@ -83,6 +86,8 @@ class tqdm_notebook(Generic[_T], std_tqdm[_T]):
         nrows: int | None = ...,
         colour: str | None = ...,
         delay: float | None = ...,
+        display: bool = ...,
+        **kwargs,
     ) -> None: ...
     def __iter__(self) -> Iterator[_T]: ...
     def update(self, n: int = ...): ...  # type: ignore[override]


### PR DESCRIPTION
Fixes a few issues I noticed after merging #8235. These `__init__` overrides in the subclasses currently have the effect of making type checkers unable to perform type inference for instances of these subclasses, unless we tediously copy/paste the whole overload stack like I propose in this PR. Some of the existing `__init__` overrides are also missing a few optional parameters that are present for the subclasses, but not the superclass.