### PR TITLE
cryptography: Rename parameter of serialize_key_and_certificates

### DIFF
--- a/stubs/cryptography/@tests/stubtest_allowlist.txt
+++ b/stubs/cryptography/@tests/stubtest_allowlist.txt
@@ -15,7 +15,6 @@ cryptography.hazmat.primitives.hashes.BLAKE2s.__init__
 cryptography.hazmat.primitives.hashes.Hash.__init__
 cryptography.hazmat.primitives.hmac.HMAC.__init__
 cryptography.hazmat.primitives.hmac.HMAC.update
-cryptography.hazmat.primitives.serialization.pkcs12.serialize_key_and_certificates
 cryptography.hazmat.primitives.serialization.pkcs7.PKCS7SignatureBuilder.__init__
 cryptography.x509.CertificateBuilder.public_key
 cryptography.x509.CertificateBuilder.serial_number

--- a/stubs/cryptography/cryptography/hazmat/primitives/serialization/pkcs12.pyi
+++ b/stubs/cryptography/cryptography/hazmat/primitives/serialization/pkcs12.pyi
@@ -14,5 +14,5 @@ def serialize_key_and_certificates(
     key: RSAPrivateKeyWithSerialization | EllipticCurvePrivateKeyWithSerialization | DSAPrivateKeyWithSerialization,
     cert: Certificate | None,
     cas: list[Certificate] | None,
-    enc: KeySerializationEncryption,
+    encryption_algorithm: KeySerializationEncryption,
 ) -> bytes: ...


### PR DESCRIPTION
It seems that an invalid parameter name was used for `serialize_key_and_certificates`.
`encryption_algorithm` should be used instead of `enc`.

Documentation: https://cryptography.io/en/latest/hazmat/primitives/asymmetric/serialization/#cryptography.hazmat.primitives.serialization.pkcs12.serialize_key_and_certificates

Source code: https://github.com/pyca/cryptography/blob/4a4f4d94ce5a641de3020042c70c1734af265d5e/src/cryptography/hazmat/primitives/serialization/pkcs12.py#L171