### PR TITLE
Add missing tagMap & typeMap in pyasn1 encoder/decoder

### DIFF
--- a/stubs/pyasn1/pyasn1/codec/ber/decoder.pyi
+++ b/stubs/pyasn1/pyasn1/codec/ber/decoder.pyi
@@ -317,6 +317,9 @@ class GeneralizedTimeDecoder(OctetStringDecoder):
 class UTCTimeDecoder(OctetStringDecoder):
     protoComponent: useful.UTCTime
 
+tagMap: dict[TagSet, AbstractDecoder]
+typeMap: dict[int, AbstractDecoder]
+
 class Decoder:
     defaultErrorState: int
     defaultRawDecoder: AnyDecoder

--- a/stubs/pyasn1/pyasn1/codec/ber/encoder.pyi
+++ b/stubs/pyasn1/pyasn1/codec/ber/encoder.pyi
@@ -2,6 +2,7 @@ from _typeshed import Incomplete
 from abc import abstractmethod
 
 from pyasn1.type.base import Asn1Type
+from pyasn1.type.tag import TagSet
 
 class AbstractItemEncoder:
     supportIndefLenMode: bool
@@ -57,6 +58,9 @@ class ChoiceEncoder(AbstractItemEncoder):
 
 class AnyEncoder(OctetStringEncoder):
     def encodeValue(self, value, asn1Spec, encodeFun, **options): ...
+
+tagMap: dict[TagSet, AbstractItemEncoder]
+typeMap: dict[int, AbstractItemEncoder]
 
 class Encoder:
     fixedDefLengthMode: bool | None

--- a/stubs/pyasn1/pyasn1/codec/cer/decoder.pyi
+++ b/stubs/pyasn1/pyasn1/codec/cer/decoder.pyi
@@ -24,6 +24,9 @@ BitStringDecoder = decoder.BitStringDecoder
 OctetStringDecoder = decoder.OctetStringDecoder
 RealDecoder = decoder.RealDecoder
 
+tagMap: dict[TagSet, decoder.AbstractDecoder]
+typeMap: dict[int, decoder.AbstractDecoder]
+
 class Decoder(decoder.Decoder): ...
 
 decode: Decoder

--- a/stubs/pyasn1/pyasn1/codec/cer/encoder.pyi
+++ b/stubs/pyasn1/pyasn1/codec/cer/encoder.pyi
@@ -1,6 +1,7 @@
 from typing import ClassVar
 
 from pyasn1.codec.ber import encoder
+from pyasn1.type.tag import TagSet
 
 class BooleanEncoder(encoder.IntegerEncoder):
     def encodeValue(self, value, asn1Spec, encodeFun, **options): ...
@@ -32,6 +33,9 @@ class SetEncoder(encoder.SequenceEncoder):
 
 class SequenceEncoder(encoder.SequenceEncoder):
     omitEmptyOptionals: bool
+
+tagMap: dict[TagSet, encoder.AbstractItemEncoder]
+typeMap: dict[int, encoder.AbstractItemEncoder]
 
 class Encoder(encoder.Encoder):
     fixedDefLengthMode: bool

--- a/stubs/pyasn1/pyasn1/codec/der/decoder.pyi
+++ b/stubs/pyasn1/pyasn1/codec/der/decoder.pyi
@@ -1,10 +1,15 @@
+from pyasn1.codec.ber import decoder as ber_decoder
 from pyasn1.codec.cer import decoder
+from pyasn1.type.tag import TagSet
 
 class BitStringDecoder(decoder.BitStringDecoder):
     supportConstructedForm: bool
 
 class OctetStringDecoder(decoder.OctetStringDecoder):
     supportConstructedForm: bool
+
+tagMap: dict[TagSet, ber_decoder.AbstractDecoder]
+typeMap: dict[int, ber_decoder.AbstractDecoder]
 
 class Decoder(decoder.Decoder):
     supportIndefLength: bool

--- a/stubs/pyasn1/pyasn1/codec/der/encoder.pyi
+++ b/stubs/pyasn1/pyasn1/codec/der/encoder.pyi
@@ -1,6 +1,11 @@
+from pyasn1.codec.ber import encoder as ber_encoder
 from pyasn1.codec.cer import encoder
+from pyasn1.type.tag import TagSet
 
 class SetEncoder(encoder.SetEncoder): ...
+
+tagMap: dict[TagSet, ber_encoder.AbstractItemEncoder]
+typeMap: dict[int, ber_encoder.AbstractItemEncoder]
 
 class Encoder(encoder.Encoder):
     fixedDefLengthMode: bool

--- a/stubs/pyasn1/pyasn1/codec/native/decoder.pyi
+++ b/stubs/pyasn1/pyasn1/codec/native/decoder.pyi
@@ -2,6 +2,8 @@ from _typeshed import Incomplete
 from collections.abc import Callable
 from typing_extensions import TypeAlias
 
+from pyasn1.type.tag import TagSet
+
 _Unused: TypeAlias = object
 
 class AbstractScalarDecoder:
@@ -18,6 +20,9 @@ class SequenceOfOrSetOfDecoder:
 
 class ChoiceDecoder:
     def __call__(self, pyObject, asn1Spec, decodeFun: Callable[..., Incomplete] | None = ..., **options): ...
+
+tagMap: dict[TagSet, AbstractScalarDecoder | SequenceOrSetDecoder | SequenceOfOrSetOfDecoder | ChoiceDecoder]
+typeMap: dict[int, AbstractScalarDecoder | SequenceOrSetDecoder | SequenceOfOrSetOfDecoder | ChoiceDecoder]
 
 class Decoder:
     def __init__(self, tagMap, typeMap) -> None: ...

--- a/stubs/pyasn1/pyasn1/codec/native/encoder.pyi
+++ b/stubs/pyasn1/pyasn1/codec/native/encoder.pyi
@@ -1,6 +1,8 @@
 from abc import abstractmethod
 from collections import OrderedDict
 
+from pyasn1.type.tag import TagSet
+
 class AbstractItemEncoder:
     @abstractmethod
     def encode(self, value, encodeFun, **options) -> None: ...
@@ -43,6 +45,9 @@ class ChoiceEncoder(SequenceEncoder): ...
 
 class AnyEncoder(AbstractItemEncoder):
     def encode(self, value, encodeFun, **options): ...
+
+tagMap: dict[TagSet, AbstractItemEncoder]
+typeMap: dict[int, AbstractItemEncoder]
 
 class Encoder:
     def __init__(self, tagMap, typeMap=...) -> None: ...


### PR DESCRIPTION
Required for #9470
These are meant to be exported (and are actually used) as a helper mapping of types for specific encoder/decoder

To avoid very large unions and complex overloads, I've kept only the base types.