### PR TITLE
`create_baseline_stubs.py`: Fix path separator on windows and ignore root `/out`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ target/
 
 # Local utility scripts
 analyze.py
+/out/
 
 # Editor backup files
 *~

--- a/.gitignore
+++ b/.gitignore
@@ -56,7 +56,6 @@ target/
 
 # Local utility scripts
 analyze.py
-/out/
 
 # Editor backup files
 *~

--- a/scripts/create_baseline_stubs.py
+++ b/scripts/create_baseline_stubs.py
@@ -167,7 +167,7 @@ def main() -> None:
         sys.exit(1)
     project, version = info
 
-    stub_dir = os.path.join("stubs", project)
+    stub_dir = os.path.join("stubs", project).replace("\\", "/")
     if os.path.exists(stub_dir):
         sys.exit(f"Error: {stub_dir} already exists (delete it first)")
 

--- a/scripts/create_baseline_stubs.py
+++ b/scripts/create_baseline_stubs.py
@@ -90,7 +90,8 @@ def add_pyright_exclusion(stub_dir: str) -> None:
     assert i < len(lines), f"Error parsing {PYRIGHT_CONFIG}"
     while not lines[i].strip().startswith("]"):
         i += 1
-    line_to_add = f'        "{stub_dir}",'
+    # Must use forward slash in the .json file
+    line_to_add = f'        "{stub_dir}",'.replace("\\", "/")
     initial = i - 1
     while lines[i].lower() > line_to_add.lower():
         i -= 1
@@ -151,7 +152,7 @@ def main() -> None:
         sys.exit(1)
     project, version = info
 
-    stub_dir = f"stubs/{project}"  # Must use forward slash in the .json file
+    stub_dir = os.path.join("stubs", project)
     if os.path.exists(stub_dir):
         sys.exit(f"Error: {stub_dir} already exists (delete it first)")
 

--- a/scripts/create_baseline_stubs.py
+++ b/scripts/create_baseline_stubs.py
@@ -46,24 +46,9 @@ def get_installed_package_info(project: str) -> tuple[str, str] | None:
     return search_pip_freeze_output(project, r.stdout)
 
 
-def run_stubgen(package: str) -> None:
-    print(f"Running stubgen: stubgen -p {package}")
-    subprocess.run(["stubgen", "-p", package], check=True)
-
-
-def copy_stubs(src_base_dir: str, package: str, stub_dir: str) -> None:
-    """Copy generated stubs to the target directory under stub_dir/."""
-    print(f"Copying stubs to {stub_dir}")
-    if not os.path.isdir(stub_dir):
-        os.mkdir(stub_dir)
-    src_dir = os.path.join(src_base_dir, package)
-    if os.path.isdir(src_dir):
-        shutil.copytree(src_dir, os.path.join(stub_dir, package))
-    else:
-        src_file = os.path.join("out", f"{package}.pyi")
-        if not os.path.isfile(src_file):
-            sys.exit("Error: Cannot find generated stubs")
-        shutil.copy(src_file, stub_dir)
+def run_stubgen(package: str, output: str) -> None:
+    print(f"Running stubgen: stubgen -o {output} -p {package}")
+    subprocess.run(["stubgen", "-o", output ,"-p", package], check=True)
 
 
 def run_black(stub_dir: str) -> None:
@@ -167,14 +152,11 @@ def main() -> None:
         sys.exit(1)
     project, version = info
 
-    stub_dir = os.path.join("stubs", project).replace("\\", "/")
+    stub_dir = f"stubs/{project}"  # Must use forward slash in the .json file
     if os.path.exists(stub_dir):
         sys.exit(f"Error: {stub_dir} already exists (delete it first)")
 
-    run_stubgen(package)
-
-    # Stubs were generated under out/. Copy them to stubs/.
-    copy_stubs("out", package, stub_dir)
+    run_stubgen(package, stub_dir)
 
     run_isort(stub_dir)
     run_black(stub_dir)

--- a/scripts/create_baseline_stubs.py
+++ b/scripts/create_baseline_stubs.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 import argparse
 import os
 import re
-import shutil
 import subprocess
 import sys
 
@@ -48,7 +47,7 @@ def get_installed_package_info(project: str) -> tuple[str, str] | None:
 
 def run_stubgen(package: str, output: str) -> None:
     print(f"Running stubgen: stubgen -o {output} -p {package}")
-    subprocess.run(["stubgen", "-o", output ,"-p", package], check=True)
+    subprocess.run(["stubgen", "-o", output, "-p", package], check=True)
 
 
 def run_black(stub_dir: str) -> None:


### PR DESCRIPTION
On windows, the stub path is generated with a backslash, which of course is not valid when added to the json file.  
`create_baseline_stubs.py` also creates a `out` folder at the root which was not gitignored.
