### PR TITLE
Add syntax highlight to all shell code blocks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ On Linux and Mac OS, you will be able to run the full test suite on Python 3.8,
 To install the necessary requirements, run the following commands from a
 terminal window:
 
-```
+```bash
 $ python3 -m venv .venv
 $ source .venv/bin/activate
 (.venv)$ pip install -U pip
@@ -71,13 +71,13 @@ which will allow you to run the full suite of tests. If you choose to install
 WSL, follow the Linux/Mac OS instructions above.
 
 If you do not wish to install WSL, run the following commands from a Windows
-terminal to install all non-pytype requirements:
+terminal to install all non-pytype requirements (powershell example):
 
-```
-> python -m venv .venv
-> ".venv/scripts/activate"
-(.venv) > pip install -U pip
-(.venv) > pip install -r requirements-tests.txt
+```powershell
+PS > python -m venv .venv
+PS > & ".venv/scripts/activate"
+(.venv) PS > pip install -U pip
+(.venv) PS > pip install -r requirements-tests.txt
 ```
 
 ## Code formatting
@@ -93,10 +93,10 @@ right away and add a commit to your PR.
 That being said, if you *want* to run the checks locally when you commit,
 you're free to do so. Either run `pycln`, `black` and `isort` manually...
 
-```
-pycln --config=pyproject.toml .
-isort .
-black .
+```bash
+$ pycln --config=pyproject.toml .
+$ isort .
+$ black .
 ```
 
 ...Or install the pre-commit hooks: please refer to the
@@ -107,8 +107,8 @@ Our code is also linted using `flake8`, with plugins `flake8-pyi`,
 flake8 before filing a PR is not required. However, if you wish to run flake8
 locally, install the test dependencies as outlined above, and then run:
 
-```
-flake8 .
+```bash
+(.venv3)$ flake8 .
 ```
 
 ## Where to make changes
@@ -248,7 +248,7 @@ To get started, fork typeshed, clone your fork, and then
 You can then install the library with `pip` into the virtualenv and run the script,
 replacing `libraryname` with the name of the library below:
 
-```
+```bash
 (.venv3)$ pip install libraryname
 (.venv3)$ python3 scripts/create_baseline_stubs.py libraryname
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,13 +71,13 @@ which will allow you to run the full suite of tests. If you choose to install
 WSL, follow the Linux/Mac OS instructions above.
 
 If you do not wish to install WSL, run the following commands from a Windows
-terminal to install all non-pytype requirements (powershell example):
+terminal to install all non-pytype requirements:
 
 ```powershell
-PS > python -m venv .venv
-PS > & ".venv/scripts/activate"
-(.venv) PS > pip install -U pip
-(.venv) PS > pip install -r requirements-tests.txt
+> python -m venv .venv
+> .venv\scripts\activate
+(.venv) > pip install -U pip
+(.venv) > pip install -r "requirements-tests.txt"
 ```
 
 ## Code formatting

--- a/tests/README.md
+++ b/tests/README.md
@@ -22,7 +22,7 @@ in the `CONTRIBUTING.md` document. In particular, we recommend running with Pyth
 ## Run all tests for a specific stub
 
 Run using:
-```
+```bash
 (.venv3)$ python3 scripts/runtests.py <stdlib-or-stubs>/<stub-to-test>
 ```
 
@@ -36,7 +36,7 @@ so: `stdlib/os` or `stubs/requests`.
 ## mypy\_test.py
 
 Run using:
-```
+```bash
 (.venv3)$ python3 tests/mypy_test.py
 ```
 
@@ -56,7 +56,7 @@ Note: this test cannot be run on Windows
 systems unless you are using Windows Subsystem for Linux.
 
 Run using:
-```
+```bash
 (.venv3)$ python3 tests/pytype_test.py
 ```
 
