### PR TITLE
plistlib: improve bytes handling

### DIFF
--- a/stdlib/plistlib.pyi
+++ b/stdlib/plistlib.pyi
@@ -1,5 +1,5 @@
 import sys
-from _typeshed import Self, ReadableBuffer
+from _typeshed import ReadableBuffer, Self
 from collections.abc import Mapping, MutableMapping
 from datetime import datetime
 from enum import Enum
@@ -48,7 +48,9 @@ FMT_BINARY = PlistFormat.FMT_BINARY
 
 if sys.version_info >= (3, 9):
     def load(fp: IO[bytes], *, fmt: PlistFormat | None = ..., dict_type: type[MutableMapping[str, Any]] = ...) -> Any: ...
-    def loads(value: ReadableBuffer, *, fmt: PlistFormat | None = ..., dict_type: type[MutableMapping[str, Any]] = ...) -> Any: ...
+    def loads(
+        value: ReadableBuffer, *, fmt: PlistFormat | None = ..., dict_type: type[MutableMapping[str, Any]] = ...
+    ) -> Any: ...
 
 else:
     def load(

--- a/stdlib/plistlib.pyi
+++ b/stdlib/plistlib.pyi
@@ -1,5 +1,5 @@
 import sys
-from _typeshed import Self
+from _typeshed import Self, ReadableBuffer
 from collections.abc import Mapping, MutableMapping
 from datetime import datetime
 from enum import Enum
@@ -48,7 +48,7 @@ FMT_BINARY = PlistFormat.FMT_BINARY
 
 if sys.version_info >= (3, 9):
     def load(fp: IO[bytes], *, fmt: PlistFormat | None = ..., dict_type: type[MutableMapping[str, Any]] = ...) -> Any: ...
-    def loads(value: bytes, *, fmt: PlistFormat | None = ..., dict_type: type[MutableMapping[str, Any]] = ...) -> Any: ...
+    def loads(value: ReadableBuffer, *, fmt: PlistFormat | None = ..., dict_type: type[MutableMapping[str, Any]] = ...) -> Any: ...
 
 else:
     def load(
@@ -59,7 +59,7 @@ else:
         dict_type: type[MutableMapping[str, Any]] = ...,
     ) -> Any: ...
     def loads(
-        value: bytes,
+        value: ReadableBuffer,
         *,
         fmt: PlistFormat | None = ...,
         use_builtin_types: bool = ...,
@@ -67,7 +67,7 @@ else:
     ) -> Any: ...
 
 def dump(
-    value: Mapping[str, Any] | list[Any] | tuple[Any, ...] | str | bool | float | bytes | datetime,
+    value: Mapping[str, Any] | list[Any] | tuple[Any, ...] | str | bool | float | bytes | bytearray | datetime,
     fp: IO[bytes],
     *,
     fmt: PlistFormat = ...,
@@ -75,7 +75,7 @@ def dump(
     skipkeys: bool = ...,
 ) -> None: ...
 def dumps(
-    value: Mapping[str, Any] | list[Any] | tuple[Any, ...] | str | bool | float | bytes | datetime,
+    value: Mapping[str, Any] | list[Any] | tuple[Any, ...] | str | bool | float | bytes | bytearray | datetime,
     *,
     fmt: PlistFormat = ...,
     skipkeys: bool = ...,
@@ -85,7 +85,7 @@ def dumps(
 if sys.version_info < (3, 9):
     def readPlist(pathOrFile: str | IO[bytes]) -> Any: ...
     def writePlist(value: Mapping[str, Any], pathOrFile: str | IO[bytes]) -> None: ...
-    def readPlistFromBytes(data: bytes) -> Any: ...
+    def readPlistFromBytes(data: ReadableBuffer) -> Any: ...
     def writePlistToBytes(value: Mapping[str, Any]) -> bytes: ...
 
 if sys.version_info < (3, 9):


### PR DESCRIPTION
## dumps

```python
>>> import plistlib
>>> plistlib.dumps(bytearray())
b'<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n<plist version="1.0">\n<data>\n</data>\n</plist>\n'
>>> plistlib.dumps(memoryview(b''))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/sobolev/.pyenv/versions/3.10.0/lib/python3.10/plistlib.py", line 901, in dumps
    dump(value, fp, fmt=fmt, skipkeys=skipkeys, sort_keys=sort_keys)
  File "/Users/sobolev/.pyenv/versions/3.10.0/lib/python3.10/plistlib.py", line 894, in dump
    writer.write(value)
  File "/Users/sobolev/.pyenv/versions/3.10.0/lib/python3.10/plistlib.py", line 325, in write
    self.write_value(value)
  File "/Users/sobolev/.pyenv/versions/3.10.0/lib/python3.10/plistlib.py", line 360, in write_value
    raise TypeError("unsupported type: %s" % type(value))
TypeError: unsupported type: <class 'memoryview'>
```

## loads

```python
>>> plistlib.loads(b'<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n<plist version="1.0">\n<integer>123</integer>\n</plist>\n')
123
>>> plistlib.loads(bytearray(b'<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n<plist version="1.0">\n<integer>123</integer>\n</plist>\n'))
123
>>> plistlib.loads(memoryview(b'<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n<plist version="1.0">\n<integer>123</integer>\n</plist>\n'))
123
```

## readPlistFromBytes

It is using the same logic `loads` does: https://github.com/python/cpython/blob/948c6794711458fd148a3fa62296cadeeb2ed631/Lib/plistlib.py#L115-L123