### PR TITLE
`pstats`: delete outdated comment

### DIFF
--- a/stdlib/pstats.pyi
+++ b/stdlib/pstats.pyi
@@ -30,7 +30,6 @@ if sys.version_info >= (3, 9):
 
     @dataclass(unsafe_hash=True)
     class FunctionProfile:
-        # Note: the annotation in the CPython codebase is "int", but the annotation in CPython is wrong! See #8712
         ncalls: str
         tottime: float
         percall_tottime: float


### PR DESCRIPTION
The annotation in CPython was fixed thanks to @ruancomelli in https://github.com/python/cpython/pull/96741!