### PR TITLE
Pyinstaller: use `StrPath` over `StrOrBytesPath`

### DIFF
--- a/stubs/pyinstaller/PyInstaller/building/build_main.pyi
+++ b/stubs/pyinstaller/PyInstaller/building/build_main.pyi
@@ -1,7 +1,7 @@
 # Referenced in: https://pyinstaller.org/en/stable/hooks.html?highlight=get_hook_config#PyInstaller.utils.hooks.get_hook_config
 # Not to be imported during runtime, but is the type reference for hooks and analysis configuration
 
-from _typeshed import StrOrBytesPath
+from _typeshed import StrPath
 from collections.abc import Iterable
 from typing import Any
 
@@ -12,7 +12,7 @@ class Analysis(Target):
     hooksconfig: dict[str, dict[str, object]]
     def __init__(
         self,
-        scripts: Iterable[StrOrBytesPath],
+        scripts: Iterable[StrPath],
         pathex=...,
         binaries=...,
         datas=...,

--- a/stubs/pyinstaller/PyInstaller/utils/hooks/__init__.pyi
+++ b/stubs/pyinstaller/PyInstaller/utils/hooks/__init__.pyi
@@ -1,6 +1,6 @@
 # https://pyinstaller.org/en/stable/hooks.html
 
-from _typeshed import StrOrBytesPath, SupportsKeysAndGetItem
+from _typeshed import StrOrBytesPath, StrPath, SupportsKeysAndGetItem
 from collections.abc import Callable, Iterable, Mapping
 from typing import Any
 from typing_extensions import Literal, TypeAlias
@@ -50,12 +50,12 @@ def collect_dynamic_libs(package: str, destdir: object = ...) -> list[tuple[str,
 def collect_data_files(
     package: str,
     include_py_files: bool = ...,
-    subdir: StrOrBytesPath | None = ...,
+    subdir: StrPath | None = ...,
     excludes: Iterable[str] | None = ...,
     includes: Iterable[str] | None = ...,
 ) -> list[tuple[str, str]]: ...
 def collect_system_data_files(
-    path: str, destdir: StrOrBytesPath | None = ..., include_py_files: bool = ...
+    path: str, destdir: StrPath | None = ..., include_py_files: bool = ...
 ) -> list[tuple[str, str]]: ...
 def copy_metadata(package_name: str, recursive: bool = ...) -> list[tuple[str, str]]: ...
 def get_installer(module: str) -> str | None: ...


### PR DESCRIPTION
Changed StrOrBytesPath to StrPath when used with strings.
`TypeError: Can't mix strings and bytes in path components` https://github.com/python/typeshed/pull/8770#discussion_r975969682