### PR TITLE
Comments explaining why `keyboard` and `tzlocal` are not run on multiple platforms

### DIFF
--- a/stubs/keyboard/METADATA.toml
+++ b/stubs/keyboard/METADATA.toml
@@ -2,3 +2,8 @@ version = "0.13.*"
 
 [tool.stubtest]
 ignore_missing_stub = false
+# While the stubs slightly differ on Windows vs Linux.
+# It's only by possible mouse buttons and event literal types.
+# As well as returning a tuple of int/long from keyboard.mouse.get_position
+# The "mouse" module is obsoleted by the "mouse" package.
+# platforms =

--- a/stubs/tzlocal/@tests/stubtest_allowlist.txt
+++ b/stubs/tzlocal/@tests/stubtest_allowlist.txt
@@ -1,2 +1,3 @@
+# Implementation details
 tzlocal.unix
 tzlocal.win32

--- a/stubs/tzlocal/tzlocal/windows_tz.pyi
+++ b/stubs/tzlocal/tzlocal/windows_tz.pyi
@@ -1,3 +1,4 @@
+# Auto-generated for tzlocal.win32. But some libraries use it to get the mappings directly
 win_tz: dict[str, str]
 tz_names: dict[str, str]
 tz_win: dict[str, str]


### PR DESCRIPTION
Added comments explaining:
- Why `tzlocal.unix`, and `tzlocal.win32` have no stub files and  `tzlocal` doesn't require running stubtest on multiple platforms (it's implementation details, the final exposed types are the same)
- Why we stub `tzlocal/windows_tz.pyi` despite being autogenerated implementation details
- Why we don't need to run `keyboard` on multiple OS despite having platform-specific elements in its stub

The keyboard comment probably doesn't need to be that verbose.

And whit this, there's only a single stub with platform-specific code left to do: `requests`. The only platform difference is the following. Is it worth?
```py
# stubs\requests\requests\utils.pyi
if sys.platform == "win32":
    def proxy_bypass_registry(host: str) -> bool: ...
    def proxy_bypass(host: str) -> bool: ...
```