### PR TITLE
CI: Use `macos-latest` for stubtest

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -19,8 +19,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # macos-11 does not have tcl/tk installed, needed for stubtesting tkinter
-        os: ["ubuntu-latest", "windows-latest", "macos-10.15"]
+        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]
       fail-fast: false
 

--- a/.github/workflows/stubtest_stdlib.yml
+++ b/.github/workflows/stubtest_stdlib.yml
@@ -25,8 +25,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # macos-11 does not have tcl/tk installed, needed for stubtesting tkinter
-        os: ["ubuntu-latest", "windows-latest", "macos-10.15"]
+        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]
       fail-fast: false
 


### PR DESCRIPTION
The `macos-10.15` Actions runner image [is deprecated, and will be removed on 30th August](https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22/). The `tkinter` thing doesn't seem to be an issue any more, so we should be good to use `macos-latest` now.