### PR TITLE
Add txt to editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,6 @@
 root = true
 
-[*.{py,pyi,rst,md,yml,yaml,toml,json}]
+[*.{py,pyi,rst,md,yml,yaml,toml,json,txt}]
 trim_trailing_whitespace = true
 insert_final_newline = true
 indent_style = space

--- a/stubs/mock/METADATA.toml
+++ b/stubs/mock/METADATA.toml
@@ -1,1 +1,4 @@
 version = "4.0.*"
+
+[tool.stubtest]
+ignore_missing_stub = false


### PR DESCRIPTION
We use it for `stubtest_allowlist` and similar tools.
Right now editors do recognise them as valid transformation targets.