### PR TITLE
Offer sensible default VSCode settings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,4 @@
 tests/stubtest_allowlists/*.txt linguist-language=ini
 tests/pytype_exclude_list.txt linguist-language=ini
 pyrightconfig*.json linguist-language=jsonc
+.vscode/*.json linguist-language=jsonc

--- a/.gitignore
+++ b/.gitignore
@@ -60,7 +60,9 @@ analyze.py
 # Editor backup files
 *~
 .*.sw?
-.vscode/
+.vscode/*
+!.vscode/settings.default.json
+!.vscode/extensions.json
 .idea/
 .venv*/
 

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,33 @@
+// Keep in alphabetical order
+{
+  "recommendations": [
+    "bierner.github-markdown-preview",
+    "bungcip.better-toml",
+    "editorconfig.editorconfig",
+    "ms-python.black-formatter",
+    "ms-python.flake8",
+    "ms-python.isort",
+    "ms-python.python",
+    "ms-python.vscode-pylance",
+    "redhat.vscode-yaml",
+],
+"unwantedRecommendations": [
+    /*
+     * Don't recommend by default for this workspace
+    */
+    "christian-kohler.npm-intellisense",
+    /*
+     * Must disable in this workspace
+     * https://github.com/microsoft/vscode/issues/40239
+    */
+    // We use black
+    "ms-python.autopep8",
+    // Not using pylint
+    "ms-python.pylint",
+    // VSCode has implemented an optimized version
+    "coenraads.bracket-pair-colorizer",
+    "coenraads.bracket-pair-colorizer-2",
+    // Obsoleted by Pylance
+    "ms-pyright.pyright",
+  ],
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,5 @@
+// ⚠ Disclaimer: The typeshed team doesn't commit to maintaining this file. It exists purely for your ease of use.
+
 // Keep in alphabetical order
 {
   "recommendations": [

--- a/.vscode/settings.default.json
+++ b/.vscode/settings.default.json
@@ -1,8 +1,10 @@
-// Copy this file as `.vscode/settings.json` to configure VSCode for this workspace.
-// Unfortunately, VSCode doesn't (yet) offer any way to have "workspace defaults" or "user-worspace settings",
-// so offering defaults to copy is the best we can do at the moment.
-//
-// ⚠ Disclaimer: The typeshed team doesn't commit to maintaining this file. It exists purely for your ease of use.
+/*
+ * Copy this file as `.vscode/settings.json` to configure VSCode for this workspace.
+ * Unfortunately, VSCode doesn't (yet) offer any way to have "workspace defaults" or "user-worspace settings",
+ * so offering defaults to copy is the best we can do at the moment.
+ *
+ * ⚠ Disclaimer: The typeshed team doesn't commit to maintaining this file. It exists purely for your ease of use.
+*/
 {
     // Don't format on save for formatters we don't explicitely control
     "editor.formatOnSave": false,

--- a/.vscode/settings.default.json
+++ b/.vscode/settings.default.json
@@ -1,4 +1,8 @@
-// Copy this file as "settings.json" for these settings to take effect.
+// Copy this file as `.vscode/settings.json` to configure VSCode for this workspace.
+// Unfortunately, VSCode doesn't (yet) offer any way to have "workspace defaults" or "user-worspace settings",
+// so offering defaults to copy is the best we can do at the moment.
+//
+// ⚠ Disclaimer: The typeshed team doesn't commit to maintaining this file. It exists purely for your ease of use.
 {
     // Don't format on save for formatters we don't explicitely control
     "editor.formatOnSave": false,
@@ -26,6 +30,12 @@
     "editor.tabSize": 2,
     "[json][jsonc][python]": {
         "editor.tabSize": 4
+    },
+    "[markdown]": {
+        "editor.rulers": [
+            90,
+            130
+        ]
     },
     "[git-commit]": {
         "editor.rulers": [

--- a/.vscode/settings.default.json
+++ b/.vscode/settings.default.json
@@ -1,0 +1,82 @@
+// Copy this file as "settings.json" for these settings to take effect.
+{
+    // Don't format on save for formatters we don't explicitely control
+    "editor.formatOnSave": false,
+    "editor.codeActionsOnSave": {
+        "source.fixAll": false
+    },
+    // Set file associations to support comments syntax highlight
+    "files.associations": {
+        "settings.default.json": "jsonc",
+        "pyrightconfig*.json": "jsonc",
+        ".flake8": "properties",
+        "stubtest_allowlist*.txt": "properties",
+        "**/stubtest_allowlists/*.txt": "properties",
+        "pytype_exclude_list.txt": "properties"
+    },
+    "files.exclude": {
+        "**/.mypy_cache": true
+    },
+    "files.insertFinalNewline": true,
+    "files.trimFinalNewlines": true,
+    "files.trimTrailingWhitespace": true,
+    "editor.comments.insertSpace": true,
+    "editor.insertSpaces": true,
+    "editor.detectIndentation": false,
+    "editor.tabSize": 2,
+    "[json][jsonc][python]": {
+        "editor.tabSize": 4
+    },
+    "[git-commit]": {
+        "editor.rulers": [
+            72
+        ]
+    },
+    "[yaml]": {
+        "editor.defaultFormatter": "redhat.vscode-yaml",
+        "editor.formatOnSave": true,
+        "editor.codeActionsOnSave": {
+            "source.fixAll": true
+        }
+    },
+    "[python]": {
+        "editor.defaultFormatter": "ms-python.black-formatter",
+        "editor.rulers": [
+            130
+        ],
+        "editor.formatOnSave": true,
+        "editor.codeActionsOnSave": {
+            "source.fixAll": true,
+            "source.fixAll.unusedImports": true,
+            "source.fixAll.convertImportFormat": true,
+            "source.organizeImports": true
+        }
+    },
+    "isort.check": true,
+    // Using the dedicated black extension
+    "black-formatter.importStrategy": "fromEnvironment",
+    "python.formatting.provider": "none",
+    // Important to follow the config in pyrightconfig.json
+    "python.analysis.useLibraryCodeForTypes": false,
+    "python.analysis.extraPaths": [
+        "tests"
+    ],
+    "python.linting.enabled": true,
+    "python.linting.mypyEnabled": true,
+    "python.linting.mypyArgs": [
+        "--show-column-numbers",
+        "--no-pretty",
+        "--custom-typeshed-dir=${workspaceFolder}",
+        "--python-version=3.7"
+    ],
+    "isort.importStrategy": "fromEnvironment",
+    // Not using bandit
+    "python.linting.banditEnabled": false,
+    // Using dedicated Flake8 extension
+    "python.linting.flake8Enabled": false,
+    "python.linting.pycodestyleEnabled": false,
+    "python.linting.prospectorEnabled": false,
+    "python.linting.pylamaEnabled": false,
+    // Use the new dedicated extensions instead (and we're not using pylint)
+    "python.linting.pylintEnabled": false
+}


### PR DESCRIPTION
Offer sensible default VSCode settings.
These are the workspace settings, specific to typeshed, that I've been using and filling in over the past few months.
Workspace settings override user settings, so we can offer sensible, all-ready configurations for the typeshed workspace, reducing a lot of the pains a new contributor can have if their favorite editor is VSCode.

These settings obviously won't configure any extension not specified in `.vscode/extensions.json > recommendations`, and will assume the user may not have all recommended extensions installed or set as the formatter. Hence I've also configure some basic VSCode settings.

---

The recommended extensions include:
- The full python extensions suite needed for typeshed
- `.editorconfig` support and syntax highlighter
- A yaml formatter and validator
- A TOML syntax highliter and validator (no formatting)
- Mardown pack for syntax highlighting, and for the Mardown preview to match Github's (no formatter, though I'd recommend [davidanson.vscode-markdownlint](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint))
For those not familiar with VSCode: Note that recommendations are not forced onto the user, a popup appears once to mention the workspace has recommended extensions, then they'll only show up under the "recommended" tab in the extensions menu.

---

It can still make sense for a user to want to modify `.vscode/settings.json` if they want to configure one of their extension to work properly with typeshed, without having to outright disable it for the workspace. It's also up to the dev to decide if they wanna follow these specific editor settings.

Unfortunately, VSCode doesn't (yet) offer any way to have "workspace defaults" or "user-worspace settings", so offering defaults to copy is the best we can do at the moment. And is what I've seen done in other open-source projects.