### PR TITLE
Use pyasn1 in python-jose

### DIFF
--- a/stubs/python-jose/METADATA.toml
+++ b/stubs/python-jose/METADATA.toml
@@ -1,5 +1,5 @@
 version = "3.3.*"
-requires = [] # excluding pyasn1, pyrsa, cryptography until typing is available
+requires = ["types-pyasn1"] # excluding pyrsa, cryptography until typing is available
 
 [tool.stubtest]
 ignore_missing_stub = false

--- a/stubs/python-jose/jose/backends/_asn1.pyi
+++ b/stubs/python-jose/jose/backends/_asn1.pyi
@@ -1,22 +1,17 @@
-from typing import Any
-from typing_extensions import TypeAlias
-
-# Enable when pyasn1 gets stubs:
-# from pyasn1.type import univ
-_Sequence: TypeAlias = Any
+from pyasn1.type import namedtype, univ
 
 RSA_ENCRYPTION_ASN1_OID: str
 
-class RsaAlgorithmIdentifier(_Sequence):
-    componentType: Any
+class RsaAlgorithmIdentifier(univ.Sequence):
+    componentType: namedtype.NamedTypes
 
-class PKCS8PrivateKey(_Sequence):
-    componentType: Any
+class PKCS8PrivateKey(univ.Sequence):
+    componentType: namedtype.NamedTypes
 
-class PublicKeyInfo(_Sequence):
-    componentType: Any
+class PublicKeyInfo(univ.Sequence):
+    componentType: namedtype.NamedTypes
 
-def rsa_private_key_pkcs8_to_pkcs1(pkcs8_key): ...
-def rsa_private_key_pkcs1_to_pkcs8(pkcs1_key): ...
-def rsa_public_key_pkcs1_to_pkcs8(pkcs1_key): ...
-def rsa_public_key_pkcs8_to_pkcs1(pkcs8_key): ...
+def rsa_private_key_pkcs8_to_pkcs1(pkcs8_key) -> bytes: ...
+def rsa_private_key_pkcs1_to_pkcs8(pkcs1_key) -> bytes: ...
+def rsa_public_key_pkcs1_to_pkcs8(pkcs1_key) -> bytes: ...
+def rsa_public_key_pkcs8_to_pkcs1(pkcs8_key) -> bytes: ...


### PR DESCRIPTION
Gonna have to wait for stubs-uploader to push `types-pyasn1` first.

Fixes 3 Any subtyping issues