### PR TITLE
subprocess: use narrower types for TimeoutExpired.std*

### DIFF
--- a/stdlib/subprocess.pyi
+++ b/stdlib/subprocess.pyi
@@ -1828,8 +1828,8 @@ class TimeoutExpired(SubprocessError):
     timeout: float
     # morally: _TXT | None
     output: Any
-    stdout: Any
-    stderr: Any
+    stdout: bytes | None
+    stderr: bytes | None
 
 class CalledProcessError(SubprocessError):
     returncode: int


### PR DESCRIPTION
See https://github.com/python/cpython/pull/97685

The union type should be acceptable given https://github.com/python/cpython/issues/87597#issuecomment-1207402415. In general I'd like us to be able to type this, since these being bytes can be surprising if you pass text=True, but we'll see what mypy_primer says