### PR TITLE
Mark `atomicwrites` as no longer updated

### DIFF
--- a/stubs/atomicwrites/METADATA.toml
+++ b/stubs/atomicwrites/METADATA.toml
@@ -1,4 +1,5 @@
 version = "1.4.*"
+no_longer_updated = true
 
 [tool.stubtest]
 ignore_missing_stub = false


### PR DESCRIPTION
[`atomicwrites`](https://github.com/untitaker/python-atomicwrites) is a package that's only really useful for Python 2/3 compatibility. It's now deprecated, archived, and unmaintained. Prior to #8883 a few days ago, marking the stubs as complete, the typeshed stubs hadn't received any significant updates for several years.

I propose we mark the stubs as no longer updated, and then remove them.