### PR TITLE
fix: pillow.ImageDraw.textlength may return float

### DIFF
--- a/stubs/Pillow/PIL/ImageDraw.pyi
+++ b/stubs/Pillow/PIL/ImageDraw.pyi
@@ -116,7 +116,7 @@ class ImageDraw:
         features: Sequence[str] | None = ...,
         language: str | None = ...,
         embedded_color: bool = ...,
-    ) -> int: ...
+    ) -> int | float: ...
     def textbbox(
         self,
         xy: tuple[float, float],


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/blob/87ecd01fc042bb67b11bfcff3db99fc2b61e702d/src/PIL/ImageDraw.py#L650

I don't think it's necessary, but pillow do return float sometimes.