### PR TITLE
Small fixes for `pynput` stubs

### DIFF
--- a/stubs/pynput/@tests/stubtest_allowlist.txt
+++ b/stubs/pynput/@tests/stubtest_allowlist.txt
@@ -1,5 +1,6 @@
 # These __init__ methods have *args, **kwargs arguments on some platforms, but not others
 pynput.keyboard.Controller.__init__
+pynput.mouse.Controller.__init__
 # stubtest issues with non-`type` metaclasses, see https://github.com/python/mypy/issues/13316
 pynput.keyboard._base.Controller._Key
 pynput.keyboard._base.Controller._KeyCode

--- a/stubs/pynput/@tests/stubtest_allowlist.txt
+++ b/stubs/pynput/@tests/stubtest_allowlist.txt
@@ -2,7 +2,6 @@
 pynput.keyboard.Controller.__init__
 pynput.mouse.Controller.__init__
 # stubtest issues with non-`type` metaclasses, see https://github.com/python/mypy/issues/13316
+pynput.keyboard.Controller._Key
 pynput.keyboard._base.Controller._Key
-pynput.keyboard._base.Controller._KeyCode
 pynput.keyboard._dummy.Controller._Key
-pynput.keyboard._dummy.Controller._KeyCode

--- a/stubs/pynput/@tests/stubtest_allowlist.txt
+++ b/stubs/pynput/@tests/stubtest_allowlist.txt
@@ -1,3 +1,7 @@
 # These __init__ methods have *args, **kwargs arguments on some platforms, but not others
 pynput.keyboard.Controller.__init__
-pynput.mouse.Controller.__init__
+# stubtest issues with non-`type` metaclasses, see https://github.com/python/mypy/issues/13316
+pynput.keyboard._base.Controller._Key
+pynput.keyboard._base.Controller._KeyCode
+pynput.keyboard._dummy.Controller._Key
+pynput.keyboard._dummy.Controller._KeyCode

--- a/stubs/pynput/@tests/stubtest_allowlist.txt
+++ b/stubs/pynput/@tests/stubtest_allowlist.txt
@@ -1,9 +1,3 @@
-# TODO: go through this allowlist, figure out which of them are false positives
-pynput.keyboard.Controller._Key
-pynput.keyboard.Controller._KeyCode
+# These __init__ methods have *args, **kwargs arguments on some platforms, but not others
 pynput.keyboard.Controller.__init__
-pynput.keyboard._base.Controller._Key
-pynput.keyboard._base.Controller._KeyCode
-pynput.keyboard._dummy.Controller._Key
-pynput.keyboard._dummy.Controller._KeyCode
 pynput.mouse.Controller.__init__

--- a/stubs/pynput/pynput/keyboard/_base.pyi
+++ b/stubs/pynput/pynput/keyboard/_base.pyi
@@ -86,8 +86,8 @@ class Key(enum.Enum):
     scroll_lock: int
 
 class Controller:
-    _KeyCode: ClassVar[KeyCode]  # undocumented
-    _Key: ClassVar[Key]  # undocumented
+    _KeyCode: ClassVar[type[KeyCode]]  # undocumented
+    _Key: ClassVar[type[Key]]  # undocumented
 
     class InvalidKeyException(Exception): ...
     class InvalidCharacterException(Exception): ...


### PR DESCRIPTION
Our stubs for `pynput` now have stubtest run on them in CI, following #8719 (hooray!). This PR gets rid of two allowlist entries, and adds better comments for the remaining entries.