### PR TITLE
Shard `mypy_primer` more

### DIFF
--- a/.github/workflows/mypy_primer.yml
+++ b/.github/workflows/mypy_primer.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        shard-index: [0, 1, 2, 3]
+        shard-index: [0, 1, 2, 3, 4, 5]
       fail-fast: false
     steps:
       - uses: actions/checkout@v3
@@ -53,7 +53,7 @@ jobs:
             --custom-typeshed-repo typeshed_to_test \
             --new-typeshed $GITHUB_SHA --old-typeshed upstream_main \
             --additional-flags="--check-untyped-defs" \
-            --num-shards 4 --shard-index ${{ matrix.shard-index }} \
+            --num-shards 6 --shard-index ${{ matrix.shard-index }} \
             --debug \
             --output concise \
             | tee diff_${{ matrix.shard-index }}.txt


### PR DESCRIPTION
Might help reduce the performance impact of #9433 on `mypy_primer` CI runs.