### PR TITLE
Fix installing dependencies for 3rd party stubtest

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           python-version: "3.9"
       - name: Install dependencies
-        run: pip install $(grep -E 'tomli|termcolor|pathspec' requirements-tests.txt)
+        run: pip install -r requirements-tests.txt
       - name: Install apt packages
         run: |
           sudo apt update

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           python-version: "3.9"
       - name: Install dependencies
-        run: pip install $(grep tomli== requirements-tests.txt) termcolor
+        run: pip install -r requirements-tests.txt
       - name: Install apt packages
         run: |
           sudo apt update

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           python-version: "3.9"
       - name: Install dependencies
-        run: pip install -r requirements-tests.txt
+        run: pip install $(grep -E 'tomli|termcolor|pathspec' requirements-tests.txt)
       - name: Install apt packages
         run: |
           sudo apt update

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -137,7 +137,7 @@ jobs:
         with:
           python-version: "3.9"
       - name: Install dependencies
-        run: pip install $(grep -E 'tomli|termcolor|pathspec' requirements-tests.txt)
+        run: pip install -r requirements-tests.txt
       - name: Run stubtest
         run: |
           STUBS=$(

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -137,7 +137,7 @@ jobs:
         with:
           python-version: "3.9"
       - name: Install dependencies
-        run: pip install $(grep tomli== requirements-tests.txt) termcolor
+        run: pip install -r requirements-tests.txt
       - name: Run stubtest
         run: |
           STUBS=$(

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -137,7 +137,7 @@ jobs:
         with:
           python-version: "3.9"
       - name: Install dependencies
-        run: pip install -r requirements-tests.txt
+        run: pip install $(grep -E 'tomli|termcolor|pathspec' requirements-tests.txt)
       - name: Run stubtest
         run: |
           STUBS=$(

--- a/stubs/appdirs/appdirs.pyi
+++ b/stubs/appdirs/appdirs.pyi
@@ -1,5 +1,4 @@
 __version_info__: tuple[int, int, int]
-
 PY3: bool
 unicode = str
 system: str

--- a/stubs/appdirs/appdirs.pyi
+++ b/stubs/appdirs/appdirs.pyi
@@ -1,4 +1,5 @@
 __version_info__: tuple[int, int, int]
+
 PY3: bool
 unicode = str
 system: str


### PR DESCRIPTION
Fixes #8805

I believe it's fine to just install all dependencies, because stubtest uses venvs that don't "inherit" the dependencies installed here. If this isn't correct, we can grep the dependencies we actually need (I actually implemented and reverted this already).