### PR TITLE
Use `TypeAlias` in builtins and complete a `TODO` item

### DIFF
--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -192,7 +192,7 @@ class super:
 
 _PositiveInteger: TypeAlias = Literal[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]
 _NegativeInteger: TypeAlias = Literal[-1, -2, -3, -4, -5, -6, -7, -8, -9, -10, -11, -12, -13, -14, -15, -16, -17, -18, -19, -20]
-_LiteralInteger = _PositiveInteger | _NegativeInteger | Literal[0]  # noqa: Y026  # TODO: Use TypeAlias once mypy bugs are fixed
+_LiteralInteger: TypeAlias = _PositiveInteger | _NegativeInteger | Literal[0]  # noqa: Y026
 
 class int:
     @overload


### PR DESCRIPTION
From https://github.com/python/typeshed/pull/9158 I understood that explicit type aliases are not a goal. But, this one is special. It has a TODO item and some history to it.

I am also curious about whether mypy now supports it.