### PR TITLE
Remove `aiofiles/aiofiles/threadpool/utils.pyi` from pyright exclude

### DIFF
--- a/pyrightconfig.stricter.json
+++ b/pyrightconfig.stricter.json
@@ -21,7 +21,6 @@
         "stdlib/xml/dom/minidom.pyi",
         "stdlib/xml/dom/pulldom.pyi",
         "stdlib/xml/sax",
-        "stubs/aiofiles/aiofiles/threadpool/utils.pyi",
         "stubs/annoy/annoy/annoylib.pyi",
         "stubs/aws-xray-sdk",
         "stubs/babel",


### PR DESCRIPTION
Looks like I've missed it in https://github.com/python/typeshed/commit/10f05d3fb60c4972f91fbb098f7cbe32d5d190a8