### PR TITLE
Fix jsonschema._format.pyi to match upstream

### DIFF
--- a/stubs/jsonschema/@tests/stubtest_allowlist.txt
+++ b/stubs/jsonschema/@tests/stubtest_allowlist.txt
@@ -1,14 +1,2 @@
-jsonschema._format.is_css21_color
-jsonschema._format.is_css_color_code
-jsonschema._format.is_datetime
-jsonschema._format.is_duration
-jsonschema._format.is_host_name
-jsonschema._format.is_idn_host_name
-jsonschema._format.is_iri
-jsonschema._format.is_iri_reference
-jsonschema._format.is_json_pointer
-jsonschema._format.is_relative_json_pointer
-jsonschema._format.is_time
-jsonschema._format.is_uri
-jsonschema._format.is_uri_reference
-jsonschema._format.is_uri_template
+# TODO: remove _FormatCheckCallable when mypy 0.980 is released
+jsonschema._format._FormatCheckCallable

--- a/stubs/jsonschema/METADATA.toml
+++ b/stubs/jsonschema/METADATA.toml
@@ -1,1 +1,4 @@
 version = "4.15.*"
+
+[tool.stubtest]
+extras = ["format"]

--- a/stubs/jsonschema/jsonschema/_format.pyi
+++ b/stubs/jsonschema/jsonschema/_format.pyi
@@ -2,7 +2,7 @@ from collections.abc import Callable, Iterable
 from typing import TypeVar, Union
 from typing_extensions import TypeAlias
 
-_FormatCheckCallable = typing.Callable[[object], bool]
+_FormatCheckCallable: TypeAlias = Callable[[object], bool]
 _F = TypeVar("_F", bound=_FormatCheckCallable)
 _RaisesType: TypeAlias = Union[type[Exception], tuple[type[Exception], ...]]
 

--- a/stubs/jsonschema/jsonschema/_format.pyi
+++ b/stubs/jsonschema/jsonschema/_format.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Callable, Iterable
-from typing import Any, TypeVar, Union
+from typing import TypeVar, Union
 from typing_extensions import TypeAlias
 
 _FormatCheckCallable = typing.Callable[[object], bool]

--- a/stubs/jsonschema/jsonschema/_format.pyi
+++ b/stubs/jsonschema/jsonschema/_format.pyi
@@ -2,18 +2,19 @@ from collections.abc import Callable, Iterable
 from typing import Any, TypeVar, Union
 from typing_extensions import TypeAlias
 
-_F = TypeVar("_F", bound=Callable[..., Any])
+_FormatCheckCallable = typing.Callable[[object], bool]
+_F = TypeVar("_F", bound=_FormatCheckCallable)
 _RaisesType: TypeAlias = Union[type[Exception], tuple[type[Exception], ...]]
 
 class FormatChecker:
-    checkers: dict[str, tuple[Callable[[Any], bool], _RaisesType]]
+    checkers: dict[str, tuple[_FormatCheckCallable, _RaisesType]]
 
     def __init__(self, formats: Iterable[str] | None = ...) -> None: ...
     def checks(self, format: str, raises: _RaisesType = ...) -> Callable[[_F], _F]: ...
     @classmethod
     def cls_checks(cls, format: str, raises: _RaisesType = ...) -> Callable[[_F], _F]: ...
-    def check(self, instance: Any, format: str) -> None: ...
-    def conforms(self, instance: Any, format: str) -> bool: ...
+    def check(self, instance: object, format: str) -> None: ...
+    def conforms(self, instance: object, format: str) -> bool: ...
 
 draft3_format_checker: FormatChecker
 draft4_format_checker: FormatChecker


### PR DESCRIPTION
This updates the types in jsonschema._format.pyi to match the upstream source's type hints:

https://github.com/python-jsonschema/jsonschema/blob/main/jsonschema/_format.py

JSONSchema's typeshed version is 4.15.*:
https://github.com/python/typeshed/blob/master/stubs/jsonschema/METADATA.toml

which was released two days ago:
https://github.com/python-jsonschema/jsonschema/releases/tag/v4.15.0

So the use of master as a reference is not a big concern here.