### PR TITLE
Improve `builtins.vars()`

### DIFF
--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -1666,8 +1666,11 @@ else:
     @overload
     def sum(__iterable: Iterable[_AddableT1], __start: _AddableT2) -> _AddableT1 | _AddableT2: ...
 
-# The argument to `vars()` has to have a `__dict__` attribute, so can't be annotated with `object`
+# The argument to `vars()` has to have a `__dict__` attribute, so the second overload can't be annotated with `object`
 # (A "SupportsDunderDict" protocol doesn't work)
+@overload
+def vars(__object: type) -> types.MappingProxyType[str, Any]: ...
+@overload
 def vars(__object: Any = ...) -> dict[str, Any]: ...
 
 class zip(Iterator[_T_co], Generic[_T_co]):

--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -1668,8 +1668,9 @@ else:
 
 # The argument to `vars()` has to have a `__dict__` attribute, so the second overload can't be annotated with `object`
 # (A "SupportsDunderDict" protocol doesn't work)
+# Use a type: ignore to make complaints about overlapping overloads go away
 @overload
-def vars(__object: type) -> types.MappingProxyType[str, Any]: ...
+def vars(__object: type) -> types.MappingProxyType[str, Any]: ...  # type: ignore[misc]
 @overload
 def vars(__object: Any = ...) -> dict[str, Any]: ...
 


### PR DESCRIPTION
```pycon
>>> class Foo: ...
...
>>> vars(Foo)
mappingproxy({'__module__': '__main__', '__dict__': <attribute '__dict__' of 'Foo' objects>, '__weakref__': <attribute '__weakref__' of 'Foo' objects>, '__doc__': None})
```