### PR TITLE
Allowlist-only fixes for stubtest windows

### DIFF
--- a/stubs/Pillow/@tests/stubtest_allowlist.txt
+++ b/stubs/Pillow/@tests/stubtest_allowlist.txt
@@ -1,5 +1,7 @@
 PIL.FpxImagePlugin
 PIL.ImageQt.ImageQt
-PIL.ImageQt.QImage  # Does exist at runtime usually, but stubtest can't see it
-PIL.ImageQt.QPixmap  # Does exist at runtime usually, but stubtest can't see it
 PIL.MicImagePlugin
+# Requires Pyside or PyQt to be installed.
+# We don't install either in stubtest so it can't see it
+PIL.ImageQt.QImage
+PIL.ImageQt.QPixmap

--- a/stubs/keyboard/@tests/stubtest_allowlist.txt
+++ b/stubs/keyboard/@tests/stubtest_allowlist.txt
@@ -2,7 +2,6 @@
 keyboard.KeyboardEvent.scan_code
 keyboard._keyboard_event.KeyboardEvent.scan_code
 # Defaults don't align with possible values
-keyboard.mouse.on_button
 keyboard.mouse.wait
 # TODO: Should this be allowlisted?
 keyboard.__main__

--- a/stubs/keyboard/@tests/stubtest_allowlist_darwin.txt
+++ b/stubs/keyboard/@tests/stubtest_allowlist_darwin.txt
@@ -1,0 +1,2 @@
+# Defaults don't align with possible values
+keyboard.mouse.on_button

--- a/stubs/keyboard/@tests/stubtest_allowlist_linux.txt
+++ b/stubs/keyboard/@tests/stubtest_allowlist_linux.txt
@@ -1,0 +1,2 @@
+# Defaults don't align with possible values
+keyboard.mouse.on_button

--- a/stubs/pywin32/@tests/stubtest_allowlist_win32.txt
+++ b/stubs/pywin32/@tests/stubtest_allowlist_win32.txt
@@ -65,6 +65,7 @@ win32com(ext)?.axdebug.documents
 win32com(ext)?.axdebug.expressions
 # failed to import, ModuleNotFoundError: No module named 'expressions'
 win32com(ext)?.axdebug.stackframe
+# Axdebug is not built on Python 3.11: https://github.com/mhammond/pywin32/blob/main/setup.py#L405
 # failed to import, ImportError: cannot import name 'axdebug' from 'win32com.axdebug'
 win32com.axdebug.gateways
 win32comext.axdebug.gateways

--- a/stubs/tree-sitter-languages/@tests/stubtest_allowlist.txt
+++ b/stubs/tree-sitter-languages/@tests/stubtest_allowlist.txt
@@ -1,5 +1,2 @@
 # No idea what this is, seems to be auto-generated
 tree_sitter_languages.core.__test__
-
-# Fails to import and is not supposed to be imported, but stubtest finds it somehow
-tree_sitter_languages.languages

--- a/stubs/tree-sitter-languages/@tests/stubtest_allowlist_darwin.txt
+++ b/stubs/tree-sitter-languages/@tests/stubtest_allowlist_darwin.txt
@@ -1,0 +1,2 @@
+# stubtest/stubgen sees languages.so as a module
+tree_sitter_languages.languages

--- a/stubs/tree-sitter-languages/@tests/stubtest_allowlist_linux.txt
+++ b/stubs/tree-sitter-languages/@tests/stubtest_allowlist_linux.txt
@@ -1,0 +1,2 @@
+# stubtest/stubgen sees languages.so as a module
+tree_sitter_languages.languages


### PR DESCRIPTION
Batch of changes in allowlist entries (no stub change) to fix some third party stubtest runs on windows.