### PR TITLE
PyYaml missed `*` re-exports

### DIFF
--- a/stubs/PyYAML/yaml/__init__.pyi
+++ b/stubs/PyYAML/yaml/__init__.pyi
@@ -3,19 +3,19 @@ from re import Pattern
 from typing import Any, TypeVar, overload
 from typing_extensions import TypeAlias
 
-from . import resolver as resolver  # Help mypy a bit; this is implied by loader and dumper
-from .constructor import BaseConstructor
-from .cyaml import *
-from .dumper import *
-from .emitter import _WriteStream
-from .error import *
-from .events import *
-from .loader import *
-from .nodes import *
-from .reader import _ReadStream
-from .representer import BaseRepresenter
-from .resolver import BaseResolver
-from .tokens import *
+from yaml import resolver as resolver  # Help mypy a bit; this is implied by loader and dumper
+from yaml.constructor import BaseConstructor
+from yaml.cyaml import *
+from yaml.dumper import *
+from yaml.emitter import _WriteStream
+from yaml.error import *
+from yaml.events import *
+from yaml.loader import *
+from yaml.nodes import *
+from yaml.reader import _ReadStream
+from yaml.representer import BaseRepresenter
+from yaml.resolver import BaseResolver
+from yaml.tokens import *
 
 # FIXME: the functions really return str if encoding is None, otherwise bytes. Waiting for python/mypy#5621
 _Yaml: TypeAlias = Any

--- a/stubs/PyYAML/yaml/_yaml.pyi
+++ b/stubs/PyYAML/yaml/_yaml.pyi
@@ -2,9 +2,9 @@ from _typeshed import SupportsRead
 from collections.abc import Mapping, Sequence
 from typing import IO, Any
 
-from .events import Event
-from .nodes import Node
-from .tokens import Token
+from yaml.events import Event
+from yaml.nodes import Node
+from yaml.tokens import Token
 
 def get_version_string() -> str: ...
 def get_version() -> tuple[int, int, int]: ...

--- a/stubs/PyYAML/yaml/composer.pyi
+++ b/stubs/PyYAML/yaml/composer.pyi
@@ -1,6 +1,8 @@
 from typing import Any
 
 from yaml.error import MarkedYAMLError
+from yaml.events import *
+from yaml.nodes import *
 from yaml.nodes import MappingNode, Node, ScalarNode, SequenceNode
 
 class ComposerError(MarkedYAMLError): ...

--- a/stubs/PyYAML/yaml/constructor.pyi
+++ b/stubs/PyYAML/yaml/constructor.pyi
@@ -3,9 +3,12 @@ from re import Pattern
 from typing import Any, TypeVar
 from typing_extensions import TypeAlias
 
+from yaml.error import *
 from yaml.error import MarkedYAMLError
 from yaml.loader import BaseLoader, FullLoader, Loader, SafeLoader, UnsafeLoader
 from yaml.nodes import Node, ScalarNode
+
+from .nodes import *
 
 _L = TypeVar("_L", bound=Loader | BaseLoader | FullLoader | SafeLoader | UnsafeLoader)
 _N = TypeVar("_N", bound=Node)

--- a/stubs/PyYAML/yaml/cyaml.pyi
+++ b/stubs/PyYAML/yaml/cyaml.pyi
@@ -3,10 +3,10 @@ from collections.abc import Mapping, Sequence
 from typing import IO, Any
 from typing_extensions import TypeAlias
 
-from ._yaml import CEmitter, CParser
-from .constructor import BaseConstructor, FullConstructor, SafeConstructor, UnsafeConstructor
-from .representer import BaseRepresenter, SafeRepresenter
-from .resolver import BaseResolver, Resolver
+from yaml._yaml import CEmitter, CParser
+from yaml.constructor import BaseConstructor, FullConstructor, SafeConstructor, UnsafeConstructor
+from yaml.representer import BaseRepresenter, SafeRepresenter
+from yaml.resolver import BaseResolver, Resolver
 
 __all__ = ["CBaseLoader", "CSafeLoader", "CFullLoader", "CUnsafeLoader", "CLoader", "CBaseDumper", "CSafeDumper", "CDumper"]
 

