### PR TITLE
inspect: improve `Attribute.kind` to literal type

### DIFF
--- a/stdlib/inspect.pyi
+++ b/stdlib/inspect.pyi
@@ -585,7 +585,7 @@ _Object: TypeAlias = object
 
 class Attribute(NamedTuple):
     name: str
-    kind: str
+    kind: Literal["class method", "static method", "property", "method", "data"]
     defining_class: type
     object: _Object
 


### PR DESCRIPTION
Change `Attribute.kind` to literal as `inspect.classify_class_attrs` docstring said.