### PR TITLE
Bump pytype version.

### DIFF
--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,5 +1,5 @@
 mypy==0.971
-pytype==2022.6.23; platform_system != "Windows"
+pytype==2022.8.3; platform_system != "Windows"
 # must match .pre-commit-config.yaml
 black==22.6.0
 # must match .pre-commit-config.yaml


### PR DESCRIPTION
Picks up a fix for the pytype test failure in
https://github.com/python/typeshed/pull/8469.