### PR TITLE
CI: Use macOS-11 for stdlib stubtest

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -19,7 +19,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
+        # tkinter doesn't import on macOS-12
+        os: ["ubuntu-latest", "windows-latest", "macos-11.7"]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]
       fail-fast: false
 

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         # tkinter doesn't import on macOS-12
-        os: ["ubuntu-latest", "windows-latest", "macos-11.7"]
+        os: ["ubuntu-latest", "windows-latest", "macos-11"]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]
       fail-fast: false
 

--- a/.github/workflows/stubtest_stdlib.yml
+++ b/.github/workflows/stubtest_stdlib.yml
@@ -29,7 +29,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
+        # tkinter doesn't import on macOS 12
+        os: ["ubuntu-latest", "windows-latest", "macos-11.7"]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]
       fail-fast: false
 

--- a/.github/workflows/stubtest_stdlib.yml
+++ b/.github/workflows/stubtest_stdlib.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         # tkinter doesn't import on macOS 12
-        os: ["ubuntu-latest", "windows-latest", "macos-11.7"]
+        os: ["ubuntu-latest", "windows-latest", "macos-11"]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]
       fail-fast: false
 


### PR DESCRIPTION
The stdlib stubtest run has started to fail on `master` (e.g. https://github.com/python/typeshed/actions/runs/3289534785/jobs/5421187095#step:6:250), due to `macos-latest` starting to default to macOS-12 in CI (https://github.com/actions/runner-images/issues/6384). `tkinter` doesn't seem to import on macOS 12, so pin to macOS-11 for now.