### PR TITLE
[stubsabot] Bump jsonschema to 4.7.*

### DIFF
--- a/stubs/jsonschema/METADATA.toml
+++ b/stubs/jsonschema/METADATA.toml
@@ -1,1 +1,1 @@
-version = "4.6.*"
+version = "4.7.*"

--- a/stubs/jsonschema/jsonschema/exceptions.pyi
+++ b/stubs/jsonschema/jsonschema/exceptions.pyi
@@ -37,7 +37,7 @@ class _Error(Exception):
         schema: Any = ...,
         schema_path: Sequence[str | int] = ...,
         parent: _Error | None = ...,
-        type_checker: TypeChecker = ...,
+        type_checker: _utils.Unset | TypeChecker = ...,
     ) -> None: ...
     @classmethod
     def create_from(cls: type[Self], other: _Error) -> Self: ...

--- a/stubs/jsonschema/jsonschema/exceptions.pyi
+++ b/stubs/jsonschema/jsonschema/exceptions.pyi
@@ -5,6 +5,7 @@ from typing import Any
 from typing_extensions import TypeAlias
 
 from jsonschema import _utils, protocols
+from jsonschema._types import TypeChecker
 
 _RelevanceFuncType: TypeAlias = Callable[[ValidationError], SupportsRichComparison]
 
@@ -36,6 +37,7 @@ class _Error(Exception):
         schema: Any = ...,
         schema_path: Sequence[str | int] = ...,
         parent: _Error | None = ...,
+        type_checker: TypeChecker = ...,
     ) -> None: ...
     @classmethod
     def create_from(cls: type[Self], other: _Error) -> Self: ...


### PR DESCRIPTION
Release: https://pypi.org/project/jsonschema/4.7.2/
Homepage: https://github.com/python-jsonschema/jsonschema
Changelog: https://github.com/python-jsonschema/jsonschema/blob/main/CHANGELOG.rst

If stubtest fails for this PR:
- Leave this PR open (as a reminder, and to prevent stubsabot from opening another PR)
- Fix stubtest failures in another PR, then close this PR
