### PR TITLE
Fix stubtest failures on `SQLAlchemy`

### DIFF
--- a/stubs/SQLAlchemy/METADATA.toml
+++ b/stubs/SQLAlchemy/METADATA.toml
@@ -1,4 +1,4 @@
-version = "1.4.*"
+version = "1.4.42"
 extra_description = """\
   The `sqlalchemy-stubs` package is an alternative to this package and also \
   includes a mypy plugin for more precise types.\

--- a/stubs/SQLAlchemy/sqlalchemy/dialects/postgresql/ext.pyi
+++ b/stubs/SQLAlchemy/sqlalchemy/dialects/postgresql/ext.pyi
@@ -6,7 +6,6 @@ from ...sql.schema import ColumnCollectionConstraint
 class aggregate_order_by(expression.ColumnElement[Any]):
     __visit_name__: str
     stringify_dialect: str
-    inherit_cache: bool
     target: Any
     type: Any
     order_by: Any


### PR DESCRIPTION
And pin `SQLAlchemy` to a micro version, so that it stops breaking typeshed's CI every other week.

Fixes #8909.