### PR TITLE
Pin `fpdf2` stubs to 2.6.0

### DIFF
--- a/stubs/fpdf2/METADATA.toml
+++ b/stubs/fpdf2/METADATA.toml
@@ -1,4 +1,4 @@
-version = "2.6.*"
+version = "2.6.0"
 requires = ["types-Pillow"]
 
 [tool.stubtest]


### PR DESCRIPTION
They will need some updates to become compatible with `fpdf2` 2.6.1.

Closes #9524