### PR TITLE
Explain why we subclass ImageQt with Any

### DIFF
--- a/stubs/Pillow/PIL/ImageQt.pyi
+++ b/stubs/Pillow/PIL/ImageQt.pyi
@@ -3,7 +3,10 @@ from typing_extensions import Literal, TypeAlias
 
 from .Image import Image
 
-QImage: TypeAlias = Any  # imported from either of {PyQt6,PySide6,PyQt5,PySide2}.QtGui
+# imported from either of {PyQt6,PySide6,PyQt5,PySide2}.QtGui
+# These are way too complex, with 4 different possible sources (2 deprecated)
+# And we don't want to force the user to install PyQt or Pyside when they may not even use it.
+QImage: TypeAlias = Any
 QPixmap: TypeAlias = Any
 
 qt_versions: Any
@@ -15,7 +18,7 @@ def fromqimage(im: Image | QImage) -> Image: ...
 def fromqpixmap(im: Image | QImage) -> Image: ...
 def align8to32(bytes: bytes, width: int, mode: Literal["1", "L", "P"]) -> bytes: ...
 
-class ImageQt(QImage):
+class ImageQt(QImage):  # type: ignore[misc]
     def __init__(self, im: Image) -> None: ...
 
 def toqimage(im: Image) -> ImageQt: ...


### PR DESCRIPTION
These are way too complex, with 4 different possible sources (2 deprecated)
And we don't want to force the user to install PyQt or Pyside when they may not even use it.

Fixes 6 subclassing errors (the same error in Pillow, D3DShot, python-xlib, fpdf2, PyScreeze, and PyAutoGUI stubs)

Ref: #9491