### PR TITLE
Add missing `__version__` to `chardet.__init__`

### DIFF
--- a/stubs/chardet/chardet/__init__.pyi
+++ b/stubs/chardet/chardet/__init__.pyi
@@ -1,6 +1,7 @@
 import sys
 
 from .universaldetector import UniversalDetector as UniversalDetector, _FinalResultType, _IntermediateResultType
+from .version import __version__ as __version__, VERSION as VERSION
 
 if sys.version_info >= (3, 8):
     from typing import TypedDict
@@ -21,9 +22,6 @@ class _SMModelType(TypedDict):
     state_table: tuple[int, ...]
     char_len_table: tuple[int, ...]
     name: str
-
-__version__: str
-VERSION: list[str]
 
 def detect(byte_str: bytes | bytearray) -> _FinalResultType: ...
 def detect_all(byte_str: bytes | bytearray, ignore_threshold: bool = ...) -> list[_IntermediateResultType]: ...

--- a/stubs/chardet/chardet/__init__.pyi
+++ b/stubs/chardet/chardet/__init__.pyi
@@ -22,6 +22,7 @@ class _SMModelType(TypedDict):
     char_len_table: tuple[int, ...]
     name: str
 
+__version__: str
 VERSION: list[str]
 
 def detect(byte_str: bytes | bytearray) -> _FinalResultType: ...

--- a/stubs/chardet/chardet/__init__.pyi
+++ b/stubs/chardet/chardet/__init__.pyi
@@ -1,7 +1,7 @@
 import sys
 
 from .universaldetector import UniversalDetector as UniversalDetector, _FinalResultType, _IntermediateResultType
-from .version import __version__ as __version__, VERSION as VERSION
+from .version import VERSION as VERSION, __version__ as __version__
 
 if sys.version_info >= (3, 8):
     from typing import TypedDict


### PR DESCRIPTION
`__version__` is part of the `__all__` of `chardet` here:
https://github.com/chardet/chardet/blob/main/chardet/__init__.py#L27

`__version__` is a string, as seen on:
https://github.com/chardet/chardet/blob/main/chardet/version.py#L8