### PR TITLE
PIL: add optimize param to save

### DIFF
--- a/stubs/Pillow/PIL/Image.pyi
+++ b/stubs/Pillow/PIL/Image.pyi
@@ -238,6 +238,7 @@ class Image:
         *,
         save_all: bool = ...,
         bitmap_format: Literal["bmp", "png"] = ...,  # for ICO files
+        optimize: bool = ...,
         **params: Any,
     ) -> None: ...
     def seek(self, frame: int) -> None: ...


### PR DESCRIPTION
This option is covered in https://github.com/python-pillow/Pillow/blob/6a2545f628b13bc4888f687c1028482fc93fafcf/docs/handbook/tutorial.rst#batch-processing

but it is pulled out of the `**params` by the `jpeg` plugin (and probably others as well)

example usage:

```python
im.save(path, optimize=True)
```

rel: https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html#jpeg-saving