### PR TITLE
Clarify how `*_exclude_list.txt` files work

### DIFF
--- a/tests/pyright_exclude_list.txt
+++ b/tests/pyright_exclude_list.txt
@@ -1,3 +1,0 @@
-Pyright is configured using a "pyrightconfig.json" file. You will find
-it at the root of the repo. It contains an "exclude" section that accepts
-globs for specifying which files and/or directories to exclude from analysis.

--- a/tests/pytype_exclude_list.txt
+++ b/tests/pytype_exclude_list.txt
@@ -1,4 +1,5 @@
 # Pytype exclude list. Files will not be tested with pytype.
+# Its path and name is hardcoded into `pytype` itself, see `load_pytype_blocklist` method in `pytype`.
 
 # pytype has its own version of these files, and thus doesn't mind if it
 # can't parse the typeshed version:


### PR DESCRIPTION
Pyright does not need this file at all. It is there just as a doc, I guess? There's no need for it.

Pytype has its path hardcoded into its codebase:

```python
def load_pytype_blocklist(self) -> List[str]:
    """List of modules that we maintain our own versions of."""
    return self._readlines("tests/pytype_exclude_list.txt")
```