### PR TITLE
Fix paramiko stubtest on Windows

### DIFF
--- a/stubs/paramiko/@tests/stubtest_allowlist.txt
+++ b/stubs/paramiko/@tests/stubtest_allowlist.txt
@@ -2,7 +2,6 @@ paramiko.SFTPServer.__init__
 paramiko.Transport.open_x11_channel
 paramiko.Transport.send_ignore
 paramiko.Transport.start_server
-paramiko._winapi
 paramiko.py3compat.input
 paramiko.py3compat.BytesIO.readlines
 paramiko.py3compat.BytesIO.seek
@@ -13,4 +12,3 @@ paramiko.transport.Transport.open_x11_channel
 paramiko.transport.Transport.send_ignore
 paramiko.transport.Transport.start_server
 paramiko.util.SupportsClose
-paramiko.win_pageant

--- a/stubs/paramiko/@tests/stubtest_allowlist_darwin.txt
+++ b/stubs/paramiko/@tests/stubtest_allowlist_darwin.txt
@@ -1,0 +1,2 @@
+paramiko._winapi
+paramiko.win_pageant

--- a/stubs/paramiko/@tests/stubtest_allowlist_linux.txt
+++ b/stubs/paramiko/@tests/stubtest_allowlist_linux.txt
@@ -1,0 +1,2 @@
+paramiko._winapi
+paramiko.win_pageant

--- a/stubs/paramiko/@tests/stubtest_allowlist_win32.txt
+++ b/stubs/paramiko/@tests/stubtest_allowlist_win32.txt
@@ -1,0 +1,2 @@
+# Type-checkers don't support architecture checks. So we have to Union
+paramiko.win_pageant.ULONG_PTR

--- a/stubs/paramiko/METADATA.toml
+++ b/stubs/paramiko/METADATA.toml
@@ -1,2 +1,6 @@
 version = "2.12.*"
 requires = ["types-cryptography"]
+
+[tool.stubtest]
+# linux and darwin are equivalent
+platforms = ["linux", "win32"]


### PR DESCRIPTION
Thanks to #8923 , I was able to fix running stubtest on Windows for paramiko.

I did not add `darwin` to `platforms` because it would be redundant with `linux`. But I still added a `stubtest_allowlist_darwin.txt` for those who would like to run it locally on macos. (This is the edge case mentioned in #9173 )