### PR TITLE
Allow stubs to depend on `numpy`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,10 +91,10 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: ${{ matrix.python-version }}
           cache: pip
           cache-dependency-path: requirements-tests.txt
-      - run: pip install -r requirements-tests.txt
+      - run: pip install $(grep mypy== requirements-tests.txt) packaging pathspec termcolor tomli typing-extensions
       - run: python ./tests/mypy_test.py --platform=${{ matrix.platform }} --python-version=${{ matrix.python-version }}
 
   regression-tests:

--- a/tests/mypy_test.py
+++ b/tests/mypy_test.py
@@ -12,11 +12,12 @@ import sys
 import tempfile
 import time
 from collections import defaultdict
+from collections.abc import Sequence
 from dataclasses import dataclass
 from itertools import product
 from pathlib import Path
 from threading import Lock
-from typing import TYPE_CHECKING, Any, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple, Tuple
 
 if TYPE_CHECKING:
     from _typeshed import StrPath
@@ -52,7 +53,7 @@ DIRECTORIES_TO_TEST = [Path("stdlib"), Path("stubs")]
 
 ReturnCode: TypeAlias = int
 VersionString: TypeAlias = Annotated[str, "Must be one of the entries in SUPPORTED_VERSIONS"]
-VersionTuple: TypeAlias = tuple[int, int]
+VersionTuple: TypeAlias = Tuple[int, int]
 Platform: TypeAlias = Annotated[str, "Must be one of the entries in SUPPORTED_PLATFORMS"]
 
 
@@ -77,6 +78,21 @@ def valid_path(cmd_arg: str) -> Path:
 parser = argparse.ArgumentParser(
     description="Typecheck typeshed's stubs with mypy. Patterns are unanchored regexps on the full path."
 )
+if sys.version_info < (3, 8):
+
+    class ExtendAction(argparse.Action):
+        def __call__(
+            self,
+            parser: argparse.ArgumentParser,
+            namespace: argparse.Namespace,
+            values: Sequence[str],
+            option_string: object = None,
+        ) -> None:
+            items = getattr(namespace, self.dest) or []
+            items.extend(values)
+            setattr(namespace, self.dest, items)
+
+    parser.register("action", "extend", ExtendAction)
 parser.add_argument(
     "filter",
     type=valid_path,
@@ -323,7 +339,7 @@ def test_third_party_distribution(
 
     mypypath = os.pathsep.join(str(Path("stubs", dist)) for dist in seen_dists)
     if args.verbose:
-        print(colored(f"\n{mypypath=}", "blue"))
+        print(colored(f"\nMYPYPATH={mypypath}", "blue"))
     code = run_mypy(
         args,
         configurations,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -8,7 +8,7 @@ import subprocess
 import sys
 import venv
 from collections.abc import Iterable, Mapping
-from functools import cache
+from functools import lru_cache
 from pathlib import Path
 from typing import NamedTuple
 from typing_extensions import Annotated
@@ -24,6 +24,10 @@ except ImportError:
     def colored(text: str, color: str | None = None, on_color: str | None = None, attrs: Iterable[str] | None = None) -> str:
         return text
 
+
+# A backport of functools.cache for Python <3.9
+# This module is imported by mypy_test.py, which needs to run on 3.7 in CI
+cache = lru_cache(None)
 
 # Used to install system-wide packages for different OS types:
 METADATA_MAPPING = {"linux": "apt_dependencies", "darwin": "brew_dependencies", "win32": "choco_dependencies"}


### PR DESCRIPTION
Currently, if a stubs package declares a dependency on `numpy`, the latest version of `numpy` will be installed in CI when testing that package. However, the CI will then fail, because mypy will detect that `numpy` is using PEP-570 syntax, and accordingly will emit errors when run with the `--python-version=3.7` flag, since PEP 570 is new in Python 3.8.

The solution is to actually run mypy _on_ 3.7 in CI, rather than simply running mypy with the `--python-version=3.7` flag. If we run mypy _on_ 3.7, pip's dependency resolver will understand that the latest version of `numpy` isn't compatible with the version of Python we're using, and will give us an older version of `numpy` that's compatible with Python 3.7.

A few tweaks to `tests/mypy_test.py` and `tests/utils.py` are required in order to make them compatible with Python 3.7. We also can't install the whole of `requirements-tests.txt` on Python 3.7, since `flake8==6.0.0` is not compatible with Python 3.7.

Helps unblock #8974