### PR TITLE
Run stubsabot daily, not weekly

### DIFF
--- a/.github/workflows/stubsabot.yml
+++ b/.github/workflows/stubsabot.yml
@@ -1,9 +1,9 @@
-name: Run stubsabot weekly  # TODO: change to daily
+name: Run stubsabot daily
 
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 0 * * 5"  # TODO: change to daily
+    - cron: "0 0 * * *"
 
 permissions:
   contents: write


### PR DESCRIPTION
I think stubsabot has been a really big success. Let's change it to a daily workflow, so that we don't get an avalanche of PRs every Friday, and so that we can see more quickly if a PR changing stubsabot has accidentally broken the script. (If that _does_ happen, it should be pretty easy to just revert the commit that accidentally broke stubsabot, and go back to a version that works pretty well.)