### PR TITLE
Improve `multiprocessing.context` module

### DIFF
--- a/stdlib/multiprocessing/context.pyi
+++ b/stdlib/multiprocessing/context.pyi
@@ -3,10 +3,9 @@ import sys
 from collections.abc import Callable, Iterable, Sequence
 from ctypes import _CData
 from logging import Logger
-from multiprocessing import queues, synchronize, popen_spawn_win32, popen_forkserver, popen_spawn_posix, popen_fork
+from multiprocessing import popen_fork, popen_forkserver, popen_spawn_posix, popen_spawn_win32, queues, synchronize
 from multiprocessing.connection import _ConnectionBase
 from multiprocessing.managers import SyncManager
-from multiprocessing.popen import Popen
 from multiprocessing.process import BaseProcess
 from multiprocessing.sharedctypes import SynchronizedArray, SynchronizedBase
 from typing import Any, ClassVar, TypeVar, overload
@@ -172,6 +171,7 @@ if sys.platform != "win32":
     class ForkServerContext(BaseContext):
         _name: str
         Process: ClassVar[type[ForkServerProcess]]
+
 else:
     class SpawnProcess(BaseProcess):
         _start_method: str
@@ -181,7 +181,6 @@ else:
     class SpawnContext(BaseContext):
         _name: str
         Process: ClassVar[type[SpawnProcess]]
-
 
 def _force_start_method(method: str) -> None: ...
 def get_spawning_popen() -> Any | None: ...

--- a/stdlib/multiprocessing/context.pyi
+++ b/stdlib/multiprocessing/context.pyi
@@ -6,6 +6,7 @@ from logging import Logger
 from multiprocessing import popen_fork, popen_forkserver, popen_spawn_posix, popen_spawn_win32, queues, synchronize
 from multiprocessing.connection import _ConnectionBase
 from multiprocessing.managers import SyncManager
+from multiprocessing.pool import Pool as _Pool
 from multiprocessing.process import BaseProcess
 from multiprocessing.sharedctypes import SynchronizedArray, SynchronizedBase
 from typing import Any, ClassVar, TypeVar, overload

--- a/stdlib/multiprocessing/context.pyi
+++ b/stdlib/multiprocessing/context.pyi
@@ -26,10 +26,11 @@ class TimeoutError(ProcessError): ...
 class AuthenticationError(ProcessError): ...
 
 class BaseContext:
-    ProcessError = ProcessError
-    BufferTooShort = BufferTooShort
-    TimeoutError = TimeoutError
-    AuthenticationError = AuthenticationError
+    Process: ClassVar[type[BaseProcess]]
+    ProcessError: ClassVar[type[Exception]]
+    BufferTooShort: ClassVar[type[Exception]]
+    TimeoutError: ClassVar[type[Exception]]
+    AuthenticationError: ClassVar[type[Exception]]
 
     # N.B. The methods below are applied at runtime to generate
     # multiprocessing.*, so the signatures should be identical (modulo self).
@@ -135,6 +136,7 @@ class Process(BaseProcess):
     def _Popen(process_obj: BaseProcess) -> DefaultContext: ...
 
 class DefaultContext(BaseContext):
+    Process: ClassVar[type[Process]]
     def __init__(self, context: BaseContext) -> None: ...
     def set_start_method(self, method: str | None, force: bool = ...) -> None: ...
     def get_start_method(self, allow_none: bool = ...) -> str: ...
@@ -151,7 +153,7 @@ class SpawnProcess(BaseProcess):
 
 class SpawnContext(BaseContext):
     _name: str
-    Process = SpawnProcess
+    Process: ClassVar[type[SpawnProcess]]
 
 if sys.platform != "win32":
     class ForkProcess(BaseProcess):
@@ -166,11 +168,11 @@ if sys.platform != "win32":
 
     class ForkContext(BaseContext):
         _name: str
-        Process = ForkProcess
+        Process: ClassVar[type[ForkProcess]]
 
     class ForkServerContext(BaseContext):
         _name: str
-        Process = ForkServerProcess
+        Process: ClassVar[type[ForkServerProcess]]
 
 def _force_start_method(method: str) -> None: ...
 def get_spawning_popen() -> Any | None: ...


### PR DESCRIPTION
Two main changes:
1. I think it is better to use assignment in case of alises where possible. For example, `Process` is simply defined as `Process = Process` in [cpython's `DefaultContext`](https://github.com/python/cpython/blob/75a6441718dcbc65d993c9544e67e25bef120e82/Lib/multiprocessing/context.py#L231). This is more accurate: it is set as an explicit classvar and we have full type info (`type[Process]` is wider)
2. There's no need to redefine `SpawnContext` and `SpawnProcess` in `if`. They are the same in case of typing. Only implementation details differ: 
  - https://github.com/python/cpython/blob/75a6441718dcbc65d993c9544e67e25bef120e82/Lib/multiprocessing/context.py#L283-L288
  - https://github.com/python/cpython/blob/75a6441718dcbc65d993c9544e67e25bef120e82/Lib/multiprocessing/context.py#L331-L336
