### PR TITLE
Exclude `stubs/cryptoghraphy` from CI to fix pyright

### DIFF
--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -5,6 +5,10 @@
         "stdlib",
         "stubs"
     ],
+    "exclude": [
+        // `cryptography` stubs are outdated and to be removed
+        "stubs/cryptography"
+    ],
     "typeCheckingMode": "basic",
     "strictListInference": true,
     "strictDictionaryInference": true,


### PR DESCRIPTION
As far as I understand `stubs/cryptography` are outdated.
We ignore it in our `stubtest` runs, but not in our `pyright` runs.

I think these stubs should be ignored for now. And removed later on.

Refs
- https://github.com/python/typeshed/issues/5618
- https://github.com/python/typeshed/issues/9127