### PR TITLE
stubsabot: Add a warning to the PR message if stubtest is skipped for a distribution

### DIFF
--- a/scripts/stubsabot.py
+++ b/scripts/stubsabot.py
@@ -12,6 +12,7 @@ import re
 import subprocess
 import sys
 import tarfile
+import textwrap
 import urllib.parse
 import zipfile
 from dataclasses import dataclass
@@ -320,12 +321,25 @@ async def suggest_typeshed_update(update: Update, session: aiohttp.ClientSession
             return
 
     body = "\n".join(f"{k}: {v}" for k, v in update.links.items())
-    body += """
 
-If stubtest fails for this PR:
-- Leave this PR open (as a reminder, and to prevent stubsabot from opening another PR)
-- Fix stubtest failures in another PR, then close this PR
-"""
+    stubtest_will_run = not meta.get("stubtest", {}).get("skip", False)
+    if stubtest_will_run:
+        body += textwrap.dedent(
+            """
+
+            If stubtest fails for this PR:
+            - Leave this PR open (as a reminder, and to prevent stubsabot from opening another PR)
+            - Fix stubtest failures in another PR, then close this PR
+            """
+        )
+    else:
+        body += textwrap.dedent(
+            f"""
+
+            :warning: Review this PR carefully, as stubtest is SKIPPED in CI for {update.distribution}! :warning:
+            """
+        )
+
     await create_or_update_pull_request(title=title, body=body, branch_name=branch_name, session=session)
 
 

--- a/scripts/stubsabot.py
+++ b/scripts/stubsabot.py
@@ -330,7 +330,6 @@ async def suggest_typeshed_update(update: Update, session: aiohttp.ClientSession
             If stubtest fails for this PR:
             - Leave this PR open (as a reminder, and to prevent stubsabot from opening another PR)
             - Fix stubtest failures in another PR, then close this PR
-            
             Note that you will need to close and re-open the PR in order to trigger CI
             """
         )

--- a/scripts/stubsabot.py
+++ b/scripts/stubsabot.py
@@ -330,13 +330,15 @@ async def suggest_typeshed_update(update: Update, session: aiohttp.ClientSession
             If stubtest fails for this PR:
             - Leave this PR open (as a reminder, and to prevent stubsabot from opening another PR)
             - Fix stubtest failures in another PR, then close this PR
+            
+            Note that you will need to close and re-open the PR in order to trigger CI
             """
         )
     else:
         body += textwrap.dedent(
             f"""
 
-            :warning: Review this PR carefully, as stubtest is SKIPPED in CI for {update.distribution}! :warning:
+            :warning: Review this PR manually, as stubtest is skipped in CI for {update.distribution}! :warning:
             """
         )
 

--- a/scripts/stubsabot.py
+++ b/scripts/stubsabot.py
@@ -330,6 +330,7 @@ async def suggest_typeshed_update(update: Update, session: aiohttp.ClientSession
             If stubtest fails for this PR:
             - Leave this PR open (as a reminder, and to prevent stubsabot from opening another PR)
             - Fix stubtest failures in another PR, then close this PR
+
             Note that you will need to close and re-open the PR in order to trigger CI
             """
         )


### PR DESCRIPTION
We tend to merge stubsabot PRs pretty quickly if stubtest passes in CI, but if stubtest is skipped for a certain distribution, there's a danger that there might be major changes to the library that we haven't noticed. For these packages, we should be more careful in reviewing PRs from stubsabot.