### PR TITLE
Update functools.wraps to return wrapped function type via ParamSpec

### DIFF
--- a/stdlib/functools.pyi
+++ b/stdlib/functools.pyi
@@ -1,8 +1,8 @@
 import sys
 import types
-from _typeshed import IdentityFunction, Self, SupportsAllComparisons, SupportsItems
+from _typeshed import Self, SupportsAllComparisons, SupportsItems
 from collections.abc import Callable, Hashable, Iterable, Sequence, Sized
-from typing import Any, Generic, NamedTuple, TypeVar, overload
+from typing import Any, Generic, NamedTuple, TypeVar, overload, ParamSpec
 from typing_extensions import Literal, TypeAlias, final
 
 if sys.version_info >= (3, 9):
@@ -30,6 +30,7 @@ if sys.version_info >= (3, 9):
 
 _AnyCallable: TypeAlias = Callable[..., object]
 
+_P = ParamSpec("_P")
 _T = TypeVar("_T")
 _S = TypeVar("_S")
 
@@ -68,7 +69,7 @@ WRAPPER_ASSIGNMENTS: tuple[
 WRAPPER_UPDATES: tuple[Literal["__dict__"]]
 
 def update_wrapper(wrapper: _T, wrapped: _AnyCallable, assigned: Sequence[str] = ..., updated: Sequence[str] = ...) -> _T: ...
-def wraps(wrapped: _AnyCallable, assigned: Sequence[str] = ..., updated: Sequence[str] = ...) -> IdentityFunction: ...
+def wraps(wrapped: Callable[_P, _T], assigned: Sequence[str] = ..., updated: Sequence[str] = ...) -> Callable[_P, _T]: ...
 def total_ordering(cls: type[_T]) -> type[_T]: ...
 def cmp_to_key(mycmp: Callable[[_T, _T], int]) -> Callable[[_T], SupportsAllComparisons]: ...
 


### PR DESCRIPTION
Fix #8317