### PR TITLE
Specify file encoding

### DIFF
--- a/scripts/create_baseline_stubs.py
+++ b/scripts/create_baseline_stubs.py
@@ -70,7 +70,7 @@ def create_metadata(stub_dir: str, version: str) -> None:
     if os.path.exists(filename):
         return
     print(f"Writing {filename}")
-    with open(filename, "w") as file:
+    with open(filename, "w", encoding="UTF-8") as file:
         file.write(
             f"""\
 version = "{version}.*"
@@ -83,7 +83,7 @@ ignore_missing_stub = false
 
 def add_pyright_exclusion(stub_dir: str) -> None:
     """Exclude stub_dir from strict pyright checks."""
-    with open(PYRIGHT_CONFIG) as f:
+    with open(PYRIGHT_CONFIG, encoding="UTF-8") as f:
         lines = f.readlines()
     i = 0
     while i < len(lines) and not lines[i].strip().startswith('"exclude": ['):
@@ -105,7 +105,7 @@ def add_pyright_exclusion(stub_dir: str) -> None:
         lines[i] = lines[i].rstrip() + ",\n"
     lines.insert(i + 1, line_to_add + "\n")
     print(f"Updating {PYRIGHT_CONFIG}")
-    with open(PYRIGHT_CONFIG, "w") as f:
+    with open(PYRIGHT_CONFIG, "w", encoding="UTF-8") as f:
         f.writelines(lines)
 
 

--- a/scripts/runtests.py
+++ b/scripts/runtests.py
@@ -33,7 +33,7 @@ def _parse_jsonc(json_text: str) -> str:
 
 
 def _get_strict_params(stub_path: str) -> list[str]:
-    with open(_STRICTER_CONFIG_FILE) as file:
+    with open(_STRICTER_CONFIG_FILE, encoding="UTF-8") as file:
         data = json.loads(_parse_jsonc(file.read()))
     if stub_path in data["exclude"]:
         return []

--- a/scripts/stubsabot.py
+++ b/scripts/stubsabot.py
@@ -610,7 +610,7 @@ async def suggest_typeshed_update(update: Update, session: aiohttp.ClientSession
         with open(update.stub_path / "METADATA.toml", "rb") as f:
             meta = tomlkit.load(f)
         meta["version"] = update.new_version_spec
-        with open(update.stub_path / "METADATA.toml", "w") as f:
+        with open(update.stub_path / "METADATA.toml", "w", encoding="UTF-8") as f:
             tomlkit.dump(meta, f)
         body = get_update_pr_body(update, meta)
         subprocess.check_call(["git", "commit", "--all", "-m", f"{title}\n\n{body}"])
@@ -638,7 +638,7 @@ async def suggest_typeshed_obsolete(obsolete: Obsolete, session: aiohttp.ClientS
         obs_string = tomlkit.string(obsolete.obsolete_since_version)
         obs_string.comment(f"Released on {obsolete.obsolete_since_date.date().isoformat()}")
         meta["obsolete_since"] = obs_string
-        with open(obsolete.stub_path / "METADATA.toml", "w") as f:
+        with open(obsolete.stub_path / "METADATA.toml", "w", encoding="UTF-8") as f:
             tomlkit.dump(meta, f)
         body = "\n".join(f"{k}: {v}" for k, v in obsolete.links.items())
         subprocess.check_call(["git", "commit", "--all", "-m", f"{title}\n\n{body}"])

--- a/stubs/requests/@tests/test_cases/check_post.py
+++ b/stubs/requests/@tests/test_cases/check_post.py
@@ -44,8 +44,8 @@ requests.post("http://httpbin.org/anything", data=b"foobar").json()["data"]
 requests.post("http://httpbin.org/anything", data="foobar").json()["data"]
 
 # Files
-requests.post("http://httpbin.org/anything", data=open("/tmp/foobar", "rb")).json()["data"]
-requests.post("http://httpbin.org/anything", data=open("/tmp/foobar", "r")).json()["data"]
+requests.post("http://httpbin.org/anything", data=open("/tmp/foobar", "rb", encoding="UTF-8")).json()["data"]
+requests.post("http://httpbin.org/anything", data=open("/tmp/foobar", "r", encoding="UTF-8")).json()["data"]
 
 # Mappings
 requests.post("http://httpbin.org/anything", data={b"foo": b"bar"}).json()["form"]

--- a/tests/check_consistent.py
+++ b/tests/check_consistent.py
@@ -71,7 +71,7 @@ def check_test_cases() -> None:
         for file in testcase_dir.rglob("*.py"):
             assert file.stem.startswith("check_"), bad_test_case_filename.format(file)
             if package_name != "stdlib":
-                with open(file) as f:
+                with open(file, encoding="UTF-8") as f:
                     lines = {line.strip() for line in f}
                 pyright_setting_not_enabled_msg = (
                     f'Third-party test-case file "{file}" must have '
@@ -93,7 +93,7 @@ def check_no_symlinks() -> None:
 
 def check_versions() -> None:
     versions = set()
-    with open("stdlib/VERSIONS") as f:
+    with open("stdlib/VERSIONS", encoding="UTF-8") as f:
         data = f.read().splitlines()
     for line in data:
         line = strip_comments(line)
@@ -128,7 +128,7 @@ def _find_stdlib_modules() -> set[str]:
 
 def check_metadata() -> None:
     for distribution in os.listdir("stubs"):
-        with open(os.path.join("stubs", distribution, "METADATA.toml")) as f:
+        with open(os.path.join("stubs", distribution, "METADATA.toml"), encoding="UTF-8") as f:
             data = tomli.loads(f.read())
         assert "version" in data, f"Missing version for {distribution}"
         version = data["version"]
@@ -153,14 +153,14 @@ def check_metadata() -> None:
 
 
 def get_txt_requirements() -> dict[str, SpecifierSet]:
-    with open("requirements-tests.txt") as requirements_file:
+    with open("requirements-tests.txt", encoding="UTF-8") as requirements_file:
         stripped_lines = map(strip_comments, requirements_file)
         requirements = map(Requirement, filter(None, stripped_lines))
         return {requirement.name: requirement.specifier for requirement in requirements}
 
 
 def get_precommit_requirements() -> dict[str, SpecifierSet]:
-    with open(".pre-commit-config.yaml") as precommit_file:
+    with open(".pre-commit-config.yaml", encoding="UTF-8") as precommit_file:
         precommit = precommit_file.read()
     yam = yaml.load(precommit, Loader=yaml.Loader)
     precommit_requirements = {}

--- a/tests/check_new_syntax.py
+++ b/tests/check_new_syntax.py
@@ -96,7 +96,7 @@ def check_new_syntax(tree: ast.AST, path: Path, stub: str) -> list[str]:
 def main() -> None:
     errors = []
     for path in chain(Path("stdlib").rglob("*.pyi"), Path("stubs").rglob("*.pyi")):
-        with open(path) as f:
+        with open(path, encoding="UTF-8") as f:
             stub = f.read()
             tree = ast.parse(stub)
         errors.extend(check_new_syntax(tree, path, stub))

--- a/tests/mypy_test.py
+++ b/tests/mypy_test.py
@@ -129,7 +129,7 @@ def match(path: Path, args: TestConfig) -> bool:
 
 def parse_versions(fname: StrPath) -> dict[str, tuple[VersionTuple, VersionTuple]]:
     result = {}
-    with open(fname) as f:
+    with open(fname, encoding="UTF-8") as f:
         for line in f:
             line = strip_comments(line)
             if line == "":

--- a/tests/stubtest_third_party.py
+++ b/tests/stubtest_third_party.py
@@ -19,12 +19,12 @@ from utils import colored, print_error, print_success_msg
 
 @functools.lru_cache()
 def get_mypy_req() -> str:
-    with open("requirements-tests.txt") as f:
+    with open("requirements-tests.txt", encoding="UTF-8") as f:
         return next(line.strip() for line in f if "mypy" in line)
 
 
 def run_stubtest(dist: Path, *, verbose: bool = False) -> bool:
-    with open(dist / "METADATA.toml") as f:
+    with open(dist / "METADATA.toml", encoding="UTF-8") as f:
         metadata = dict(tomli.loads(f.read()))
 
     print(f"{dist.name}... ", end="")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -101,7 +101,7 @@ def get_all_testcase_directories() -> list[PackageInfo]:
 
 @cache
 def get_gitignore_spec() -> pathspec.PathSpec:
-    with open(".gitignore") as f:
+    with open(".gitignore", encoding="UTF-8") as f:
         return pathspec.PathSpec.from_lines("gitwildmatch", f.readlines())
 
 


### PR DESCRIPTION
See https://peps.python.org/pep-0597/
This also happened to me on Windows in #8879 because of mathematical unicode characters as part of the comments:
```py
(.venv) PS C:\Users\Avasam\Documents\Git\typeshed> python .\tests\check_new_syntax.py
Traceback (most recent call last):
  File "C:\Users\Avasam\Documents\Git\typeshed\tests\check_new_syntax.py", line 110, in <module>
    main()
  File "C:\Users\Avasam\Documents\Git\typeshed\tests\check_new_syntax.py", line 100, in main
    stub = f.read()
  File "C:\Program Files\Python39\lib\encodings\cp1252.py", line 23, in decode 
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position 176166: 
character maps to <undefined>
```

There are linters to catch this, namely [pylint (unspecified-encoding)](https://pylint.pycqa.org/en/latest/user_guide/messages/warning/unspecified-encoding.html), [flake8-encodings](https://pypi.org/project/flake8-encodings/) and [flake8-file-encoding](https://pypi.org/project/flake8-file-encoding/). I have tried both flake8 plugins mentioned and they gave me the same results, other than slightly different error messages:
![image](https://user-images.githubusercontent.com/1350584/195191981-4be0c6e2-0adf-433e-ba7b-081e2834ab5a.png)
