### PR TITLE
colorama: re-export just_fix_windows_console at top level

### DIFF
--- a/stubs/colorama/colorama/__init__.pyi
+++ b/stubs/colorama/colorama/__init__.pyi
@@ -1,3 +1,9 @@
 from .ansi import Back as Back, Cursor as Cursor, Fore as Fore, Style as Style
 from .ansitowin32 import AnsiToWin32 as AnsiToWin32
-from .initialise import colorama_text as colorama_text, deinit as deinit, init as init, reinit as reinit
+from .initialise import (
+    colorama_text as colorama_text,
+    deinit as deinit,
+    init as init,
+    reinit as reinit,
+    just_fix_windows_console as just_fix_windows_console,
+)

--- a/stubs/colorama/colorama/__init__.pyi
+++ b/stubs/colorama/colorama/__init__.pyi
@@ -4,6 +4,6 @@ from .initialise import (
     colorama_text as colorama_text,
     deinit as deinit,
     init as init,
-    reinit as reinit,
     just_fix_windows_console as just_fix_windows_console,
+    reinit as reinit,
 )


### PR DESCRIPTION
Added here: https://github.com/tartley/colorama/pull/352

Re-export can be seen here:

https://github.com/tartley/colorama/blob/21c4b94fe21ce29c85c896ace828da24b7527641/colorama/__init__.py#L2

I don't know why all the exports are "X as X" instead of just "X", but I followed the same style for consistency.