### PR TITLE
Remove unused `__future__` import

### DIFF
--- a/stubs/six/six/__init__.pyi
+++ b/stubs/six/six/__init__.pyi
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import builtins
 import types
 import unittest


### PR DESCRIPTION
Mypy does not process `print_function` future import anymore, because python2 is not supported.