### PR TITLE
Add comment explaining NonCallableMock's Any subclassing

### DIFF
--- a/stdlib/unittest/mock.pyi
+++ b/stdlib/unittest/mock.pyi
@@ -102,7 +102,10 @@ class _CallList(list[_Call]):
 class Base:
     def __init__(self, *args: Any, **kwargs: Any) -> None: ...
 
-class NonCallableMock(Base, Any):
+# Defining this and other mock classes exactly like the source causes
+# many false positives with mypy and production code.
+# We improve by use a class with an "Any" base class.
+class NonCallableMock(Base, Any):  # type: ignore[misc]
     def __new__(__cls: type[Self], *args: Any, **kw: Any) -> Self: ...
     def __init__(
         self,

--- a/stdlib/unittest/mock.pyi
+++ b/stdlib/unittest/mock.pyi
@@ -102,9 +102,8 @@ class _CallList(list[_Call]):
 class Base:
     def __init__(self, *args: Any, **kwargs: Any) -> None: ...
 
-# Defining this and other mock classes exactly like the source causes
-# many false positives with mypy and production code.
-# We improve by use a class with an "Any" base class.
+# We subclass with "Any" because defining this and other mock classes exactly like the source
+# causes many false positives with mypy and production code.
 class NonCallableMock(Base, Any):  # type: ignore[misc]
     def __new__(__cls: type[Self], *args: Any, **kw: Any) -> Self: ...
     def __init__(

--- a/stubs/mock/mock/mock.pyi
+++ b/stubs/mock/mock/mock.pyi
@@ -76,7 +76,10 @@ class _CallList(list[_Call]):
 class Base:
     def __init__(self, *args: Any, **kwargs: Any) -> None: ...
 
-class NonCallableMock(Base, Any):
+# Defining this and other mock classes exactly like the source causes
+# many false positives with mypy and production code.
+# We improve by use a class with an "Any" base class.
+class NonCallableMock(Base, Any):  # type: ignore[misc]
     def __new__(
         cls: type[Self],
         spec: list[str] | object | type[object] | None = ...,

--- a/stubs/mock/mock/mock.pyi
+++ b/stubs/mock/mock/mock.pyi
@@ -76,9 +76,8 @@ class _CallList(list[_Call]):
 class Base:
     def __init__(self, *args: Any, **kwargs: Any) -> None: ...
 
-# Defining this and other mock classes exactly like the source causes
-# many false positives with mypy and production code.
-# We improve by use a class with an "Any" base class.
+# We subclass with "Any" because defining this and other mock classes exactly like the source
+# causes many false positives with mypy and production code.
 class NonCallableMock(Base, Any):  # type: ignore[misc]
     def __new__(
         cls: type[Self],


### PR DESCRIPTION
Brought back and reworded a 5yo comment explaining why `NonCallableMock` is subclassed with `Any`.

Feel free to wordsmith.

Ref: #9491