### PR TITLE
`mypy_test.py`: Try using a process pool instead of a thread pool

### DIFF
--- a/tests/mypy_test.py
+++ b/tests/mypy_test.py
@@ -435,7 +435,7 @@ def setup_virtual_environments(distributions: dict[str, PackageDependencies], ar
 
     venv_start_time = time.perf_counter()
 
-    with concurrent.futures.ThreadPoolExecutor() as executor:
+    with concurrent.futures.ProcessPoolExecutor() as executor:
         venv_info_futures = [
             executor.submit(setup_venv_for_external_requirements_set, requirements_set, tempdir)
             for requirements_set in external_requirements_to_distributions


### PR DESCRIPTION
Implements @srittau's idea in https://github.com/python/typeshed/issues/9537#issuecomment-1384096983, which seems worth a shot. Timings locally are the same as with using a threadpool for setting up the venvs.