### PR TITLE
`pyautogui`: just skip stubtest

### DIFF
--- a/stubs/PyAutoGUI/@tests/stubtest_allowlist.txt
+++ b/stubs/PyAutoGUI/@tests/stubtest_allowlist.txt
@@ -1,3 +1,0 @@
-# pyautogui requires a display, resulting in the following error on the CI:
-# failed to import, KeyError: 'DISPLAY'
-pyautogui

--- a/stubs/PyAutoGUI/METADATA.toml
+++ b/stubs/PyAutoGUI/METADATA.toml
@@ -1,4 +1,6 @@
 version = "0.9.*"
 
 [tool.stubtest]
-ignore_missing_stub = false
+# pyautogui requires a display, resulting in the following error on the CI:
+# failed to import, KeyError: 'DISPLAY'
+skip = true


### PR DESCRIPTION
I realised immediately after merging the pyautogui PR that there's not much point running stubtest on this package, since stubtest isn't able to import any of PyAutoGUI without access to a display screen