### PR TITLE
Improve some `tkinter` unions

### DIFF
--- a/stdlib/tkinter/__init__.pyi
+++ b/stdlib/tkinter/__init__.pyi
@@ -178,13 +178,11 @@ _ButtonCommand: TypeAlias = str | Callable[[], Any]  # accepts string of tcl cod
 _CanvasItemId: TypeAlias = int
 _Color: TypeAlias = str  # typically '#rrggbb', '#rgb' or color names.
 _Compound: TypeAlias = Literal["top", "left", "center", "right", "bottom", "none"]  # -compound in manual page named 'options'
-_Cursor: TypeAlias = Union[
-    str, tuple[str], tuple[str, str], tuple[str, str, str], tuple[str, str, str, str]
-]  # manual page: Tk_GetCursor
-_EntryValidateCommand: TypeAlias = (
-    str | list[str] | tuple[str, ...] | Callable[[], bool]
-)  # example when it's sequence:  entry['invalidcommand'] = [entry.register(print), '%P']
-_GridIndex: TypeAlias = int | str | Literal["all"]
+# manual page: Tk_GetCursor
+_Cursor: TypeAlias = Union[str, tuple[str], tuple[str, str], tuple[str, str, str], tuple[str, str, str, str]]
+# example when it's sequence:  entry['invalidcommand'] = [entry.register(print), '%P']
+_EntryValidateCommand: TypeAlias = str | list[str] | tuple[str, ...] | Callable[[], bool]
+_GridIndex: TypeAlias = int | str
 _ImageSpec: TypeAlias = _Image | str  # str can be from e.g. tkinter.image_names()
 _Relief: TypeAlias = Literal["raised", "sunken", "flat", "ridge", "solid", "groove"]  # manual page: Tk_GetRelief
 _ScreenUnits: TypeAlias = str | float  # Often the right type instead of int. Manual page: Tk_GetPixels

--- a/stdlib/tkinter/ttk.pyi
+++ b/stdlib/tkinter/ttk.pyi
@@ -937,7 +937,7 @@ class _TreeviewTagDict(TypedDict):
     foreground: tkinter._Color
     background: tkinter._Color
     font: _FontDescription
-    image: Literal[""] | str  # not wrapped in list :D
+    image: str  # not wrapped in list :D
 
 class _TreeviewHeaderDict(TypedDict):
     text: str
@@ -963,7 +963,7 @@ class Treeview(Widget, tkinter.XView, tkinter.YView):
         class_: str = ...,
         columns: str | list[str] | tuple[str, ...] = ...,
         cursor: tkinter._Cursor = ...,
-        displaycolumns: str | list[str] | tuple[str, ...] | list[int] | tuple[int, ...] | Literal["#all"] = ...,
+        displaycolumns: str | list[str] | tuple[str, ...] | list[int] | tuple[int, ...] = ...,
         height: int = ...,
         name: str = ...,
         padding: _Padding = ...,
@@ -985,7 +985,7 @@ class Treeview(Widget, tkinter.XView, tkinter.YView):
         *,
         columns: str | list[str] | tuple[str, ...] = ...,
         cursor: tkinter._Cursor = ...,
-        displaycolumns: str | list[str] | tuple[str, ...] | list[int] | tuple[int, ...] | Literal["#all"] = ...,
+        displaycolumns: str | list[str] | tuple[str, ...] | list[int] | tuple[int, ...] = ...,
         height: int = ...,
         padding: _Padding = ...,
         selectmode: Literal["extended", "browse", "none"] = ...,


### PR DESCRIPTION
Remove redundant `str | Literal[foo]` unions, and clean up the formatting of a few type aliases.

Unblocks https://github.com/PyCQA/flake8-pyi/pull/279. See @Akuli's comments here: https://github.com/PyCQA/flake8-pyi/pull/279#issuecomment-1232100333.