### PR TITLE
`editdistance`: delete the `bycython` submodule

### DIFF
--- a/stubs/editdistance/@tests/stubtest_allowlist.txt
+++ b/stubs/editdistance/@tests/stubtest_allowlist.txt
@@ -1,0 +1,2 @@
+# Not public API -- the submodule is an implementation detail due to it being a cythonized package
+editdistance.bycython

--- a/stubs/editdistance/editdistance/bycython.pyi
+++ b/stubs/editdistance/editdistance/bycython.pyi
@@ -1,5 +1,0 @@
-from _typeshed import Incomplete
-
-def eval(*args: Incomplete, **kwargs: Incomplete) -> Incomplete: ...
-
-__test__: dict[Incomplete, Incomplete]


### PR DESCRIPTION
This submodule is undocumented and appears to just be an implementation detail of the fact that the package is cythonized. Deleting this file fixes a third-party stubtest failure seen in #9368 that will cause the daily test to fail this evening: https://github.com/python/typeshed/actions/runs/3725223267/jobs/6317896104