### PR TITLE
google.protobuf: Add an __init__ stub to fix type checking

### DIFF
--- a/stubs/protobuf/@tests/stubtest_allowlist.txt
+++ b/stubs/protobuf/@tests/stubtest_allowlist.txt
@@ -27,9 +27,7 @@ google.protobuf.service.Service.GetDescriptor
 # These are deliberately omitted in the stub.
 # The classes can't be constructed directly anyway,
 # so the signatures of their constructors are somewhat irrelevant.
-google.protobuf.descriptor.Descriptor.__init__
 google.protobuf.descriptor.Descriptor.__new__
-google.protobuf.descriptor.ServiceDescriptor.__init__
 google.protobuf.descriptor.ServiceDescriptor.__new__
 
 # Set to None at runtime - which doesn't match the Sequence base class.

--- a/stubs/protobuf/google/protobuf/descriptor.pyi
+++ b/stubs/protobuf/google/protobuf/descriptor.pyi
@@ -60,6 +60,27 @@ class Descriptor(_NestedDescriptorBase):
     oneofs: Any
     oneofs_by_name: Any
     syntax: Any
+    def __init__(
+        self,
+        name: str,
+        full_name: str,
+        filename: Any,
+        containing_type: Descriptor | None,
+        fields: list[FieldDescriptor],
+        nested_types: list[FieldDescriptor],
+        enum_types: list[EnumDescriptor],
+        extensions: list[FieldDescriptor],
+        options: Any | None = ...,
+        serialized_options: Any | None = ...,
+        is_extendable: bool | None = ...,
+        extension_ranges: Any | None = ...,
+        oneofs: list[OneofDescriptor] | None = ...,
+        file: FileDescriptor | None = ...,
+        serialized_start: Any | None = ...,
+        serialized_end: Any | None = ...,
+        syntax: str | None = ...,
+        create_key: Any | None = ...,
+    ): ...
     def EnumValueName(self, enum, value): ...
     def CopyToProto(self, proto): ...
     def GetOptions(self) -> MessageOptions: ...
@@ -227,6 +248,19 @@ class ServiceDescriptor(_NestedDescriptorBase):
     index: Any
     methods: Any
     methods_by_name: Any
+    def __init__(
+        self,
+        name: str,
+        full_name: str,
+        index: int,
+        methods: list[MethodDescriptor],
+        options: ServiceOptions | None = ...,
+        serialized_options: Any | None = ...,
+        file: FileDescriptor | None = ...,
+        serialized_start: Any | None = ...,
+        serialized_end: Any | None = ...,
+        create_key: Any | None = ...,
+    ): ...
     def FindMethodByName(self, name): ...
     def CopyToProto(self, proto): ...
     def GetOptions(self) -> ServiceOptions: ...


### PR DESCRIPTION
`google.protobuf.descriptor.Descriptor` was missing a type hint for its `__init__` function. 

This causes `typing` to look at its parent, `_NestedDescriptorBase`'s `__init__` function, which requires a different set of arguments and causes failures.