### PR TITLE
Stubtest: Don't allowlist `termios` and `posix` constants on Windows

### DIFF
--- a/tests/stubtest_allowlists/darwin.txt
+++ b/tests/stubtest_allowlists/darwin.txt
@@ -21,6 +21,11 @@ select.POLLMSG   # system dependent
 (posix.preadv)?
 (posix.pwritev)?
 
+# Platform differences that cannot be captured by the type system
+(posix.O_[A-Z_]+)?
+(posix.ST_[A-Z]+)?
+(termios.[A-Z0-9_]+)?
+
 # Exists at runtime, but missing from stubs
 distutils.msvccompiler.MSVCCompiler.get_msvc_paths
 distutils.msvccompiler.MSVCCompiler.set_path_env_var

--- a/tests/stubtest_allowlists/linux.txt
+++ b/tests/stubtest_allowlists/linux.txt
@@ -23,6 +23,11 @@ selectors.DefaultSelector.fileno
 spwd.struct_spwd.sp_nam
 spwd.struct_spwd.sp_pwd
 
+# Platform differences that cannot be captured by the type system
+(posix.O_[A-Z_]+)?
+(posix.ST_[A-Z]+)?
+(termios.[A-Z0-9_]+)?
+
 _ctypes.dlclose
 _ctypes.dlopen
 _ctypes.dlsym

--- a/tests/stubtest_allowlists/py3_common.txt
+++ b/tests/stubtest_allowlists/py3_common.txt
@@ -544,10 +544,7 @@ xml.sax
 
 # Platform differences that cannot be captured by the type system
 os.O_[A-Z_]+
-(posix.O_[A-Z_]+)?
-(posix.ST_[A-Z]+)?
 socket.AF_DECnet
-(termios.[A-Z0-9_]+)?
 
 # Loadable SQLite extensions are disabled on GitHub runners
 (sqlite3(.dbapi2)?.Connection.enable_load_extension)?


### PR DESCRIPTION
These modules don't exist on Windows