### PR TITLE
sendmsg can accept None for the address

### DIFF
--- a/stdlib/_socket.pyi
+++ b/stdlib/_socket.pyi
@@ -624,7 +624,7 @@ class socket:
             __buffers: Iterable[ReadableBuffer],
             __ancdata: Iterable[_CMSGArg] = ...,
             __flags: int = ...,
-            __address: _Address = ...,
+            __address: _Address | None = ...,
         ) -> int: ...
     if sys.platform == "linux":
         def sendmsg_afalg(


### PR DESCRIPTION
Per the Python docs and socketmodule.c source, the address argument can be None.