### PR TITLE
Fix issue #9296 (calling register on KeysView subclass causes false positive error)

### DIFF
--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -804,7 +804,7 @@ class bytearray(MutableSequence[int], ByteString):
     def __alloc__(self) -> int: ...
 
 @final
-class memoryview(Sized, Sequence[int]):
+class memoryview(Sequence[int]):
     @property
     def format(self) -> str: ...
     @property

--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -804,7 +804,7 @@ class bytearray(MutableSequence[int], ByteString):
     def __alloc__(self) -> int: ...
 
 @final
-class memoryview(Sequence[int]):
+class memoryview(Sized, Sequence[int]):
     @property
     def format(self) -> str: ...
     @property

--- a/stdlib/typing.pyi
+++ b/stdlib/typing.pyi
@@ -325,7 +325,7 @@ class SupportsRound(Protocol[_T_co]):
     def __round__(self, __ndigits: int) -> _T_co: ...
 
 @runtime_checkable
-class Sized(Protocol):
+class Sized(Protocol, metaclass=ABCMeta):
     @abstractmethod
     def __len__(self) -> int: ...
 

--- a/stdlib/typing.pyi
+++ b/stdlib/typing.pyi
@@ -452,7 +452,10 @@ class Container(Protocol[_T_co]):
     def __contains__(self, __x: object) -> bool: ...
 
 @runtime_checkable
-class Collection(Sized, Iterable[_T_co], Container[_T_co], Protocol[_T_co]): ...
+class Collection(Iterable[_T_co], Container[_T_co], Protocol[_T_co]):
+    # Implement Sized (but don't have it as a base class).
+    @abstractmethod
+    def __len__(self) -> int: ...
 
 class Sequence(Collection[_T_co], Reversible[_T_co], Generic[_T_co]):
     @overload

--- a/test_cases/stdlib/typing/check_regression_issue_9296.py
+++ b/test_cases/stdlib/typing/check_regression_issue_9296.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import typing as t
 
-
 KT = t.TypeVar("KT")
 
 
@@ -15,4 +14,3 @@ dict_keys = type(d.keys())
 
 # This should not cause an error like `Member "register" is unknown`:
 MyKeysView.register(dict_keys)
-

--- a/test_cases/stdlib/typing/check_regression_issue_9296.py
+++ b/test_cases/stdlib/typing/check_regression_issue_9296.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import typing as t
+
+
+KT = t.TypeVar("KT")
+
+
+class MyKeysView(t.KeysView[KT]):
+    pass
+
+
+d: dict[t.Any, t.Any] = {}
+dict_keys = type(d.keys())
+
+# This should not cause an error like `Member "register" is unknown`:
+MyKeysView.register(dict_keys)
+


### PR DESCRIPTION
As per discussion in #9296, this PR reverts the commits in #8977 and #9058 that resulted in false positive errors when e.g. calling register() on a KeysView subclass, until a non-buggy implementation is landed. This also adds a regression test.