### PR TITLE
Revert "Use `Literal` for `compression` in `zipfile` (#9346)"

### DIFF
--- a/stdlib/zipfile.pyi
+++ b/stdlib/zipfile.pyi
@@ -29,7 +29,6 @@ _DateTuple: TypeAlias = tuple[int, int, int, int, int, int]
 _ReadWriteMode: TypeAlias = Literal["r", "w"]
 _ReadWriteBinaryMode: TypeAlias = Literal["r", "w", "rb", "wb"]
 _ZipFileMode: TypeAlias = Literal["r", "w", "x", "a"]
-_CompressionMode: TypeAlias = Literal[0, 8, 12, 14]
 
 class BadZipFile(Exception): ...
 
@@ -101,7 +100,7 @@ class ZipFile:
     fp: IO[bytes] | None
     NameToInfo: dict[str, ZipInfo]
     start_dir: int  # undocumented
-    compression: _CompressionMode  # undocumented
+    compression: int  # undocumented
     compresslevel: int | None  # undocumented
     mode: _ZipFileMode  # undocumented
     pwd: bytes | None  # undocumented
@@ -111,7 +110,7 @@ class ZipFile:
             self,
             file: StrPath | IO[bytes],
             mode: Literal["r"] = ...,
-            compression: _CompressionMode = ...,
+            compression: int = ...,
             allowZip64: bool = ...,
             compresslevel: int | None = ...,
             *,
@@ -123,7 +122,7 @@ class ZipFile:
             self,
             file: StrPath | IO[bytes],
             mode: _ZipFileMode = ...,
-            compression: _CompressionMode = ...,
+            compression: int = ...,
             allowZip64: bool = ...,
             compresslevel: int | None = ...,
             *,
@@ -135,7 +134,7 @@ class ZipFile:
             self,
             file: StrPath | IO[bytes],
             mode: _ZipFileMode = ...,
-            compression: _CompressionMode = ...,
+            compression: int = ...,
             allowZip64: bool = ...,
             compresslevel: int | None = ...,
             *,
@@ -146,7 +145,7 @@ class ZipFile:
             self,
             file: StrPath | IO[bytes],
             mode: _ZipFileMode = ...,
-            compression: _CompressionMode = ...,
+            compression: int = ...,
             allowZip64: bool = ...,
             compresslevel: int | None = ...,
         ) -> None: ...
@@ -185,19 +184,14 @@ class ZipFile:
 
 class PyZipFile(ZipFile):
     def __init__(
-        self,
-        file: str | IO[bytes],
-        mode: _ZipFileMode = ...,
-        compression: _CompressionMode = ...,
-        allowZip64: bool = ...,
-        optimize: int = ...,
+        self, file: str | IO[bytes], mode: _ZipFileMode = ..., compression: int = ..., allowZip64: bool = ..., optimize: int = ...
     ) -> None: ...
     def writepy(self, pathname: str, basename: str = ..., filterfunc: Callable[[str], bool] | None = ...) -> None: ...
 
 class ZipInfo:
     filename: str
     date_time: _DateTuple
-    compress_type: _CompressionMode
+    compress_type: int
     comment: bytes
     extra: bytes
     create_system: int
@@ -275,10 +269,10 @@ if sys.version_info >= (3, 8):
 
 def is_zipfile(filename: StrOrBytesPath | _SupportsReadSeekTell) -> bool: ...
 
-ZIP_STORED: Literal[0]
-ZIP_DEFLATED: Literal[8]
+ZIP_STORED: int
+ZIP_DEFLATED: int
 ZIP64_LIMIT: int
 ZIP_FILECOUNT_LIMIT: int
 ZIP_MAX_COMMENT: int
-ZIP_BZIP2: Literal[12]
-ZIP_LZMA: Literal[14]
+ZIP_BZIP2: int
+ZIP_LZMA: int


### PR DESCRIPTION
This reverts commit 034cfab4d6b25b2d3da2fe72e6839a61b2bf5e2c.

The commit exposed the value of the compression constants, which seem to be implementation details, in the public API. I don't see anything in the documentation about the values of the constants such as `ZIP_STORED`:
https://docs.python.org/3/library/zipfile.html?highlight=zipfile#zipfile.ZipFile

Example where this makes a difference:
```
from typing import Literal
import zipfile

def f1(p: str, compression: int) -> None:
    # Error: compression should have the type Literal[0, 8, 12, 14]
    zipfile.ZipFile(p, compression=compression)

def f2(p: str, compression: Literal[0, 8, 12, 14]) -> None:
    # Works, but cryptic and exposes internal implementation details
    zipfile.ZipFile(p, compression=compression)
```

The integer values of named constants need to be explicitly specified if somebody wants to wrap `zipfipe.ZipFile`, which arguably exposes implementation details in a problematic fashion.

Here is a real-world example where this caused a regression: https://github.com/pytorch/vision/blob/main/torchvision/datasets/utils.py#L301