### PR TITLE
PyYAML: Add missing types to _N TypeVar

### DIFF
--- a/stubs/PyYAML/yaml/constructor.pyi
+++ b/stubs/PyYAML/yaml/constructor.pyi
@@ -9,7 +9,7 @@ from yaml.loader import BaseLoader, FullLoader, Loader, SafeLoader, UnsafeLoader
 from yaml.nodes import MappingNode, Node, ScalarNode, SequenceNode
 
 _L = TypeVar("_L", bound=Loader | BaseLoader | FullLoader | SafeLoader | UnsafeLoader)
-_N = TypeVar("_N", bound=Node)
+_N = TypeVar("_N", bound=Node | MappingNode | ScalarNode | SequenceNode)
 
 _Scalar: TypeAlias = str | int | float | bool | None
 


### PR DESCRIPTION
In https://github.com/python/typeshed/blob/294b03f75bd23d95cf4709ba14547cc4190aacdd/stubs/PyYAML/yaml/constructor.pyi the signature for `construct_sequence()` defines  `SequenceNode` as the type for **node** (which is correct), however the `_N` TypeVar used in the signature for `add_constructor()` only allows for `Node`.

It would seem that `MappingNode`, `ScalarNode` and `SequenceNode` are missing from the TypeVar definition since `add_constructor()` does not consider any of them as compatible. For example:

```bash
error: Argument 2 to "add_constructor" has incompatible type "Callable[[Loader, SequenceNode], str]"; expected "Callable[[Union[Loader, FullLoader, UnsafeLoader], Node], Any]"
```

This PR addresses the above.