### PR TITLE
Added _ExtendAction to argparse

### DIFF
--- a/stdlib/argparse.pyi
+++ b/stdlib/argparse.pyi
@@ -400,6 +400,9 @@ class _StoreFalseAction(_StoreConstAction):
 class _AppendAction(Action): ...
 
 # undocumented
+class _ExtendAction(_AppendAction): ...
+
+# undocumented
 class _AppendConstAction(Action):
     if sys.version_info >= (3, 11):
         def __init__(

--- a/stdlib/argparse.pyi
+++ b/stdlib/argparse.pyi
@@ -400,7 +400,8 @@ class _StoreFalseAction(_StoreConstAction):
 class _AppendAction(Action): ...
 
 # undocumented
-class _ExtendAction(_AppendAction): ...
+if sys.version_info >= (3, 8):
+    class _ExtendAction(_AppendAction): ...
 
 # undocumented
 class _AppendConstAction(Action):


### PR DESCRIPTION
_ExtendAction was added to argparse since python 3.8. I am adding it here, since it is missing

Reference of the addition to the standard library: python/cpython@aa32a7e