### PR TITLE
Add test case for recent `types-regex` regression

### DIFF
--- a/stubs/regex/@tests/test_cases/check_finditer.py
+++ b/stubs/regex/@tests/test_cases/check_finditer.py
@@ -1,0 +1,13 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=true
+
+from __future__ import annotations
+
+from typing import List
+from typing_extensions import assert_type
+
+import regex
+
+# Regression tests for #9263
+assert_type(list(regex.finditer(r"foo", "foo")), List[regex.Match[str]])
+pat = regex.compile(rb"foo")
+assert_type(list(pat.finditer(b"foo")), List[regex.Match[bytes]])


### PR DESCRIPTION
As @sobolevn says, the fact that there are two `Scanner` classes in the `regex` package is pretty confusing. Let's add a test case to ensure that #9263 doesn't happen again.