### PR TITLE
Bump various test dependencies; pin Python to <3.11 in CI to workaround pytype incompatibility

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.9 - 3.10"
+          python-version: "3.10"
       - run: pip install -r requirements-tests.txt
       - run: ./tests/check_consistent.py
 
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.9 - 3.10"
+          python-version: "3.10"
       - run: ./tests/check_new_syntax.py
 
   flake8:
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.9 - 3.10"
+          python-version: "3.10"
       - run: pip install -r requirements-tests.txt
       - run: flake8
 
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.9 - 3.10"
+          python-version: "3.10"
       - run: pip install -r requirements-tests.txt
       - run: python ./tests/mypy_test.py --platform=${{ matrix.platform }} --python-version=${{ matrix.python-version }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.x
+          python-version: "3.9 - 3.10"
       - run: pip install -r requirements-tests.txt
       - run: ./tests/check_consistent.py
 
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.x
+          python-version: "3.9 - 3.10"
       - run: ./tests/check_new_syntax.py
 
   flake8:
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.x
+          python-version: "3.9 - 3.10"
       - run: pip install -r requirements-tests.txt
       - run: flake8
 
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.x
+          python-version: "3.9 - 3.10"
       - run: pip install -r requirements-tests.txt
       - run: python ./tests/mypy_test.py --platform=${{ matrix.platform }} --python-version=${{ matrix.python-version }}
 

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,4 +1,4 @@
-aiohttp==3.8.1
+aiohttp==3.8.3
 black==22.10.0          # must match .pre-commit-config.yaml
 flake8==5.0.4           # must match .pre-commit-config.yaml
 flake8-bugbear==22.7.1  # must match .pre-commit-config.yaml
@@ -10,8 +10,8 @@ packaging==21.3
 pathspec
 pycln==2.1.1            # must match .pre-commit-config.yaml
 pyyaml==6.0
-pytype==2022.08.30; platform_system != "Windows"
+pytype==2022.10.26; platform_system != "Windows" and python_version < "3.11"
 termcolor>=2
-tomli==1.2.2
-tomlkit==0.11.4
+tomli==2.0.1
+tomlkit==0.11.6
 types-pyyaml


### PR DESCRIPTION
Fixes #9067 (I've run CI several times on my fork, to check)