### PR TITLE
`io.IOBase`: correct metaclass

### DIFF
--- a/stdlib/io.pyi
+++ b/stdlib/io.pyi
@@ -1,3 +1,4 @@
+import abc
 import builtins
 import codecs
 import sys
@@ -47,7 +48,7 @@ BlockingIOError = builtins.BlockingIOError
 
 class UnsupportedOperation(OSError, ValueError): ...
 
-class IOBase:
+class IOBase(metaclass=abc.ABCMeta):
     def __iter__(self) -> Iterator[bytes]: ...
     def __next__(self) -> bytes: ...
     def __enter__(self: Self) -> Self: ...


### PR DESCRIPTION
`io.IOBase` has `ABCMeta` as the metaclass at runtime: https://github.com/python/cpython/blob/75a6441718dcbc65d993c9544e67e25bef120e82/Lib/io.py#L71

But not currently in the stub. This is causing an unexpected stubtest failure for a `urllib3` PR here: https://github.com/python/typeshed/runs/7633083101?check_suite_focus=true