### PR TITLE
json: improve bytes handling

### DIFF
--- a/stdlib/json/__init__.pyi
+++ b/stdlib/json/__init__.pyi
@@ -37,7 +37,7 @@ def dump(
     **kwds: Any,
 ) -> None: ...
 def loads(
-    s: str | bytes,
+    s: str | bytes | bytearray,
     *,
     cls: type[JSONDecoder] | None = ...,
     object_hook: Callable[[dict[Any, Any]], Any] | None = ...,
@@ -58,4 +58,4 @@ def load(
     object_pairs_hook: Callable[[list[tuple[Any, Any]]], Any] | None = ...,
     **kwds: Any,
 ) -> Any: ...
-def detect_encoding(b: bytes) -> str: ...  # undocumented
+def detect_encoding(b: bytes | bytearray) -> str: ...  # undocumented


### PR DESCRIPTION
`dumps` and `detect_encoding` support `bytearray`:

```python
>>> import json

>>> json.loads(bytearray(b'false'))
False

>>> json.detect_encoding(bytearray(b''))
'utf-8'
```

But, not `memoryview`:

```python
>>> json.loads(memoryview(b'false'))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/sobolev/.pyenv/versions/3.10.0/lib/python3.10/json/__init__.py", line 339, in loads
    raise TypeError(f'the JSON object must be str, bytes or bytearray, '
TypeError: the JSON object must be str, bytes or bytearray, not memoryview
```