### PR TITLE
Bump test dependencies; improve `pycln` config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,9 @@
 repos:
   - repo: https://github.com/hadialqattan/pycln
-    rev: v2.1.1 # must match requirements-tests.txt
+    rev: v2.1.2 # must match requirements-tests.txt
     hooks:
       - id: pycln
-        args: [--all, stubs, stdlib, tests, scripts]
+        args: [--config=pyproject.toml, stubs, stdlib, tests, scripts]
   - repo: https://github.com/psf/black
     rev: 22.10.0 # must match requirements-tests.txt
     hooks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,7 +94,7 @@ That being said, if you *want* to run the checks locally when you commit,
 you're free to do so. Either run `pycln`, `black` and `isort` manually...
 
 ```
-pycln --all .
+pycln --config=pyproject.toml .
 isort .
 black .
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,3 +55,7 @@ extra_standard_library = [
     "opcode",
     "pyexpat",
 ]
+
+[tool.pycln]
+all = true
+disable_all_dunder_policy = true

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -5,12 +5,12 @@ flake8-bugbear==22.10.27  # must match .pre-commit-config.yaml
 flake8-noqa==1.2.9        # must match .pre-commit-config.yaml
 flake8-pyi==22.10.0       # must match .pre-commit-config.yaml
 isort==5.10.1             # must match .pre-commit-config.yaml
-mypy==0.990
+mypy==0.991
 packaging==21.3
 pathspec
-pycln==2.1.1              # must match .pre-commit-config.yaml
+pycln==2.1.2              # must match .pre-commit-config.yaml
 pyyaml==6.0
-pytype==2022.10.26; platform_system != "Windows" and python_version < "3.11"
+pytype==2022.11.10; platform_system != "Windows" and python_version < "3.11"
 termcolor>=2
 tomli==2.0.1
 tomlkit==0.11.6


### PR DESCRIPTION
- Bump mypy to 0.991
- Bump pytype to 2022.11.10
- Bump pycln to 2.1.2
- Enable the new `disable_all_dunder_policy` flag for pycln.

  This flag means that pycln treats `__init__.py(i)` files just like normal `.py(i)` files. By default, pycln is much more cautious when removing imports from `__init__.py(i)` files due to the fact that many projects use "redundant" imports in `__init__.py` files for implicit reexports. But it doesn't make sense for pycln to apply the same level of caution to `__init__.pyi` files in stubs, where all imports are "private to the stub" except imports using the `import foo as foo` idiom. So it makes sense to enable this flag for typeshed.
- Put all pycln config in the `pyproject.toml` file instead of hardcoding it into the `.pre-commit-config.yaml` file.
