### PR TITLE
fix: add missing multiprocessing.popen_spawn_posix stubs

### DIFF
--- a/stdlib/multiprocessing/popen_spawn_posix.pyi
+++ b/stdlib/multiprocessing/popen_spawn_posix.pyi
@@ -15,9 +15,8 @@ if sys.platform != "win32":
         def detach(self) -> int: ...
 
     class Popen(popen_fork.Popen):
-        DupFd: type[_DupFd]
+        DupFd: ClassVar[type[_DupFd]]
         finalizer: Finalize
-        method: ClassVar[str]
         pid: int  # may not exist if _launch raises in second try / except
         sentinel: int  # may not exist if _launch raises in second try / except
 

--- a/stdlib/multiprocessing/popen_spawn_posix.pyi
+++ b/stdlib/multiprocessing/popen_spawn_posix.pyi
@@ -1,0 +1,26 @@
+import sys
+
+from multiprocessing.process import BaseProcess
+from typing import ClassVar
+
+from .util import Finalize
+from . import popen_fork
+
+if sys.platform != "win32":
+    __all__ = ["Popen"]
+
+    class _DupFd:
+        fd: int
+
+        def __init__(self, fd: int) -> None: ...
+        def detach(self) -> int: ...
+
+    class Popen(popen_fork.Popen):
+        DupFd: type[_DupFd]
+        finalizer: Finalize
+        method: ClassVar[str]
+        pid: int  # may not exist if _launch raises in second try / except
+        sentinel: int  # may not exist if _launch raises in second try / except
+
+        def __init__(self, process_obj: BaseProcess) -> None: ...
+        def duplicate_for_child(self, fd: int) -> int: ...

--- a/stdlib/multiprocessing/popen_spawn_posix.pyi
+++ b/stdlib/multiprocessing/popen_spawn_posix.pyi
@@ -1,10 +1,9 @@
 import sys
-
 from multiprocessing.process import BaseProcess
 from typing import ClassVar
 
-from .util import Finalize
 from . import popen_fork
+from .util import Finalize
 
 if sys.platform != "win32":
     __all__ = ["Popen"]

--- a/tests/stubtest_allowlists/win32.txt
+++ b/tests/stubtest_allowlists/win32.txt
@@ -56,9 +56,10 @@ syslog
 termios
 xxlimited
 
-# multiprocessing.popen_fork and popen_forkserver exist on Windows but fail to import
+# multiprocessing.popen_fork, popen_forkserver, and popen_spawn_posix exist on Windows but fail to import
 multiprocessing.popen_fork
 multiprocessing.popen_forkserver
+multiprocessing.popen_spawn_posix
 
 # Modules that rely on _curses
 curses


### PR DESCRIPTION
X-Ref: https://github.com/python/typeshed/issues/6799

This adds the missing stubs for multiprocessing.popen_spawn_posix from:
https://github.com/python/cpython/blob/main/Lib/multiprocessing/popen_spawn_posix.py