### PR TITLE
`six`: Fix incorrect `type[type[Any]]` annotation

### DIFF
--- a/stubs/six/six/__init__.pyi
+++ b/stubs/six/six/__init__.pyi
@@ -28,7 +28,7 @@ PY34: Literal[True]
 
 string_types: tuple[type[str]]
 integer_types: tuple[type[int]]
-class_types: tuple[type[type[Any]]]
+class_types: tuple[type[type]]
 text_type = str
 binary_type = bytes
 


### PR DESCRIPTION
Mypy will (correctly, I think) start flagging `type[type[Any]]` as an illegal annotation when mypy 0.980 comes out. Let's fix it now, before it comes out.