### PR TITLE
fix: add missing stubs in datetimerange

### DIFF
--- a/stubs/DateTimeRange/datetimerange/__init__.pyi
+++ b/stubs/DateTimeRange/datetimerange/__init__.pyi
@@ -4,9 +4,13 @@ from collections.abc import Iterable
 from typing import ClassVar
 
 from dateutil.relativedelta import relativedelta
-
-__license__: str
-__email__: str
+from .__version__ import (
+    __author__ as __author__,
+    __copyright__ as __copyright__,
+    __email__ as __email__,
+    __license__ as __license__,
+    __version__ as __version__,
+)
 
 class DateTimeRange:
     NOT_A_TIME_STR: ClassVar[str]

--- a/stubs/DateTimeRange/datetimerange/__init__.pyi
+++ b/stubs/DateTimeRange/datetimerange/__init__.pyi
@@ -4,6 +4,7 @@ from collections.abc import Iterable
 from typing import ClassVar
 
 from dateutil.relativedelta import relativedelta
+
 from .__version__ import (
     __author__ as __author__,
     __copyright__ as __copyright__,

--- a/stubs/DateTimeRange/datetimerange/__version__.pyi
+++ b/stubs/DateTimeRange/datetimerange/__version__.pyi
@@ -1,3 +1,6 @@
-__maintainer__: str
-__email__: str
+__author__: str
+__copyright__: str
 __license__: str
+__version__: str
+__maintainer__ = __author__
+__email__: str

--- a/stubs/DateTimeRange/datetimerange/__version__.pyi
+++ b/stubs/DateTimeRange/datetimerange/__version__.pyi
@@ -1,4 +1,4 @@
-__author__: str
+__author__: str = ...
 __copyright__: str
 __license__: str
 __version__: str


### PR DESCRIPTION
Fix a few missing variables from https://github.com/thombashi/DateTimeRange and clean up the re-export from the other file rather than re-definition