@@ -67,7 +67,7 @@ This test works similarly to `mypy_test.py`, except it uses `pytype`.
 This test requires [Node.js](https://nodejs.org) to be installed. Although
 typeshed runs pyright in CI, it does not currently use this script. However,
 this script uses the same pyright version and configuration as the CI.
-```
+```bash
 (.venv3)$ python3 tests/pyright_test.py                                # Check all files
 (.venv3)$ python3 tests/pyright_test.py stdlib/sys.pyi                 # Check one file
 (.venv3)$ python3 tests/pyright_test.py -p pyrightconfig.stricter.json # Check with the stricter config.
@@ -88,14 +88,14 @@ for information on the various configuration options.
 ## check\_consistent.py
 
 Run using:
-```
-python3 tests/check_consistent.py
+```bash
+$ python3 tests/check_consistent.py
 ```
 
 ## stubtest\_stdlib.py
 
 Run using
-```
+```bash
 (.venv3)$ python3 tests/stubtest_stdlib.py
 ```
 
@@ -124,7 +124,7 @@ this script locally if you know you can trust the packages you're running
 stubtest on.
 
 Run using
-```
+```bash
 (.venv3)$ python3 tests/stubtest_third_party.py
 ```
 
@@ -132,13 +132,13 @@ Similar to `stubtest_stdlib.py`, but tests the third party stubs. By default,
 it checks all third-party stubs, but you can provide the distributions to
 check on the command line:
 
-```
+```bash
 (.venv3)$ python3 tests/stubtest_third_party.py Pillow toml  # check stubs/Pillow and stubs/toml
 ```
 
 If you have the runtime package installed in your local virtual environment, you can also run stubtest
 directly, with
-```
+```bash
 (.venv3)$ MYPYPATH=<path-to-module-stubs> python3 -m mypy.stubtest \
   --custom-typeshed-dir <path-to-typeshed> \
   <third-party-module>
@@ -173,7 +173,7 @@ for missing objects rather than trying to match the runtime in every detail.
 ## typecheck\_typeshed.py
 
 Run using
-```
+```bash
 (.venv3)$ python3 tests/typecheck_typeshed.py
 ```
 


### PR DESCRIPTION
- Using bash by default, powershell for Windows-specific
- Added missing start-of-line markers

Please read https://github.com/python/typeshed/pull/9434#discussion_r1060189157 as for the motivation why, as well as why use `bash` specifically (mainly for semantic reasons)

As for using powershell for Windows-specific commands over cmd/batch:
- powershell is meant to [replace Command Prompt](https://support.microsoft.com/en-us/windows/powershell-is-replacing-command-prompt-fdb690cf-876c-d866-2124-21b6fb29a45f)
- is the default in Microsoft's own IDEs

<details>
<summary>Full explanation with examples (linked comment)</summary>

As far as https://github.com/github/linguist/blob/master/lib/linguist/languages.yml#L6204 is concerned, `shell`, `sh`, `shell-script`, `bash` and `zsh` are all the same, and look fine.

bash
```bash
(.venv3)$ python tests/get_external_dependencies.py <third_party_stub>  # List external dependencies for <third_party_stub>
(.venv3)$ python tests/get_external_dependencies.py <third_party_stub1> <third_party_stub2>  # List external dependencies for <third_party_stub1> and <third_party_stub2>
(.venv3)$ python tests/get_external_dependencies.py  # List external dependencies for all non stubs packages in typeshed
(.venv3)$ pip install $(python tests/get_external_dependencies.py <third_party_stub>)  # Install non-types dependencies
```

shell
```shell
(.venv3)$ python tests/get_external_dependencies.py <third_party_stub>  # List external dependencies for <third_party_stub>
(.venv3)$ python tests/get_external_dependencies.py <third_party_stub1> <third_party_stub2>  # List external dependencies for <third_party_stub1> and <third_party_stub2>
(.venv3)$ python tests/get_external_dependencies.py  # List external dependencies for all non stubs packages in typeshed
(.venv3)$ pip install $(python tests/get_external_dependencies.py <third_party_stub>)  # Install non-types dependencies
```

powershell
```powershell
(.venv3)$ python tests/get_external_dependencies.py <third_party_stub>  # List external dependencies for <third_party_stub>
(.venv3)$ python tests/get_external_dependencies.py <third_party_stub1> <third_party_stub2>  # List external dependencies for <third_party_stub1> and <third_party_stub2>
(.venv3)$ python tests/get_external_dependencies.py  # List external dependencies for all non stubs packages in typeshed
(.venv3)$ pip install $(python tests/get_external_dependencies.py <third_party_stub>)  # Install non-types dependencies
```

empty
```
(.venv3)$ python tests/get_external_dependencies.py <third_party_stub>  # List external dependencies for <third_party_stub>
(.venv3)$ python tests/get_external_dependencies.py <third_party_stub1> <third_party_stub2>  # List external dependencies for <third_party_stub1> and <third_party_stub2>
(.venv3)$ python tests/get_external_dependencies.py  # List external dependencies for all non stubs packages in typeshed
(.venv3)$ pip install $(python tests/get_external_dependencies.py <third_party_stub>)  # Install non-types dependencies
```

It doesn't outright break the syntax, if anything it highlights that you need to replace this part. It also correctly handles comments and inline commands.

Editors may have different implementations. This is in VSCode with popular markdown syntax highlight (and github-like previewer) that I use:
![image](https://user-images.githubusercontent.com/1350584/210277536-d7a99f33-f61c-4f79-92f0-7676e860f5d1.png)

This is with plugins disabled:
![image](https://user-images.githubusercontent.com/1350584/210277640-a3c80730-1a3d-4a13-b662-cc0f6a4a0cf3.png)

You can see here that "shell" isn't naturally supported in the preview. (code syntax highlight has no difference). But I wouldn't use that as an argument.
Of course the exact look will depend on the editor's implementation.
In any case, having **a** language specifier here only seems better than **no** language specifier.

Another reason to use bash specifically, from a purely semantic point of view, is that the doc seems to assume all commands are to be run on linux, where afaik bash (or bash-like) is most often the default. (and bash-like code usually works in powershell on Windows)

</details>