### PR TITLE
Further enhance `check_consistent.py`

### DIFF
--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -12,4 +12,6 @@ tomli==1.2.2
 # must match .pre-commit-config.yaml
 pycln==2.1.1
 packaging==21.3
+pyyaml==6.0
 termcolor
+types-pyyaml

--- a/tests/check_consistent.py
+++ b/tests/check_consistent.py
@@ -33,7 +33,7 @@ def assert_consistent_filetypes(directory: Path, *, kind: str, allowed: set[str]
         if entry.is_file():
             assert entry.stem.isidentifier(), f"Files must be valid modules, got: {entry}"
             bad_filetype = (
-                f'Only {extension_descriptions[kind]} files allowed in the "{directory}" directory; ' f"got: {entry.suffix!r}"
+                f'Only {extension_descriptions[kind]} files allowed in the "{directory}" directory; got: {entry.suffix!r}'
             )
             assert entry.suffix == kind, bad_filetype
         else:

--- a/tests/check_consistent.py
+++ b/tests/check_consistent.py
@@ -167,11 +167,9 @@ def get_precommit_requirements() -> dict[str, SpecifierSet]:
 def check_requirements() -> None:
     requirements_txt_requirements = get_txt_requirements()
     precommit_requirements = get_precommit_requirements()
+    no_txt_entry_msg = "All pre-commit requirements must also be listed in `requirements-tests.txt` (missing {requirement!r})"
     for requirement, specifier in precommit_requirements.items():
-        no_txt_entry_msg = (
-            f"All pre-commit requirements must also be listed in `requirements-tests.txt` (missing {requirement!r})"
-        )
-        assert requirement in requirements_txt_requirements, no_txt_entry_msg
+        assert requirement in requirements_txt_requirements, no_txt_entry_msg.format(requirement)
         specifier_mismatch = (
             f'Specifier "{specifier}" for {requirement!r} in `.pre-commit-config.yaml` '
             f'does not match specifier "{requirements_txt_requirements[requirement]}" in `requirements-tests.txt`'

--- a/tests/check_consistent.py
+++ b/tests/check_consistent.py
@@ -32,9 +32,7 @@ def assert_consistent_filetypes(directory: Path, *, kind: str, allowed: set[str]
             continue
         if entry.is_file():
             assert entry.stem.isidentifier(), f'Files must be valid modules, got: "{entry}"'
-            bad_filetype = (
-                f'Only {extension_descriptions[kind]!r} files allowed in the "{directory}" directory; got: {entry}'
-            )
+            bad_filetype = f'Only {extension_descriptions[kind]!r} files allowed in the "{directory}" directory; got: {entry}'
             assert entry.suffix == kind, bad_filetype
         else:
             assert entry.name.isidentifier(), f"Directories must be valid packages, got: {entry}"


### PR DESCRIPTION
Add tests to make sure that:
- All files in `test_cases` are `.py` files.
- All `.py` files in `test_cases` have names starting with `test_`.
- All requirements listed in `.pre-commit.config.yaml` also appear in `requirements-tests.txt`
- All requirements listed in `.pre-commit.config.yaml` have the same version specifier as the ones in `requirements-tests.txt`

Also rename the `check_same_files()` function to `check_no_symlinks()`, which is more accurate these days.