### PR TITLE
[stubsabot] Bump ujson to 5.4.*

### DIFF
--- a/stubs/ujson/METADATA.toml
+++ b/stubs/ujson/METADATA.toml
@@ -1,4 +1,4 @@
-version = "5.3.*"
+version = "5.4.*"
 
 [tool.stubtest]
 ignore_missing_stub = false


### PR DESCRIPTION
Release: https://pypi.org/project/ujson/5.4.0/
Homepage: https://github.com/ultrajson/ultrajson

If stubtest fails for this PR:
- Leave this PR open (as a reminder, and to prevent stubsabot from opening another PR)
- Fix stubtest failures in another PR, then close this PR
