### PR TITLE
`Xlib`: Import `Pattern` from `re`, not `typing`

### DIFF
--- a/stubs/python-xlib/Xlib/display.pyi
+++ b/stubs/python-xlib/Xlib/display.pyi
@@ -1,6 +1,7 @@
 from collections.abc import Callable, Iterable, Sequence
+from re import Pattern
 from types import FunctionType, MethodType
-from typing import Any, Pattern, overload
+from typing import Any, overload
 from typing_extensions import Literal, TypeAlias, TypedDict
 
 from Xlib import error


### PR DESCRIPTION
Refs https://github.com/PyCQA/flake8-pyi/pull/324