### PR TITLE
venv: add logger

### DIFF
--- a/stdlib/venv/__init__.pyi
+++ b/stdlib/venv/__init__.pyi
@@ -1,7 +1,10 @@
+import logging
 import sys
 from _typeshed import StrOrBytesPath
 from collections.abc import Sequence
 from types import SimpleNamespace
+
+logger: logging.Logger
 
 if sys.version_info >= (3, 9):
     CORE_VENV_DEPS: tuple[str, ...]


### PR DESCRIPTION
Not particularly useful but unreleased stubtest will require this:
https://github.com/python/typeshed/actions/runs/3898630022/jobs/6657546205
