### PR TITLE
Fix Any subclassing in pyinstaller

### DIFF
--- a/stubs/pyinstaller/PyInstaller/utils/hooks/conda.pyi
+++ b/stubs/pyinstaller/PyInstaller/utils/hooks/conda.pyi
@@ -3,14 +3,17 @@
 import sys
 from _typeshed import StrOrBytesPath
 from collections.abc import Iterable
-from pathlib import Path
-from typing import Any
-from typing_extensions import TypeAlias, TypedDict
+from pathlib import Path, PurePosixPath
+from typing_extensions import TypedDict
 
 if sys.version_info >= (3, 8):
     from importlib.metadata import PackagePath as _PackagePath
 else:
-    _PackagePath: TypeAlias = Any
+    # Same as importlib_metadata.PackagePath
+    class _PackagePath(PurePosixPath):
+        def read_text(self, encoding: str = ...) -> str: ...
+        def read_binary(self) -> str: ...
+        def locate(self) -> Path: ...
 
 CONDA_ROOT: Path
 CONDA_META_DIR: Path


### PR DESCRIPTION
This one was easy to fix without having to resort to external requires. Plus it's Python 3.7 only

Ref: #9491