### PR TITLE
Update tensorflow to 2.11

### DIFF
--- a/stubs/tensorflow/METADATA.toml
+++ b/stubs/tensorflow/METADATA.toml
@@ -1,3 +1,3 @@
-version = "2.10.*"
+version = "2.11.*"
 # requires a version of numpy with a `py.typed` file
 requires = ["numpy>=1.20"]

--- a/stubs/tensorflow/tensorflow/__init__.pyi
+++ b/stubs/tensorflow/tensorflow/__init__.pyi
@@ -112,6 +112,7 @@ class Variable(Tensor, metaclass=_VariableMetaclass):
         synchronization: VariableSynchronization = VariableSynchronization.AUTO,
         aggregation: VariableAggregation = VariableAggregation.NONE,
         shape: _ShapeLike | None = None,
+        experimental_enable_variable_lifting: _bool = True,
     ) -> None: ...
     def __getattr__(self, name: str) -> Incomplete: ...
 


### PR DESCRIPTION
Fixes stubtest failure in [stubsabot](https://github.com/python/typeshed/pull/9539).