### PR TITLE
`mypy_primer`: Run on Python 3.11

### DIFF
--- a/.github/workflows/mypy_primer.yml
+++ b/.github/workflows/mypy_primer.yml
@@ -31,7 +31,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Install dependencies
         run: pip install git+https://github.com/hauntsaninja/mypy_primer.git
       - name: Run mypy_primer


### PR DESCRIPTION
`mypy_primer` currently runs on Python 3.10 in CI, meaning we don't have any `mypy_primer` coverage for PRs fiddling with `ExceptionGroup`s or other new features added in Python 3.11