### PR TITLE
Autoformat YAML files

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -6,8 +6,8 @@ on:
     - cron: "0 0 * * *"
   pull_request:
     paths:
-      - 'requirements-tests.txt'
-      - '.github/workflows/daily.yml'
+      - "requirements-tests.txt"
+      - ".github/workflows/daily.yml"
 
 # Please keep the permissions minimal, as stubtest runs arbitrary code from pypi.
 permissions:
@@ -20,7 +20,7 @@ concurrency:
 env:
   PIP_DISABLE_PIP_VERSION_CHECK: 1
   FORCE_COLOR: 1
-  TERM: xterm-256color  # needed for FORCE_COLOR to work on mypy on Ubuntu, see https://github.com/python/mypy/issues/13817
+  TERM: xterm-256color # needed for FORCE_COLOR to work on mypy on Ubuntu, see https://github.com/python/mypy/issues/13817
 
 jobs:
   stubtest-stdlib:

--- a/.github/workflows/mypy_primer.yml
+++ b/.github/workflows/mypy_primer.yml
@@ -4,10 +4,10 @@ on:
   # Only run on PR, since we diff against main
   pull_request:
     paths:
-    - 'stdlib/**'
-    - 'stubs/**/*.pyi'
-    - '.github/workflows/mypy_primer.yml'
-    - '.github/workflows/mypy_primer_comment.yml'
+      - "stdlib/**"
+      - "stubs/**/*.pyi"
+      - ".github/workflows/mypy_primer.yml"
+      - ".github/workflows/mypy_primer_comment.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/stubtest_stdlib.yml
+++ b/.github/workflows/stubtest_stdlib.yml
@@ -7,9 +7,9 @@ on:
       - main
   pull_request:
     paths:
-      - 'stdlib/**'
-      - '.github/workflows/stubtest_stdlib.yml'
-      - 'tests/**'
+      - "stdlib/**"
+      - ".github/workflows/stubtest_stdlib.yml"
+      - "tests/**"
       # When requirements.txt changes, we run `daily.yml`, which includes stdlib stubtest
 
 permissions:
@@ -18,7 +18,7 @@ permissions:
 env:
   PIP_DISABLE_PIP_VERSION_CHECK: 1
   FORCE_COLOR: 1
-  TERM: xterm-256color  # needed for FORCE_COLOR to work on mypy on Ubuntu, see https://github.com/python/mypy/issues/13817
+  TERM: xterm-256color # needed for FORCE_COLOR to work on mypy on Ubuntu, see https://github.com/python/mypy/issues/13817
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/stubtest_third_party.yml
+++ b/.github/workflows/stubtest_third_party.yml
@@ -3,9 +3,9 @@ name: Third-party stubtest
 on:
   pull_request:
     paths:
-      - 'stubs/**'
-      - '.github/workflows/stubtest_third_party.yml'
-      - 'tests/**'
+      - "stubs/**"
+      - ".github/workflows/stubtest_third_party.yml"
+      - "tests/**"
       # When requirements.txt changes, we run `daily.yml`, which includes third-party stubtest
 
 permissions:
@@ -14,7 +14,7 @@ permissions:
 env:
   PIP_DISABLE_PIP_VERSION_CHECK: 1
   FORCE_COLOR: 1
-  TERM: xterm-256color  # needed for FORCE_COLOR to work on mypy on Ubuntu, see https://github.com/python/mypy/issues/13817
+  TERM: xterm-256color # needed for FORCE_COLOR to work on mypy on Ubuntu, see https://github.com/python/mypy/issues/13817
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,8 +7,8 @@ on:
       - main
   pull_request:
     paths-ignore:
-      - '**/*.md'
-      - 'scripts/**'
+      - "**/*.md"
+      - "scripts/**"
 
 permissions:
   contents: read
@@ -116,8 +116,8 @@ jobs:
         uses: SebRollen/toml-action@v1.0.2
         id: pyright_version
         with:
-          file: 'pyproject.toml'
-          field: 'tool.typeshed.pyright_version'
+          file: "pyproject.toml"
+          field: "tool.typeshed.pyright_version"
       - uses: jakebailey/pyright-action@v1
         with:
           version: ${{ steps.pyright_version.outputs.value }}
@@ -137,7 +137,7 @@ jobs:
           version: ${{ steps.pyright_version.outputs.value }}
           python-platform: ${{ matrix.python-platform }}
           python-version: ${{ matrix.python-version }}
-          no-comments: ${{ matrix.python-version != '3.10' || matrix.python-platform != 'Linux' }}  # Having each job create the same comment is too noisy.
+          no-comments: ${{ matrix.python-version != '3.10' || matrix.python-platform != 'Linux' }} # Having each job create the same comment is too noisy.
 
   stub-uploader:
     name: Run the stub_uploader tests

