### PR TITLE
Fix `invoke` regression

### DIFF
--- a/stubs/invoke/@tests/test_cases/check_task.py
+++ b/stubs/invoke/@tests/test_cases/check_task.py
@@ -6,6 +6,7 @@ from invoke import Context, task
 # This snippet is a regression test for #8936
 # ===========================================
 
+
 @task
 def docker_build(context: Context) -> None:
     pass

--- a/stubs/invoke/@tests/test_cases/check_task.py
+++ b/stubs/invoke/@tests/test_cases/check_task.py
@@ -1,0 +1,11 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=true
+
+from invoke import task, Context
+
+@task
+def docker_build(context: Context) -> None:
+    pass
+
+@task(docker_build)
+def docker_push(context: Context) -> None:
+    pass

--- a/stubs/invoke/@tests/test_cases/check_task.py
+++ b/stubs/invoke/@tests/test_cases/check_task.py
@@ -2,6 +2,9 @@
 
 from invoke import Context, task
 
+# ===========================================
+# This snippet is a regression test for #8936
+# ===========================================
 
 @task
 def docker_build(context: Context) -> None:

--- a/stubs/invoke/@tests/test_cases/check_task.py
+++ b/stubs/invoke/@tests/test_cases/check_task.py
@@ -1,10 +1,12 @@
 # pyright: reportUnnecessaryTypeIgnoreComment=true
 
-from invoke import task, Context
+from invoke import Context, task
+
 
 @task
 def docker_build(context: Context) -> None:
     pass
+
 
 @task(docker_build)
 def docker_push(context: Context) -> None:

--- a/stubs/invoke/invoke/tasks.pyi
+++ b/stubs/invoke/invoke/tasks.pyi
@@ -59,8 +59,6 @@ class Task(Generic[_P, _R_co]):
     def get_arguments(self, ignore_unknown_help: bool | None = ...) -> list[Argument]: ...
 
 @overload
-def task(__func: Callable[_P, _R_co]) -> Task[_P, _R_co]: ...
-@overload
 def task(
     *args: Task[..., Any],
     name: str | None = ...,
@@ -93,6 +91,8 @@ def task(
     incrementable: Iterable[str] | None = ...,
     klass: type[_TaskT],
 ) -> Callable[[Callable[..., Any]], _TaskT]: ...
+@overload
+def task(__func: Callable[_P, _R_co]) -> Task[_P, _R_co]: ...
 
 class Call:
     task: Task[..., Any]


### PR DESCRIPTION
Refs #8936.

This implements @Akuli's suggested idea in https://github.com/python/typeshed/issues/8936#issuecomment-1285748131. I've added a test case (@kasium's snippet in https://github.com/python/typeshed/issues/8936#issue-1416013788), which fails without this change.

@kasium, are you able to do any additional testing of this PR, to check that this doesn't have any unintended side effects?