### PR TITLE
unittest: cannot use bytes regexes

### DIFF
--- a/stdlib/unittest/case.pyi
+++ b/stdlib/unittest/case.pyi
@@ -157,7 +157,7 @@ class TestCase:
     def assertRaisesRegex(  # type: ignore[misc]
         self,
         expected_exception: type[BaseException] | tuple[type[BaseException], ...],
-        expected_regex: str | bytes | Pattern[str] | Pattern[bytes],
+        expected_regex: str | Pattern[str],
         callable: Callable[..., Any],
         *args: Any,
         **kwargs: Any,
@@ -166,7 +166,7 @@ class TestCase:
     def assertRaisesRegex(
         self,
         expected_exception: type[_E] | tuple[type[_E], ...],
-        expected_regex: str | bytes | Pattern[str] | Pattern[bytes],
+        expected_regex: str | Pattern[str],
         *,
         msg: Any = ...,
     ) -> _AssertRaisesContext[_E]: ...
@@ -186,7 +186,7 @@ class TestCase:
     def assertWarnsRegex(  # type: ignore[misc]
         self,
         expected_warning: type[Warning] | tuple[type[Warning], ...],
-        expected_regex: str | bytes | Pattern[str] | Pattern[bytes],
+        expected_regex: str | Pattern[str],
         callable: Callable[_P, Any],
         *args: _P.args,
         **kwargs: _P.kwargs,
@@ -195,7 +195,7 @@ class TestCase:
     def assertWarnsRegex(
         self,
         expected_warning: type[Warning] | tuple[type[Warning], ...],
-        expected_regex: str | bytes | Pattern[str] | Pattern[bytes],
+        expected_regex: str | Pattern[str],
         *,
         msg: Any = ...,
     ) -> _AssertWarnsContext: ...

--- a/stdlib/unittest/case.pyi
+++ b/stdlib/unittest/case.pyi
@@ -164,11 +164,7 @@ class TestCase:
     ) -> None: ...
     @overload
     def assertRaisesRegex(
-        self,
-        expected_exception: type[_E] | tuple[type[_E], ...],
-        expected_regex: str | Pattern[str],
-        *,
-        msg: Any = ...,
+        self, expected_exception: type[_E] | tuple[type[_E], ...], expected_regex: str | Pattern[str], *, msg: Any = ...
     ) -> _AssertRaisesContext[_E]: ...
     @overload
     def assertWarns(  # type: ignore[misc]
@@ -193,11 +189,7 @@ class TestCase:
     ) -> None: ...
     @overload
     def assertWarnsRegex(
-        self,
-        expected_warning: type[Warning] | tuple[type[Warning], ...],
-        expected_regex: str | Pattern[str],
-        *,
-        msg: Any = ...,
+        self, expected_warning: type[Warning] | tuple[type[Warning], ...], expected_regex: str | Pattern[str], *, msg: Any = ...
     ) -> _AssertWarnsContext: ...
     def assertLogs(
         self, logger: str | logging.Logger | None = ..., level: int | str | None = ...


### PR DESCRIPTION
```pycon
>>> from unittest.case import TestCase
>>> c = TestCase()
>>> with c.assertRaisesRegex(Exception, b"x"): 1/0
...
ZeroDivisionError: division by zero

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/unittest/case.py", line 274, in __exit__
    if not expected_regex.search(str(exc_value)):
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: cannot use a bytes pattern on a string-like object
```