### PR TITLE
Accurate, deduplicated, `termcolor.colored` fallback

### DIFF
--- a/scripts/runtests.py
+++ b/scripts/runtests.py
@@ -3,18 +3,14 @@ from __future__ import annotations
 
 import json
 import os
+import pathlib
 import re
 import subprocess
 import sys
 from pathlib import Path
 
-try:
-    from termcolor import colored
-except ImportError:
-
-    def colored(text: str, color: str = "") -> str:  # type: ignore[misc]
-        return text
-
+sys.path.append(str(pathlib.Path(__file__).parent.parent / "tests"))
+from utils import colored  # type: ignore[import]  # noqa: E402
 
 _STRICTER_CONFIG_FILE = "pyrightconfig.stricter.json"
 _SUCCESS = colored("Success", "green")

--- a/scripts/runtests.py
+++ b/scripts/runtests.py
@@ -3,14 +3,19 @@ from __future__ import annotations
 
 import json
 import os
-import pathlib
 import re
 import subprocess
 import sys
 from pathlib import Path
+from typing import Iterable
 
-sys.path.append(str(pathlib.Path(__file__).parent.parent / "tests"))
-from utils import colored  # type: ignore[import]  # noqa: E402
+try:
+    from termcolor import colored
+except ImportError:
+
+    def colored(text: str, color: str | None = None, on_color: str | None = None, attrs: Iterable[str] | None = None) -> str:
+        return text
+
 
 _STRICTER_CONFIG_FILE = "pyrightconfig.stricter.json"
 _SUCCESS = colored("Success", "green")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -10,12 +10,20 @@ import venv
 from collections.abc import Mapping
 from functools import cache
 from pathlib import Path
-from typing import NamedTuple
+from typing import Iterable, NamedTuple
 from typing_extensions import Annotated
 
 import pathspec  # type: ignore[import]
 import tomli
 from packaging.requirements import Requirement
+
+try:
+    from termcolor import colored as colored
+except ImportError:
+
+    def colored(text: str, color: str | None = None, on_color: str | None = None, attrs: Iterable[str] | None = None) -> str:
+        return text
+
 
 # Used to install system-wide packages for different OS types:
 METADATA_MAPPING = {"linux": "apt_dependencies", "darwin": "brew_dependencies", "win32": "choco_dependencies"}
@@ -23,14 +31,6 @@ METADATA_MAPPING = {"linux": "apt_dependencies", "darwin": "brew_dependencies", 
 
 def strip_comments(text: str) -> str:
     return text.split("#")[0].strip()
-
-
-try:
-    from termcolor import colored as colored
-except ImportError:
-
-    def colored(s: str, _: str) -> str:  # type: ignore[misc]
-        return s
 
 
 def print_error(error: str, end: str = "\n", fix_path: tuple[str, str] = ("", "")) -> None:


### PR DESCRIPTION
`utils.colored`'s signature now correctly reflects `termcolor.colored`
Attempt in `scripts/runtests.py` to deduplicate the same fallback (using utils module in an outside folder).
~~I think the solution is fine, but you tell me.~~ VSCode can pick-up the source just fine, ~~mypy might need an extra `mypy_path="tests"` to remove `# type: ignore[import]` at line 13.~~
Edit: Apparently it wasn't a great solution (see comments below)