### PR TITLE
`compile` can only work with `ast.Module | ast.Expression | ast.Interactive`

### DIFF
--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -1,6 +1,6 @@
 import sys
+import _ast
 import types
-from _ast import AST
 from _collections_abc import dict_items, dict_keys, dict_values
 from _typeshed import (
     AnyStr_co,
@@ -1223,7 +1223,7 @@ if sys.version_info >= (3, 10):
 # TODO: `compile` has a more precise return type in reality; work on a way of expressing that?
 if sys.version_info >= (3, 8):
     def compile(
-        source: str | ReadableBuffer | AST,
+        source: str | ReadableBuffer | _ast.Expression,
         filename: str | ReadableBuffer | _PathLike[Any],
         mode: str,
         flags: int = ...,
@@ -1235,7 +1235,7 @@ if sys.version_info >= (3, 8):
 
 else:
     def compile(
-        source: str | ReadableBuffer | AST,
+        source: str | ReadableBuffer | _ast.Expression,
         filename: str | ReadableBuffer | _PathLike[Any],
         mode: str,
         flags: int = ...,

--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -1,5 +1,5 @@
-import sys
 import _ast
+import sys
 import types
 from _collections_abc import dict_items, dict_keys, dict_values
 from _typeshed import (

--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -1223,7 +1223,7 @@ if sys.version_info >= (3, 10):
 # TODO: `compile` has a more precise return type in reality; work on a way of expressing that?
 if sys.version_info >= (3, 8):
     def compile(
-        source: str | ReadableBuffer | _ast.Expression,
+        source: str | ReadableBuffer | _ast.Module | _ast.Expression | _ast.Interactive,
         filename: str | ReadableBuffer | _PathLike[Any],
         mode: str,
         flags: int = ...,
@@ -1235,7 +1235,7 @@ if sys.version_info >= (3, 8):
 
 else:
     def compile(
-        source: str | ReadableBuffer | _ast.Expression,
+        source: str | ReadableBuffer | _ast.Module | _ast.Expression | _ast.Interactive,
         filename: str | ReadableBuffer | _PathLike[Any],
         mode: str,
         flags: int = ...,


### PR DESCRIPTION
Proof: https://github.com/python/cpython/blob/f10f503b24a35a43910a632ee50c7568bedd6664/Python/Python-ast.c#L12247-L12269

```python
>>> import ast

>>> compile(ast.Not(), 'test', 'exec')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: expected Module node, got Not

>>> compile(ast.Not(), 'test', 'eval')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: expected Expression node, got Not

>>> compile(ast.Not(), 'test', 'single')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: expected Interactive node, got Not
```

We can also have specific overloads later.