### PR TITLE
Add `FileDescriptorOrPath` and `Unused` type aliases

### DIFF
--- a/stdlib/_typeshed/__init__.pyi
+++ b/stdlib/_typeshed/__init__.pyi
@@ -36,6 +36,9 @@ AnyStr_co = TypeVar("AnyStr_co", str, bytes, covariant=True)  # noqa: Y001
 # "Incomplete | None" instead of "Any | None".
 Incomplete: TypeAlias = Any
 
+# To describe a method parameter that is unused and will work with anything.
+Unused: TypeAlias = object
+
 # stable
 class IdentityFunction(Protocol):
     def __call__(self, __x: _T) -> _T: ...
@@ -205,6 +208,7 @@ class HasFileno(Protocol):
 
 FileDescriptor: TypeAlias = int  # stable
 FileDescriptorLike: TypeAlias = int | HasFileno  # stable
+FileDescriptorOrPath: TypeAlias = int | StrOrBytesPath
 
 # stable
 class SupportsRead(Protocol[_T_co]):

--- a/stdlib/_typeshed/__init__.pyi
+++ b/stdlib/_typeshed/__init__.pyi
@@ -36,7 +36,7 @@ AnyStr_co = TypeVar("AnyStr_co", str, bytes, covariant=True)  # noqa: Y001
 # "Incomplete | None" instead of "Any | None".
 Incomplete: TypeAlias = Any
 
-# To describe a method parameter that is unused and will work with anything.
+# To describe a function parameter that is unused and will work with anything.
 Unused: TypeAlias = object
 
 # stable


### PR DESCRIPTION
Closes #9297 and see https://github.com/python/typeshed/pull/9470#discussion_r1063745593

I found myself using a `_Unused` TypeAlias a lot for semantic reasons.

Of course they can't be used everywhere until the next mypy update.