### PR TITLE
Stdlib stubtest: Temporarily pin Python to 3.10.8 and 3.11.0 in CI

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -30,7 +30,7 @@ jobs:
       matrix:
         # tkinter doesn't import on macOS-12
         os: ["ubuntu-latest", "windows-latest", "macos-11"]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10.8", "3.11.0"]
       fail-fast: false
 
     steps:

--- a/.github/workflows/stubtest_stdlib.yml
+++ b/.github/workflows/stubtest_stdlib.yml
@@ -30,7 +30,7 @@ jobs:
       matrix:
         # tkinter doesn't import on macOS 12
         os: ["ubuntu-latest", "windows-latest", "macos-11"]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10.8", "3.11.0"]
       fail-fast: false
 
     steps:


### PR DESCRIPTION
Python 3.10.9 and 3.11.1 were recently released. They have some differences to 3.10.8 and 3.11.0, which have been causing our stdlib stubtest to intermittently fail today:

- https://github.com/python/typeshed/actions/runs/3697681779/jobs/6262969113
- https://github.com/python/typeshed/actions/runs/3693960198/jobs/6254570009

Pin Python to 3.10.8 and 3.11.0 in CI for now, until we can rely on GitHub runners picking up 3.10.9 and 3.11.1 when "3.10" and "3.11" are specified.