### PR TITLE
Add missing symbols in `pyaudio` stubs

### DIFF
--- a/stubs/pyaudio/@tests/stubtest_allowlist.txt
+++ b/stubs/pyaudio/@tests/stubtest_allowlist.txt
@@ -1,2 +1,0 @@
-pyaudio.PaMacCoreStreamInfo
-pyaudio.paMacCoreStreamInfo

--- a/stubs/pyaudio/METADATA.toml
+++ b/stubs/pyaudio/METADATA.toml
@@ -1,5 +1,6 @@
 version = "0.2.*"
 
 [tool.stubtest]
+ignore_missing_stub = false
 platforms = ["linux"]
 apt_dependencies = ["portaudio19-dev"]

--- a/stubs/pyaudio/pyaudio.pyi
+++ b/stubs/pyaudio/pyaudio.pyi
@@ -1,5 +1,8 @@
+import sys
 from collections.abc import Callable, Mapping, Sequence
-from typing_extensions import Final, TypeAlias
+from typing_extensions import Final, TypeAlias, final
+
+__docformat__: str
 
 paFloat32: Final[int]
 paInt32: Final[int]
@@ -64,7 +67,45 @@ paOutputUnderflow: Final[int]
 paOutputOverflow: Final[int]
 paPrimingOutput: Final[int]
 
-paMacCoreStreamInfo: PaMacCoreStreamInfo
+paFramesPerBufferUnspecified: Final[int]
+
+if sys.platform == "darwin":
+    @final
+    class paMacCoreStreamInfo:
+        paMacCoreChangeDeviceParameters: Final[int]
+        paMacCoreFailIfConversionRequired: Final[int]
+        paMacCoreConversionQualityMin: Final[int]
+        paMacCoreConversionQualityMedium: Final[int]
+        paMacCoreConversionQualityLow: Final[int]
+        paMacCoreConversionQualityHigh: Final[int]
+        paMacCoreConversionQualityMax: Final[int]
+        paMacCorePlayNice: Final[int]
+        paMacCorePro: Final[int]
+        paMacCoreMinimizeCPUButPlayNice: Final[int]
+        paMacCoreMinimizeCPU: Final[int]
+        flags: Final[int]
+        channel_map: Final[_ChannelMap | None]
+        def __init__(self, flags: int | None = ..., channel_map: _ChannelMap | None = ...) -> None: ...
+
+    class PaMacCoreStreamInfo:
+        paMacCoreChangeDeviceParameters: Final[int]
+        paMacCoreFailIfConversionRequired: Final[int]
+        paMacCoreConversionQualityMin: Final[int]
+        paMacCoreConversionQualityMedium: Final[int]
+        paMacCoreConversionQualityLow: Final[int]
+        paMacCoreConversionQualityHigh: Final[int]
+        paMacCoreConversionQualityMax: Final[int]
+        paMacCorePlayNice: Final[int]
+        paMacCorePro: Final[int]
+        paMacCoreMinimizeCPUButPlayNice: Final[int]
+        paMacCoreMinimizeCPU: Final[int]
+        def __init__(self, flags: int | None = ..., channel_map: _ChannelMap | None = ...) -> None: ...
+        def get_flags(self) -> int: ...
+        def get_channel_map(self) -> _ChannelMap | None: ...
+
+    _PaMacCoreStreamInfo: TypeAlias = PaMacCoreStreamInfo
+else:
+    _PaMacCoreStreamInfo: TypeAlias = None
 
 # Auxiliary types
 _ChannelMap: TypeAlias = Sequence[int]
@@ -90,8 +131,8 @@ class Stream:
         output_device_index: int | None = ...,
         frames_per_buffer: int = ...,
         start: bool = ...,
-        input_host_api_specific_stream_info: PaMacCoreStreamInfo | None = ...,
-        output_host_api_specific_stream_info: PaMacCoreStreamInfo | None = ...,
+        input_host_api_specific_stream_info: _PaMacCoreStreamInfo | None = ...,
+        output_host_api_specific_stream_info: _PaMacCoreStreamInfo | None = ...,
         stream_callback: _StreamCallback | None = ...,
     ) -> None: ...
     def close(self) -> None: ...
@@ -143,24 +184,8 @@ class PyAudio:
         output_device_index: int | None = ...,
         frames_per_buffer: int = ...,
         start: bool = ...,
-        input_host_api_specific_stream_info: PaMacCoreStreamInfo | None = ...,
-        output_host_api_specific_stream_info: PaMacCoreStreamInfo | None = ...,
+        input_host_api_specific_stream_info: _PaMacCoreStreamInfo | None = ...,
+        output_host_api_specific_stream_info: _PaMacCoreStreamInfo | None = ...,
         stream_callback: _StreamCallback | None = ...,
     ) -> Stream: ...
     def terminate(self) -> None: ...
-
-class PaMacCoreStreamInfo:
-    paMacCoreChangeDeviceParameters: Final[int] = ...
-    paMacCoreFailIfConversionRequired: Final[int] = ...
-    paMacCoreConversionQualityMin: Final[int] = ...
-    paMacCoreConversionQualityMedium: Final[int] = ...
-    paMacCoreConversionQualityLow: Final[int] = ...
-    paMacCoreConversionQualityHigh: Final[int] = ...
-    paMacCoreConversionQualityMax: Final[int] = ...
-    paMacCorePlayNice: Final[int] = ...
-    paMacCorePro: Final[int] = ...
-    paMacCoreMinimizeCPUButPlayNice: Final[int] = ...
-    paMacCoreMinimizeCPU: Final[int] = ...
-    def __init__(self, flags: int | None = ..., channel_map: _ChannelMap | None = ...) -> None: ...
-    def get_flags(self) -> int: ...
-    def get_channel_map(self) -> _ChannelMap | None: ...

--- a/stubs/pyaudio/pyaudio.pyi
+++ b/stubs/pyaudio/pyaudio.pyi
@@ -85,7 +85,7 @@ if sys.platform == "darwin":
         paMacCoreMinimizeCPU: Final[int]
         flags: Final[int]
         channel_map: Final[_ChannelMap | None]
-        def __init__(self, flags: int | None = ..., channel_map: _ChannelMap | None = ...) -> None: ...
+        def __init__(self, flags: int = ..., channel_map: _ChannelMap = ...) -> None: ...
 
     class PaMacCoreStreamInfo:
         paMacCoreChangeDeviceParameters: Final[int]


### PR DESCRIPTION
Split off from #9187
Turned off `ignore_missing_stub` for pyaudio stubs.
Ensured it's valid for Windows and MacOS.