### PR TITLE
Use `ClassVar` for class-level attributes in `cmd`

### DIFF
--- a/stdlib/cmd.pyi
+++ b/stdlib/cmd.pyi
@@ -8,7 +8,6 @@ PROMPT: Literal["(Cmd) "]
 IDENTCHARS: str  # Too big to be `Literal`
 
 class Cmd:
-    prompt: ClassVar[str]
     identchars: ClassVar[str]
     ruler: ClassVar[str]
     doc_leader: ClassVar[str]
@@ -17,6 +16,7 @@ class Cmd:
     undoc_header: ClassVar[str]
     nohelp: ClassVar[str]
     use_rawinput: ClassVar[bool]
+    prompt: str
     lastcmd: str
     intro: Any | None
     stdin: IO[str]

--- a/stdlib/cmd.pyi
+++ b/stdlib/cmd.pyi
@@ -11,14 +11,14 @@ class Cmd:
     prompt: ClassVar[str]
     identchars: ClassVar[str]
     ruler: ClassVar[str]
-    lastcmd: ClassVar[str]
-    intro: Any | None
     doc_leader: ClassVar[str]
     doc_header: ClassVar[str]
     misc_header: ClassVar[str]
     undoc_header: ClassVar[str]
     nohelp: ClassVar[str]
     use_rawinput: ClassVar[bool]
+    lastcmd: str
+    intro: Any | None
     stdin: IO[str]
     stdout: IO[str]
     cmdqueue: list[str]

--- a/stdlib/cmd.pyi
+++ b/stdlib/cmd.pyi
@@ -12,7 +12,7 @@ class Cmd:
     identchars: ClassVar[str]
     ruler: ClassVar[str]
     lastcmd: ClassVar[str]
-    intro: ClassVar[Any | None]
+    intro: Any | None
     doc_leader: ClassVar[str]
     doc_header: ClassVar[str]
     misc_header: ClassVar[str]

--- a/stdlib/cmd.pyi
+++ b/stdlib/cmd.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Callable
-from typing import IO, Any
+from typing import IO, Any, ClassVar
 from typing_extensions import Literal
 
 __all__ = ["Cmd"]
@@ -8,23 +8,23 @@ PROMPT: Literal["(Cmd) "]
 IDENTCHARS: str  # Too big to be `Literal`
 
 class Cmd:
-    prompt: str
-    identchars: str
-    ruler: str
-    lastcmd: str
-    intro: Any | None
-    doc_leader: str
-    doc_header: str
-    misc_header: str
-    undoc_header: str
-    nohelp: str
-    use_rawinput: bool
+    prompt: ClassVar[str]
+    identchars: ClassVar[str]
+    ruler: ClassVar[str]
+    lastcmd: ClassVar[str]
+    intro: ClassVar[Any | None]
+    doc_leader: ClassVar[str]
+    doc_header: ClassVar[str]
+    misc_header: ClassVar[str]
+    undoc_header: ClassVar[str]
+    nohelp: ClassVar[str]
+    use_rawinput: ClassVar[bool]
     stdin: IO[str]
     stdout: IO[str]
     cmdqueue: list[str]
     completekey: str
     def __init__(self, completekey: str = ..., stdin: IO[str] | None = ..., stdout: IO[str] | None = ...) -> None: ...
-    old_completer: Callable[[str, int], str | None] | None
+    old_completer: Callable[[str, int], str | None] | None  # only defined after `cmdloop` call
     def cmdloop(self, intro: Any | None = ...) -> None: ...
     def precmd(self, line: str) -> str: ...
     def postcmd(self, stop: bool, line: str) -> bool: ...
@@ -36,7 +36,7 @@ class Cmd:
     def default(self, line: str) -> None: ...
     def completedefault(self, *ignored: Any) -> list[str]: ...
     def completenames(self, text: str, *ignored: Any) -> list[str]: ...
-    completion_matches: list[str] | None
+    completion_matches: list[str] | None  # only defined after `complete` call
     def complete(self, text: str, state: int) -> list[str] | None: ...
     def get_names(self) -> list[str]: ...
     # Only the first element of args matters.

--- a/stdlib/cmd.pyi
+++ b/stdlib/cmd.pyi
@@ -16,6 +16,8 @@ class Cmd:
     undoc_header: ClassVar[str]
     nohelp: ClassVar[str]
     use_rawinput: ClassVar[bool]
+    # "prompt", "lastcmd" and "intro" all have class-level default values,
+    # but are commonly overridden on instances, so shouldn't be ClassVars
     prompt: str
     lastcmd: str
     intro: Any | None


### PR DESCRIPTION
Source: https://github.com/python/cpython/blob/f177f6f29b069f522a0b3ba44eaae19852b6d2b0/Lib/cmd.py#L64-L74
Docs: https://docs.python.org/3/library/cmd.html