### PR TITLE
Update `json.dump` to only require `fp: SupportsWrite[str]`

### DIFF
--- a/stdlib/json/__init__.pyi
+++ b/stdlib/json/__init__.pyi
@@ -1,6 +1,6 @@
-from _typeshed import SupportsRead
+from _typeshed import SupportsRead, SupportsWrite
 from collections.abc import Callable
-from typing import IO, Any
+from typing import Any
 
 from .decoder import JSONDecodeError as JSONDecodeError, JSONDecoder as JSONDecoder
 from .encoder import JSONEncoder as JSONEncoder
@@ -23,7 +23,7 @@ def dumps(
 ) -> str: ...
 def dump(
     obj: Any,
-    fp: IO[str],
+    fp: SupportsWrite[str],
     *,
     skipkeys: bool = ...,
     ensure_ascii: bool = ...,


### PR DESCRIPTION
Instead of requiring `fp` be an object of type `IO[str]`, this weakens the annotation to only require `fp` be of type `SupportsWrite[str]`.

This is all [the documentation requires](https://docs.python.org/3/library/json.html#json.dump) and is all [the implementation requires](https://github.com/python/cpython/blob/3e715e0cc811ebccce4234c3e25ef30787151d00/Lib/json/__init__.py#L180).