### PR TITLE
Fix setuptools stubtest on windows

### DIFF
--- a/stubs/setuptools/@tests/stubtest_allowlist.txt
+++ b/stubs/setuptools/@tests/stubtest_allowlist.txt
@@ -29,7 +29,3 @@ pkg_resources.to_filename
 
 # Only present if docutils is installed
 setuptools._distutils.command.check.SilentReporter
-
-# Shim for implementation details, unintended re-exports
-setuptools.msvc.environ
-setuptools.msvc.winreg

--- a/stubs/setuptools/@tests/stubtest_allowlist.txt
+++ b/stubs/setuptools/@tests/stubtest_allowlist.txt
@@ -29,3 +29,7 @@ pkg_resources.to_filename
 
 # Only present if docutils is installed
 setuptools._distutils.command.check.SilentReporter
+
+# Shim for implementation details, unintended re-exports
+setuptools.msvc.environ
+setuptools.msvc.winreg

--- a/stubs/setuptools/setuptools/msvc.pyi
+++ b/stubs/setuptools/setuptools/msvc.pyi
@@ -1,11 +1,5 @@
 from typing import Any
 
-class winreg:
-    HKEY_USERS: Any
-    HKEY_CURRENT_USER: Any
-    HKEY_LOCAL_MACHINE: Any
-    HKEY_CLASSES_ROOT: Any
-
 PLAT_SPEC_TO_RUNTIME: Any
 
 def msvc14_get_vc_env(plat_spec): ...


### PR DESCRIPTION
I'm fairly certain that's just a shim for implementation details.
Fixes stubtest on windows. Stub on windows and linux should be equivalent now.