### PR TITLE
Import `Match` and `Pattern` from `re`, not `typing`

### DIFF
--- a/stdlib/argparse.pyi
+++ b/stdlib/argparse.pyi
@@ -1,6 +1,7 @@
 import sys
 from collections.abc import Callable, Generator, Iterable, Sequence
-from typing import IO, Any, Generic, NewType, NoReturn, Pattern, Protocol, TypeVar, overload
+from re import Pattern
+from typing import IO, Any, Generic, NewType, NoReturn, Protocol, TypeVar, overload
 from typing_extensions import Literal, TypeAlias
 
 __all__ = [

--- a/stdlib/configparser.pyi
+++ b/stdlib/configparser.pyi
@@ -1,7 +1,8 @@
 import sys
 from _typeshed import StrOrBytesPath, SupportsWrite
 from collections.abc import Callable, ItemsView, Iterable, Iterator, Mapping, MutableMapping, Sequence
-from typing import Any, ClassVar, Pattern, TypeVar, overload
+from re import Pattern
+from typing import Any, ClassVar, TypeVar, overload
 from typing_extensions import Literal, TypeAlias
 
 __all__ = [

--- a/stdlib/distutils/command/config.pyi
+++ b/stdlib/distutils/command/config.pyi
@@ -1,5 +1,6 @@
 from collections.abc import Sequence
-from typing import Any, Pattern
+from re import Pattern
+from typing import Any
 
 from ..ccompiler import CCompiler
 from ..cmd import Command

--- a/stdlib/distutils/filelist.pyi
+++ b/stdlib/distutils/filelist.pyi
@@ -1,5 +1,6 @@
 from collections.abc import Iterable
-from typing import Pattern, overload
+from re import Pattern
+from typing import overload
 from typing_extensions import Literal
 
 # class is entirely undocumented

--- a/stdlib/distutils/version.pyi
+++ b/stdlib/distutils/version.pyi
@@ -1,6 +1,6 @@
 from _typeshed import Self
 from abc import abstractmethod
-from typing import Pattern
+from re import Pattern
 
 class Version:
     def __eq__(self, other: object) -> bool: ...

--- a/stdlib/email/_header_value_parser.pyi
+++ b/stdlib/email/_header_value_parser.pyi
@@ -3,7 +3,8 @@ from _typeshed import Self
 from collections.abc import Iterable, Iterator
 from email.errors import HeaderParseError, MessageDefect
 from email.policy import Policy
-from typing import Any, Pattern
+from re import Pattern
+from typing import Any
 from typing_extensions import Final
 
 WSP: Final[set[str]]

--- a/stdlib/html/parser.pyi
+++ b/stdlib/html/parser.pyi
@@ -1,5 +1,5 @@
 from _markupbase import ParserBase
-from typing import Pattern
+from re import Pattern
 
 __all__ = ["HTMLParser"]
 

--- a/stdlib/http/cookiejar.pyi
+++ b/stdlib/http/cookiejar.pyi
@@ -2,7 +2,8 @@ import sys
 from _typeshed import StrPath
 from collections.abc import Iterable, Iterator, Sequence
 from http.client import HTTPResponse
-from typing import ClassVar, Pattern, TypeVar, overload
+from re import Pattern
+from typing import ClassVar, TypeVar, overload
 from urllib.request import Request
 
 __all__ = [

--- a/stdlib/imaplib.pyi
+++ b/stdlib/imaplib.pyi
@@ -4,10 +4,11 @@ import time
 from _typeshed import Self
 from builtins import list as _list  # conflicts with a method named "list"
 from collections.abc import Callable
+from re import Pattern
 from socket import socket as _socket
 from ssl import SSLContext, SSLSocket
 from types import TracebackType
-from typing import IO, Any, Pattern
+from typing import IO, Any
 from typing_extensions import Literal, TypeAlias
 
 __all__ = ["IMAP4", "IMAP4_stream", "Internaldate2tuple", "Int2AP", "ParseFlags", "Time2Internaldate", "IMAP4_SSL"]

--- a/stdlib/importlib/metadata/__init__.pyi
+++ b/stdlib/importlib/metadata/__init__.pyi
@@ -7,7 +7,8 @@ from email.message import Message
 from importlib.abc import MetaPathFinder
 from os import PathLike
 from pathlib import Path
-from typing import Any, ClassVar, NamedTuple, Pattern, overload
+from re import Pattern
+from typing import Any, ClassVar, NamedTuple, overload
 
 __all__ = [
     "Distribution",

--- a/stdlib/json/encoder.pyi
+++ b/stdlib/json/encoder.pyi
@@ -1,5 +1,6 @@
 from collections.abc import Callable, Iterator
-from typing import Any, Pattern
+from re import Pattern
+from typing import Any
 
 ESCAPE: Pattern[str]
 ESCAPE_ASCII: Pattern[str]

--- a/stdlib/lib2to3/pgen2/literals.pyi
+++ b/stdlib/lib2to3/pgen2/literals.pyi
@@ -1,4 +1,4 @@
-from typing import Match
+from re import Match
 
 simple_escapes: dict[str, str]
 

--- a/stdlib/logging/__init__.pyi
+++ b/stdlib/logging/__init__.pyi
@@ -3,10 +3,11 @@ import threading
 from _typeshed import Self, StrPath, SupportsWrite
 from collections.abc import Callable, Iterable, Mapping, MutableMapping, Sequence
 from io import TextIOWrapper
+from re import Pattern
 from string import Template
 from time import struct_time
 from types import FrameType, TracebackType
-from typing import Any, ClassVar, Generic, Pattern, TextIO, TypeVar, Union, overload
+from typing import Any, ClassVar, Generic, TextIO, TypeVar, Union, overload
 from typing_extensions import Literal, TypeAlias
 
 if sys.version_info >= (3, 11):

--- a/stdlib/logging/config.pyi
+++ b/stdlib/logging/config.pyi
@@ -2,8 +2,9 @@ import sys
 from _typeshed import StrOrBytesPath
 from collections.abc import Callable, Sequence
 from configparser import RawConfigParser
+from re import Pattern
 from threading import Thread
-from typing import IO, Any, Pattern
+from typing import IO, Any
 
 from . import _Level
 

--- a/stdlib/logging/handlers.pyi
+++ b/stdlib/logging/handlers.pyi
@@ -6,8 +6,9 @@ from _typeshed import StrPath
 from collections.abc import Callable
 from logging import FileHandler, Handler, LogRecord
 from queue import Queue, SimpleQueue
+from re import Pattern
 from socket import SocketKind, socket
-from typing import Any, ClassVar, Pattern
+from typing import Any, ClassVar
 
 DEFAULT_TCP_LOGGING_PORT: int
 DEFAULT_UDP_LOGGING_PORT: int

--- a/stdlib/poplib.pyi
+++ b/stdlib/poplib.pyi
@@ -1,7 +1,8 @@
 import socket
 import ssl
 from builtins import list as _list  # conflicts with a method named "list"
-from typing import Any, BinaryIO, NoReturn, Pattern, overload
+from re import Pattern
+from typing import Any, BinaryIO, NoReturn, overload
 from typing_extensions import Literal, TypeAlias
 
 __all__ = ["POP3", "error_proto", "POP3_SSL"]

--- a/stdlib/smtplib.pyi
+++ b/stdlib/smtplib.pyi
@@ -2,10 +2,11 @@ import sys
 from _typeshed import Self
 from collections.abc import Sequence
 from email.message import Message as _Message
+from re import Pattern
 from socket import socket
 from ssl import SSLContext
 from types import TracebackType
-from typing import Any, Pattern, Protocol, overload
+from typing import Any, Protocol, overload
 from typing_extensions import TypeAlias
 
 __all__ = [

--- a/stdlib/sre_compile.pyi
+++ b/stdlib/sre_compile.pyi
@@ -1,7 +1,8 @@
+from re import Pattern
 from sre_constants import *
 from sre_constants import _NamedIntConstant
 from sre_parse import SubPattern
-from typing import Any, Pattern
+from typing import Any
 
 MAXCODE: int
 

--- a/stdlib/sre_parse.pyi
+++ b/stdlib/sre_parse.pyi
@@ -1,8 +1,9 @@
 import sys
 from collections.abc import Iterable
+from re import Match, Pattern as _Pattern
 from sre_constants import *
 from sre_constants import _NamedIntConstant as _NIC, error as _Error
-from typing import Any, Match, Pattern as _Pattern, overload
+from typing import Any, overload
 from typing_extensions import TypeAlias
 
 SPECIAL_CHARS: str

--- a/stdlib/string.pyi
+++ b/stdlib/string.pyi
@@ -1,12 +1,7 @@
 import sys
 from collections.abc import Iterable, Mapping, Sequence
-from re import RegexFlag
+from re import Pattern, RegexFlag
 from typing import Any
-
-if sys.version_info >= (3, 8):
-    from re import Pattern
-else:
-    from typing import Pattern
 
 __all__ = [
     "ascii_letters",

--- a/stdlib/telnetlib.pyi
+++ b/stdlib/telnetlib.pyi
@@ -1,8 +1,9 @@
 import socket
 from _typeshed import Self
 from collections.abc import Callable, Sequence
+from re import Match, Pattern
 from types import TracebackType
-from typing import Any, Match, Pattern
+from typing import Any
 
 __all__ = ["Telnet"]
 

--- a/stdlib/textwrap.pyi
+++ b/stdlib/textwrap.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Callable
-from typing import Pattern
+from re import Pattern
 
 __all__ = ["TextWrapper", "wrap", "fill", "dedent", "indent", "shorten"]
 

--- a/stdlib/tokenize.pyi
+++ b/stdlib/tokenize.pyi
@@ -2,8 +2,9 @@ import sys
 from _typeshed import StrOrBytesPath
 from builtins import open as _builtin_open
 from collections.abc import Callable, Generator, Iterable, Sequence
+from re import Pattern
 from token import *
-from typing import Any, NamedTuple, Pattern, TextIO
+from typing import Any, NamedTuple, TextIO
 from typing_extensions import TypeAlias
 
 __all__ = [

--- a/stdlib/unittest/case.pyi
+++ b/stdlib/unittest/case.pyi
@@ -4,6 +4,7 @@ import unittest.result
 from _typeshed import Self, SupportsDunderGE, SupportsDunderGT, SupportsDunderLE, SupportsDunderLT, SupportsRSub, SupportsSub
 from collections.abc import Callable, Container, Iterable, Mapping, Sequence, Set as AbstractSet
 from contextlib import AbstractContextManager
+from re import Pattern
 from types import TracebackType
 from typing import (
     Any,
@@ -12,7 +13,6 @@ from typing import (
     Generic,
     NamedTuple,
     NoReturn,
-    Pattern,
     Protocol,
     SupportsAbs,
     SupportsRound,

--- a/stdlib/unittest/loader.pyi
+++ b/stdlib/unittest/loader.pyi
@@ -2,8 +2,9 @@ import unittest.case
 import unittest.result
 import unittest.suite
 from collections.abc import Callable, Sequence
+from re import Pattern
 from types import ModuleType
-from typing import Any, Pattern
+from typing import Any
 from typing_extensions import TypeAlias
 
 _SortComparisonMethod: TypeAlias = Callable[[str, str], int]

--- a/stdlib/urllib/request.pyi
+++ b/stdlib/urllib/request.pyi
@@ -5,7 +5,8 @@ from collections.abc import Callable, Iterable, Mapping, MutableMapping, Sequenc
 from email.message import Message
 from http.client import HTTPMessage, HTTPResponse, _HTTPConnectionProtocol
 from http.cookiejar import CookieJar
-from typing import IO, Any, ClassVar, NoReturn, Pattern, TypeVar, overload
+from re import Pattern
+from typing import IO, Any, ClassVar, NoReturn, TypeVar, overload
 from typing_extensions import TypeAlias
 from urllib.error import HTTPError as HTTPError
 from urllib.response import addclosehook, addinfourl

--- a/stdlib/wsgiref/headers.pyi
+++ b/stdlib/wsgiref/headers.pyi
@@ -1,4 +1,5 @@
-from typing import Pattern, overload
+from re import Pattern
+from typing import overload
 from typing_extensions import TypeAlias
 
 _HeaderList: TypeAlias = list[tuple[str, str]]

--- a/stdlib/xml/etree/ElementPath.pyi
+++ b/stdlib/xml/etree/ElementPath.pyi
@@ -1,5 +1,6 @@
 from collections.abc import Callable, Generator
-from typing import Pattern, TypeVar
+from re import Pattern
+from typing import TypeVar
 from typing_extensions import TypeAlias
 from xml.etree.ElementTree import Element
 

--- a/stdlib/xmlrpc/server.pyi
+++ b/stdlib/xmlrpc/server.pyi
@@ -3,7 +3,8 @@ import pydoc
 import socketserver
 from collections.abc import Callable, Iterable, Mapping
 from datetime import datetime
-from typing import Any, ClassVar, Pattern, Protocol
+from re import Pattern
+from typing import Any, ClassVar, Protocol
 from typing_extensions import TypeAlias
 from xmlrpc.client import Fault
 

--- a/stubs/Flask-Cors/flask_cors/core.pyi
+++ b/stubs/Flask-Cors/flask_cors/core.pyi
@@ -1,7 +1,8 @@
 from collections.abc import Iterable
 from datetime import timedelta
 from logging import Logger
-from typing import Any, Pattern, TypeVar, overload
+from re import Pattern
+from typing import Any, TypeVar, overload
 from typing_extensions import TypeAlias, TypedDict
 
 _IterableT = TypeVar("_IterableT", bound=Iterable[Any])

--- a/stubs/Flask-Cors/flask_cors/decorator.pyi
+++ b/stubs/Flask-Cors/flask_cors/decorator.pyi
@@ -1,7 +1,8 @@
 from collections.abc import Callable, Iterable
 from datetime import timedelta
 from logging import Logger
-from typing import Any, Pattern
+from re import Pattern
+from typing import Any
 from typing_extensions import ParamSpec
 
 _P = ParamSpec("_P")

--- a/stubs/Flask-SQLAlchemy/flask_sqlalchemy/model.pyi
+++ b/stubs/Flask-SQLAlchemy/flask_sqlalchemy/model.pyi
@@ -1,4 +1,5 @@
-from typing import Any, Pattern
+from re import Pattern
+from typing import Any
 
 from sqlalchemy.ext.declarative import DeclarativeMeta
 

--- a/stubs/Markdown/markdown/blockprocessors.pyi
+++ b/stubs/Markdown/markdown/blockprocessors.pyi
@@ -1,5 +1,6 @@
 from logging import Logger
-from typing import Any, Match, Pattern
+from re import Match, Pattern
+from typing import Any
 from xml.etree.ElementTree import Element
 
 from markdown import Markdown

--- a/stubs/Markdown/markdown/extensions/abbr.pyi
+++ b/stubs/Markdown/markdown/extensions/abbr.pyi
@@ -1,4 +1,5 @@
-from typing import Any, Pattern
+from re import Pattern
+from typing import Any
 
 from markdown.blockprocessors import BlockProcessor
 from markdown.extensions import Extension

--- a/stubs/Markdown/markdown/extensions/admonition.pyi
+++ b/stubs/Markdown/markdown/extensions/admonition.pyi
@@ -1,4 +1,5 @@
-from typing import Any, Pattern
+from re import Pattern
+from typing import Any
 
 from markdown.blockprocessors import BlockProcessor
 from markdown.extensions import Extension

--- a/stubs/Markdown/markdown/extensions/attr_list.pyi
+++ b/stubs/Markdown/markdown/extensions/attr_list.pyi
@@ -1,4 +1,4 @@
-from typing import Pattern
+from re import Pattern
 
 from markdown.extensions import Extension
 from markdown.treeprocessors import Treeprocessor

--- a/stubs/Markdown/markdown/extensions/def_list.pyi
+++ b/stubs/Markdown/markdown/extensions/def_list.pyi
@@ -1,4 +1,4 @@
-from typing import Pattern
+from re import Pattern
 
 from markdown.blockprocessors import BlockProcessor, ListIndentProcessor
 from markdown.extensions import Extension

--- a/stubs/Markdown/markdown/extensions/fenced_code.pyi
+++ b/stubs/Markdown/markdown/extensions/fenced_code.pyi
@@ -1,4 +1,5 @@
-from typing import Any, Pattern
+from re import Pattern
+from typing import Any
 
 from markdown.extensions import Extension
 from markdown.preprocessors import Preprocessor

--- a/stubs/Markdown/markdown/extensions/footnotes.pyi
+++ b/stubs/Markdown/markdown/extensions/footnotes.pyi
@@ -1,4 +1,5 @@
-from typing import Any, Pattern
+from re import Pattern
+from typing import Any
 
 from markdown.extensions import Extension
 from markdown.inlinepatterns import InlineProcessor

--- a/stubs/Markdown/markdown/extensions/legacy_attrs.pyi
+++ b/stubs/Markdown/markdown/extensions/legacy_attrs.pyi
@@ -1,4 +1,4 @@
-from typing import Pattern
+from re import Pattern
 
 from markdown.extensions import Extension
 from markdown.treeprocessors import Treeprocessor

--- a/stubs/Markdown/markdown/extensions/meta.pyi
+++ b/stubs/Markdown/markdown/extensions/meta.pyi
@@ -1,4 +1,5 @@
-from typing import Any, Pattern
+from re import Pattern
+from typing import Any
 
 from markdown.extensions import Extension
 from markdown.preprocessors import Preprocessor

--- a/stubs/Markdown/markdown/extensions/toc.pyi
+++ b/stubs/Markdown/markdown/extensions/toc.pyi
@@ -1,4 +1,5 @@
-from typing import Any, Pattern
+from re import Pattern
+from typing import Any
 
 from markdown.extensions import Extension
 from markdown.treeprocessors import Treeprocessor

--- a/stubs/Markdown/markdown/inlinepatterns.pyi
+++ b/stubs/Markdown/markdown/inlinepatterns.pyi
@@ -1,5 +1,6 @@
 import typing
-from typing import Any, ClassVar, Match
+from re import Match
+from typing import Any, ClassVar
 from xml.etree.ElementTree import Element
 
 def build_inlinepatterns(md, **kwargs): ...

--- a/stubs/Markdown/markdown/postprocessors.pyi
+++ b/stubs/Markdown/markdown/postprocessors.pyi
@@ -1,4 +1,5 @@
-from typing import Any, Pattern
+from re import Pattern
+from typing import Any
 
 from . import util
 

--- a/stubs/Markdown/markdown/preprocessors.pyi
+++ b/stubs/Markdown/markdown/preprocessors.pyi
@@ -1,4 +1,5 @@
-from typing import Any, Pattern
+from re import Pattern
+from typing import Any
 
 from . import util
 

--- a/stubs/Markdown/markdown/util.pyi
+++ b/stubs/Markdown/markdown/util.pyi
@@ -1,4 +1,5 @@
-from typing import Any, Pattern, overload
+from re import Pattern
+from typing import Any, overload
 
 PY37: bool
 __deprecated__: dict[str, tuple[str, Any]]

--- a/stubs/PyYAML/yaml/__init__.pyi
+++ b/stubs/PyYAML/yaml/__init__.pyi
@@ -1,5 +1,6 @@
 from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
-from typing import Any, Pattern, TypeVar, overload
+from re import Pattern
+from typing import Any, TypeVar, overload
 from typing_extensions import TypeAlias
 
 from . import resolver as resolver  # Help mypy a bit; this is implied by loader and dumper

--- a/stubs/PyYAML/yaml/constructor.pyi
+++ b/stubs/PyYAML/yaml/constructor.pyi
@@ -1,5 +1,6 @@
 from collections.abc import Callable
-from typing import Any, Pattern, TypeVar
+from re import Pattern
+from typing import Any, TypeVar
 from typing_extensions import TypeAlias
 
 from yaml.error import MarkedYAMLError

--- a/stubs/beautifulsoup4/bs4/element.pyi
+++ b/stubs/beautifulsoup4/bs4/element.pyi
@@ -1,6 +1,7 @@
 from _typeshed import Self
 from collections.abc import Callable, Iterable, Iterator
-from typing import Any, Generic, Pattern, TypeVar, overload
+from re import Pattern
+from typing import Any, Generic, TypeVar, overload
 from typing_extensions import TypeAlias
 
 from . import BeautifulSoup

--- a/stubs/bleach/bleach/linkifier.pyi
+++ b/stubs/bleach/bleach/linkifier.pyi
@@ -1,5 +1,6 @@
 from collections.abc import Container, Iterable, MutableMapping
-from typing import Any, Pattern, Protocol
+from re import Pattern
+from typing import Any, Protocol
 from typing_extensions import TypeAlias
 
 from .html5lib_shim import Filter

--- a/stubs/bleach/bleach/sanitizer.pyi
+++ b/stubs/bleach/bleach/sanitizer.pyi
@@ -1,5 +1,6 @@
 from collections.abc import Callable, Container, Iterable
-from typing import Any, Pattern
+from re import Pattern
+from typing import Any
 from typing_extensions import TypeAlias
 
 from .css_sanitizer import CSSSanitizer

--- a/stubs/chardet/chardet/universaldetector.pyi
+++ b/stubs/chardet/chardet/universaldetector.pyi
@@ -1,5 +1,5 @@
 from logging import Logger
-from typing import Pattern
+from re import Pattern
 from typing_extensions import TypedDict
 
 class _FinalResultType(TypedDict):

--- a/stubs/colorama/colorama/ansitowin32.pyi
+++ b/stubs/colorama/colorama/ansitowin32.pyi
@@ -1,8 +1,9 @@
 import sys
 from _typeshed import SupportsWrite
 from collections.abc import Callable, Sequence
+from re import Pattern
 from types import TracebackType
-from typing import Any, Pattern, TextIO
+from typing import Any, TextIO
 from typing_extensions import TypeAlias
 
 if sys.platform == "win32":

--- a/stubs/dateparser/dateparser/date.pyi
+++ b/stubs/dateparser/dateparser/date.pyi
@@ -1,7 +1,8 @@
 import collections
 from collections.abc import Callable, Iterable, Iterator
 from datetime import datetime
-from typing import ClassVar, Pattern, overload
+from re import Pattern
+from typing import ClassVar, overload
 from typing_extensions import Literal, TypeAlias
 
 from dateparser import _Settings

--- a/stubs/dateparser/dateparser/languages/locale.pyi
+++ b/stubs/dateparser/dateparser/languages/locale.pyi
@@ -1,11 +1,6 @@
-import sys
+from re import Pattern
 
 from dateparser.conf import Settings
-
-if sys.version_info >= (3, 8):
-    from re import Pattern
-else:
-    from typing import Pattern
 
 DIGIT_GROUP_PATTERN: Pattern[str]
 NUMERAL_PATTERN: Pattern[str]

--- a/stubs/decorator/decorator.pyi
+++ b/stubs/decorator/decorator.pyi
@@ -2,7 +2,8 @@ from builtins import dict as _dict  # alias to avoid conflicts with attribute na
 from collections.abc import Callable, Iterator
 from contextlib import _GeneratorContextManager
 from inspect import getfullargspec as getfullargspec, iscoroutinefunction as iscoroutinefunction
-from typing import Any, Pattern, TypeVar
+from re import Pattern
+from typing import Any, TypeVar
 from typing_extensions import ParamSpec
 
 _C = TypeVar("_C", bound=Callable[..., Any])

--- a/stubs/emoji/emoji/core.pyi
+++ b/stubs/emoji/emoji/core.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Callable
-from typing import Pattern
+from re import Pattern
 from typing_extensions import Literal, TypedDict
 
 _DEFAULT_DELIMITER: str

--- a/stubs/entrypoints/entrypoints.pyi
+++ b/stubs/entrypoints/entrypoints.pyi
@@ -7,7 +7,7 @@ from typing import Any
 if sys.version_info >= (3, 8):
     from re import Pattern
 else:
-    from typing import Pattern
+    from re import Pattern
 
 entry_point_pattern: Pattern[str]
 file_in_zip_pattern: Pattern[str]

--- a/stubs/humanfriendly/humanfriendly/__init__.pyi
+++ b/stubs/humanfriendly/humanfriendly/__init__.pyi
@@ -1,6 +1,7 @@
 import datetime
+from re import Pattern
 from types import TracebackType
-from typing import Any, NamedTuple, Pattern
+from typing import Any, NamedTuple
 
 class SizeUnit(NamedTuple):
     divider: int

--- a/stubs/paramiko/paramiko/config.pyi
+++ b/stubs/paramiko/paramiko/config.pyi
@@ -1,6 +1,7 @@
 from _typeshed import Self
 from collections.abc import Iterable
-from typing import IO, Any, Pattern
+from re import Pattern
+from typing import IO, Any
 
 from paramiko.ssh_exception import ConfigParseError as ConfigParseError, CouldNotCanonicalize as CouldNotCanonicalize
 

--- a/stubs/paramiko/paramiko/pkey.pyi
+++ b/stubs/paramiko/paramiko/pkey.pyi
@@ -1,5 +1,6 @@
 from _typeshed import Self
-from typing import IO, Pattern
+from re import Pattern
+from typing import IO
 
 from paramiko.message import Message
 

--- a/stubs/parsimonious/parsimonious/expressions.pyi
+++ b/stubs/parsimonious/parsimonious/expressions.pyi
@@ -1,6 +1,7 @@
 import collections.abc
 from collections.abc import Callable, Mapping
-from typing import Any, Pattern, Union
+from re import Pattern
+from typing import Any, Union
 from typing_extensions import TypeAlias
 
 from parsimonious.exceptions import ParseError

--- a/stubs/parsimonious/parsimonious/nodes.pyi
+++ b/stubs/parsimonious/parsimonious/nodes.pyi
@@ -1,5 +1,6 @@
 from collections.abc import Callable, Iterator, Sequence
-from typing import Any, Match, NoReturn, TypeVar
+from re import Match
+from typing import Any, NoReturn, TypeVar
 
 from parsimonious.exceptions import VisitationError as VisitationError
 from parsimonious.expressions import Expression

--- a/stubs/passpy/passpy/store.pyi
+++ b/stubs/passpy/passpy/store.pyi
@@ -1,6 +1,6 @@
 from _typeshed import StrPath
 from collections.abc import Iterator
-from typing import Match
+from re import Match
 
 class Store:
     def __init__(

--- a/stubs/pyflakes/pyflakes/api.pyi
+++ b/stubs/pyflakes/pyflakes/api.pyi
@@ -1,5 +1,6 @@
 from collections.abc import Iterable, Iterator, Sequence
-from typing import Any, Pattern
+from re import Pattern
+from typing import Any
 
 from pyflakes.reporter import Reporter
 

--- a/stubs/pyflakes/pyflakes/checker.pyi
+++ b/stubs/pyflakes/pyflakes/checker.pyi
@@ -1,8 +1,9 @@
 import ast
 import sys
 from collections.abc import Callable, Iterable, Iterator
+from re import Pattern
 from tokenize import TokenInfo
-from typing import Any, ClassVar, Pattern, TypeVar, overload
+from typing import Any, ClassVar, TypeVar, overload
 from typing_extensions import Literal, ParamSpec, TypeAlias
 
 from pyflakes.messages import Message

--- a/stubs/redis/redis/client.pyi
+++ b/stubs/redis/redis/client.pyi
@@ -2,8 +2,9 @@ import threading
 from _typeshed import Incomplete, Self, SupportsItems
 from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from datetime import datetime, timedelta
+from re import Pattern
 from types import TracebackType
-from typing import Any, ClassVar, Generic, Pattern, TypeVar, overload
+from typing import Any, ClassVar, Generic, TypeVar, overload
 from typing_extensions import Literal, TypeAlias
 
 from redis import RedisError

--- a/stubs/simplejson/simplejson/decoder.pyi
+++ b/stubs/simplejson/simplejson/decoder.pyi
@@ -1,4 +1,5 @@
-from typing import Any, Match
+from re import Match
+from typing import Any
 
 class JSONDecoder:
     def __init__(self, **kwargs: Any) -> None: ...

--- a/stubs/six/six/__init__.pyi
+++ b/stubs/six/six/__init__.pyi
@@ -9,7 +9,8 @@ from collections.abc import Callable, ItemsView, Iterable, Iterator as _Iterator
 from functools import wraps as wraps
 from importlib.util import spec_from_loader as spec_from_loader
 from io import BytesIO as BytesIO, StringIO as StringIO
-from typing import Any, AnyStr, NoReturn, Pattern, TypeVar, overload
+from re import Pattern
+from typing import Any, AnyStr, NoReturn, TypeVar, overload
 from typing_extensions import Literal
 
 from . import moves as moves

--- a/stubs/toml/toml/decoder.pyi
+++ b/stubs/toml/toml/decoder.pyi
@@ -1,7 +1,8 @@
 from _typeshed import SupportsRead
 from collections.abc import Callable, MutableMapping
 from pathlib import PurePath
-from typing import Any, Generic, Pattern, TypeVar, overload
+from re import Pattern
+from typing import Any, Generic, TypeVar, overload
 from typing_extensions import TypeAlias
 
 _MutableMappingT = TypeVar("_MutableMappingT", bound=MutableMapping[str, Any])

--- a/stubs/tqdm/tqdm/utils.pyi
+++ b/stubs/tqdm/tqdm/utils.pyi
@@ -1,6 +1,7 @@
 from _typeshed import Incomplete
 from collections.abc import Callable
-from typing import Pattern, Protocol, TypeVar
+from re import Pattern
+from typing import Protocol, TypeVar
 from typing_extensions import ParamSpec
 
 CUR_OS: str

--- a/stubs/waitress/waitress/parser.pyi
+++ b/stubs/waitress/waitress/parser.pyi
@@ -1,6 +1,7 @@
 from collections.abc import Mapping, Sequence
 from io import BytesIO
-from typing import Any, Pattern
+from re import Pattern
+from typing import Any
 
 from waitress.adjustments import Adjustments
 from waitress.receiver import ChunkedReceiver, FixedStreamReceiver

--- a/stubs/waitress/waitress/runner.pyi
+++ b/stubs/waitress/waitress/runner.pyi
@@ -1,6 +1,7 @@
 from collections.abc import Callable, Sequence
 from io import TextIOWrapper
-from typing import Any, Pattern
+from re import Pattern
+from typing import Any
 
 HELP: str
 RUNNER_PATTERN: Pattern[Any]

--- a/stubs/waitress/waitress/utilities.pyi
+++ b/stubs/waitress/waitress/utilities.pyi
@@ -1,7 +1,8 @@
 from _typeshed.wsgi import StartResponse
 from collections.abc import Iterator, Mapping, Sequence
 from logging import Logger
-from typing import Any, Match, Pattern
+from re import Match, Pattern
+from typing import Any
 
 logger: Logger
 queue_logger: Logger

--- a/stubs/whatthepatch/whatthepatch/patch.pyi
+++ b/stubs/whatthepatch/whatthepatch/patch.pyi
@@ -1,5 +1,6 @@
 from collections.abc import Iterable, Iterator
-from typing import NamedTuple, Pattern
+from re import Pattern
+from typing import NamedTuple
 
 from . import exceptions as exceptions
 from .snippets import findall_regex as findall_regex, split_by_regex as split_by_regex

--- a/stubs/whatthepatch/whatthepatch/snippets.pyi
+++ b/stubs/whatthepatch/whatthepatch/snippets.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Sequence
-from typing import Pattern
+from re import Pattern
 
 def remove(path: str) -> None: ...
 def findall_regex(items: Sequence[str], regex: Pattern[str]) -> list[int]: ...

--- a/stubs/zxcvbn/zxcvbn/matching.pyi
+++ b/stubs/zxcvbn/zxcvbn/matching.pyi
@@ -1,6 +1,7 @@
 from collections.abc import Iterable, Mapping
 from decimal import Decimal
-from typing import Any, Pattern
+from re import Pattern
+from typing import Any
 from typing_extensions import Literal, NotRequired, TypedDict
 
 from .adjacency_graphs import _Graph

--- a/stubs/zxcvbn/zxcvbn/scoring.pyi
+++ b/stubs/zxcvbn/zxcvbn/scoring.pyi
@@ -1,6 +1,6 @@
 from collections.abc import Iterable
 from decimal import Decimal
-from typing import Pattern
+from re import Pattern
 from typing_extensions import TypedDict
 
 from .adjacency_graphs import _Graph


### PR DESCRIPTION
This is possible now that we have dropped support for Python 3.6