### PR TITLE
Use `ClassVar` in `string.Template`

### DIFF
--- a/stdlib/string.pyi
+++ b/stdlib/string.pyi
@@ -2,7 +2,7 @@ import sys
 from _typeshed import StrOrLiteralStr
 from collections.abc import Iterable, Mapping, Sequence
 from re import Pattern, RegexFlag
-from typing import Any, overload
+from typing import Any, ClassVar, overload
 from typing_extensions import LiteralString
 
 __all__ = [
@@ -34,11 +34,11 @@ def capwords(s: StrOrLiteralStr, sep: StrOrLiteralStr | None = ...) -> StrOrLite
 
 class Template:
     template: str
-    delimiter: str
-    idpattern: str
-    braceidpattern: str | None
-    flags: RegexFlag
-    pattern: Pattern[str]
+    delimiter: ClassVar[str]
+    idpattern: ClassVar[str]
+    braceidpattern: ClassVar[str | None]
+    flags: ClassVar[RegexFlag]
+    pattern: ClassVar[Pattern[str]]
     def __init__(self, template: str) -> None: ...
     def substitute(self, __mapping: Mapping[str, object] = ..., **kwds: object) -> str: ...
     def safe_substitute(self, __mapping: Mapping[str, object] = ..., **kwds: object) -> str: ...


### PR DESCRIPTION
They are all used as `cls.ATTR_NAME`: https://github.com/python/cpython/blame/a36235d5c7863a85fa323b2048d3d254116a958e/Lib/string.py#L69-L85