### PR TITLE
Always use `bool` and `Literal` for Python compat code

### DIFF
--- a/stubs/SQLAlchemy/sqlalchemy/util/compat.pyi
+++ b/stubs/SQLAlchemy/sqlalchemy/util/compat.pyi
@@ -12,6 +12,7 @@ from io import BytesIO as BytesIO, StringIO as StringIO
 from itertools import zip_longest as zip_longest
 from time import perf_counter as perf_counter
 from typing import TYPE_CHECKING as TYPE_CHECKING, Any, NamedTuple
+from typing_extensions import Literal
 from urllib.parse import (
     parse_qsl as parse_qsl,
     quote as quote,
@@ -22,17 +23,17 @@ from urllib.parse import (
 
 byte_buffer = BytesIO
 
-py39: Any
-py38: Any
-py37: Any
-py3k: Any
-py2k: Any
-pypy: Any
-cpython: Any
-win32: Any
-osx: Any
-arm: Any
-has_refcount_gc: Any
+py39: bool
+py38: bool
+py37: bool
+py3k: Literal[True]
+py2k: Literal[False]
+pypy: bool
+cpython: bool
+win32: bool
+osx: bool
+arm: bool
+has_refcount_gc: bool
 contextmanager = contextlib.contextmanager
 dottedgetter = operator.attrgetter
 namedtuple = collections.namedtuple  # noqa: Y024

--- a/stubs/Send2Trash/send2trash/compat.pyi
+++ b/stubs/Send2Trash/send2trash/compat.pyi
@@ -1,6 +1,7 @@
 from typing import Any
+from typing_extensions import Literal
 
-PY3: Any
+PY3: Literal[True]
 text_type = str
 binary_type = bytes
 environb: Any

--- a/stubs/appdirs/appdirs.pyi
+++ b/stubs/appdirs/appdirs.pyi
@@ -1,5 +1,7 @@
+from typing_extensions import Literal
+
 __version_info__: tuple[int, int, int]
-PY3: bool
+PY3: Literal[True]
 unicode = str
 system: str
 

--- a/stubs/aws-xray-sdk/aws_xray_sdk/core/utils/compat.pyi
+++ b/stubs/aws-xray-sdk/aws_xray_sdk/core/utils/compat.pyi
@@ -1,7 +1,8 @@
 from typing import Any
+from typing_extensions import Literal
 
-PY2: Any
-PY35: Any
+PY2: Literal[False]
+PY35: Literal[False]
 annotation_value_types: Any
 string_types = str
 

--- a/stubs/pyinstaller/PyInstaller/compat.pyi
+++ b/stubs/pyinstaller/PyInstaller/compat.pyi
@@ -8,8 +8,8 @@ from typing_extensions import Literal, TypeAlias
 _OpenFile: TypeAlias = StrOrBytesPath | FileDescriptor
 
 is_64bits: bool
-is_py35: bool
-is_py36: bool
+is_py35: Literal[False]
+is_py36: Literal[False]
 is_py37: bool
 is_py38: bool
 is_py39: bool

--- a/stubs/python-crontab/crontab.pyi
+++ b/stubs/python-crontab/crontab.pyi
@@ -6,6 +6,7 @@ from collections.abc import Callable, Generator
 from logging import Logger
 from types import TracebackType
 from typing import Any
+from typing_extensions import Literal
 
 __pkgname__: str
 ITEMREX: re.Pattern[str]
@@ -16,7 +17,7 @@ MONTH_ENUM: list[str | None]
 SPECIALS: dict[str, str]
 SPECIAL_IGNORE: list[str]
 S_INFO: list[dict[str, Any]]
-PY3: bool
+PY3: Literal[True]
 WINOS: bool
 POSIX: bool
 SYSTEMV: bool

--- a/stubs/requests/requests/compat.pyi
+++ b/stubs/requests/requests/compat.pyi
@@ -1,6 +1,6 @@
 from builtins import bytes as bytes, str as str
 from collections import OrderedDict as OrderedDict
-from typing_extensions import TypeAlias
+from typing_extensions import Literal, TypeAlias
 from urllib.parse import (
     quote as quote,
     quote_plus as quote_plus,
@@ -15,8 +15,8 @@ from urllib.parse import (
 )
 from urllib.request import getproxies as getproxies, parse_http_list as parse_http_list, proxy_bypass as proxy_bypass
 
-is_py2: bool
-is_py3: bool
+is_py2: Literal[False]
+is_py3: Literal[True]
 has_simplejson: bool
 
 builtin_str: TypeAlias = str  # noqa: Y042

--- a/stubs/waitress/waitress/compat.pyi
+++ b/stubs/waitress/waitress/compat.pyi
@@ -1,8 +1,9 @@
 from io import TextIOWrapper
 from typing import Any
+from typing_extensions import Literal
 
-PY2: bool
-PY3: bool
+PY2: Literal[False]
+PY3: Literal[True]
 WIN: bool
 string_types: tuple[str]
 integer_types: tuple[int]


### PR DESCRIPTION
When values used for python compat are defined, they are always `bool`. 
But, we can also highlight that some versions are not supported at all: by marking them as `Literal[False]`.