### PR TITLE
Bump flake8-bugbear; ignore flake8-bugbear in stub files

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -6,6 +6,7 @@
 #     E501   line too long
 
 # Some rules are considered irrelevant to stub files:
+#     B      All flake8-bugbear rules are .py-specific
 #     E701   multiple statements on one line (colon) -- disallows "..." on the same line
 #     F401   imported but unused -- does not recognize re-exports
 #            https://github.com/PyCQA/pyflakes/issues/474
@@ -29,14 +30,14 @@
 [flake8]
 per-file-ignores =
   *.py: E203, E301, E302, E305, E501
-  *.pyi: E301, E302, E305, E501, E701, E741, NQA102, F401, F403, F405, F822, Y037
+  *.pyi: B, E301, E302, E305, E501, E701, E741, NQA102, F401, F403, F405, F822, Y037
   # Since typing.pyi defines "overload" this is not recognized by flake8 as typing.overload.
   # Unfortunately, flake8 does not allow to "noqa" just a specific error inside the file itself.
   # https://github.com/PyCQA/flake8/issues/1079
   #     F811 redefinition of unused '...'
-  stdlib/typing.pyi: E301, E302, E305, E501, E701, E741, NQA102, F401, F403, F405, F811, F822, Y037
+  stdlib/typing.pyi: B, E301, E302, E305, E501, E701, E741, NQA102, F401, F403, F405, F811, F822, Y037
   # Generated protobuf files include docstrings
-  *_pb2.pyi: E301, E302, E305, E501, E701, NQA102, Y021, Y026
+  *_pb2.pyi: B, E301, E302, E305, E501, E701, NQA102, Y021, Y026
 
 exclude = .venv*,.git
 noqa_require_code = true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,9 +19,9 @@ repos:
     hooks:
       - id: flake8
         additional_dependencies:
-          - 'flake8-bugbear==22.7.1'  # must match requirements-tests.txt
-          - 'flake8-noqa==1.2.9'      # must match requirements-tests.txt
-          - 'flake8-pyi==22.10.0'     # must match requirements-tests.txt
+          - 'flake8-bugbear==22.10.27'  # must match requirements-tests.txt
+          - 'flake8-noqa==1.2.9'        # must match requirements-tests.txt
+          - 'flake8-pyi==22.10.0'       # must match requirements-tests.txt
 
 ci:
     autofix_commit_msg: '[pre-commit.ci] auto fixes from pre-commit.com hooks'

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,14 +1,14 @@
 aiohttp==3.8.3
-black==22.10.0          # must match .pre-commit-config.yaml
-flake8==5.0.4           # must match .pre-commit-config.yaml
-flake8-bugbear==22.7.1  # must match .pre-commit-config.yaml
-flake8-noqa==1.2.9      # must match .pre-commit-config.yaml
-flake8-pyi==22.10.0     # must match .pre-commit-config.yaml
-isort==5.10.1           # must match .pre-commit-config.yaml
+black==22.10.0            # must match .pre-commit-config.yaml
+flake8==5.0.4             # must match .pre-commit-config.yaml
+flake8-bugbear==22.10.27  # must match .pre-commit-config.yaml
+flake8-noqa==1.2.9        # must match .pre-commit-config.yaml
+flake8-pyi==22.10.0       # must match .pre-commit-config.yaml
+isort==5.10.1             # must match .pre-commit-config.yaml
 mypy==0.982
 packaging==21.3
 pathspec
-pycln==2.1.1            # must match .pre-commit-config.yaml
+pycln==2.1.1              # must match .pre-commit-config.yaml
 pyyaml==6.0
 pytype==2022.10.26; platform_system != "Windows" and python_version < "3.11"
 termcolor>=2


### PR DESCRIPTION
flake8-bugbear now has 2 checks that cause a lot of false positives for stubs, but don't have any true positives: B024 and B027. But actually, none of flake8-bugbear's checks are really relevant for stub files. Keep it in CI for linting our scripts, but just ignore it for our stubs.