### PR TITLE
Fix urllib3 Url.port type

### DIFF
--- a/stubs/urllib3/urllib3/util/url.pyi
+++ b/stubs/urllib3/urllib3/util/url.pyi
@@ -11,7 +11,7 @@ class _UrlBase(NamedTuple):
     fragment: str | None
     host: str | None
     path: str | None
-    port: str | None
+    port: int | None
     query: str | None
     scheme: str | None
 
@@ -21,7 +21,7 @@ class Url(_UrlBase):
         scheme: str | None = ...,
         auth: str | None = ...,
         host: str | None = ...,
-        port: str | None = ...,
+        port: int | None = ...,
         path: str | None = ...,
         query: str | None = ...,
         fragment: str | None = ...,


### PR DESCRIPTION
I maintain urllib3 and can confirm the [port is an int](https://github.com/urllib3/urllib3/blob/8b8e4b5a148d0eb706daf5ac48b4423b434495f5/src/urllib3/util/url.py#L381).

Thankfully, the upcoming 2.0 release is fully type annotated!