### PR TITLE
Add classmethod to stripe.PaymentIntent.confirm.

### DIFF
--- a/stubs/stripe/@tests/stubtest_allowlist.txt
+++ b/stubs/stripe/@tests/stubtest_allowlist.txt
@@ -1,2 +1,3 @@
-# DeletableAPIResource.delete is has a custom classmethod overload
+# The following methods have custom classmethod decorators
 stripe\..*\.delete
+stripe\..*PaymentIntent\.confirm

--- a/stubs/stripe/stripe/api_resources/payment_intent.pyi
+++ b/stubs/stripe/stripe/api_resources/payment_intent.pyi
@@ -1,3 +1,5 @@
+from typing import overload
+
 from stripe.api_resources.abstract import (
     CreateableAPIResource as CreateableAPIResource,
     ListableAPIResource as ListableAPIResource,
@@ -9,4 +11,11 @@ class PaymentIntent(CreateableAPIResource, ListableAPIResource, UpdateableAPIRes
     OBJECT_NAME: str
     def cancel(self, idempotency_key: str | None = ..., **params): ...
     def capture(self, idempotency_key: str | None = ..., **params): ...
-    def confirm(self, idempotency_key: str | None = ..., **params): ...
+    @overload
+    @classmethod
+    def confirm(
+        cls, intent: str, api_key: str | None = ..., stripe_version: str | None = ..., stripe_account: str | None = ..., **params
+    ): ...
+    @overload
+    @classmethod
+    def confirm(cls, idempotency_key: str | None = ..., **params): ...


### PR DESCRIPTION
Similar to #7230, `stripe.PaymentIntent.confirm` can be called as an
instance method or a `classmethod`.