### PR TITLE
`regr_test.py`: improve interaction between `--all` and `--quiet` flags

### DIFF
--- a/test_cases/stdlib/typing/check_regression_issue_9296.py
+++ b/test_cases/stdlib/typing/check_regression_issue_9296.py
@@ -13,4 +13,4 @@ d: dict[t.Any, t.Any] = {}
 dict_keys = type(d.keys())
 
 # This should not cause an error like `Member "register" is unknown`:
-MyKeysView.regixster(dict_keys)
+MyKeysView.register(dict_keys)

--- a/test_cases/stdlib/typing/check_regression_issue_9296.py
+++ b/test_cases/stdlib/typing/check_regression_issue_9296.py
@@ -13,4 +13,4 @@ d: dict[t.Any, t.Any] = {}
 dict_keys = type(d.keys())
 
 # This should not cause an error like `Member "register" is unknown`:
-MyKeysView.register(dict_keys)
+MyKeysView.regixster(dict_keys)

--- a/tests/regr_test.py
+++ b/tests/regr_test.py
@@ -89,9 +89,9 @@ def test_testcase_directory(package: PackageInfo, version: str, platform: str, q
     package_name, test_case_directory = package
     is_stdlib = package_name == "stdlib"
 
+    msg = f"Running mypy --platform {platform} --python-version {version} on the "
+    msg += "standard library test cases..." if is_stdlib else f"test cases for {package_name!r}..."
     if not quiet:
-        msg = f"Running mypy --platform {platform} --python-version {version} on the "
-        msg += "standard library test cases..." if is_stdlib else f"test cases for {package_name!r}..."
         print(msg, end=" ")
 
     # "--enable-error-code ignore-without-code" is purposefully ommited. See https://github.com/python/typeshed/pull/8083
@@ -152,6 +152,11 @@ def test_testcase_directory(package: PackageInfo, version: str, platform: str, q
         result = subprocess.run([sys.executable, "-m", "mypy", *flags], capture_output=True, env=env_vars)
 
     if result.returncode:
+        if quiet:
+            # We'll already have printed this if --quiet wasn't passed.
+            # If--quiet was passed, only print this if there were errors.
+            # If there are errors, the output is inscrutable if this isn't printed.
+            print(msg, end=" ")
         print_error("failure\n")
         replacements = (str(new_test_case_dir), str(test_case_directory))
         if result.stderr:


### PR DESCRIPTION
cf. #9348 cc @jab