### PR TITLE
Bump tabular to `0.9` version

### DIFF
--- a/stubs/tabulate/METADATA.toml
+++ b/stubs/tabulate/METADATA.toml
@@ -1,4 +1,4 @@
-version = "0.8.*"
+version = "0.9.*"
 
 [tool.stubtest]
 ignore_missing_stub = false

--- a/stubs/tabulate/tabulate/__init__.pyi
+++ b/stubs/tabulate/tabulate/__init__.pyi
@@ -2,6 +2,8 @@ from collections.abc import Callable, Container, Iterable, Mapping, Sequence
 from typing import Any, NamedTuple
 from typing_extensions import TypeAlias
 
+__version__: str
+
 LATEX_ESCAPE_RULES: dict[str, str]
 MIN_PADDING: int
 PRESERVE_WHITESPACE: bool
@@ -39,6 +41,7 @@ def tabulate(
     headers: str | dict[str, str] | Sequence[str] = ...,
     tablefmt: str | TableFormat = ...,
     floatfmt: str | Iterable[str] = ...,
+    intfmt: str | Iterable[str] = ...,
     numalign: str | None = ...,
     stralign: str | None = ...,
     missingval: str | Iterable[str] = ...,
@@ -46,4 +49,6 @@ def tabulate(
     disable_numparse: bool | Iterable[int] = ...,
     colalign: Iterable[str | None] | None = ...,
     maxcolwidths: int | Iterable[int | None] | None = ...,
+    rowalign: str | Iterable[str] | None = ...,
+    maxheadercolwidths: int | Iterable[int] | None = ...,
 ) -> str: ...

--- a/stubs/tabulate/tabulate/version.pyi
+++ b/stubs/tabulate/tabulate/version.pyi
@@ -1,0 +1,1 @@
+version: str


### PR DESCRIPTION
Closes https://github.com/python/typeshed/pull/8860

Source: https://github.com/astanin/python-tabulate/blob/90fbd7e5b127bafd0aecfe118798743589b1a60b/tabulate/__init__.py