### PR TITLE
Use stubgen's `--export-less` option in `create_baseline_stubs.py`

### DIFF
--- a/scripts/create_baseline_stubs.py
+++ b/scripts/create_baseline_stubs.py
@@ -47,7 +47,7 @@ def get_installed_package_info(project: str) -> tuple[str, str] | None:
 
 def run_stubgen(package: str, output: str) -> None:
     print(f"Running stubgen: stubgen -o {output} -p {package}")
-    subprocess.run(["stubgen", "-o", output, "-p", package], check=True)
+    subprocess.run(["stubgen", "-o", output, "-p", package, "--export-less"], check=True)
 
 
 def run_black(stub_dir: str) -> None:


### PR DESCRIPTION
This seems to work pretty well, from playing around with it locally. Closes #8837