### PR TITLE
Revert "Use `--additional-flags='check-untyped-defs'` when running mypy_primer"

### DIFF
--- a/.github/workflows/mypy_primer.yml
+++ b/.github/workflows/mypy_primer.yml
@@ -52,7 +52,6 @@ jobs:
             --new v${MYPY_VERSION} --old v${MYPY_VERSION} \
             --custom-typeshed-repo typeshed_to_test \
             --new-typeshed $GITHUB_SHA --old-typeshed upstream_main \
-            --additional-flags="--check-untyped-defs" \
             --num-shards 4 --shard-index ${{ matrix.shard-index }} \
             --debug \
             --output concise \


### PR DESCRIPTION
Reverts python/typeshed#9433.

I think 15+ minutes for `mypy_primer` is too long. The slowdown seems primarily caused by `manticore` (see #9443), and we don't want to skip `mypy_primer` on `manticore` (https://github.com/python/typeshed/pull/9433#issuecomment-1369375446). The performance situation may well be significantly improved when mypy 1.0 comes along, but that could still be a few weeks away. Let's revert #9433 for now so that we can have `mypy_primer` runs that are <10 minutes in the meantime.