### PR TITLE
Fix CI failure when no third-party stubs were updated

### DIFF
--- a/.github/workflows/stubtest_third_party.yml
+++ b/.github/workflows/stubtest_third_party.yml
@@ -41,8 +41,8 @@ jobs:
           # This only runs stubtest on changed stubs, because it is much faster.
           # Use the daily.yml workflow to run stubtest on all third party stubs.
           STUBS=$(
-            git diff --name-only origin/${{ github.base_ref }} HEAD |
-            { egrep '^stubs/' || echo '' } | cut -d "/" -f 2 | sort -u |
+            git diff --name-only origin/${{ github.base_ref }} HEAD | \
+            { egrep '^stubs/' || echo '' } | cut -d "/" -f 2 | sort -u | \
             (while read stub; do [ -d "stubs/$stub" ] && echo "$stub" || true; done)
           )
 

--- a/.github/workflows/stubtest_third_party.yml
+++ b/.github/workflows/stubtest_third_party.yml
@@ -42,7 +42,7 @@ jobs:
           # Use the daily.yml workflow to run stubtest on all third party stubs.
           STUBS=$(
             git diff --name-only origin/${{ github.base_ref }} HEAD | \
-            { egrep '^stubs/' || echo '' } | cut -d "/" -f 2 | sort -u | \
+            egrep ^stubs/ | cut -d "/" -f 2 | sort -u | \
             (while read stub; do [ -d "stubs/$stub" ] && echo "$stub" || true; done)
           )
 

--- a/.github/workflows/stubtest_third_party.yml
+++ b/.github/workflows/stubtest_third_party.yml
@@ -38,10 +38,12 @@ jobs:
       - name: Run stubtest
         shell: bash
         run: |
+          # This only runs stubtest on changed stubs, because it is much faster.
+          # Use the daily.yml workflow to run stubtest on all third party stubs.
           STUBS=$(
             git diff --name-only origin/${{ github.base_ref }} HEAD |
-            # Use the daily.yml workflow to run stubtest on all third party stubs
-            egrep ^stubs/ | cut -d "/" -f 2 | sort -u | (while read stub; do [ -d stubs/$stub ] && echo $stub || true; done)
+            { egrep '^stubs/' || echo '' } | cut -d "/" -f 2 | sort -u |
+            (while read stub; do [ -d "stubs/$stub" ] && echo "$stub" || true; done)
           )
 
           if [ -n "$STUBS" ]; then

--- a/.github/workflows/stubtest_third_party.yml
+++ b/.github/workflows/stubtest_third_party.yml
@@ -40,11 +40,12 @@ jobs:
         run: |
           # This only runs stubtest on changed stubs, because it is much faster.
           # Use the daily.yml workflow to run stubtest on all third party stubs.
-          STUBS=$(
+          function find_stubs {
             git diff --name-only origin/${{ github.base_ref }} HEAD | \
             egrep ^stubs/ | cut -d "/" -f 2 | sort -u | \
             (while read stub; do [ -d "stubs/$stub" ] && echo "$stub" || true; done)
-          )
+          }
+          STUBS=$(find_stubs || echo '')
 
           if [ -n "$STUBS" ]; then
             echo "Testing $STUBS..."


### PR DESCRIPTION
Testing the CI after https://github.com/python/typeshed/actions/runs/3445520575/jobs/5749332275