### PR TITLE
refactor: prefer f-strings to other format/concatentation styles

### DIFF
--- a/scripts/create_baseline_stubs.py
+++ b/scripts/create_baseline_stubs.py
@@ -59,7 +59,7 @@ def copy_stubs(src_base_dir: str, package: str, stub_dir: str) -> None:
     if os.path.isdir(src_dir):
         shutil.copytree(src_dir, os.path.join(stub_dir, package))
     else:
-        src_file = os.path.join("out", package + ".pyi")
+        src_file = os.path.join("out", f"{package}.pyi")
         if not os.path.isfile(src_file):
             sys.exit("Error: Cannot find generated stubs")
         shutil.copy(src_file, stub_dir)

--- a/scripts/stubsabot.py
+++ b/scripts/stubsabot.py
@@ -148,7 +148,7 @@ async def package_contains_py_typed(release_to_download: dict[str, Any], session
 
 
 def _check_spec(updated_spec: str, version: packaging.version.Version) -> str:
-    assert version in packaging.specifiers.SpecifierSet("==" + updated_spec), f"{version} not in {updated_spec}"
+    assert version in packaging.specifiers.SpecifierSet(f"=={updated_spec}"), f"{version} not in {updated_spec}"
     return updated_spec
 
 
@@ -183,7 +183,7 @@ async def determine_action(stub_path: Path, session: aiohttp.ClientSession) -> U
         return NoUpdate(stub_info.distribution, "no longer updated")
 
     pypi_info = await fetch_pypi_info(stub_info.distribution, session)
-    spec = packaging.specifiers.SpecifierSet("==" + stub_info.version_spec)
+    spec = packaging.specifiers.SpecifierSet(f"=={stub_info.version_spec}")
     if pypi_info.version in spec:
         return NoUpdate(stub_info.distribution, "up to date")
 

--- a/tests/mypy_test.py
+++ b/tests/mypy_test.py
@@ -147,7 +147,7 @@ def parse_versions(fname: StrPath) -> dict[str, tuple[MinVersion, MaxVersion]]:
             if line == "":
                 continue
             m = _VERSION_LINE_RE.match(line)
-            assert m, "invalid VERSIONS line: " + line
+            assert m, f"invalid VERSIONS line: {line}"
             mod: str = m.group(1)
             min_version = parse_version(m.group(2))
             max_version = parse_version(m.group(3)) if m.group(3) else (99, 99)
@@ -160,7 +160,7 @@ _VERSION_RE = re.compile(r"^([23])\.(\d+)$")
 
 def parse_version(v_str: str) -> tuple[int, int]:
     m = _VERSION_RE.match(v_str)
-    assert m, "invalid version: " + v_str
+    assert m, f"invalid version: {v_str}"
     return int(m.group(1)), int(m.group(2))
 
 

--- a/tests/pyright_test.py
+++ b/tests/pyright_test.py
@@ -27,7 +27,7 @@ def main() -> None:
         print("error running npx; is Node.js installed?", file=sys.stderr)
         sys.exit(1)
 
-    command = [npx, "-p", "pyright@" + _PYRIGHT_VERSION, "pyright"] + sys.argv[1:]
+    command = [npx, "-p", f"pyright@{_PYRIGHT_VERSION}", "pyright"] + sys.argv[1:]
 
     ret = subprocess.run(command).returncode
     sys.exit(ret)

--- a/tests/stubtest_stdlib.py
+++ b/tests/stubtest_stdlib.py
@@ -46,7 +46,7 @@ def run_stubtest(typeshed_dir: Path) -> int:
             "\nNB: stubtest output depends on the Python version (and system) it is run with. "
             "See README.md for more details.\n"
             "NB: We only check positional-only arg accuracy for Python 3.10.\n"
-            "\nCommand run was: {}\n".format(" ".join(cmd)),
+            f"\nCommand run was: {' '.join(cmd)}\n",
             file=sys.stderr,
         )
         print("\n\n", file=sys.stderr)


### PR DESCRIPTION
Use f-strings for concatenating strings instead of `'+'` or `.format`

Python added f-strings in version 3.6, with [PEP 498](https://www.python.org/dev/peps/pep-0498/). F-strings are a flexible and powerful way to concatenate strings. They make the code shorter and more readable, since the code now looks more like the output. In addition, they also come with performance benefits as they reduce the number of times the string must be processed, resulting in faster string processing.

This aligns with the desire to ensure that scripts and tests should support currently supported versions of Python outlined [here](https://devguide.python.org/versions/#versions)