### PR TITLE
`typed_ast.ast3`: `arguments.kw_defaults` should be `list[expr | None]`

### DIFF
--- a/stubs/typed-ast/typed_ast/ast3.pyi
+++ b/stubs/typed-ast/typed_ast/ast3.pyi
@@ -358,7 +358,7 @@ class arguments(AST):
     args: list[arg]
     vararg: arg | None
     kwonlyargs: list[arg]
-    kw_defaults: list[expr]
+    kw_defaults: list[expr | None]
     kwarg: arg | None
     defaults: list[expr]
 


### PR DESCRIPTION
```python
>>> from typed_ast import ast3
>>> print(ast3.dump(ast3.parse('def foo(*, arg: int) -> None: ...')))
Module(body=[FunctionDef(name='foo', args=arguments(args=[], vararg=None, kwonlyargs=[arg(arg='arg', annotation=Name(id='int', ctx=Load()), type_comment=None)], kw_defaults=[None], kwarg=None, defaults=[]), body=[Expr(value=Ellipsis())], decorator_list=[], returns=NameConstant(value=None), type_comment=None)], type_ignores=[])
```

This bug was discovered in https://github.com/python/mypy/pull/13547