### PR TITLE
Colorize output of stdlib stubtest in CI

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -20,6 +20,7 @@ concurrency:
 env:
   PIP_DISABLE_PIP_VERSION_CHECK: 1
   FORCE_COLOR: 1
+  TERM: xterm-256color  # needed for FORCE_COLOR to work on mypy on Ubuntu, see https://github.com/python/mypy/issues/13817
 
 jobs:
   stubtest-stdlib:

--- a/.github/workflows/stubtest_stdlib.yml
+++ b/.github/workflows/stubtest_stdlib.yml
@@ -17,6 +17,8 @@ permissions:
 
 env:
   PIP_DISABLE_PIP_VERSION_CHECK: 1
+  FORCE_COLOR: 1
+  TERM: xterm-256color  # needed for FORCE_COLOR to work on mypy on Ubuntu, see https://github.com/python/mypy/issues/13817
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
Example of a failing run before: 
![image](https://user-images.githubusercontent.com/66076021/208265687-89fec838-d670-47df-a74d-21f74765dbf1.png)

Example of a failing run after:
![image](https://user-images.githubusercontent.com/66076021/208265711-921e8ad4-304a-4d83-a3ef-bb7f0b1bb529.png)
