### PR TITLE
Allow adding test cases testing version-dependent Python features

### DIFF
--- a/test_cases/README.md
+++ b/test_cases/README.md
@@ -93,3 +93,17 @@ extensions, and since the tests need to pass on all Python versions >=3.7, PEP
 PEP 585 syntax can also not be used in the `test_cases` directory. Use
 `typing.Tuple` instead of `tuple`, `typing.Callable` instead of
 `collections.abc.Callable`, and `typing.Match` instead of `re.Match` (etc.).
+
+### Version-dependent tests
+
+Some tests will only pass on mypy
+with a specific Python version passed on the command line to the `tests/regr_test.py` script.
+To mark a test-case file as being skippable on lower versions of Python,
+append `-py3*` to the filename.
+For example, if `foo` is a stdlib feature that's new in Python 3.9,
+test cases for `foo` should be put in a file named `test_cases/stdlib/check_foo-py39.py`.
+This means that mypy will only run the test case
+if `--python-version 3.9`, `--python-version 3.10` or `--python-version 3.11`
+is passed on the command line to `tests/regr_test.py`,
+but it *won't* run the test case if `--python-version 3.7` or `--python-version 3.8`
+is passed on the command line.

--- a/tests/regr_test.py
+++ b/tests/regr_test.py
@@ -136,8 +136,9 @@ def test_testcase_directory(package: PackageInfo, version: str, platform: str) -
         # only run the test if --python-version was set to 3.9 or higher (for example)
         for path in new_test_case_dir.rglob("*.py"):
             if match := re.fullmatch(r".*-py3(\d{1,2})", path.stem):
-                assert f"3.{match[1]}" in SUPPORTED_VERSIONS
-                if int(match[1]) <= int(version.split(".")[1]):
+                minor_version_required = int(match[1])
+                assert f"3.{minor_version_required}" in SUPPORTED_VERSIONS
+                if minor_version_required <= int(version.split(".")[1]):
                     flags.append(str(path))
             else:
                 flags.append(str(path))

--- a/tests/regr_test.py
+++ b/tests/regr_test.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -130,7 +131,18 @@ def test_testcase_directory(package: PackageInfo, version: str, platform: str) -
                 shutil.copytree(Path("stubs", requirement), new_typeshed / "stubs" / requirement)
             env_vars["MYPYPATH"] = os.pathsep.join(map(str, new_typeshed.glob("stubs/*")))
             flags.extend(["--custom-typeshed-dir", str(td_path / "typeshed")])
-        result = subprocess.run([sys.executable, "-m", "mypy", new_test_case_dir, *flags], capture_output=True, env=env_vars)
+
+        # If the test-case filename ends with -py39,
+        # only run the test if --python-version was set to 3.9 or higher (for example)
+        for path in new_test_case_dir.rglob("*.py"):
+            if match := re.fullmatch(r".*-py3(\d{1,2})", path.stem):
+                assert f"3.{match[1]}" in SUPPORTED_VERSIONS
+                if int(match[1]) <= int(version.split(".")[1]):
+                    flags.append(str(path))
+            else:
+                flags.append(str(path))
+
+        result = subprocess.run([sys.executable, "-m", "mypy", *flags], capture_output=True, env=env_vars)
 
     if result.returncode:
         print_error("failure\n")


### PR DESCRIPTION
It's currently impossible to add a test case for `ExceptionGroup` or `BaseExceptionGroup`: see #9230. You'd think that you'd be able to just put the test behind an `if sys.version_info >= (3, 11)` guard, and pyright is indeed fine with that. Mypy, however, is not: when you run the test case with `--python-version 3.10`, it complains about many "unused type ignore" comments (it detects the `type: ignore` comments behind the `if sys.version_info >= (3, 11)` guard, even though it considers the whole block unreachable with `--python-version 3.10`, meaning it considers all `type: ignore`s within that block to be "unused").

This PR works around that mypy annoyance. If this PR is merged, the test-case file can simply be renamed to be `test_cases/stdlib/builtins/check_exception_group-py311.py`, and `python tests/regr_test.py --all` should pass.

Cc. @sobolevn