### PR TITLE
Allow PIL.Image.MAX_IMAGE_PIXELS to be None

### DIFF
--- a/stubs/Pillow/PIL/Image.pyi
+++ b/stubs/Pillow/PIL/Image.pyi
@@ -39,7 +39,7 @@ CONTAINER: Literal[2]
 class DecompressionBombWarning(RuntimeWarning): ...
 class DecompressionBombError(Exception): ...
 
-MAX_IMAGE_PIXELS: int
+MAX_IMAGE_PIXELS: int | None
 
 NONE: Literal[0]
 


### PR DESCRIPTION
`_decompression_bomb_check()` explicitly checks for `None` and handles it as "unlimited".