### PR TITLE
`typing.pyi`: Improve comments for `IO`/`TextIO`

### DIFF
--- a/stdlib/typing.pyi
+++ b/stdlib/typing.pyi
@@ -638,7 +638,9 @@ TYPE_CHECKING: bool
 # This differs from runtime, but better reflects the fact that in reality
 # classes deriving from IO use different names for the arguments.
 class IO(Iterator[AnyStr], Generic[AnyStr]):
-    # TODO use abstract properties
+    # At runtime these are all abstract properties,
+    # but making them abstract in the stub is hugely disruptive, for not much gain.
+    # See #8726
     @property
     def mode(self) -> str: ...
     @property
@@ -691,7 +693,7 @@ class BinaryIO(IO[bytes]):
     def __enter__(self) -> BinaryIO: ...
 
 class TextIO(IO[str]):
-    # TODO use abstractproperty
+    # See comment regarding the @properties in the `IO` class
     @property
     def buffer(self) -> BinaryIO: ...
     @property


### PR DESCRIPTION
#8726 proposed to make these properties abstract, but it would have broken half the typed-Python ecosystem, and we've since decided that it's not worth taking action on this (https://github.com/python/typeshed/issues/2146#event-7450564547). This PR rephrases the comments to make clear that there isn't really anything actionable that can be done here.