### PR TITLE
Add `CTYPES_MAX_ARGCOUNT` to `_ctypes`

### DIFF
--- a/stdlib/_ctypes.pyi
+++ b/stdlib/_ctypes.pyi
@@ -2,6 +2,9 @@ import sys
 from ctypes import _CArgObject, _PointerLike
 from typing_extensions import TypeAlias
 
+if sys.version_info >= (3, 11):
+    CTYPES_MAX_ARGCOUNT: int
+
 if sys.platform == "win32":
     # Description, Source, HelpFile, HelpContext, scode
     _COMError_Details: TypeAlias = tuple[str | None, str | None, str | None, int | None, int | None]

--- a/tests/stubtest_allowlists/py311.txt
+++ b/tests/stubtest_allowlists/py311.txt
@@ -12,7 +12,6 @@ _collections_abc.MappingView.__class_getitem__
 _collections_abc.ValuesView.__reversed__
 _csv.Reader
 _csv.Writer
-_ctypes.CTYPES_MAX_ARGCOUNT
 _operator.attrgetter.__vectorcalloffset__
 _operator.itemgetter.__vectorcalloffset__
 argparse._MutuallyExclusiveGroup.add_mutually_exclusive_group


### PR DESCRIPTION
After reviewing https://github.com/python/typeshed/pull/8582 I've noticed that `_ctypes` right now misses quite a few definitions.

Let's start adding them.

`CTYPES_MAX_ARGCOUNT` is always defined in `_ctypes` since 3.11: https://github.com/python/cpython/blob/3.11/Modules/_ctypes/ctypes.h#L21-L27