### PR TITLE
`check_consistent.py`: ignore `.gitignore`d files

### DIFF
--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -7,6 +7,7 @@ flake8-pyi==22.8.2      # must match .pre-commit-config.yaml
 isort==5.10.1           # must match .pre-commit-config.yaml
 mypy==0.981
 packaging==21.3
+pathspec>=0.10.1
 pycln==2.1.1            # must match .pre-commit-config.yaml
 pyyaml==6.0
 pytype==2022.08.30; platform_system != "Windows"

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -7,7 +7,7 @@ flake8-pyi==22.8.2      # must match .pre-commit-config.yaml
 isort==5.10.1           # must match .pre-commit-config.yaml
 mypy==0.981
 packaging==21.3
-pathspec>=0.10.1
+pathspec
 pycln==2.1.1            # must match .pre-commit-config.yaml
 pyyaml==6.0
 pytype==2022.08.30; platform_system != "Windows"

--- a/tests/check_consistent.py
+++ b/tests/check_consistent.py
@@ -11,7 +11,7 @@ import re
 import sys
 from pathlib import Path
 
-import pathspec
+import pathspec  # type: ignore[import]
 import tomli
 import yaml
 from packaging.requirements import Requirement
@@ -34,7 +34,7 @@ def _spec_matches_path(spec: pathspec.PathSpec, path: Path) -> bool:
     normalized_path = path.as_posix()
     if path.is_dir():
         normalized_path += "/"
-    return spec.match_file(normalized_path)
+    return spec.match_file(normalized_path)  # type: ignore[no-any-return]
 
 
 def assert_consistent_filetypes(directory: Path, *, kind: str, allowed: set[str]) -> None:

--- a/tests/mypy_test.py
+++ b/tests/mypy_test.py
@@ -21,7 +21,16 @@ if TYPE_CHECKING:
 from typing_extensions import Annotated, TypeAlias
 
 import tomli
-from utils import VERSIONS_RE as VERSION_LINE_RE, colored, print_error, print_success_msg, read_dependencies, strip_comments
+from utils import (
+    VERSIONS_RE as VERSION_LINE_RE,
+    colored,
+    get_gitignore_spec,
+    print_error,
+    print_success_msg,
+    read_dependencies,
+    spec_matches_path,
+    strip_comments,
+)
 
 SUPPORTED_VERSIONS = ["3.11", "3.10", "3.9", "3.8", "3.7"]
 SUPPORTED_PLATFORMS = ("linux", "win32", "darwin")
@@ -305,11 +314,6 @@ def test_third_party_distribution(distribution: str, args: TestConfig) -> TestRe
     return TestResults(code, len(files))
 
 
-def is_probably_stubs_folder(distribution: str, distribution_path: Path) -> bool:
-    """Validate that `dist_path` is a folder containing stubs"""
-    return distribution != ".mypy_cache" and distribution_path.is_dir()
-
-
 def test_stdlib(code: int, args: TestConfig) -> TestResults:
     seen = {"builtins", "typing"}  # Always ignore these.
     files: list[Path] = []
@@ -336,11 +340,12 @@ def test_third_party_stubs(code: int, args: TestConfig) -> TestResults:
     print("Testing third-party packages...")
     print("Running mypy " + " ".join(get_mypy_flags(args, "/tmp/...")))
     files_checked = 0
+    gitignore_spec = get_gitignore_spec()
 
     for distribution in sorted(os.listdir("stubs")):
         distribution_path = Path("stubs", distribution)
 
-        if not is_probably_stubs_folder(distribution, distribution_path):
+        if spec_matches_path(gitignore_spec, distribution_path):
             continue
 
         this_code, checked = test_third_party_distribution(distribution, args)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -6,6 +6,7 @@ from functools import cache
 from pathlib import Path
 from typing import NamedTuple
 
+import pathspec  # type: ignore[import]
 import tomli
 
 
@@ -81,3 +82,21 @@ def get_all_testcase_directories() -> list[PackageInfo]:
         if potential_testcase_dir.is_dir():
             testcase_directories.append(PackageInfo(package_name, potential_testcase_dir))
     return sorted(testcase_directories)
+
+
+# ====================================================================
+# Parsing .gitignore
+# ====================================================================
+
+
+@cache
+def get_gitignore_spec() -> pathspec.PathSpec:
+    with open(".gitignore") as f:
+        return pathspec.PathSpec.from_lines("gitwildmatch", f.readlines())
+
+
+def spec_matches_path(spec: pathspec.PathSpec, path: Path) -> bool:
+    normalized_path = path.as_posix()
+    if path.is_dir():
+        normalized_path += "/"
+    return spec.match_file(normalized_path)  # type: ignore[no-any-return]


### PR DESCRIPTION
I often have `.mypy_cache` folders hanging around in odd places in my local typeshed clone. It's annoying that `check_consistent.py` starts failing locally whenever I have one of these folders in the `stubs/` or `stdlib/` directories. Having these folders around locally is harmless; since they're globally `gitignore`d, they'll never be committed as part of a PR.

This PR uses the `pathspec` third-party library to skip checking all `gitignore`d files in the `check_consistent.py` functions `assert_consistent_filetypes()` and `check_stubs()`. It also reuses this logic to get rid of some existing hacks in `mypy_test.py`.

`pathspec` is the library `black` uses to identify which files it should skip when it does its autoformatting. This means that we all already have it installed in our virtual environments already.