### PR TITLE
refactor: fix type of `mysqlclient.release.version_info`

### DIFF
--- a/stubs/mysqlclient/MySQLdb/release.pyi
+++ b/stubs/mysqlclient/MySQLdb/release.pyi
@@ -1,3 +1,1 @@
-from typing import Any
-
-version_info: Any
+version_info: tuple[int, int, int, str, int]


### PR DESCRIPTION
The `mysqlclient.release.version_info` variable is a 5-tuple. This is generated dynamically but is verified as a tuple in the unit tests seen here and a length of five:

https://github.com/PyMySQL/mysqlclient/blob/180c9df4ab8325b75f6b26070951fd852ec76614/tests/test_MySQLdb_nonstandard.py#L33-L34

This is not tested in other locations.

This can also be verified against the runtime behavior:

```
In [1]: from MySQLdb.release import version_info

In [2]: version_info
Out[2]: (2, 1, 1, 'final', 0)
```

Version info is set from metadata.cfg during the build, so this corresponds to:
https://github.com/PyMySQL/mysqlclient/blob/dac24e7b05b83eb1511e25e3cd8f8c20b7fbe112/metadata.cfg#L3