### PR TITLE
Run `flake8-noqa` in CI

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,37 +1,42 @@
 # The following rules are incompatible with or enforced by black:
-#       E203 whitespace before ':' -- scripts only
-#       E301 expected 1 blank line
-#       E302 expected 2 blank lines
-#       E305 expected 2 blank lines
-#       E501 line too long
+#     E203   whitespace before ':' -- scripts only
+#     E301   expected 1 blank line
+#     E302   expected 2 blank lines
+#     E305   expected 2 blank lines
+#     E501   line too long
 
 # Some rules are considered irrelevant to stub files:
-#       E701 multiple statements on one line (colon) -- disallows "..." on the same line
-#       F401 imported but unused -- does not recognize re-exports
+#     E701   multiple statements on one line (colon) -- disallows "..." on the same line
+#     F401   imported but unused -- does not recognize re-exports
 #            https://github.com/PyCQA/pyflakes/issues/474
-#       F822 undefined name in __all__ -- flake8 does not recognize 'foo: Any'
+#     F822   undefined name in __all__ -- flake8 does not recognize 'foo: Any'
 #            https://github.com/PyCQA/pyflakes/issues/533
 
 # Rules that are out of the control of stub authors:
-#       E741 ambiguous variable name
-#       F403 import *' used; unable to detect undefined names
-#       F405 defined from star imports
+#     E741   ambiguous variable name
+#     F403   import *' used; unable to detect undefined names
+#     F405   defined from star imports
 
 # Rules that we'd like to enable in the future:
-#       Y037 Use PEP 604 syntax instead of `typing.Union` and `typing.Optional`.
+#     Y037   Use PEP 604 syntax instead of `typing.Union` and `typing.Optional`.
 #            Currently can't be enabled due to a few lingering bugs in mypy regarding
 #            PEP 604 type aliases (see #4819).
+#     NQA102 "noqa" code has no matching violations. We often introduce "noqa" comments
+#            into the typeshed codebase to unblock flake8-pyi PRs, meaning these comments
+#            have "no matching violations" since the relevant flake8-pyi checks haven't
+#            yet been released.
 
 [flake8]
 per-file-ignores =
   *.py: E203, E301, E302, E305, E501
-  *.pyi: E301, E302, E305, E501, E701, E741, F401, F403, F405, F822, Y037
+  *.pyi: E301, E302, E305, E501, E701, E741, NQA102, F401, F403, F405, F822, Y037
   # Since typing.pyi defines "overload" this is not recognized by flake8 as typing.overload.
   # Unfortunately, flake8 does not allow to "noqa" just a specific error inside the file itself.
   # https://github.com/PyCQA/flake8/issues/1079
   #     F811 redefinition of unused '...'
-  stdlib/typing.pyi: E301, E302, E305, E501, E701, E741, F401, F403, F405, F811, F822, Y037
+  stdlib/typing.pyi: E301, E302, E305, E501, E701, E741, NQA102, F401, F403, F405, F811, F822, Y037
   # Generated protobuf files include docstrings
-  *_pb2.pyi: E301, E302, E305, E501, E701, Y021, Y026
+  *_pb2.pyi: E301, E302, E305, E501, E701, NQA102, Y021, Y026
 
 exclude = .venv*,.git
+noqa_require_code = true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,7 @@ repos:
       - id: flake8
         additional_dependencies:
           - 'flake8-bugbear==22.7.1'  # must match requirements-tests.txt
+          - 'flake8-noqa==1.2.9'      # must match requirements-tests.txt
           - 'flake8-pyi==22.8.1'      # must match requirements-tests.txt
 
 ci:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,7 +102,7 @@ black .
 ...Or install the pre-commit hooks: please refer to the
 [pre-commit](https://pre-commit.com/) documentation.
 
-Our code is also linted using `flake8`, with plugins `flake8-pyi`
+Our code is also linted using `flake8`, with plugins `flake8-pyi`,
 `flake8-bugbear`, and flake8-noqa. As with our other checks, running
 flake8 before filing a PR is not required. However, if you wish to run flake8
 locally, install the test dependencies as outlined above, and then run:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,7 +102,8 @@ black .
 ...Or install the pre-commit hooks: please refer to the
 [pre-commit](https://pre-commit.com/) documentation.
 
-Our code is also linted using `flake8`, with plugins `flake8-pyi` and `flake8-bugbear`. As with our other checks, running
+Our code is also linted using `flake8`, with plugins `flake8-pyi`
+`flake8-bugbear`, and flake8-noqa. As with our other checks, running
 flake8 before filing a PR is not required. However, if you wish to run flake8
 locally, install the test dependencies as outlined above, and then run:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,7 +103,7 @@ black .
 [pre-commit](https://pre-commit.com/) documentation.
 
 Our code is also linted using `flake8`, with plugins `flake8-pyi`,
-`flake8-bugbear`, and flake8-noqa. As with our other checks, running
+`flake8-bugbear`, and `flake8-noqa`. As with our other checks, running
 flake8 before filing a PR is not required. However, if you wish to run flake8
 locally, install the test dependencies as outlined above, and then run:
 

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -2,6 +2,7 @@ aiohttp==3.8.1
 black==22.6.0           # must match .pre-commit-config.yaml
 flake8==5.0.4           # must match .pre-commit-config.yaml
 flake8-bugbear==22.7.1  # must match .pre-commit-config.yaml
+flake8-noqa==1.2.9      # must match .pre-commit-config.yaml
 flake8-pyi==22.8.1      # must match .pre-commit-config.yaml
 isort==5.10.1           # must match .pre-commit-config.yaml
 mypy==0.971


### PR DESCRIPTION
[flake8-noqa](https://github.com/plinss/flake8-noqa) is a plugin for validating `noqa` comments. Mypy recently added it to their CI, and I think it would be good for us to add it as well.

Unfortunately, we cannot enable `NQA102`, probably the most useful `flake8-noqa` check, which detects unused `noqa` comments. This is because we quite often have unused `noqa` comments in typeshed for unreleased flake8-pyi checks.

Nonetheless, flake8-noqa has a number of other useful checks, so I think it would be a worthy addition to our CI anyway.