### PR TITLE
Fix `UDPServer` to correctly inherit from `TCPServer`

### DIFF
--- a/stdlib/socketserver.pyi
+++ b/stdlib/socketserver.pyi
@@ -70,7 +70,8 @@ class BaseServer:
     def close_request(self, request: _RequestType) -> None: ...  # undocumented
 
 class TCPServer(BaseServer):
-    allow_reuse_port: bool
+    if sys.version_info >= (3, 11):
+        allow_reuse_port: bool
     request_queue_size: int
     def __init__(
         self: Self,

--- a/stdlib/socketserver.pyi
+++ b/stdlib/socketserver.pyi
@@ -81,11 +81,9 @@ class TCPServer(BaseServer):
     ) -> None: ...
     def get_request(self) -> tuple[_socket, Any]: ...
 
-class UDPServer(BaseServer):
-    if sys.version_info >= (3, 11):
-        allow_reuse_port: bool
+class UDPServer(TCPServer):
     max_packet_size: ClassVar[int]
-    def get_request(self) -> tuple[tuple[bytes, _socket], Any]: ...
+    def get_request(self) -> tuple[tuple[bytes, _socket], Any]: ...  # type: ignore[override]
 
 if sys.platform != "win32":
     class UnixStreamServer(BaseServer):


### PR DESCRIPTION
This is documented and implemented as such, and means that the signatures of some of the methods (notably `__init__`) actually differ from those on `BaseServer`.

This also fixes the definition of the (new in Python 3.11, via https://github.com/python/cpython/pull/30072) `allow_reuse_port` attribute on these classes that would otherwise have been in conflict with the inheritance change.