### PR TITLE
shutil.rmtree: add avoids_symlink_attacks attribute

### DIFF
--- a/stdlib/shutil.pyi
+++ b/stdlib/shutil.pyi
@@ -88,7 +88,12 @@ class _RmtreeType(Protocol):
     avoids_symlink_attacks: bool
     if sys.version_info >= (3, 11):
         def __call__(
-            self, path: StrOrBytesPath, ignore_errors: bool = ..., onerror: _OnErrorCallback | None = ..., *, dir_fd: int | None = ...
+            self,
+            path: StrOrBytesPath,
+            ignore_errors: bool = ...,
+            onerror: _OnErrorCallback | None = ...,
+            *,
+            dir_fd: int | None = ...,
         ) -> None: ...
 
     else:

--- a/stdlib/shutil.pyi
+++ b/stdlib/shutil.pyi
@@ -2,7 +2,7 @@ import os
 import sys
 from _typeshed import BytesPath, StrOrBytesPath, StrPath, SupportsRead, SupportsWrite
 from collections.abc import Callable, Iterable, Sequence
-from typing import Any, AnyStr, NamedTuple, TypeVar, overload
+from typing import Any, AnyStr, NamedTuple, Protocol, TypeVar, overload
 from typing_extensions import TypeAlias
 
 __all__ = [
@@ -84,13 +84,17 @@ else:
 
 _OnErrorCallback: TypeAlias = Callable[[Callable[..., Any], Any, Any], object]
 
-if sys.version_info >= (3, 11):
-    def rmtree(
-        path: StrOrBytesPath, ignore_errors: bool = ..., onerror: _OnErrorCallback | None = ..., *, dir_fd: int | None = ...
-    ) -> None: ...
+class _RmtreeType(Protocol):
+    avoids_symlink_attacks: bool
+    if sys.version_info >= (3, 11):
+        def __call__(
+            self, path: StrOrBytesPath, ignore_errors: bool = ..., onerror: _OnErrorCallback | None = ..., *, dir_fd: int | None = ...
+        ) -> None: ...
 
-else:
-    def rmtree(path: StrOrBytesPath, ignore_errors: bool = ..., onerror: _OnErrorCallback | None = ...) -> None: ...
+    else:
+        def __call__(self, path: StrOrBytesPath, ignore_errors: bool = ..., onerror: _OnErrorCallback | None = ...) -> None: ...
+
+rmtree: _RmtreeType
 
 _CopyFn: TypeAlias = Callable[[str, str], object] | Callable[[StrPath, StrPath], object]
 

--- a/tests/stubtest_allowlists/py3_common.txt
+++ b/tests/stubtest_allowlists/py3_common.txt
@@ -165,6 +165,7 @@ poplib.POP3_SSL.stls  # bad declaration of inherited function. See poplib.pyi
 pyexpat.expat_CAPI
 select.poll  # Depends on configuration
 selectors.DevpollSelector  # Depends on configuration
+shutil.rmtree  # stubtest doesn't like that we have this as an instance of a callback protocol instead of a function
 socketserver.BaseServer.RequestHandlerClass  # is defined as a property, because we need `Self` type
 socketserver.BaseServer.fileno  # implemented in derived classes
 socketserver.BaseServer.get_request  # implemented in derived classes


### PR DESCRIPTION
Fixes #9365