### PR TITLE
Add exact `**kwargs` types to `dateutil.parser.parse`

### DIFF
--- a/stubs/python-dateutil/dateutil/parser/__init__.pyi
+++ b/stubs/python-dateutil/dateutil/parser/__init__.pyi
@@ -43,7 +43,6 @@ class parser:
         yearfirst: bool | None = ...,
         fuzzy: bool = ...,
         fuzzy_with_tokens: bool = ...,
-        **kwargs: Any,
     ) -> datetime: ...
 
 DEFAULTPARSER: parser
@@ -59,7 +58,6 @@ def parse(
     fuzzy_with_tokens: bool = ...,
     default: datetime | None = ...,
     tzinfos: _TzInfo | None = ...,
-    **kwargs: Any,
 ) -> datetime: ...
 
 class _tzparser: ...

--- a/stubs/python-dateutil/dateutil/parser/__init__.pyi
+++ b/stubs/python-dateutil/dateutil/parser/__init__.pyi
@@ -1,4 +1,4 @@
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from datetime import datetime, tzinfo
 from typing import IO, Any
 from typing_extensions import TypeAlias
@@ -6,6 +6,8 @@ from typing_extensions import TypeAlias
 from .isoparser import isoparse as isoparse, isoparser as isoparser
 
 _FileOrStr: TypeAlias = bytes | str | IO[str] | IO[Any]
+_TzData: TypeAlias = tzinfo | int | str | None
+_TzInfo: TypeAlias = Mapping[str, _TzData] | Callable[[str, int], _TzData]
 
 class parserinfo:
     JUMP: list[str]
@@ -35,13 +37,30 @@ class parser:
         timestr: _FileOrStr,
         default: datetime | None = ...,
         ignoretz: bool = ...,
-        tzinfos: Mapping[str, tzinfo] | None = ...,
+        tzinfos: _TzInfo | None = ...,
+        *,
+        dayfirst: bool | None = ...,
+        yearfirst: bool | None = ...,
+        fuzzy: bool = ...,
+        fuzzy_with_tokens: bool = ...,
         **kwargs: Any,
     ) -> datetime: ...
 
 DEFAULTPARSER: parser
 
-def parse(timestr: _FileOrStr, parserinfo: parserinfo | None = ..., **kwargs: Any) -> datetime: ...
+def parse(
+    timestr: _FileOrStr,
+    parserinfo: parserinfo | None = ...,
+    *,
+    dayfirst: bool | None = ...,
+    yearfirst: bool | None = ...,
+    ignoretz: bool = ...,
+    fuzzy: bool = ...,
+    fuzzy_with_tokens: bool = ...,
+    default: datetime | None = ...,
+    tzinfos: _TzInfo | None = ...,
+    **kwargs: Any,
+) -> datetime: ...
 
 class _tzparser: ...
 


### PR DESCRIPTION
Sorry, @JelleZijlstra for taking this over, but I had a similar task: converting `python-dateutil` to a completed package.

Source https://github.com/dateutil/dateutil/blob/322fa34bc5fafb2e1c725e97909bf490a9dec1c8/src/dateutil/parser/_parser.py

Closes https://github.com/python/typeshed/issues/9122