### PR TITLE
fix: Return `Never` rather than `None` from `signal.default_int_handler`

### DIFF
--- a/stdlib/signal.pyi
+++ b/stdlib/signal.pyi
@@ -4,7 +4,7 @@ from collections.abc import Callable, Iterable
 from enum import IntEnum
 from types import FrameType
 from typing import Any, Union
-from typing_extensions import Final, TypeAlias, final
+from typing_extensions import Final, TypeAlias, final, Never
 
 NSIG: int
 
@@ -64,7 +64,7 @@ SIG_IGN: Handlers
 _SIGNUM: TypeAlias = int | Signals
 _HANDLER: TypeAlias = Union[Callable[[int, FrameType | None], Any], int, Handlers, None]
 
-def default_int_handler(__signalnum: int, __frame: FrameType | None) -> None: ...
+def default_int_handler(__signalnum: int, __frame: FrameType | None) -> Never: ...
 
 if sys.version_info >= (3, 10):  # arguments changed in 3.10.2
     def getsignal(signalnum: _SIGNUM) -> _HANDLER: ...


### PR DESCRIPTION
Fix: #8214 

Fixes the type of `signal.default_int_handler` to return `Never` rather than `None` per https://github.com/python/cpython/blob/774ef28814d0d9d57ec813cb31b0a7af6c476127/Modules/signalmodule.c#L258

It appears to always throw the Keyboard exception.

The only question I had was whether `Never` was correct or `NoReturn` was correct