### PR TITLE
Temporarily pin stubtest to 3.10.5

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -20,7 +20,8 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]
+        # temporarily pin to 3.10.5 until 3.10.6 is available on all platforms
+        python-version: ["3.7", "3.8", "3.9", "3.10.5", "3.11-dev"]
       fail-fast: false
 
     steps:

--- a/.github/workflows/stubtest_stdlib.yml
+++ b/.github/workflows/stubtest_stdlib.yml
@@ -26,7 +26,8 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]
+        # temporarily pin to 3.10.5 until 3.10.6 is available on all platforms
+        python-version: ["3.7", "3.8", "3.9", "3.10.5", "3.11-dev"]
       fail-fast: false
 
     steps:


### PR DESCRIPTION
Refs #8510 (but let's keep that issue open as a reminder to us to unpin ASAP)