### PR TITLE
Use `Literal` for `compression` in `zipfile`

### DIFF
--- a/stdlib/zipfile.pyi
+++ b/stdlib/zipfile.pyi
@@ -275,10 +275,10 @@ if sys.version_info >= (3, 8):
 
 def is_zipfile(filename: StrOrBytesPath | _SupportsReadSeekTell) -> bool: ...
 
-ZIP_STORED: int
-ZIP_DEFLATED: int
-ZIP64_LIMIT: int
-ZIP_FILECOUNT_LIMIT: int
-ZIP_MAX_COMMENT: int
-ZIP_BZIP2: int
-ZIP_LZMA: int
+ZIP_STORED: Literal[0]
+ZIP_DEFLATED: Literal[8]
+ZIP64_LIMIT: Literal[2147483647]
+ZIP_FILECOUNT_LIMIT: Literal[65535]
+ZIP_MAX_COMMENT: Literal[65535]
+ZIP_BZIP2: Literal[12]
+ZIP_LZMA: Literal[14]

--- a/stdlib/zipfile.pyi
+++ b/stdlib/zipfile.pyi
@@ -277,8 +277,8 @@ def is_zipfile(filename: StrOrBytesPath | _SupportsReadSeekTell) -> bool: ...
 
 ZIP_STORED: Literal[0]
 ZIP_DEFLATED: Literal[8]
-ZIP64_LIMIT: Literal[2147483647]
-ZIP_FILECOUNT_LIMIT: Literal[65535]
-ZIP_MAX_COMMENT: Literal[65535]
+ZIP64_LIMIT: int
+ZIP_FILECOUNT_LIMIT: int
+ZIP_MAX_COMMENT: int
 ZIP_BZIP2: Literal[12]
 ZIP_LZMA: Literal[14]

--- a/stdlib/zipfile.pyi
+++ b/stdlib/zipfile.pyi
@@ -29,6 +29,7 @@ _DateTuple: TypeAlias = tuple[int, int, int, int, int, int]
 _ReadWriteMode: TypeAlias = Literal["r", "w"]
 _ReadWriteBinaryMode: TypeAlias = Literal["r", "w", "rb", "wb"]
 _ZipFileMode: TypeAlias = Literal["r", "w", "x", "a"]
+_CompressionMode: TypeAlias = Literal[0, 8, 12, 14]
 
 class BadZipFile(Exception): ...
 
@@ -100,7 +101,7 @@ class ZipFile:
     fp: IO[bytes] | None
     NameToInfo: dict[str, ZipInfo]
     start_dir: int  # undocumented
-    compression: int  # undocumented
+    compression: _CompressionMode  # undocumented
     compresslevel: int | None  # undocumented
     mode: _ZipFileMode  # undocumented
     pwd: bytes | None  # undocumented
@@ -110,7 +111,7 @@ class ZipFile:
             self,
             file: StrPath | IO[bytes],
             mode: Literal["r"] = ...,
-            compression: int = ...,
+            compression: _CompressionMode = ...,
             allowZip64: bool = ...,
             compresslevel: int | None = ...,
             *,
@@ -122,7 +123,7 @@ class ZipFile:
             self,
             file: StrPath | IO[bytes],
             mode: _ZipFileMode = ...,
-            compression: int = ...,
+            compression: _CompressionMode = ...,
             allowZip64: bool = ...,
             compresslevel: int | None = ...,
             *,
@@ -134,7 +135,7 @@ class ZipFile:
             self,
             file: StrPath | IO[bytes],
             mode: _ZipFileMode = ...,
-            compression: int = ...,
+            compression: _CompressionMode = ...,
             allowZip64: bool = ...,
             compresslevel: int | None = ...,
             *,
@@ -145,7 +146,7 @@ class ZipFile:
             self,
             file: StrPath | IO[bytes],
             mode: _ZipFileMode = ...,
-            compression: int = ...,
+            compression: _CompressionMode = ...,
             allowZip64: bool = ...,
             compresslevel: int | None = ...,
         ) -> None: ...
@@ -184,14 +185,19 @@ class ZipFile:
 
 class PyZipFile(ZipFile):
     def __init__(
-        self, file: str | IO[bytes], mode: _ZipFileMode = ..., compression: int = ..., allowZip64: bool = ..., optimize: int = ...
+        self,
+        file: str | IO[bytes],
+        mode: _ZipFileMode = ...,
+        compression: _CompressionMode = ...,
+        allowZip64: bool = ...,
+        optimize: int = ...,
     ) -> None: ...
     def writepy(self, pathname: str, basename: str = ..., filterfunc: Callable[[str], bool] | None = ...) -> None: ...
 
 class ZipInfo:
     filename: str
     date_time: _DateTuple
-    compress_type: int
+    compress_type: _CompressionMode
     comment: bytes
     extra: bytes
     create_system: int


### PR DESCRIPTION
According to [docs](https://docs.python.org/3/library/zipfile.html?highlight=zipfile#zipfile.ZipFile):

> compression is the ZIP compression method to use when writing the archive, and should be [ZIP_STORED](https://docs.python.org/3/library/zipfile.html?highlight=zipfile#zipfile.ZIP_STORED), [ZIP_DEFLATED](https://docs.python.org/3/library/zipfile.html?highlight=zipfile#zipfile.ZIP_DEFLATED), [ZIP_BZIP2](https://docs.python.org/3/library/zipfile.html?highlight=zipfile#zipfile.ZIP_BZIP2) or [ZIP_LZMA](https://docs.python.org/3/library/zipfile.html?highlight=zipfile#zipfile.ZIP_LZMA); unrecognized values will cause [NotImplementedError](https://docs.python.org/3/library/exceptions.html#NotImplementedError) to be raised.

`Literal` could be used for the `compresslevel` parameter as well:

> The compresslevel parameter controls the compression level to use when writing files to the archive. When using [ZIP_STORED](https://docs.python.org/3/library/zipfile.html?highlight=zipfile#zipfile.ZIP_STORED) or [ZIP_LZMA](https://docs.python.org/3/library/zipfile.html?highlight=zipfile#zipfile.ZIP_LZMA) it has no effect. When using [ZIP_DEFLATED](https://docs.python.org/3/library/zipfile.html?highlight=zipfile#zipfile.ZIP_DEFLATED) integers 0 through 9 are accepted (see [zlib](https://docs.python.org/3/library/zlib.html#zlib.compressobj) for more information). When using [ZIP_BZIP2](https://docs.python.org/3/library/zipfile.html?highlight=zipfile#zipfile.ZIP_BZIP2) integers 1 through 9 are accepted (see [bz2](https://docs.python.org/3/library/bz2.html#bz2.BZ2File) for more information).

But this would require extra overloads for each `compression` value, so considering the fact that there's already a split between `3.8` and `3.11` this would make things more complicated.

Note: We could use `Literal` for the module constants, e.g. `ZIP_STORED`, `ZIP_DEFLATED`, etc. I can add another commit to this PR if required.