### PR TITLE
Add two more methods to `pep8-naming` stub

### DIFF
--- a/stubs/pep8-naming/pep8ext_naming.pyi
+++ b/stubs/pep8-naming/pep8ext_naming.pyi
@@ -1,6 +1,6 @@
 import ast
 from argparse import Namespace
-from collections.abc import Generator
+from collections.abc import Generator, Iterable
 from typing import Any
 
 __version__: str
@@ -23,6 +23,8 @@ class NamingChecker:
     @classmethod
     def parse_options(cls, option: Namespace) -> None: ...
     def run(self) -> Generator[tuple[int, int, str, type[Any]], None, None]: ...
+    def tag_class_functions(self, cls_node: ast.ClassDef) -> None: ...
+    def set_function_nodes_types(self, nodes: Iterable[ast.AST], ismetaclass: bool, late_decoration: dict[str, str]) -> None: ...
     def __getattr__(self, name: str) -> Any: ...  # incomplete (other attributes are normally not accessed)
 
 def __getattr__(name: str) -> Any: ...  # incomplete (other attributes are normally not accessed)


### PR DESCRIPTION
I am using these two methods in: https://github.com/wemake-services/wemake-python-styleguide/blob/534008bb26577ebad9da6cbbf2b15cdc42c6ecb9/wemake_python_styleguide/transformations/ast_tree.py#L25

Source: https://github.com/PyCQA/pep8-naming/blob/b3492eeede12a26d35c0ee9e6b9c37a7e5484bf6/src/pep8ext_naming.py#L195-L242