### PR TITLE
Make the `ldap3` stubs platform-agnostic

### DIFF
--- a/stubs/ldap3/ldap3/core/server.pyi
+++ b/stubs/ldap3/ldap3/core/server.pyi
@@ -1,9 +1,5 @@
-import sys
 from typing import Any
 from typing_extensions import Literal
-
-if sys.platform != "win32":
-    from socket import AF_UNIX as AF_UNIX
 
 unix_socket_available: bool
 


### PR DESCRIPTION
`AF_UNIX` seems like an incidental re-export from `socket` (source: https://github.com/cannatag/ldap3/blob/dev/ldap3/core/server.py#L47). Some implementation detail is also hidden behind `socket`. Meaning that stubtest for this stub should be the same on all platforms.