### PR TITLE
update SimpleHTTPRequestHandler

### DIFF
--- a/stdlib/http/server.pyi
+++ b/stdlib/http/server.pyi
@@ -52,7 +52,7 @@ class BaseHTTPRequestHandler(socketserver.StreamRequestHandler):
 class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
     extensions_map: dict[str, str]
     if sys.version_info >= (3, 12):
-        index_pages: tuple[str, ...]
+        index_pages: ClassVar[tuple[str, ...]]
     def __init__(
         self,
         request: socketserver._RequestType,

--- a/stdlib/http/server.pyi
+++ b/stdlib/http/server.pyi
@@ -52,25 +52,15 @@ class BaseHTTPRequestHandler(socketserver.StreamRequestHandler):
 class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
     extensions_map: dict[str, str]
     if sys.version_info >= (3, 12):
-        def __init__(
-            self,
-            request: socketserver._RequestType,
-            client_address: socketserver._AddressType,
-            server: socketserver.BaseServer,
-            *,
-            directory: str | None = ...,
-            index_pages: Sequence[str] | None = ...,
-        ) -> None: ...
-    else:
-        def __init__(
-            self,
-            request: socketserver._RequestType,
-            client_address: socketserver._AddressType,
-            server: socketserver.BaseServer,
-            *,
-            directory: str | None = ...,
-        ) -> None: ...
-
+        index_pages: tuple[str, ...]
+    def __init__(
+        self,
+        request: socketserver._RequestType,
+        client_address: socketserver._AddressType,
+        server: socketserver.BaseServer,
+        *,
+        directory: str | None = ...,
+    ) -> None: ...
     def do_GET(self) -> None: ...
     def do_HEAD(self) -> None: ...
     def send_head(self) -> io.BytesIO | BinaryIO | None: ...  # undocumented


### PR DESCRIPTION
The `index_pages` parameter has been removed from `__init__` as subclassing is the encouraged method for modifying `SimpleHttpRequestHandler`.

`index_pages` should be a tuple of 0 or more strings (not sure I have the type hint correct).