### PR TITLE
Do not override `AbstractRedis.RESPONSE_CALLBACKS`

### DIFF
--- a/stubs/redis/redis/client.pyi
+++ b/stubs/redis/redis/client.pyi
@@ -74,10 +74,9 @@ def parse_slowlog_get(response, **options): ...
 _LockType = TypeVar("_LockType")
 
 class AbstractRedis:
-    RESPONSE_CALLBACKS: dict[Any, Any]
+    RESPONSE_CALLBACKS: dict[str, Any]
 
 class Redis(AbstractRedis, RedisModuleCommands, CoreCommands[_StrType], SentinelCommands, Generic[_StrType]):
-    RESPONSE_CALLBACKS: Any
     @overload
     @classmethod
     def from_url(


### PR DESCRIPTION
Source: https://github.com/redis/redis-py/blob/b5ebada842c715e9ee74ea638a7e6d11afcddae1/redis/client.py#L683