### PR TITLE
add and migrate constants from `ctypes/__init__.pyi` to `_ctypes.pyi`

### DIFF
--- a/stdlib/_ctypes.pyi
+++ b/stdlib/_ctypes.pyi
@@ -2,6 +2,13 @@ import sys
 from ctypes import _CArgObject, _PointerLike
 from typing_extensions import TypeAlias
 
+FUNCFLAG_CDECL: int
+FUNCFLAG_PYTHONAPI: int
+FUNCFLAG_USE_ERRNO: int
+FUNCFLAG_USE_LASTERROR: int
+RTLD_GLOBAL: int
+RTLD_LOCAL: int
+
 if sys.version_info >= (3, 11):
     CTYPES_MAX_ARGCOUNT: int
 

--- a/stdlib/ctypes/__init__.pyi
+++ b/stdlib/ctypes/__init__.pyi
@@ -5,7 +5,9 @@ from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from typing import Any, ClassVar, Generic, TypeVar, Union as _UnionT, overload
 from typing_extensions import TypeAlias
 
-from _ctypes import RTLD_GLOBAL as RTLD_GLOBAL, RTLD_LOCAL as RTLD_LOCAL
+# TODO: import these from _ctypes once it no longer breaks pytype
+RTLD_GLOBAL: int
+RTLD_LOCAL: int
 
 if sys.version_info >= (3, 9):
     from types import GenericAlias

--- a/stdlib/ctypes/__init__.pyi
+++ b/stdlib/ctypes/__init__.pyi
@@ -5,6 +5,8 @@ from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from typing import Any, ClassVar, Generic, TypeVar, Union as _UnionT, overload
 from typing_extensions import TypeAlias
 
+from _ctypes import RTLD_GLOBAL as RTLD_GLOBAL, RTLD_LOCAL as RTLD_LOCAL
+
 if sys.version_info >= (3, 9):
     from types import GenericAlias
 
@@ -12,8 +14,6 @@ _T = TypeVar("_T")
 _DLLT = TypeVar("_DLLT", bound=CDLL)
 _CT = TypeVar("_CT", bound=_CData)
 
-RTLD_GLOBAL: int
-RTLD_LOCAL: int
 DEFAULT_MODE: int
 
 class CDLL:

--- a/tests/pytype_exclude_list.txt
+++ b/tests/pytype_exclude_list.txt
@@ -12,6 +12,8 @@ stubs/mysqlclient/MySQLdb/cursors.pyi
 
 # errors about circular imports
 stdlib/ctypes/__init__.pyi
+stdlib/ctypes/util.pyi
+stdlib/ctypes/wintypes.pyi
 stdlib/_ctypes.pyi
 
 # _pb2.pyi have some constructs that break pytype

--- a/tests/pytype_exclude_list.txt
+++ b/tests/pytype_exclude_list.txt
@@ -10,12 +10,6 @@ stubs/mysqlclient/MySQLdb/__init__.pyi
 stubs/mysqlclient/MySQLdb/connections.pyi
 stubs/mysqlclient/MySQLdb/cursors.pyi
 
-# errors about circular imports
-stdlib/ctypes/__init__.pyi
-stdlib/ctypes/util.pyi
-stdlib/ctypes/wintypes.pyi
-stdlib/_ctypes.pyi
-
 # _pb2.pyi have some constructs that break pytype
 # Eg
 # pytype.pyi.parser.ParseError:   File: "/Users/nipunn/src/typeshed/third_party/2and3/google/protobuf/descriptor_pb2.pyi", line 195

--- a/tests/pytype_exclude_list.txt
+++ b/tests/pytype_exclude_list.txt
@@ -10,6 +10,10 @@ stubs/mysqlclient/MySQLdb/__init__.pyi
 stubs/mysqlclient/MySQLdb/connections.pyi
 stubs/mysqlclient/MySQLdb/cursors.pyi
 
+# errors about the circular imports
+stdlib/ctypes/__init__.pyi
+stdlib/_ctypes.pyi
+
 # _pb2.pyi have some constructs that break pytype
 # Eg
 # pytype.pyi.parser.ParseError:   File: "/Users/nipunn/src/typeshed/third_party/2and3/google/protobuf/descriptor_pb2.pyi", line 195

--- a/tests/pytype_exclude_list.txt
+++ b/tests/pytype_exclude_list.txt
@@ -10,7 +10,7 @@ stubs/mysqlclient/MySQLdb/__init__.pyi
 stubs/mysqlclient/MySQLdb/connections.pyi
 stubs/mysqlclient/MySQLdb/cursors.pyi
 
-# errors about the circular imports
+# errors about circular imports
 stdlib/ctypes/__init__.pyi
 stdlib/_ctypes.pyi
 

--- a/tests/stubtest_allowlists/py3_common.txt
+++ b/tests/stubtest_allowlists/py3_common.txt
@@ -341,16 +341,10 @@ wave.Wave_write.initfp
 
 _ctypes.Array
 _ctypes.CFuncPtr
-_ctypes.FUNCFLAG_CDECL
-_ctypes.FUNCFLAG_PYTHONAPI
-_ctypes.FUNCFLAG_USE_ERRNO
-_ctypes.FUNCFLAG_USE_LASTERROR
 _ctypes.POINTER
 _ctypes.PyObj_FromPtr
 _ctypes.Py_DECREF
 _ctypes.Py_INCREF
-_ctypes.RTLD_GLOBAL
-_ctypes.RTLD_LOCAL
 _ctypes.Structure
 _ctypes.Union
 _ctypes.addressof


### PR DESCRIPTION
I have moved some constants in `ctypes/__init__.pyi` to `_ctypes.pyi` as defined in the implementation.

I also added some constants defined in `_ctypes`.

I will move other stuffs eventually, but I will try to do it little by little.

- related to #8571 and #8633