### PR TITLE
stubsabot: Add the PR body to the commit message

### DIFF
--- a/scripts/stubsabot.py
+++ b/scripts/stubsabot.py
@@ -309,8 +309,7 @@ BRANCH_PREFIX = "stubsabot"
 
 
 def get_pr_body(update: Update, metadata: dict[str, Any]) -> str:
-    body = "Project links:\n - "
-    body += "\n - ".join(f"{k}: {v}" for k, v in update.links.items())
+    body = "\n".join(f"{k}: {v}" for k, v in update.links.items())
     stubtest_will_run = not metadata.get("stubtest", {}).get("skip", False)
     if stubtest_will_run:
         body += textwrap.dedent(
@@ -346,7 +345,7 @@ async def suggest_typeshed_update(update: Update, session: aiohttp.ClientSession
         with open(update.stub_path / "METADATA.toml", "w") as f:
             tomlkit.dump(meta, f)
         body = get_pr_body(update, meta)
-        subprocess.check_call(["git", "commit", "--all", "-m", f"{title}\n{body}"])
+        subprocess.check_call(["git", "commit", "--all", "-m", f"{title}\n\n{body}"])
         if action_level <= ActionLevel.local:
             return
         somewhat_safe_force_push(branch_name)

--- a/scripts/stubsabot.py
+++ b/scripts/stubsabot.py
@@ -308,7 +308,7 @@ _repo_lock = asyncio.Lock()
 BRANCH_PREFIX = "stubsabot"
 
 
-def get_pr_body(update: Update, metadata: dict[str, Any]) -> str:
+def get_update_pr_body(update: Update, metadata: dict[str, Any]) -> str:
     body = "\n".join(f"{k}: {v}" for k, v in update.links.items())
     stubtest_will_run = not metadata.get("stubtest", {}).get("skip", False)
     if stubtest_will_run:
@@ -344,7 +344,7 @@ async def suggest_typeshed_update(update: Update, session: aiohttp.ClientSession
         meta["version"] = update.new_version_spec
         with open(update.stub_path / "METADATA.toml", "w") as f:
             tomlkit.dump(meta, f)
-        body = get_pr_body(update, meta)
+        body = get_update_pr_body(update, meta)
         subprocess.check_call(["git", "commit", "--all", "-m", f"{title}\n\n{body}"])
         if action_level <= ActionLevel.local:
             return

--- a/scripts/stubsabot.py
+++ b/scripts/stubsabot.py
@@ -369,14 +369,14 @@ async def suggest_typeshed_obsolete(obsolete: Obsolete, session: aiohttp.ClientS
         meta["obsolete_since"] = obs_string
         with open(obsolete.stub_path / "METADATA.toml", "w") as f:
             tomlkit.dump(meta, f)
-        subprocess.check_call(["git", "commit", "--all", "-m", title])
+        body = "\n".join(f"{k}: {v}" for k, v in obsolete.links.items())
+        subprocess.check_call(["git", "commit", "--all", "-m", f"{title}\n\n{body}"])
         if action_level <= ActionLevel.local:
             return
         somewhat_safe_force_push(branch_name)
         if action_level <= ActionLevel.fork:
             return
 
-    body = "\n".join(f"{k}: {v}" for k, v in obsolete.links.items())
     await create_or_update_pull_request(title=title, body=body, branch_name=branch_name, session=session)
 
 

--- a/scripts/stubsabot.py
+++ b/scripts/stubsabot.py
@@ -308,28 +308,10 @@ _repo_lock = asyncio.Lock()
 BRANCH_PREFIX = "stubsabot"
 
 
-async def suggest_typeshed_update(update: Update, session: aiohttp.ClientSession, action_level: ActionLevel) -> None:
-    if action_level <= ActionLevel.nothing:
-        return
-    title = f"[stubsabot] Bump {update.distribution} to {update.new_version_spec}"
-    async with _repo_lock:
-        branch_name = f"{BRANCH_PREFIX}/{normalize(update.distribution)}"
-        subprocess.check_call(["git", "checkout", "-B", branch_name, "origin/master"])
-        with open(update.stub_path / "METADATA.toml", "rb") as f:
-            meta = tomlkit.load(f)
-        meta["version"] = update.new_version_spec
-        with open(update.stub_path / "METADATA.toml", "w") as f:
-            tomlkit.dump(meta, f)
-        subprocess.check_call(["git", "commit", "--all", "-m", title])
-        if action_level <= ActionLevel.local:
-            return
-        somewhat_safe_force_push(branch_name)
-        if action_level <= ActionLevel.fork:
-            return
-
-    body = "\n".join(f"{k}: {v}" for k, v in update.links.items())
-
-    stubtest_will_run = not meta.get("stubtest", {}).get("skip", False)
+def get_pr_body(update: Update, metadata: dict[str, Any]) -> str:
+    body = "Project links:\n - "
+    body += "\n - ".join(f"{k}: {v}" for k, v in update.links.items())
+    stubtest_will_run = not metadata.get("stubtest", {}).get("skip", False)
     if stubtest_will_run:
         body += textwrap.dedent(
             """
@@ -348,6 +330,28 @@ async def suggest_typeshed_update(update: Update, session: aiohttp.ClientSession
             :warning: Review this PR manually, as stubtest is skipped in CI for {update.distribution}! :warning:
             """
         )
+    return body
+
+
+async def suggest_typeshed_update(update: Update, session: aiohttp.ClientSession, action_level: ActionLevel) -> None:
+    if action_level <= ActionLevel.nothing:
+        return
+    title = f"[stubsabot] Bump {update.distribution} to {update.new_version_spec}"
+    async with _repo_lock:
+        branch_name = f"{BRANCH_PREFIX}/{normalize(update.distribution)}"
+        subprocess.check_call(["git", "checkout", "-B", branch_name, "origin/master"])
+        with open(update.stub_path / "METADATA.toml", "rb") as f:
+            meta = tomlkit.load(f)
+        meta["version"] = update.new_version_spec
+        with open(update.stub_path / "METADATA.toml", "w") as f:
+            tomlkit.dump(meta, f)
+        body = get_pr_body(update, meta)
+        subprocess.check_call(["git", "commit", "--all", "-m", f"{title}\n{body}"])
+        if action_level <= ActionLevel.local:
+            return
+        somewhat_safe_force_push(branch_name)
+        if action_level <= ActionLevel.fork:
+            return
 
     await create_or_update_pull_request(title=title, body=body, branch_name=branch_name, session=session)
 


### PR DESCRIPTION
Having the PR body as part of the commit message makes it easier to test changes to the stubsabot PR messages if you're hacking on stubsabot locally. (As it currently is, it's difficult to test changes to the PR message unless you run stubsabot with `--action-level everything`, which will actually create a PR against typeshed.)