### PR TITLE
`regr_test.py`: fix typo in `--help`

### DIFF
--- a/tests/regr_test.py
+++ b/tests/regr_test.py
@@ -75,7 +75,7 @@ parser.add_argument(
     nargs="*",
     action="extend",
     help=(
-        "Run mypy for certain Python versions (defaults to sys.version_info[:2])"
+        "Run mypy for certain Python versions (defaults to sys.version_info[:2]). "
         "Note that this cannot be specified if --all is also specified."
     ),
 )


### PR DESCRIPTION
It used to be:

```
  -p [{3.11,3.10,3.9,3.8,3.7} ...], --python-version [{3.11,3.10,3.9,3.8,3.7} ...]
                        Run mypy for certain Python versions (defaults to
                        sys.version_info[:2])Note that this cannot be specified if
                        --all is also specified.
```