### PR TITLE
regex: fix type signatures using Scanner

### DIFF
--- a/stubs/regex/regex/regex.pyi
+++ b/stubs/regex/regex/regex.pyi
@@ -182,7 +182,7 @@ def finditer(
     timeout: float | None = ...,
     ignore_unused: bool = ...,
     **kwargs: Any,
-) -> Scanner[str]: ...
+) -> _regex.Scanner[str]: ...
 @overload
 def finditer(
     pattern: ReadableBuffer | Pattern[bytes],
@@ -196,7 +196,7 @@ def finditer(
     timeout: float | None = ...,
     ignore_unused: bool = ...,
     **kwargs: Any,
-) -> Scanner[bytes]: ...
+) -> _regex.Scanner[bytes]: ...
 @overload
 def sub(
     pattern: str | Pattern[str],
@@ -438,7 +438,7 @@ class Pattern(Generic[AnyStr]):
         overlapped: bool = ...,
         concurrent: bool | None = ...,
         timeout: float | None = ...,
-    ) -> Scanner[str]: ...
+    ) -> _regex.Scanner[str]: ...
     @overload
     def finditer(
         self: Pattern[bytes],
@@ -448,7 +448,7 @@ class Pattern(Generic[AnyStr]):
         overlapped: bool = ...,
         concurrent: bool | None = ...,
         timeout: float | None = ...,
-    ) -> Scanner[bytes]: ...
+    ) -> _regex.Scanner[bytes]: ...
     @overload
     def sub(
         self: Pattern[str],
@@ -554,7 +554,7 @@ class Pattern(Generic[AnyStr]):
         overlapped: bool = ...,
         concurrent: bool | None = ...,
         timeout: float | None = ...,
-    ) -> Scanner[str]: ...
+    ) -> _regex.Scanner[str]: ...
     @overload
     def scanner(
         self: Pattern[bytes],
@@ -564,7 +564,7 @@ class Pattern(Generic[AnyStr]):
         overlapped: bool = ...,
         concurrent: bool | None = ...,
         timeout: float | None = ...,
-    ) -> Scanner[bytes]: ...
+    ) -> _regex.Scanner[bytes]: ...
     def __copy__(self: Self) -> Self: ...
     def __deepcopy__(self: Self) -> Self: ...
     if sys.version_info >= (3, 9):


### PR DESCRIPTION
There are two type stubs for `Scanner` in the regex module:

- `regex._regex.Scanner`
- `regex._regex_core.Scanner`

Currently, the typeshed stubs for `regex` use `regex._regex_core.Scanner`, but it should be `regex._regex.Scanner`.

This can be seen by inspecting the properties of the returned objects of the `regex` runtime:

```python
>>> import regex
>>> dir(regex.compile(".*").finditer("foo"))
[..., '__iter__', '__next__', 'match', 'pattern', 'search']
>>> dir(regex.compile(".*").scanner("foo"))
[..., '__iter__', '__next__', 'match', 'pattern', 'search']
>>> dir(regex.finditer(".*", "foo"))
[..., '__iter__', '__next__', 'match', 'pattern', 'search']
```

---

This PR is the minimal change to make mypy happy with, e.g.

```python
import regex

rx = regex.compile("foo|bar")
matches = list(rx.finditer("foo"))
print(matches)  # [<regex.Match object; span=(0, 3), match='foo'>]
```

Which currently fails typechecking with the following output, as `mypy` does not think `Scanner` is an `Iterable`, due to not having an `__iter__` property:

```log
repro.py:4: error: No overload variant of "list" matches argument type "Scanner[str]"  [call-overload]
repro.py:4: note: Possible overload variants:
repro.py:4: note:     def [_T] __init__(self) -> List[_T]
repro.py:4: note:     def [_T] __init__(self, Iterable[_T], /) -> List[_T]
Found 1 error in 1 file (checked 1 source file)
```