### PR TITLE
Don't run `mypy_primer` on stubsabot PRs

### DIFF
--- a/.github/workflows/mypy_primer.yml
+++ b/.github/workflows/mypy_primer.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     paths:
     - 'stdlib/**'
-    - 'stubs/**'
+    - 'stubs/**/*.pyi'
     - '.github/workflows/mypy_primer.yml'
     - '.github/workflows/mypy_primer_comment.yml'
 


### PR DESCRIPTION
We can be fairly confident that PRs updating only a `METADATA.toml` file will never produce an interesting `mypy_primer` diff.