### PR TITLE
Improve the `daily.yml` workflow

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   stubtest-stdlib:
     name: Check stdlib with stubtest
-    if: github.repository == 'python/typeshed'
+    if: ${{ github.repository == 'python/typeshed' || github.event_name == 'workflow_dispatch' }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -38,7 +38,7 @@ jobs:
 
   stubtest-third-party:
     name: Check third party stubs with stubtest
-    if: github.repository == 'python/typeshed'
+    if: ${{ github.repository == 'python/typeshed' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-20.04
     strategy:
       matrix:
@@ -76,4 +76,5 @@ jobs:
               repo: "typeshed",
               title: `Stubtest failed on ${new Date().toDateString()}`,
               body: "Stubtest runs are listed here: https://github.com/python/typeshed/actions/workflows/daily.yml",
+              labels: ["help wanted"],
             })


### PR DESCRIPTION
1. Make it easier to run the workflow from a typeshed fork using the `workflow_dispatch` trigger. This is something I do sporadically if a mypy release is coming up, so we don't get blindsided by loads of very disruptive stubtest changes when the release is cut. Making this change means I don't have to manually edit the workflow to run it from my private fork, which is a pain :)
2. Auto-add the "help wanted" label to issues created by the bot when the daily test fails. @kkirsche brought up in https://github.com/python/typeshed/issues/8481#issuecomment-1221384969 that it's sometimes pretty difficult for contributors to know which typeshed issues we'd welcome help on, and which issues aren't really actionable, or are pretty out of date. I think that's a very reasonably criticism, and I've been trying to improve on that by using the "help wanted" label more often, to indicate issues where a maintainer has confirmed that a PR to fix the issue would be welcome. Pretty much any issue auto-created by the bot due to a stubtest failure can be considered "auto-triaged", so let's automatically add the label to those issues.

(`github.event_name` is documented [here](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context). Using the GitHub API to create issues with specific labels is documented [here](https://docs.github.com/en/rest/issues/issues#create-an-issue).)