--- a/stubs/PyYAML/yaml/dumper.pyi
+++ b/stubs/PyYAML/yaml/dumper.pyi
@@ -1,12 +1,10 @@
 from collections.abc import Mapping
 from typing import Any
 
-from yaml.emitter import Emitter
+from yaml.emitter import Emitter, _WriteStream
 from yaml.representer import BaseRepresenter, Representer, SafeRepresenter
 from yaml.resolver import BaseResolver, Resolver
 from yaml.serializer import Serializer
-
-from .emitter import _WriteStream
 
 class BaseDumper(Emitter, Serializer, BaseRepresenter, BaseResolver):
     def __init__(

--- a/stubs/PyYAML/yaml/emitter.pyi
+++ b/stubs/PyYAML/yaml/emitter.pyi
@@ -1,6 +1,7 @@
 from typing import Any, Protocol, TypeVar
 
 from yaml.error import YAMLError
+from yaml.events import *
 
 _T_contra = TypeVar("_T_contra", str, bytes, contravariant=True)
 

--- a/stubs/PyYAML/yaml/loader.pyi
+++ b/stubs/PyYAML/yaml/loader.pyi
@@ -1,11 +1,9 @@
 from yaml.composer import Composer
 from yaml.constructor import BaseConstructor, Constructor, FullConstructor, SafeConstructor
 from yaml.parser import Parser
-from yaml.reader import Reader
+from yaml.reader import Reader, _ReadStream
 from yaml.resolver import BaseResolver, Resolver
 from yaml.scanner import Scanner
-
-from .reader import _ReadStream
 
 class BaseLoader(Reader, Scanner, Parser, Composer, BaseConstructor, BaseResolver):
     def __init__(self, stream: _ReadStream) -> None: ...

--- a/stubs/PyYAML/yaml/parser.pyi
+++ b/stubs/PyYAML/yaml/parser.pyi
@@ -1,6 +1,9 @@
 from typing import Any
 
 from yaml.error import MarkedYAMLError
+from yaml.events import *
+from yaml.scanner import Scanner as Scanner
+from yaml.tokens import *
 
 class ParserError(MarkedYAMLError): ...
 

--- a/stubs/PyYAML/yaml/representer.pyi
+++ b/stubs/PyYAML/yaml/representer.pyi
@@ -4,7 +4,9 @@ from collections.abc import Callable, Iterable, Mapping
 from types import BuiltinFunctionType, FunctionType, ModuleType
 from typing import Any, ClassVar, NoReturn, TypeVar
 
+from yaml.error import *
 from yaml.error import YAMLError as YAMLError
+from yaml.nodes import *
 from yaml.nodes import MappingNode as MappingNode, Node as Node, ScalarNode as ScalarNode, SequenceNode as SequenceNode
 
 _T = TypeVar("_T")

--- a/stubs/PyYAML/yaml/resolver.pyi
+++ b/stubs/PyYAML/yaml/resolver.pyi
@@ -1,6 +1,8 @@
 from typing import Any
 
+from yaml.error import *
 from yaml.error import YAMLError
+from yaml.nodes import *
 
 class ResolverError(YAMLError): ...
 

--- a/stubs/PyYAML/yaml/scanner.pyi
+++ b/stubs/PyYAML/yaml/scanner.pyi
@@ -1,6 +1,7 @@
 from typing import Any
 
 from yaml.error import MarkedYAMLError
+from yaml.tokens import *
 
 class ScannerError(MarkedYAMLError): ...
 

--- a/stubs/PyYAML/yaml/serializer.pyi
+++ b/stubs/PyYAML/yaml/serializer.pyi
@@ -1,6 +1,8 @@
 from typing import Any
 
 from yaml.error import YAMLError
+from yaml.events import *
+from yaml.nodes import *
 from yaml.nodes import Node
 
 class SerializerError(YAMLError): ...


### PR DESCRIPTION
Noticed here: https://github.com/aws/aws-sam-cli/blob/develop/samcli/yamlhelper.py#L27