### PR TITLE
`mypy_test.py`: Simplify `add_third_party_files()`

### DIFF
--- a/tests/mypy_test.py
+++ b/tests/mypy_test.py
@@ -284,20 +284,8 @@ def add_third_party_files(
     if distribution in seen_dists:
         return
     seen_dists.add(distribution)
-
-    stubs_dir = Path("stubs")
-    dependencies = get_recursive_requirements(distribution).typeshed_pkgs
-
-    for dependency in dependencies:
-        if dependency in seen_dists:
-            continue
-        seen_dists.add(dependency)
-        files_to_add = sorted((stubs_dir / dependency).rglob("*.pyi"))
-        files.extend(files_to_add)
-        for file in files_to_add:
-            log(args, file, f"included as a dependency of {distribution!r}")
-
-    root = stubs_dir / distribution
+    seen_dists.update(get_recursive_requirements(distribution).typeshed_pkgs)
+    root = Path("stubs", distribution)
     for name in os.listdir(root):
         if name.startswith("."):
             continue


### PR DESCRIPTION
This is a cleanup PR, removing logic from `mypy_test.py` that's no longer necessary.

This logic was introduced in #8800 to ensure that running e.g. `python tests/mypy_test.py stubs/caldav` locally would work, fixing #8797. However, following #8360 (for which the logic was reworked somewhat in #9408), we now add typeshed dependencies of a stubs package to `MYPYPATH` when testing that stubs package. That means this logic is no longer necessary; `python tests/mypy_test.py stubs/caldav` still works fine when run locally with this logic removed. If you want to see exactly which directories are being added to `MYPYPATH`, you can run `python tests/mypy_test.py stubs/caldav --verbose --verbose` for a detailed log to the terminal.