### PR TITLE
Add typing-extensions to `requirements-tests.txt`

### DIFF
--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -15,3 +15,4 @@ termcolor>=2
 tomli==2.0.1
 tomlkit==0.11.6
 types-pyyaml
+typing-extensions


### PR DESCRIPTION
From the following comment: https://github.com/python/typeshed/pull/9434#discussion_r1059690783
> I think typing_extensions is only available here because mypy depends on it, and we have mypy in our requirements-tests.txt file. We should probably add it to requirements-tests.txt, since implicit dependencies are generally a bad idea, and we also need the dependency for e.g. stubtest_stdlib.py. Want to make another PR adding it to requirements-tests.txt?