### PR TITLE
In `ctypes/__init__.pyi`, `RTLD_GLOBAL` and `RTLD_LOCAL` are imported from `_ctypes.pyi`

### DIFF
--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -9,7 +9,7 @@ mypy==0.971
 packaging==21.3
 pycln==2.1.1            # must match .pre-commit-config.yaml
 pyyaml==6.0
-pytype==2022.8.23; platform_system != "Windows"
+pytype==2022.8.30; platform_system != "Windows"
 termcolor
 tomli==1.2.2
 tomlkit==0.11.4

--- a/stdlib/ctypes/__init__.pyi
+++ b/stdlib/ctypes/__init__.pyi
@@ -5,9 +5,7 @@ from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from typing import Any, ClassVar, Generic, TypeVar, Union as _UnionT, overload
 from typing_extensions import TypeAlias
 
-# TODO: import these from _ctypes once it no longer breaks pytype
-RTLD_GLOBAL: int
-RTLD_LOCAL: int
+from _ctypes import RTLD_GLOBAL as RTLD_GLOBAL, RTLD_LOCAL as RTLD_LOCAL
 
 if sys.version_info >= (3, 9):
     from types import GenericAlias


### PR DESCRIPTION
Thanks to google/pytype#1281 and google/pytype#1282, importing `RTLD_GLOBAL` and `RTLD_LOCAL` from `_ctypes` will not fail the `pytype` test on CI if the `pytype==2022.08.30` version is specified.

[Other stuffs that should be defined in `_ctypes`](https://github.com/python/typeshed/issues/8633#issuecomment-1231672437) will be migrated after `pytype` stops using its own `_ctypes` stubs and starts using `typeshed`'s `_ctypes` stubs.

- related to #8571, #8633 and #8643