### PR TITLE
Minor improvements to `tests/regr_test.py`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -99,7 +99,7 @@ jobs:
           cache: pip
           cache-dependency-path: requirements-tests.txt
       - run: pip install -r requirements-tests.txt
-      - run: python ./tests/regr_test.py --all
+      - run: python ./tests/regr_test.py --all --quiet
 
   pyright:
     name: Test typeshed with pyright

--- a/tests/regr_test.py
+++ b/tests/regr_test.py
@@ -37,6 +37,8 @@ def package_with_test_cases(package_name: str) -> PackageInfo:
         return PackageInfo("stdlib", Path("test_cases"))
     test_case_dir = testcase_dir_from_package_name(package_name)
     if test_case_dir.is_dir():
+        if not os.listdir(test_case_dir):
+            raise argparse.ArgumentTypeError(f"{package_name!r} has a 'test_cases' directory but it is empty!")
         return PackageInfo(package_name, test_case_dir)
     raise argparse.ArgumentTypeError(f"No test cases found for {package_name!r}!")
 
@@ -57,6 +59,7 @@ parser.add_argument(
         "Note that this cannot be specified if --platform and/or --python-version are specified."
     ),
 )
+parser.add_argument("--quiet", action="store_true", help="Print less output to the terminal")
 parser.add_argument(
     "--platform",
     dest="platforms_to_test",
@@ -82,13 +85,14 @@ parser.add_argument(
 )
 
 
-def test_testcase_directory(package: PackageInfo, version: str, platform: str) -> ReturnCode:
+def test_testcase_directory(package: PackageInfo, version: str, platform: str, quiet: bool) -> ReturnCode:
     package_name, test_case_directory = package
     is_stdlib = package_name == "stdlib"
 
-    msg = f"Running mypy --platform {platform} --python-version {version} on the "
-    msg += "standard library test cases..." if is_stdlib else f"test cases for {package_name!r}..."
-    print(msg, end=" ")
+    if not quiet:
+        msg = f"Running mypy --platform {platform} --python-version {version} on the "
+        msg += "standard library test cases..." if is_stdlib else f"test cases for {package_name!r}..."
+        print(msg, end=" ")
 
     flags = [
         "--python-version",
@@ -152,7 +156,7 @@ def test_testcase_directory(package: PackageInfo, version: str, platform: str) -
             print_error(result.stderr.decode(), fix_path=replacements)
         if result.stdout:
             print_error(result.stdout.decode(), fix_path=replacements)
-    else:
+    elif not quiet:
         print_success_msg()
     return result.returncode
 
@@ -163,9 +167,9 @@ def main() -> ReturnCode:
     testcase_directories = args.packages_to_test or get_all_testcase_directories()
     if args.all:
         if args.platforms_to_test:
-            raise TypeError("Cannot specify both --platform and --all")
+            parser.error("Cannot specify both --platform and --all")
         if args.versions_to_test:
-            raise TypeError("Cannot specify both --python-version and --all")
+            parser.error("Cannot specify both --python-version and --all")
         platforms_to_test, versions_to_test = SUPPORTED_PLATFORMS, SUPPORTED_VERSIONS
     else:
         platforms_to_test = args.platforms_to_test or [sys.platform]
@@ -173,7 +177,7 @@ def main() -> ReturnCode:
 
     code = 0
     for platform, version, directory in product(platforms_to_test, versions_to_test, testcase_directories):
-        code = max(code, test_testcase_directory(directory, version, platform))
+        code = max(code, test_testcase_directory(directory, version, platform, args.quiet))
     if code:
         print_error("\nTest completed with errors")
     else:

--- a/tests/regr_test.py
+++ b/tests/regr_test.py
@@ -104,6 +104,7 @@ def test_testcase_directory(package: PackageInfo, version: str, platform: str, q
         platform,
         "--no-site-packages",
         "--strict",
+        "--pretty",
     ]
 
     # --warn-unused-ignores doesn't work for files inside typeshed.


### PR DESCRIPTION
As the number of third-party stubs with test cases grows, the output in CI is getting kind of noisy (e.g. https://github.com/python/typeshed/actions/runs/3547587578/jobs/5957872274). Add a `--quiet` option, and use it in CI, to limit the amount of stuff that's printed to the terminal.

Also add slightly better error handling in a few places. Lastly, add the `--pretty` flag when running mypy, so it's easy to see where the errors are, if there are any.