### PR TITLE
gdb: add missing automatic imports

### DIFF
--- a/stubs/gdb/gdb/__init__.pyi
+++ b/stubs/gdb/gdb/__init__.pyi
@@ -8,12 +8,13 @@ from contextlib import AbstractContextManager
 from typing import Protocol, overload
 from typing_extensions import TypeAlias
 
-# The following submodules are automatically imported
-import gdb.events as events
-import gdb.printing as printing
-import gdb.prompt as prompt
 import gdb.types
-import gdb.types as types
+
+# The following submodules are automatically imported
+from . import events as events
+from . import printing as printing
+from . import prompt as prompt
+from . import types as types
 
 # Basic
 

--- a/stubs/gdb/gdb/__init__.pyi
+++ b/stubs/gdb/gdb/__init__.pyi
@@ -8,12 +8,11 @@ from contextlib import AbstractContextManager
 from typing import Protocol, overload
 from typing_extensions import TypeAlias
 
-import gdb.types
-
 # The following submodules are automatically imported
 import gdb.events as events
 import gdb.printing as printing
 import gdb.prompt as prompt
+import gdb.types
 import gdb.types as types
 
 # Basic

--- a/stubs/gdb/gdb/__init__.pyi
+++ b/stubs/gdb/gdb/__init__.pyi
@@ -11,10 +11,7 @@ from typing_extensions import TypeAlias
 import gdb.types
 
 # The following submodules are automatically imported
-from . import events as events
-from . import printing as printing
-from . import prompt as prompt
-from . import types as types
+from . import events as events, printing as printing, prompt as prompt, types as types
 
 # Basic
 

--- a/stubs/gdb/gdb/__init__.pyi
+++ b/stubs/gdb/gdb/__init__.pyi
@@ -8,6 +8,10 @@ from contextlib import AbstractContextManager
 from typing import Protocol, overload
 from typing_extensions import TypeAlias
 
+# The following submodules are automatically imported
+import gdb.events
+import gdb.printing
+import gdb.prompt
 import gdb.types
 
 # Basic

--- a/stubs/gdb/gdb/__init__.pyi
+++ b/stubs/gdb/gdb/__init__.pyi
@@ -8,11 +8,13 @@ from contextlib import AbstractContextManager
 from typing import Protocol, overload
 from typing_extensions import TypeAlias
 
-# The following submodules are automatically imported
-import gdb.events
-import gdb.printing
-import gdb.prompt
 import gdb.types
+
+# The following submodules are automatically imported
+import gdb.events as events
+import gdb.printing as printing
+import gdb.prompt as prompt
+import gdb.types as types
 
 # Basic
 


### PR DESCRIPTION
When GDB has just started, several `gdb` submodules are automatically loaded, so user code does not have to manually import them (for instance `import gdb.events`). Reflect that in `gdb` stubs.