### PR TITLE
redis: Improve `kwargs` typing in `sentinel`

### DIFF
--- a/stubs/redis/redis/sentinel.pyi
+++ b/stubs/redis/redis/sentinel.pyi
@@ -27,7 +27,6 @@ class SentinelManagedSSLConnection(SentinelManagedConnection, SSLConnection): ..
 class SentinelConnectionPool(ConnectionPool):
     is_master: bool
     check_connection: bool
-    connection_kwargs: Any
     service_name: str
     sentinel_manager: Sentinel
     def __init__(self, service_name: str, sentinel_manager: Sentinel, **kwargs) -> None: ...
@@ -37,10 +36,10 @@ class SentinelConnectionPool(ConnectionPool):
     def rotate_slaves(self) -> Iterator[_AddressAndPort]: ...
 
 class Sentinel(SentinelCommands):
-    sentinel_kwargs: Any
+    sentinel_kwargs: dict[str, Any | None]
     sentinels: list[Redis[Any]]
     min_other_sentinels: int
-    connection_kwargs: Any
+    connection_kwargs: dict[str, Any]
     def __init__(
         self,
         sentinels: Iterable[_AddressAndPort],

--- a/stubs/redis/redis/sentinel.pyi
+++ b/stubs/redis/redis/sentinel.pyi
@@ -36,7 +36,7 @@ class SentinelConnectionPool(ConnectionPool):
     def rotate_slaves(self) -> Iterator[_AddressAndPort]: ...
 
 class Sentinel(SentinelCommands):
-    sentinel_kwargs: dict[str, Any | None]
+    sentinel_kwargs: dict[str, Any]
     sentinels: list[Redis[Any]]
     min_other_sentinels: int
     connection_kwargs: dict[str, Any]
@@ -44,7 +44,7 @@ class Sentinel(SentinelCommands):
         self,
         sentinels: Iterable[_AddressAndPort],
         min_other_sentinels: int = ...,
-        sentinel_kwargs: Any | None = ...,
+        sentinel_kwargs: dict[str, Any] | None = ...,
         **connection_kwargs,
     ) -> None: ...
     def check_master_state(self, state: _SentinelState, service_name: str) -> bool: ...


### PR DESCRIPTION
1. `ConnectionPool` super-class has better typing of `kwargs`: https://github.com/python/typeshed/blob/master/stubs/redis/redis/connection.pyi#L195 So, I removed it from a child
2. Other changes are trivial: `kwargs` are always `dict[str, *]`