### PR TITLE
Cancel old `mypy_primer` builds 

### DIFF
--- a/.github/workflows/mypy_primer.yml
+++ b/.github/workflows/mypy_primer.yml
@@ -9,13 +9,17 @@ on:
     - '.github/workflows/mypy_primer.yml'
     - '.github/workflows/mypy_primer_comment.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   mypy_primer:
     name: Run
-    if: github.actor != 'pre-commit-ci[bot]'
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     strategy:
       matrix:
         shard-index: [0, 1, 2, 3]

--- a/.github/workflows/mypy_primer_comment.yml
+++ b/.github/workflows/mypy_primer_comment.yml
@@ -14,6 +14,7 @@ permissions:
 jobs:
   comment:
     name: Comment PR from mypy_primer
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: Download diffs

--- a/.github/workflows/mypy_primer_comment.yml
+++ b/.github/workflows/mypy_primer_comment.yml
@@ -1,5 +1,5 @@
 name: Post mypy_primer comment
-# cancel build
+
 on:
   workflow_run:
     workflows:

--- a/.github/workflows/mypy_primer_comment.yml
+++ b/.github/workflows/mypy_primer_comment.yml
@@ -1,5 +1,5 @@
 name: Post mypy_primer comment
-
+# cancel build
 on:
   workflow_run:
     workflows:


### PR DESCRIPTION
Several changes:
1. Now old `mypy_primer` builds are auto-canceled on new commits
2. `mypy_primer_comment` is only executed if `mypy_primer` succeeded
3. `pre-commit.ci` can run `mypy_primer` now, because it cancels the previous build
4. I moved `permissions` on the top level for better visibility

Docs: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-a-workflow-based-on-the-conclusion-of-another-workflow

Refs https://github.com/python/mypy/pull/13846
CC @hauntsaninja 