### PR TITLE
stubsabot: use an ssh-key when checking out typeshed

### DIFF
--- a/.github/workflows/stubsabot.yml
+++ b/.github/workflows/stubsabot.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          ssh-key: ${{ secrets.STUBSABOT_SSH_PRIVATE_KEY }}
       - uses: actions/setup-python@v4
         with:
           python-version: "3.10"

--- a/.github/workflows/stubsabot.yml
+++ b/.github/workflows/stubsabot.yml
@@ -18,6 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
+          # use an ssh key so that checks automatically run on stubsabot PRs
           ssh-key: ${{ secrets.STUBSABOT_SSH_PRIVATE_KEY }}
       - uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
Fixes #8434.

This uses a new ssh key that @JelleZijlstra just set up for our repo ([this option](https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#push-using-ssh-deploy-keys) in Peter Evans's guide to getting checks to run on automated PRs. It seems to be a good option in terms of both security and usability. It's also the option used by `oddbird/MetaDeploy` [here](https://github.com/oddbird/MetaDeploy/blob/main/.github/workflows/upgrade-deps.yml#L20), and they seem pretty happy about it (they wrote a nice blog post about their automated PRs for uprading dependencies [here](https://www.oddbird.net/2022/06/01/dependabot-single-pull-request/).)