### PR TITLE
Add win32-specific constants to `_ctypes`

### DIFF
--- a/stdlib/_ctypes.pyi
+++ b/stdlib/_ctypes.pyi
@@ -17,3 +17,6 @@ if sys.platform == "win32":
         def __init__(self, hresult: int, text: str | None, details: _COMError_Details) -> None: ...
 
     def CopyComPointer(src: _PointerLike, dst: _PointerLike | _CArgObject) -> int: ...
+
+    FUNCFLAG_HRESULT: int
+    FUNCFLAG_STDCALL: int

--- a/tests/stubtest_allowlists/win32.txt
+++ b/tests/stubtest_allowlists/win32.txt
@@ -26,8 +26,6 @@ ssl.SSLSocket.recvmsg
 ssl.SSLSocket.recvmsg_into
 ssl.SSLSocket.sendmsg
 winreg.HKEYType.handle
-_ctypes.FUNCFLAG_HRESULT
-_ctypes.FUNCFLAG_STDCALL
 _ctypes.FormatError
 _ctypes.FreeLibrary
 _ctypes.LoadLibrary


### PR DESCRIPTION
I added win32-specific constants to `_ctypes`.

(related to #8582 that `stdlib/_ctypes.pyi` was added)