### PR TITLE
Cancel old `daily` CI jobs on PRs

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -13,6 +13,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   PIP_DISABLE_PIP_VERSION_CHECK: 1
 


### PR DESCRIPTION
Since now `daily` CI jobs can be executed on PRs, I think we need to cancel old builds on new commits. This will be in line with other CI workflows.

`cron` and `workflow_dispatch` triggers are not affected by this, because they usually don't have parallel execution. (Technically sequential `workflow_dispatch` actions will be canceled as well, but I think this is also a good thing).