### PR TITLE
Bump various test dependencies

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -26,10 +26,13 @@
 # Outdated rules in flake8-pyi that should possibly be deprecated altogether:
 #     Y011   All default values for typed function arguments must be `...`
 #     Y015   Attribute must not have a default value other than `...`
+#
+# A bugbear rule that has many false positives:
+#     B028   consider using the `!r` conversion flag instead of manually surrounding things in quotes
 
 [flake8]
 per-file-ignores =
-  *.py: E203, E301, E302, E305, E501
+  *.py: B028, E203, E301, E302, E305, E501
   *.pyi: B, E301, E302, E305, E501, E701, E741, F401, F403, F405, F822, Y011, Y015, Y037
   # Since typing.pyi defines "overload" this is not recognized by flake8 as typing.overload.
   # Unfortunately, flake8 does not allow to "noqa" just a specific error inside the file itself.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/hadialqattan/pycln
-    rev: v2.1.2 # must match requirements-tests.txt
+    rev: v2.1.3 # must match requirements-tests.txt
     hooks:
       - id: pycln
         args: [--config=pyproject.toml, stubs, stdlib, tests, scripts]
@@ -21,7 +21,7 @@ repos:
         additional_dependencies:
           - "flake8-bugbear==22.12.6" # must match requirements-tests.txt
           - "flake8-noqa==1.3.0" # must match requirements-tests.txt
-          - "flake8-pyi==22.11.0" # must match requirements-tests.txt
+          - "flake8-pyi==23.1.0" # must match requirements-tests.txt
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v3.0.0-alpha.4
     python_requirement: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     hooks:
       - id: flake8
         additional_dependencies:
-          - "flake8-bugbear==22.12.6" # must match requirements-tests.txt
+          - "flake8-bugbear==23.1.14" # must match requirements-tests.txt
           - "flake8-noqa==1.3.0" # must match requirements-tests.txt
           - "flake8-pyi==23.1.0" # must match requirements-tests.txt
   - repo: https://github.com/pre-commit/mirrors-prettier

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,14 +1,14 @@
 aiohttp==3.8.3
 black==22.12.0                                    # must match .pre-commit-config.yaml
 flake8==6.0.0; python_version >= "3.8"            # must match .pre-commit-config.yaml
-flake8-bugbear==22.12.6; python_version >= "3.8"  # must match .pre-commit-config.yaml
+flake8-bugbear==23.1.14; python_version >= "3.8"  # must match .pre-commit-config.yaml
 flake8-noqa==1.3.0; python_version >= "3.8"       # must match .pre-commit-config.yaml
-flake8-pyi==22.11.0; python_version >= "3.8"      # must match .pre-commit-config.yaml
+flake8-pyi==23.1.0; python_version >= "3.8"       # must match .pre-commit-config.yaml
 isort==5.11.4                                     # must match .pre-commit-config.yaml
 mypy==0.991
-packaging==22.0
-pathspec
-pycln==2.1.2                                      # must match .pre-commit-config.yaml
+packaging==23.0
+pathspec>=0.10.3
+pycln==2.1.3                                      # must match .pre-commit-config.yaml
 pyyaml==6.0
 pytype==2023.1.10; platform_system != "Windows" and python_version < "3.11"
 termcolor>=2

--- a/stdlib/_collections_abc.pyi
+++ b/stdlib/_collections_abc.pyi
@@ -1,6 +1,6 @@
 import sys
 from types import MappingProxyType
-from typing import (  # noqa: Y027,Y038
+from typing import (  # noqa: Y022,Y038
     AbstractSet as Set,
     AsyncGenerator as AsyncGenerator,
     AsyncIterable as AsyncIterable,

--- a/stdlib/array.pyi
+++ b/stdlib/array.pyi
@@ -3,7 +3,7 @@ from _typeshed import ReadableBuffer, Self, SupportsRead, SupportsWrite
 from collections.abc import Iterable
 
 # pytype crashes if array inherits from collections.abc.MutableSequence instead of typing.MutableSequence
-from typing import Any, Generic, MutableSequence, TypeVar, overload  # noqa: Y027
+from typing import Any, Generic, MutableSequence, TypeVar, overload  # noqa: Y022
 from typing_extensions import Literal, SupportsIndex, TypeAlias
 
 _IntTypeCode: TypeAlias = Literal["b", "B", "h", "H", "i", "I", "l", "L", "q", "Q"]

--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -32,7 +32,7 @@ from io import BufferedRandom, BufferedReader, BufferedWriter, FileIO, TextIOWra
 from types import CodeType, TracebackType, _Cell
 
 # mypy crashes if any of {ByteString, Sequence, MutableSequence, Mapping, MutableMapping} are imported from collections.abc in builtins.pyi
-from typing import (  # noqa: Y027
+from typing import (  # noqa: Y022
     IO,
     Any,
     BinaryIO,

--- a/stdlib/types.pyi
+++ b/stdlib/types.pyi
@@ -16,7 +16,7 @@ from collections.abc import (
 from importlib.machinery import ModuleSpec
 
 # pytype crashes if types.MappingProxyType inherits from collections.abc.Mapping instead of typing.Mapping
-from typing import Any, ClassVar, Generic, Mapping, Protocol, TypeVar, overload  # noqa: Y027
+from typing import Any, ClassVar, Generic, Mapping, Protocol, TypeVar, overload  # noqa: Y022
 from typing_extensions import Literal, ParamSpec, final
 
 __all__ = [

--- a/stdlib/typing_extensions.pyi
+++ b/stdlib/typing_extensions.pyi
@@ -6,7 +6,7 @@ import typing
 from _collections_abc import dict_items, dict_keys, dict_values
 from _typeshed import IdentityFunction, Incomplete
 from collections.abc import Iterable
-from typing import (  # noqa: Y022,Y027,Y039
+from typing import (  # noqa: Y022,Y039
     TYPE_CHECKING as TYPE_CHECKING,
     Any as Any,
     AsyncContextManager as AsyncContextManager,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import NamedTuple
 from typing_extensions import Annotated
 
-import pathspec  # type: ignore[import]
+import pathspec
 import tomli
 from packaging.requirements import Requirement
 
@@ -215,4 +215,4 @@ def spec_matches_path(spec: pathspec.PathSpec, path: Path) -> bool:
     normalized_path = path.as_posix()
     if path.is_dir():
         normalized_path += "/"
-    return spec.match_file(normalized_path)  # type: ignore[no-any-return]
+    return spec.match_file(normalized_path)


### PR DESCRIPTION
- Bump `packaging` to 23.0
- Bump `flake-pyi` to 23.1.0, which I just released. This requires changing a few `# noqa` codes. It will also mean that we can reenable Y011 and Y015, but we can do that in another PR.
- Bump `pycln` to 2.1.3. Thanks to @Avasam's recent PR https://github.com/hadialqattan/pycln/pull/186, this means we can use the latest version of `pathspec`, which includes inline types, thus meaning we can get rid of a few `type: ignore` comments in our test suite!