### PR TITLE
Allow `create_baseline_stubs.py` to add packages to existing stub

### DIFF
--- a/scripts/create_baseline_stubs.py
+++ b/scripts/create_baseline_stubs.py
@@ -62,15 +62,16 @@ def run_isort(stub_dir: str) -> None:
 
 def create_metadata(stub_dir: str, version: str) -> None:
     """Create a METADATA.toml file."""
-    m = re.match(r"[0-9]+.[0-9]+", version)
-    if m is None:
+    match = re.match(r"[0-9]+.[0-9]+", version)
+    if match is None:
         sys.exit(f"Error: Cannot parse version number: {version}")
-    fnam = os.path.join(stub_dir, "METADATA.toml")
-    version = m.group(0)
-    assert not os.path.exists(fnam)
-    print(f"Writing {fnam}")
-    with open(fnam, "w") as f:
-        f.write(
+    filename = os.path.join(stub_dir, "METADATA.toml")
+    version = match.group(0)
+    if os.path.exists(filename):
+        return
+    print(f"Writing {filename}")
+    with open(filename, "w") as file:
+        file.write(
             f"""\
 version = "{version}.*"
 
@@ -153,8 +154,9 @@ def main() -> None:
     project, version = info
 
     stub_dir = os.path.join("stubs", project)
-    if os.path.exists(stub_dir):
-        sys.exit(f"Error: {stub_dir} already exists (delete it first)")
+    package_dir = os.path.join(stub_dir, package)
+    if os.path.exists(package_dir):
+        sys.exit(f"Error: {package_dir} already exists (delete it first)")
 
     run_stubgen(package, stub_dir)
 


### PR DESCRIPTION
I was looking into pywin32 stubs, which has multiple packages. And I couldn't specify multiple packages to `create_baseline_stubs.py`, or run it multiple times with different packages.

This adds support for that, but still ensures we don't overwrite existing stubs.

An example of existing stub that has multiple packages is PyInstaller.

I could also make the `pyrightconfig.stricter.json` "exclude" more granular by specifying the package as well. I feel this would be especially important when adding a package to an existing stub, and help with coverage by not having too wide of an exclude.