### PR TITLE
urllib.parse.urlencode: encoding and errors can be None

### DIFF
--- a/stdlib/urllib/parse.pyi
+++ b/stdlib/urllib/parse.pyi
@@ -158,10 +158,10 @@ _Q = TypeVar("_Q", bound=str | Iterable[int])
 
 def urlencode(
     query: Mapping[Any, Any] | Mapping[Any, Sequence[Any]] | Sequence[tuple[Any, Any]] | Sequence[tuple[Any, Sequence[Any]]],
-    doseq: bool = ...,
+    doseq: bool = False,
     safe: _Q = ...,
-    encoding: str = ...,
-    errors: str = ...,
+    encoding: str | None = None,
+    errors: str | None = None,
     quote_via: Callable[[AnyStr, _Q, str, str], str] = ...,
 ) -> str: ...
 def urljoin(base: AnyStr, url: AnyStr | None, allow_fragments: bool = ...) -> AnyStr: ...


### PR DESCRIPTION
The runtime defaults are None. Found in #9501.
