### PR TITLE
usjon: Add default keyword argument

### DIFF
--- a/stubs/ujson/ujson.pyi
+++ b/stubs/ujson/ujson.pyi
@@ -10,6 +10,7 @@ def encode(
     escape_forward_slashes: bool = ...,
     sort_keys: bool = ...,
     indent: int = ...,
+    default: Any = ...,
 ) -> str: ...
 def dumps(
     obj: Any,
@@ -19,6 +20,7 @@ def dumps(
     escape_forward_slashes: bool = ...,
     sort_keys: bool = ...,
     indent: int = ...,
+    default: Any = ...,
 ) -> str: ...
 def dump(
     obj: Any,


### PR DESCRIPTION
Add missing `default` keyword argument to `dump` and `dumps` functions.

Introduced since https://github.com/ultrajson/ultrajson/releases/tag/4.2.0

Relates to https://github.com/ultrajson/ultrajson/pull/470