### PR TITLE
Flask-SQLAlchemy: type session as Session

### DIFF
--- a/stubs/Flask-SQLAlchemy/flask_sqlalchemy/__init__.pyi
+++ b/stubs/Flask-SQLAlchemy/flask_sqlalchemy/__init__.pyi
@@ -59,7 +59,7 @@ def get_state(app): ...
 class SQLAlchemy:
     Query: Any
     use_native_unicode: Any
-    session: Any
+    session: Session
     Model: Model
     app: Any
     def __init__(


### PR DESCRIPTION
`SQLAlchemy().session` will always be of type `Session`: https://github.com/pallets-eco/flask-sqlalchemy/blob/2d9257e79b8246632b7518c613fb24bc523f9b1d/src/flask_sqlalchemy/__init__.py#L760 (technically a `ScopedSession`, but just `Session` will go a hell of a long way for type hinting).