### PR TITLE
stdlib/_ast.pyi: Fix ast.ImportFrom arg module _identifier to str

### DIFF
--- a/stdlib/_ast.pyi
+++ b/stdlib/_ast.pyi
@@ -194,7 +194,7 @@ class Import(stmt):
 class ImportFrom(stmt):
     if sys.version_info >= (3, 10):
         __match_args__ = ("module", "names", "level")
-    module: _Identifier | None
+    module: str | None
     names: list[alias]
     level: int
 


### PR DESCRIPTION
ast.ImportFrom module field should be `str | None`.

`from ..a.b import f` dumps `ImportFrom(module='a.b', ..., level=2)`

So _identifier typing is incorrect
