### PR TITLE
stdlib(imaplib): add type-hint for `imaplib.Commands`

### DIFF
--- a/stdlib/imaplib.pyi
+++ b/stdlib/imaplib.pyi
@@ -18,6 +18,8 @@ _CommandResults: TypeAlias = tuple[str, list[Any]]
 
 _AnyResponseData: TypeAlias = list[None] | list[bytes | tuple[bytes, bytes]]
 
+Commands: dict[str, tuple[str, ...]]
+
 class IMAP4:
     class error(Exception): ...
     class abort(error): ...


### PR DESCRIPTION
Add type-hints for `imaplib.Commands` which is defined here in
imaplib.py:
https://github.com/python/cpython/blob/6442a9dd212fa18343db21849cf05c0181662c1f/Lib/imaplib.py#L58-L102

Closes: #8261