### PR TITLE
Fix Any subclassing in setuptools

### DIFF
--- a/stubs/setuptools/METADATA.toml
+++ b/stubs/setuptools/METADATA.toml
@@ -1,1 +1,2 @@
 version = "65.6.*"
+requires = ["types-docutils"]

--- a/stubs/setuptools/setuptools/_distutils/command/check.pyi
+++ b/stubs/setuptools/setuptools/_distutils/command/check.pyi
@@ -1,12 +1,11 @@
 from typing import Any
-from typing_extensions import TypeAlias
+
+import docutils.utils
 
 from ..cmd import Command
 
-_Reporter: TypeAlias = Any  # really docutils.utils.Reporter
-
 # Only defined if docutils is installed.
-class SilentReporter(_Reporter):
+class SilentReporter(docutils.utils.Reporter):
     messages: Any
     def __init__(
         self,


### PR DESCRIPTION
Reference the docutils stub.

As far as I understand, there's no issue with this if docutils isn't installed. And gives proper type when it is.

Fixes 3 subclassing errors (the same error in setuptools, pyinstaller and Pygments stubs)