### PR TITLE
check_consistent.py: Add check ensuring packages are not installed for unspecified platforms

### DIFF
--- a/tests/check_consistent.py
+++ b/tests/check_consistent.py
@@ -198,9 +198,7 @@ def check_metadata() -> None:
         # Check that only specified platforms install packages:
         for supported_plat in supported_stubtest_platforms:
             if supported_plat not in specified_stubtest_platforms:
-                assert not tool_stubtest.get(
-                    metadata_mapping[supported_plat]
-                ), f"Installing system deps for unspecified platform {supported_plat} for {distribution}"
+                assert metadata_mapping[supported_plat] not in tool_stubtest, f"Installing system deps for unspecified platform {supported_plat} for {distribution}"
 
 
 def get_txt_requirements() -> dict[str, SpecifierSet]:

--- a/tests/check_consistent.py
+++ b/tests/check_consistent.py
@@ -16,10 +16,10 @@ from packaging.requirements import Requirement
 from packaging.specifiers import SpecifierSet
 from packaging.version import Version
 from utils import (
+    METADATA_MAPPING,
     VERSIONS_RE,
     get_all_testcase_directories,
     get_gitignore_spec,
-    METADATA_MAPPING,
     spec_matches_path,
     strip_comments,
 )

--- a/tests/check_consistent.py
+++ b/tests/check_consistent.py
@@ -19,7 +19,7 @@ from utils import (
     VERSIONS_RE,
     get_all_testcase_directories,
     get_gitignore_spec,
-    metadata_mapping,
+    METADATA_MAPPING,
     spec_matches_path,
     strip_comments,
 )
@@ -198,7 +198,7 @@ def check_metadata() -> None:
         # Check that only specified platforms install packages:
         for supported_plat in supported_stubtest_platforms:
             if supported_plat not in specified_stubtest_platforms:
-                assert metadata_mapping[supported_plat] not in tool_stubtest, f"Installing system deps for unspecified platform {supported_plat} for {distribution}"
+                assert METADATA_MAPPING[supported_plat] not in tool_stubtest, f"Installing system deps for unspecified platform {supported_plat} for {distribution}"
 
 
 def get_txt_requirements() -> dict[str, SpecifierSet]:

--- a/tests/check_consistent.py
+++ b/tests/check_consistent.py
@@ -19,9 +19,9 @@ from utils import (
     VERSIONS_RE,
     get_all_testcase_directories,
     get_gitignore_spec,
+    metadata_mapping,
     spec_matches_path,
     strip_comments,
-    metadata_mapping,
 )
 
 metadata_keys = {

--- a/tests/check_consistent.py
+++ b/tests/check_consistent.py
@@ -15,7 +15,14 @@ import yaml
 from packaging.requirements import Requirement
 from packaging.specifiers import SpecifierSet
 from packaging.version import Version
-from utils import VERSIONS_RE, get_all_testcase_directories, get_gitignore_spec, spec_matches_path, strip_comments
+from utils import (
+    VERSIONS_RE,
+    get_all_testcase_directories,
+    get_gitignore_spec,
+    spec_matches_path,
+    strip_comments,
+    metadata_mapping,
+)
 
 metadata_keys = {
     "version",
@@ -182,10 +189,18 @@ def check_metadata() -> None:
             for key in data.get("tool", {}).get(tool, {}):
                 assert key in tk, f"Unrecognised {tool} key {key} for {distribution}"
 
-        specified_stubtest_platforms = set(data.get("tool", {}).get("stubtest", {}).get("platforms", []))
+        tool_stubtest = data.get("tool", {}).get("stubtest", {})
+        specified_stubtest_platforms = set(tool_stubtest.get("platforms", []))
         assert (
             specified_stubtest_platforms <= supported_stubtest_platforms
         ), f"Unrecognised platforms specified: {supported_stubtest_platforms - specified_stubtest_platforms}"
+
+        # Check that only specified platforms install packages:
+        for supported_plat in supported_stubtest_platforms:
+            if supported_plat not in specified_stubtest_platforms:
+                assert not tool_stubtest.get(
+                    metadata_mapping[supported_plat]
+                ), f"Installing system deps for unspecified platform {supported_plat} for {distribution}"
 
 
 def get_txt_requirements() -> dict[str, SpecifierSet]:

--- a/tests/get_packages.py
+++ b/tests/get_packages.py
@@ -3,15 +3,15 @@ import os
 import sys
 
 import tomli
-from utils import metadata_mapping
+from utils import METADATA_MAPPING
 
 platform = sys.platform
 distributions = sys.argv[1:]
 if not distributions:
     distributions = os.listdir("stubs")
 
-if platform in metadata_mapping:
+if platform in METADATA_MAPPING:
     for distribution in distributions:
         with open(f"stubs/{distribution}/METADATA.toml", "rb") as file:
-            for package in tomli.load(file).get("tool", {}).get("stubtest", {}).get(metadata_mapping[platform], []):
+            for package in tomli.load(file).get("tool", {}).get("stubtest", {}).get(METADATA_MAPPING[platform], []):
                 print(package)

--- a/tests/get_packages.py
+++ b/tests/get_packages.py
@@ -4,12 +4,12 @@ import sys
 
 import tomli
 
+from utils import metadata_mapping
+
 platform = sys.platform
 distributions = sys.argv[1:]
 if not distributions:
     distributions = os.listdir("stubs")
-
-metadata_mapping = {"linux": "apt_dependencies", "darwin": "brew_dependencies", "win32": "choco_dependencies"}
 
 if platform in metadata_mapping:
     for distribution in distributions:

--- a/tests/get_packages.py
+++ b/tests/get_packages.py
@@ -3,7 +3,6 @@ import os
 import sys
 
 import tomli
-
 from utils import metadata_mapping
 
 platform = sys.platform

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -12,6 +12,9 @@ from typing import NamedTuple
 import pathspec  # type: ignore[import]
 import tomli
 
+# Used to install system-wide packages for different OS types:
+metadata_mapping = {"linux": "apt_dependencies", "darwin": "brew_dependencies", "win32": "choco_dependencies"}
+
 
 def strip_comments(text: str) -> str:
     return text.split("#")[0].strip()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -13,7 +13,7 @@ import pathspec  # type: ignore[import]
 import tomli
 
 # Used to install system-wide packages for different OS types:
-metadata_mapping = {"linux": "apt_dependencies", "darwin": "brew_dependencies", "win32": "choco_dependencies"}
+METADATA_MAPPING = {"linux": "apt_dependencies", "darwin": "brew_dependencies", "win32": "choco_dependencies"}
 
 
 def strip_comments(text: str) -> str:


### PR DESCRIPTION
I've missed this during review, good ideas always come late.

Right now we can install deps if they are specified for any platform.
Even if it is not tested. This can consume time of workers and lead to errors.

This PR allows:

```toml
platforms = ["linux", "win32"]
apt_dependencies = ["one"]
# brew_dependencies = ["some"]
```

```toml
platforms = ["linux", "win32"]
brew_dependencies = []
```

(I can remove ^ this)

But not:

```toml
platforms = ["linux", "win32"]
brew_dependencies = ["some"]
```

Refs https://github.com/python/typeshed/pull/9187