### PR TITLE
stubsabot: Improve argument-parsing for `--action-level`

### DIFF
--- a/scripts/stubsabot.py
+++ b/scripts/stubsabot.py
@@ -44,6 +44,13 @@ class ActionLevel(enum.IntEnum):
         member.__doc__ = doc
         return member
 
+    @classmethod
+    def from_cmd_arg(cls, cmd_arg: str) -> ActionLevel:
+        try:
+            return cls[cmd_arg]
+        except KeyError:
+            raise argparse.ArgumentTypeError(f'Argument must be one of "{list(cls.__members__)}"')
+
     nothing = 0, "make no changes"
     local = 1, "make changes that affect local repo"
     fork = 2, "make changes that affect remote repo, but won't open PRs against upstream"
@@ -376,7 +383,7 @@ async def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--action-level",
-        type=lambda x: getattr(ActionLevel, x),  # type: ignore[no-any-return]
+        type=ActionLevel.from_cmd_arg,
         default=ActionLevel.everything,
         help="Limit actions performed to achieve dry runs for different levels of dryness",
     )


### PR DESCRIPTION
Before:

```
(.venv) C:\Users\alexw\coding\typeshed>python scripts/stubsabot.py --action-level 2
Traceback (most recent call last):
  File "C:\Users\alexw\coding\typeshed\scripts\stubsabot.py", line 441, in <module>
    asyncio.run(main())
  File "C:\Users\alexw\AppData\Local\Programs\Python\Python310\lib\asyncio\runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "C:\Users\alexw\AppData\Local\Programs\Python\Python310\lib\asyncio\base_events.py", line 646, in run_until_complete
    return future.result()
  File "C:\Users\alexw\coding\typeshed\scripts\stubsabot.py", line 389, in main
    args = parser.parse_args()
  File "C:\Users\alexw\AppData\Local\Programs\Python\Python310\lib\argparse.py", line 1826, in parse_args
    args, argv = self.parse_known_args(args, namespace)
  File "C:\Users\alexw\AppData\Local\Programs\Python\Python310\lib\argparse.py", line 1859, in parse_known_args
    namespace, args = self._parse_known_args(args, namespace)
  File "C:\Users\alexw\AppData\Local\Programs\Python\Python310\lib\argparse.py", line 2068, in _parse_known_args
    start_index = consume_optional(start_index)
  File "C:\Users\alexw\AppData\Local\Programs\Python\Python310\lib\argparse.py", line 2008, in consume_optional
    take_action(action, args, option_string)
  File "C:\Users\alexw\AppData\Local\Programs\Python\Python310\lib\argparse.py", line 1920, in take_action
    argument_values = self._get_values(action, argument_strings)
  File "C:\Users\alexw\AppData\Local\Programs\Python\Python310\lib\argparse.py", line 2451, in _get_values
    value = self._get_value(action, arg_string)
  File "C:\Users\alexw\AppData\Local\Programs\Python\Python310\lib\argparse.py", line 2484, in _get_value
    result = type_func(arg_string)
  File "C:\Users\alexw\coding\typeshed\scripts\stubsabot.py", line 379, in <lambda>
    type=lambda x: getattr(ActionLevel, x),  # type: ignore[no-any-return]
  File "C:\Users\alexw\AppData\Local\Programs\Python\Python310\lib\enum.py", line 437, in __getattr__
    raise AttributeError(name) from None
AttributeError: 2
```

After:

```
(.venv) C:\Users\alexw\coding\typeshed>python scripts/stubsabot.py --action-level 2
usage: stubsabot.py [-h] [--action-level ACTION_LEVEL] [--action-count-limit ACTION_COUNT_LIMIT]
stubsabot.py: error: argument --action-level: Argument must be one of "['nothing', 'local', 'fork', 'everything']"
```