### PR TITLE
`typecheck_typeshed.py`: Make `dir` command-line argument positional-only

### DIFF
--- a/tests/typecheck_typeshed.py
+++ b/tests/typecheck_typeshed.py
@@ -18,6 +18,13 @@ DIRECTORIES_TO_TEST = ("scripts", "tests")
 
 parser = argparse.ArgumentParser(description="Run mypy on typeshed's own code in the `scripts` and `tests` directories.")
 parser.add_argument(
+    "dir",
+    choices=DIRECTORIES_TO_TEST,
+    nargs="*",
+    action="extend",
+    help=f"Test only these top-level typeshed directories (defaults to {DIRECTORIES_TO_TEST!r})",
+)
+parser.add_argument(
     "--platform",
     choices=SUPPORTED_PLATFORMS,
     nargs="*",
@@ -31,14 +38,6 @@ parser.add_argument(
     nargs="*",
     action="extend",
     help="Run mypy for certain Python versions (defaults to sys.version_info[:2])",
-)
-parser.add_argument(
-    "-d",
-    "--dir",
-    choices=DIRECTORIES_TO_TEST,
-    nargs="*",
-    action="extend",
-    help=f"Test only these top-level typeshed directories (defaults to {DIRECTORIES_TO_TEST!r})",
 )
 
 

--- a/tests/typecheck_typeshed.py
+++ b/tests/typecheck_typeshed.py
@@ -19,7 +19,7 @@ DIRECTORIES_TO_TEST = ("scripts", "tests")
 parser = argparse.ArgumentParser(description="Run mypy on typeshed's own code in the `scripts` and `tests` directories.")
 parser.add_argument(
     "dir",
-    choices=DIRECTORIES_TO_TEST,
+    choices=DIRECTORIES_TO_TEST + ([],),
     nargs="*",
     action="extend",
     help=f"Test only these top-level typeshed directories (defaults to {DIRECTORIES_TO_TEST!r})",


### PR DESCRIPTION
It's annoying to have to go `python tests/typecheck_typeshed.py --dir tests` to run mypy on the `test` directory. `python tests/typecheck_typeshed.py tests` is faster to type :)