### PR TITLE
Fix stdlib/curses.pyi TODO RE: Concatenate usage

### DIFF
--- a/stdlib/curses/__init__.pyi
+++ b/stdlib/curses/__init__.pyi
@@ -1,6 +1,6 @@
 import sys
 from collections.abc import Callable
-from typing import Any, TypeVar
+from typing import TypeVar
 from typing_extensions import Concatenate, ParamSpec
 
 if sys.platform != "win32":

--- a/stdlib/curses/__init__.pyi
+++ b/stdlib/curses/__init__.pyi
@@ -1,12 +1,14 @@
 import sys
 from collections.abc import Callable
 from typing import Any, TypeVar
+from typing_extensions import Concatenate, ParamSpec
 
 if sys.platform != "win32":
     from _curses import *
     from _curses import _CursesWindow as _CursesWindow
 
     _T = TypeVar("_T")
+    _P = ParamSpec("_P")
 
     # available after calling `curses.initscr()`
     LINES: int
@@ -15,6 +17,5 @@ if sys.platform != "win32":
     # available after calling `curses.start_color()`
     COLORS: int
     COLOR_PAIRS: int
-    # TODO: wait for `Concatenate` support
-    # def wrapper(__func: Callable[Concatenate[_CursesWindow, _P], _T], *arg: _P.args, **kwds: _P.kwargs) -> _T: ...
-    def wrapper(__func: Callable[..., _T], *arg: Any, **kwds: Any) -> _T: ...
+
+    def wrapper(__func: Callable[Concatenate[_CursesWindow, _P], _T], *arg: _P.args, **kwds: _P.kwargs) -> _T: ...


### PR DESCRIPTION
This merge request updates the `wrapper` `__func` parameter to use ParamSpec and Concatenate to address a todo.