### PR TITLE
Cancel old test jobs in CI

### DIFF
--- a/.github/workflows/stubtest_stdlib.yml
+++ b/.github/workflows/stubtest_stdlib.yml
@@ -19,6 +19,10 @@ permissions:
 env:
   PIP_DISABLE_PIP_VERSION_CHECK: 1
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   stubtest-stdlib:
     name: Check stdlib with stubtest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,10 @@ permissions:
 env:
   PIP_DISABLE_PIP_VERSION_CHECK: 1
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   file-consistency:
     name: Check file consistency

--- a/.github/workflows/typecheck_typeshed_code.yml
+++ b/.github/workflows/typecheck_typeshed_code.yml
@@ -19,6 +19,10 @@ permissions:
 env:
   PIP_DISABLE_PIP_VERSION_CHECK: 1
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   mypy:
     name: Run mypy against the scripts and tests directories


### PR DESCRIPTION
This change means that new pushes to a PR branch will cancel old jobs in CI for our `tests`, `stubtest_stdlib` and `typecheck_typeshed_code` workflows. Mypy did this a few weeks ago in https://github.com/python/mypy/pull/13249, and it seems to be working pretty well. On days with a lot of PRs, our CI still occasionally gets backed up, so I think it would be good for us to make this change as well.

Docs here: https://docs.github.com/en/actions/using-jobs/using-concurrency