### PR TITLE
Improve mypy flags for regr_test.py and typecheck_typeshed.py

### DIFF
--- a/tests/regr_test.py
+++ b/tests/regr_test.py
@@ -166,7 +166,6 @@ def run_testcases(
         "--python-version",
         version,
         "--show-traceback",
-        "--show-error-codes",
         "--no-error-summary",
         "--platform",
         platform,

--- a/tests/typecheck_typeshed.py
+++ b/tests/typecheck_typeshed.py
@@ -52,12 +52,11 @@ def run_mypy_as_subprocess(directory: str, platform: str, version: str) -> Retur
         "--python-version",
         version,
         "--strict",
+        "--pretty",
         "--show-traceback",
-        "--show-error-codes",
         "--no-error-summary",
         "--enable-error-code",
         "ignore-without-code",
-        "--namespace-packages",
     ]
     if directory == "tests" and platform == "win32":
         command.extend(["--exclude", "tests/pytype_test.py"])


### PR DESCRIPTION
- Remove redundant flags that are now enabled by default.
- Add `--pretty` to `typecheck_typeshed.py`.

`mypy_test.py` flags are being reworked in #9408.