### PR TITLE
Allow default values in stubs.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -26,7 +26,7 @@
 [flake8]
 per-file-ignores =
   *.py: E203, E301, E302, E305, E501
-  *.pyi: B, E301, E302, E305, E501, E701, E741, F401, F403, F405, F822, Y037
+  *.pyi: B, E301, E302, E305, E501, E701, E741, F401, F403, F405, F822, Y011, Y037
   # Since typing.pyi defines "overload" this is not recognized by flake8 as typing.overload.
   # Unfortunately, flake8 does not allow to "noqa" just a specific error inside the file itself.
   # https://github.com/PyCQA/flake8/issues/1079

--- a/.flake8
+++ b/.flake8
@@ -26,7 +26,7 @@
 [flake8]
 per-file-ignores =
   *.py: E203, E301, E302, E305, E501
-  *.pyi: B, E301, E302, E305, E501, E701, E741, F401, F403, F405, F822, Y011, Y037
+  *.pyi: B, E301, E302, E305, E501, E701, E741, F401, F403, F405, F822, Y011, Y015, Y037
   # Since typing.pyi defines "overload" this is not recognized by flake8 as typing.overload.
   # Unfortunately, flake8 does not allow to "noqa" just a specific error inside the file itself.
   # https://github.com/PyCQA/flake8/issues/1079

--- a/.flake8
+++ b/.flake8
@@ -23,6 +23,10 @@
 #            Currently can't be enabled due to a few lingering bugs in mypy regarding
 #            PEP 604 type aliases (see #4819).
 
+# Outdated rules in flake8-pyi that should possibly be deprecated altogether:
+#     Y011   All default values for typed function arguments must be `...`
+#     Y015   Attribute must not have a default value other than `...`
+
 [flake8]
 per-file-ignores =
   *.py: E203, E301, E302, E305, E501
@@ -31,7 +35,7 @@ per-file-ignores =
   # Unfortunately, flake8 does not allow to "noqa" just a specific error inside the file itself.
   # https://github.com/PyCQA/flake8/issues/1079
   #     F811 redefinition of unused '...'
-  stdlib/typing.pyi: B, E301, E302, E305, E501, E701, E741, F401, F403, F405, F811, F822, Y037
+  stdlib/typing.pyi: B, E301, E302, E305, E501, E701, E741, F401, F403, F405, F811, F822, Y011, Y015, Y037
   # Generated protobuf files include docstrings
   *_pb2.pyi: B, E301, E302, E305, E501, E701, Y021, Y026
 


### PR DESCRIPTION
https://github.com/python/typeshed/issues/8988 based on this discussion simple default values seem to be fine to allow now. Y011 is default value rule for function arguments. Y015 is default attribute rule for things like Enums/class constants. There's also Y014 a variation of Y011 that I'm neutral on.