### PR TITLE
http.server.SimpleHTTPRequestHandler: Fix version branching

### DIFF
--- a/stdlib/http/server.pyi
+++ b/stdlib/http/server.pyi
@@ -59,6 +59,7 @@ class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
             server: socketserver.BaseServer,
             *,
             directory: str | None = ...,
+            index_pages: Sequence[str] | None = ...,
         ) -> None: ...
     else:
         def __init__(
@@ -68,7 +69,6 @@ class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
             server: socketserver.BaseServer,
             *,
             directory: str | None = ...,
-            index_pages: Sequence[str] | None = ...,
         ) -> None: ...
 
     def do_GET(self) -> None: ...


### PR DESCRIPTION
The stub currently implies that the index_pages parameter has been removed in 3.12. Actually, it was only added in 3.12 :)

See https://github.com/python/cpython/pull/31985. (This is a follow-up to https://github.com/python/typeshed/pull/9055 — cc. @JelleZijlstra.)