### PR TITLE
Mark object.__module__ as ClassVar

### DIFF
--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -80,7 +80,7 @@ _AwaitableT_co = TypeVar("_AwaitableT_co", bound=Awaitable[Any], covariant=True)
 class object:
     __doc__: str | None
     __dict__: dict[str, Any]
-    __module__: str
+    __module__: ClassVar[str]
     __annotations__: dict[str, Any]
     @property
     def __class__(self: Self) -> type[Self]: ...


### PR DESCRIPTION
The reported use case for this isn't particularly compelling, so if this causes too many errors I will close.