### PR TITLE
Use environment marker to restrict flake8 install

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -43,7 +43,7 @@ jobs:
           cache: pip
           cache-dependency-path: requirements-tests.txt
       - name: Install dependencies
-        run: pip install -r requirements-tests.txt
+        run: pip install $(grep mypy== requirements-tests.txt)
       - name: Run stubtest
         run: python tests/stubtest_stdlib.py
 

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -43,7 +43,7 @@ jobs:
           cache: pip
           cache-dependency-path: requirements-tests.txt
       - name: Install dependencies
-        run: pip install $(grep tomli== requirements-tests.txt) $(grep mypy== requirements-tests.txt)
+        run: pip install -r requirements-tests.txt
       - name: Run stubtest
         run: python tests/stubtest_stdlib.py
 

--- a/.github/workflows/stubtest_stdlib.yml
+++ b/.github/workflows/stubtest_stdlib.yml
@@ -44,6 +44,6 @@ jobs:
           cache: pip
           cache-dependency-path: requirements-tests.txt
       - name: Install dependencies
-        run: pip install $(grep mypy== requirements-tests.txt)
+        run: pip install -r requirements-tests.txt
       - name: Run stubtest
         run: python tests/stubtest_stdlib.py

--- a/.github/workflows/stubtest_stdlib.yml
+++ b/.github/workflows/stubtest_stdlib.yml
@@ -44,6 +44,6 @@ jobs:
           cache: pip
           cache-dependency-path: requirements-tests.txt
       - name: Install dependencies
-        run: pip install -r requirements-tests.txt
+        run: pip install $(grep mypy== requirements-tests.txt)
       - name: Run stubtest
         run: python tests/stubtest_stdlib.py

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -94,7 +94,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: pip
           cache-dependency-path: requirements-tests.txt
-      - run: pip install $(grep mypy== requirements-tests.txt) packaging pathspec termcolor tomli typing-extensions
+      - run: pip install -r requirements-tests.txt
       - run: python ./tests/mypy_test.py --platform=${{ matrix.platform }} --python-version=${{ matrix.python-version }}
 
   regression-tests:

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,14 +1,14 @@
 aiohttp==3.8.3
-black==22.12.0            # must match .pre-commit-config.yaml
-flake8==6.0.0             # must match .pre-commit-config.yaml
-flake8-bugbear==22.12.6   # must match .pre-commit-config.yaml
-flake8-noqa==1.3.0        # must match .pre-commit-config.yaml
-flake8-pyi==22.11.0       # must match .pre-commit-config.yaml
-isort==5.11.4             # must match .pre-commit-config.yaml
+black==22.12.0                                    # must match .pre-commit-config.yaml
+flake8==6.0.0; python_version >= "3.8"            # must match .pre-commit-config.yaml
+flake8-bugbear==22.12.6; python_version >= "3.8"  # must match .pre-commit-config.yaml
+flake8-noqa==1.3.0; python_version >= "3.8"       # must match .pre-commit-config.yaml
+flake8-pyi==22.11.0; python_version >= "3.8"      # must match .pre-commit-config.yaml
+isort==5.11.4                                     # must match .pre-commit-config.yaml
 mypy==0.991
 packaging==22.0
 pathspec
-pycln==2.1.2              # must match .pre-commit-config.yaml
+pycln==2.1.2                                      # must match .pre-commit-config.yaml
 pyyaml==6.0
 pytype==2023.1.10; platform_system != "Windows" and python_version < "3.11"
 termcolor>=2


### PR DESCRIPTION
From https://github.com/python/typeshed/pull/8974#discussion_r1067873831

Use of environment marker to indicate that a dependency isn't usable with Python 3.7

- More obvious than grepping
- Reduces duplication
- Keeps the CI the same as others
- Works locally
- pip will event log why it's not installing flake8