### PR TITLE
Stubsabot/pyinstaller

### DIFF
--- a/stubs/pyinstaller/METADATA.toml
+++ b/stubs/pyinstaller/METADATA.toml
@@ -1,4 +1,4 @@
-version = "5.5.*"
+version = "5.6.*"
 requires = ["types-setuptools"]
 
 [tool.stubtest]

--- a/stubs/pyinstaller/PyInstaller/utils/hooks/__init__.pyi
+++ b/stubs/pyinstaller/PyInstaller/utils/hooks/__init__.pyi
@@ -75,3 +75,9 @@ def include_or_exclude_file(
     include_list: Iterable[StrOrBytesPath] | None = ...,
     exclude_list: Iterable[StrOrBytesPath] | None = ...,
 ) -> bool: ...
+def collect_delvewheel_libs_directory(
+    package_name: str,
+    libdir_name: StrPath | None = ...,
+    datas: list[tuple[str, str]] | None = ...,
+    binaries: list[tuple[str, str]] | None = ...,
+) -> tuple[list[tuple[str, str]], list[tuple[str, str]]]: ...


### PR DESCRIPTION
Closes #8979

I'm fairly certain the parameters have to be lists here because of the list concatenation https://github.com/pyinstaller/pyinstaller/blob/develop/PyInstaller/utils/hooks/__init__.py#L1429