### PR TITLE
`fpdf2`: Remove redundant `str | Literal['DEPRECATED']` union

### DIFF
--- a/stubs/fpdf2/fpdf/fpdf.pyi
+++ b/stubs/fpdf2/fpdf/fpdf.pyi
@@ -139,7 +139,7 @@ class FPDF:
         orientation: _Orientation = ...,
         unit: _Unit | float = ...,
         format: _Format | tuple[float, float] = ...,
-        font_cache_dir: str | Literal["DEPRECATED"] = ...,
+        font_cache_dir: Literal["DEPRECATED"] = ...,
     ) -> None: ...
     @property
     def font_size_pt(self) -> float: ...


### PR DESCRIPTION
Refs https://github.com/PyCQA/flake8-pyi/pull/279.

I think it's probably best to just use `Literal["DEPRECATED"]` here. If you put anything else, you get an annoying warning, and the parameter is now entirely unused: https://github.com/PyFPDF/fpdf2/blob/a14c93fc747de39121047efafeffcca7272eda9e/fpdf/fpdf.py#L381-L386