### PR TITLE
Pin `redis` to 4.3.4 in CI

### DIFF
--- a/stubs/redis/METADATA.toml
+++ b/stubs/redis/METADATA.toml
@@ -1,1 +1,1 @@
-version = "4.3.*"
+version = "4.3.4"


### PR DESCRIPTION
We're about to get a daily test failure with 63 stubtest errors (see the Ubuntu stubtest failure in #9187) due to the release of redis-py 4.3.5, and I'd rather that didn't happen.