### PR TITLE
set session.headers to MutableMapping

### DIFF
--- a/stubs/requests/requests/sessions.pyi
+++ b/stubs/requests/requests/sessions.pyi
@@ -116,7 +116,7 @@ class Session(SessionRedirectMixin):
     # See https://github.com/psf/requests/issues/5020#issuecomment-989082461:
     # requests sets this as a CaseInsensitiveDict, but users may set it to any MutableMapping
     # or None.
-    headers: MutableMapping[str, str | bytes] | None
+    headers: MutableMapping[str, str | bytes]
     auth: _Auth | None
     proxies: _TextMapping
     # Don't complain if:

--- a/stubs/requests/requests/sessions.pyi
+++ b/stubs/requests/requests/sessions.pyi
@@ -115,7 +115,6 @@ class Session(SessionRedirectMixin):
     __attrs__: Any
     # See https://github.com/psf/requests/issues/5020#issuecomment-989082461:
     # requests sets this as a CaseInsensitiveDict, but users may set it to any MutableMapping
-    # or None.
     headers: MutableMapping[str, str | bytes]
     auth: _Auth | None
     proxies: _TextMapping

--- a/stubs/requests/requests/sessions.pyi
+++ b/stubs/requests/requests/sessions.pyi
@@ -113,7 +113,7 @@ class _Settings(TypedDict):
 
 class Session(SessionRedirectMixin):
     __attrs__: Any
-    headers: CaseInsensitiveDict[str | bytes]
+    headers: MutableMapping[str, str | bytes | None]
     auth: _Auth | None
     proxies: _TextMapping
     # Don't complain if:

--- a/stubs/requests/requests/sessions.pyi
+++ b/stubs/requests/requests/sessions.pyi
@@ -116,7 +116,7 @@ class Session(SessionRedirectMixin):
     # See https://github.com/psf/requests/issues/5020#issuecomment-989082461:
     # requests sets this as a CaseInsensitiveDict, but users may set it to any MutableMapping
     # or None.
-    headers: MutableMapping[str, str | bytes ] | None
+    headers: MutableMapping[str, str | bytes] | None
     auth: _Auth | None
     proxies: _TextMapping
     # Don't complain if:

--- a/stubs/requests/requests/sessions.pyi
+++ b/stubs/requests/requests/sessions.pyi
@@ -115,6 +115,7 @@ class Session(SessionRedirectMixin):
     __attrs__: Any
     # See https://github.com/psf/requests/issues/5020#issuecomment-989082461:
     # requests sets this as a CaseInsensitiveDict, but users may set it to any MutableMapping
+    # or None.
     headers: MutableMapping[str, str | bytes ] | None
     auth: _Auth | None
     proxies: _TextMapping

--- a/stubs/requests/requests/sessions.pyi
+++ b/stubs/requests/requests/sessions.pyi
@@ -113,6 +113,8 @@ class _Settings(TypedDict):
 
 class Session(SessionRedirectMixin):
     __attrs__: Any
+    # See https://github.com/psf/requests/issues/5020#issuecomment-989082461:
+    # requests sets this as a CaseInsensitiveDict, but users may set it to any MutableMapping
     headers: MutableMapping[str, str | bytes | None]
     auth: _Auth | None
     proxies: _TextMapping

--- a/stubs/requests/requests/sessions.pyi
+++ b/stubs/requests/requests/sessions.pyi
@@ -115,7 +115,7 @@ class Session(SessionRedirectMixin):
     __attrs__: Any
     # See https://github.com/psf/requests/issues/5020#issuecomment-989082461:
     # requests sets this as a CaseInsensitiveDict, but users may set it to any MutableMapping
-    headers: MutableMapping[str, str | bytes | None]
+    headers: MutableMapping[str, str | bytes ] | None
     auth: _Auth | None
     proxies: _TextMapping
     # Don't complain if:


### PR DESCRIPTION
Resolves #9390.

The session.headers may be set to any mapping according to the project, and mutable mapping appears to be the most correct annotation.