### PR TITLE
fix: add missing multiprocessing.popen_forkserver.pyi stubs

### DIFF
--- a/stdlib/multiprocessing/popen_forkserver.pyi
+++ b/stdlib/multiprocessing/popen_forkserver.pyi
@@ -1,20 +1,23 @@
+import sys
+
 from multiprocessing.process import BaseProcess
 from typing import ClassVar
 
 from . import popen_fork
 from .util import Finalize
 
-__all__ = ["Popen"]
+if sys.platform != "win32":
+    __all__ = ["Popen"]
 
-class _DupFd:
-    def __init__(self, ind: int) -> None: ...
-    def detach(self) -> int: ...
+    class _DupFd:
+        def __init__(self, ind: int) -> None: ...
+        def detach(self) -> int: ...
 
-class Popen(popen_fork.Popen):
-    DupFd: ClassVar[type[_DupFd]]
-    finalizer: Finalize
-    sentinel: int
+    class Popen(popen_fork.Popen):
+        DupFd: ClassVar[type[_DupFd]]
+        finalizer: Finalize
+        sentinel: int
 
-    def __init__(self, process_obj: BaseProcess) -> None: ...
-    def duplicate_for_child(self, fd: int) -> int: ...
-    def poll(self, flag: int = ...) -> int | None: ...
+        def __init__(self, process_obj: BaseProcess) -> None: ...
+        def duplicate_for_child(self, fd: int) -> int: ...
+        def poll(self, flag: int = ...) -> int | None: ...

--- a/stdlib/multiprocessing/popen_forkserver.pyi
+++ b/stdlib/multiprocessing/popen_forkserver.pyi
@@ -1,16 +1,17 @@
 from multiprocessing.process import BaseProcess
-from typing import ClassVar, Protocol
+from typing import ClassVar
 
 from . import popen_fork
 from .util import Finalize
 
 __all__ = ["Popen"]
 
-class _SupportsDetach(Protocol):
+class _DupFd:
+    def __init__(self, ind: int) -> None: ...
     def detach(self) -> int: ...
 
 class Popen(popen_fork.Popen):
-    DupFd: ClassVar[_SupportsDetach]
+    DupFd: ClassVar[type[_DupFd]]
     finalizer: Finalize
     sentinel: int
 

--- a/stdlib/multiprocessing/popen_forkserver.pyi
+++ b/stdlib/multiprocessing/popen_forkserver.pyi
@@ -1,0 +1,21 @@
+from multiprocessing.process import BaseProcess
+from typing import ClassVar, Protocol
+
+from . import popen_fork
+from .util import Finalize
+
+__all__ = ["Popen"]
+
+class _SupportsDetach(Protocol):
+    def detach(self) -> int: ...
+
+class Popen(popen_fork.Popen):
+    DupFd: ClassVar[_SupportsDetach]
+    finalizer: Finalize
+    method: ClassVar[str]
+    pid: int
+    sentinel: int
+
+    def __init__(self, process_obj: BaseProcess) -> None: ...
+    def duplicate_for_child(self, fd: int) -> int: ...
+    def poll(self, flag: int = ...) -> int | None: ...

--- a/stdlib/multiprocessing/popen_forkserver.pyi
+++ b/stdlib/multiprocessing/popen_forkserver.pyi
@@ -12,8 +12,6 @@ class _SupportsDetach(Protocol):
 class Popen(popen_fork.Popen):
     DupFd: ClassVar[_SupportsDetach]
     finalizer: Finalize
-    method: ClassVar[str]
-    pid: int
     sentinel: int
 
     def __init__(self, process_obj: BaseProcess) -> None: ...

--- a/stdlib/multiprocessing/popen_forkserver.pyi
+++ b/stdlib/multiprocessing/popen_forkserver.pyi
@@ -1,5 +1,4 @@
 import sys
-
 from multiprocessing.process import BaseProcess
 from typing import ClassVar
 

--- a/tests/stubtest_allowlists/win32.txt
+++ b/tests/stubtest_allowlists/win32.txt
@@ -56,8 +56,9 @@ syslog
 termios
 xxlimited
 
-# Multiprocessing.popen_fork exists on Windows but fails to import
+# Multiprocessing.popen_fork and popen_forkserver exists on Windows but fails to import
 multiprocessing.popen_fork
+multiprocessing.popen_forkserver
 
 # Modules that rely on _curses
 curses

--- a/tests/stubtest_allowlists/win32.txt
+++ b/tests/stubtest_allowlists/win32.txt
@@ -56,7 +56,7 @@ syslog
 termios
 xxlimited
 
-# Multiprocessing.popen_fork and popen_forkserver exists on Windows but fails to import
+# multiprocessing.popen_fork and popen_forkserver exist on Windows but fail to import
 multiprocessing.popen_fork
 multiprocessing.popen_forkserver
 


### PR DESCRIPTION
X-Ref: https://github.com/python/typeshed/issues/6799

This adds best-effort types to multiprocessing.popen_fork to continue to address issue https://github.com/python/typeshed/issues/6799

The source file can be viewed here:
https://github.com/python/cpython/blob/main/Lib/multiprocessing/popen_forkserver.py

Note that the forkserver version inherits from `popen_fork`, so `_launch` is called explicitly as was the case there. This only includes new or overriding attributes on the `Popen` class, ignoring attributes like `pid` which are identical with the parent. `sentinel` is defined here even though it matches `popen_fork.Popen` because it doesn't have the same condition as the comment in the other stub.