### PR TITLE
Use `--additional-flags='check-untyped-defs'` when running mypy_primer

### DIFF
--- a/.github/workflows/mypy_primer.yml
+++ b/.github/workflows/mypy_primer.yml
@@ -52,6 +52,7 @@ jobs:
             --new v${MYPY_VERSION} --old v${MYPY_VERSION} \
             --custom-typeshed-repo typeshed_to_test \
             --new-typeshed $GITHUB_SHA --old-typeshed upstream_main \
+            --additional-flags="--check-untyped-defs" \
             --num-shards 4 --shard-index ${{ matrix.shard-index }} \
             --debug \
             --output concise \


### PR DESCRIPTION
This was suggested by @Avasam in https://github.com/hauntsaninja/mypy_primer/issues/64, and by @Akuli in https://github.com/hauntsaninja/mypy_primer/issues/66. It could conceivably yield much more interesting diffs for some PRs. For example, `comtypes` makes heavy use of `pywin32`, so it shows up a lot in primer diffs for PRs affecting our `pywin32` stubs. But the diffs usually aren't very interesting, because the vast majority of `comtypes`'s functions are untyped, so mypy just ignores them.

I think this is worth experimenting with, and if it doesn't work for whatever reason, we can always revert it.