### PR TITLE
PIL: fix image convert palette type

### DIFF
--- a/stubs/Pillow/PIL/Image.pyi
+++ b/stubs/Pillow/PIL/Image.pyi
@@ -178,7 +178,7 @@ class Image:
         mode: _Mode | None = ...,
         matrix: _ConversionMatrix | None = ...,
         dither: int | None = ...,
-        palette: Literal[Palette.WEB] = ...,
+        palette: Palette | Literal[0, 1] = ...,
         colors: int = ...,
     ) -> Image: ...
     def quantize(


### PR DESCRIPTION
Hello,

The `PIL.Image.Image.convert` method should accept `Palette.WEB` or `Palette.ADAPTIVE` as possible values for the `palette` parameter.