### PR TITLE
google-cloud-ndb: drop dependency on types-six

### DIFF
--- a/stubs/google-cloud-ndb/METADATA.toml
+++ b/stubs/google-cloud-ndb/METADATA.toml
@@ -1,2 +1,2 @@
 version = "1.11.*"
-requires = ["types-six"]
+requires = []


### PR DESCRIPTION
For https://github.com/typeshed-internal/stub_uploader/pull/61#discussion_r979327370