### PR TITLE
Remove types-SQLAlchemy requirement from Flask-SQLAlchemy

### DIFF
--- a/stubs/Flask-SQLAlchemy/METADATA.toml
+++ b/stubs/Flask-SQLAlchemy/METADATA.toml
@@ -1,2 +1,2 @@
 version = "2.5.*"
-requires = ["types-SQLAlchemy"]
+requires = []


### PR DESCRIPTION
This removes the types-SQLAlchemy requirement from Flask-SQLAlchemy because the user may instead be using sqlalchemy-provided stubs rather than third-party stubs.

If there is a way to instead make this conditional, this should be closed and that approach should be used instead to isolate the version appropriately.