### PR TITLE
typing: remove metaclass from Sized

### DIFF
--- a/stdlib/typing.pyi
+++ b/stdlib/typing.pyi
@@ -325,7 +325,7 @@ class SupportsRound(Protocol[_T_co]):
     def __round__(self, __ndigits: int) -> _T_co: ...
 
 @runtime_checkable
-class Sized(Protocol, metaclass=ABCMeta):
+class Sized(Protocol):
     @abstractmethod
     def __len__(self) -> int: ...
 


### PR DESCRIPTION
as per https://github.com/python/typeshed/pull/8977#issuecomment-1297872394