### PR TITLE
Support for npx 8 and pyright PyPI package

### DIFF
--- a/tests/pyright_test.py
+++ b/tests/pyright_test.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import os
 import shutil
 import subprocess
 import sys
@@ -27,7 +28,9 @@ def main() -> None:
         print("error running npx; is Node.js installed?", file=sys.stderr)
         sys.exit(1)
 
-    command = [npx, "-p", f"pyright@{_PYRIGHT_VERSION}", "pyright"] + sys.argv[1:]
+    os.environ["PYRIGHT_PYTHON_FORCE_VERSION"] = _PYRIGHT_VERSION
+    command = [npx, f"pyright@{_PYRIGHT_VERSION}"] + sys.argv[1:]
+    print("Running:", " ".join(command))
 
     ret = subprocess.run(command).returncode
     sys.exit(ret)


### PR DESCRIPTION
Fix the npx command for npx 8:
`'pyright@1.1.270' is not recognized as an internal or external command,`

Also ensures that the right version of pyright will be used if https://pypi.org/project/pyright/ is installed

Found these issues while investigating the work needed for #8686 and #8770