--- a/.github/workflows/typecheck_typeshed_code.yml
+++ b/.github/workflows/typecheck_typeshed_code.yml
@@ -7,10 +7,10 @@ on:
       - main
   pull_request:
     paths:
-      - 'scripts/**'
-      - 'tests/**'
-      - '.github/workflows/typecheck_typeshed_code.yml'
-      - 'requirements-tests.txt'
+      - "scripts/**"
+      - "tests/**"
+      - ".github/workflows/typecheck_typeshed_code.yml"
+      - "requirements-tests.txt"
 
 permissions:
   contents: read

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,7 @@ repos:
           - "flake8-pyi==22.11.0" # must match requirements-tests.txt
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v2.7.1
+    python_requirement: false
     hooks:
       - id: prettier
         types_or: [yaml]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,23 +10,23 @@ repos:
       - id: black
         language_version: python3.9
   - repo: https://github.com/pycqa/isort
-    rev: 5.11.4  # must match requirements-tests.txt
+    rev: 5.11.4 # must match requirements-tests.txt
     hooks:
       - id: isort
         name: isort (python)
   - repo: https://github.com/pycqa/flake8
-    rev: 6.0.0  # must match requirements-tests.txt
+    rev: 6.0.0 # must match requirements-tests.txt
     hooks:
       - id: flake8
         additional_dependencies:
-          - 'flake8-bugbear==22.12.6'   # must match requirements-tests.txt
-          - 'flake8-noqa==1.3.0'        # must match requirements-tests.txt
-          - 'flake8-pyi==22.11.0'       # must match requirements-tests.txt
+          - "flake8-bugbear==22.12.6" # must match requirements-tests.txt
+          - "flake8-noqa==1.3.0"      # must match requirements-tests.txt
+          - "flake8-pyi==22.11.0"     # must match requirements-tests.txt
 
 ci:
-    autofix_commit_msg: '[pre-commit.ci] auto fixes from pre-commit.com hooks'
-    autofix_prs: true
-    autoupdate_commit_msg: '[pre-commit.ci] pre-commit autoupdate'
-    autoupdate_schedule: weekly
-    skip: [flake8]
-    submodules: false
+  autofix_commit_msg: "[pre-commit.ci] auto fixes from pre-commit.com hooks"
+  autofix_prs: true
+  autoupdate_commit_msg: "[pre-commit.ci] pre-commit autoupdate"
+  autoupdate_schedule: weekly
+  skip: [flake8]
+  submodules: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,8 +20,13 @@ repos:
       - id: flake8
         additional_dependencies:
           - "flake8-bugbear==22.12.6" # must match requirements-tests.txt
-          - "flake8-noqa==1.3.0"      # must match requirements-tests.txt
-          - "flake8-pyi==22.11.0"     # must match requirements-tests.txt
+          - "flake8-noqa==1.3.0" # must match requirements-tests.txt
+          - "flake8-pyi==22.11.0" # must match requirements-tests.txt
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v2.7.1
+    hooks:
+      - id: prettier
+        types_or: [yaml]
 
 ci:
   autofix_commit_msg: "[pre-commit.ci] auto fixes from pre-commit.com hooks"

--- a/tests/check_consistent.py
+++ b/tests/check_consistent.py
@@ -216,6 +216,8 @@ def get_precommit_requirements() -> dict[str, SpecifierSet]:
     yam = yaml.load(precommit, Loader=yaml.Loader)
     precommit_requirements = {}
     for repo in yam["repos"]:
+        if not repo.get("python_requirement", True):
+            continue
         hook = repo["hooks"][0]
         package_name, package_rev = hook["id"], repo["rev"]
         package_specifier = SpecifierSet(f"=={package_rev.removeprefix('v')}")


### PR DESCRIPTION
A quick formatting run of YAML files for things like consistent single vs double quotes, spacing before comments and indentation.
Adds a pre-commit hook to autoformat YAML files. I don't have a strong opinion on which formatter to use for YAML.

<details>
<summary>Old PR description</summary>

Just a quick formatting run of YAML files. Consistent single vs double quotes, spacing before comments and indentation. I don't think there's an established preference for YAML style so I let [redhat.vscode-yaml](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml) use its default settings.

I'm open to suggestions for a formatter to add to pre-commit. (vscode-yaml itself uses prettier, which I'm not a great fan of personally, at least in JS environments where I prefer ESLint+[dprint](https://dprint.dev/plugins/typescript/). But its up to you, seems fine for yaml, maybe markdown, etc.)

</details>