### PR TITLE
create_datagram_endpoint expects a str when family=AF_UNIX

### DIFF
--- a/stdlib/asyncio/base_events.pyi
+++ b/stdlib/asyncio/base_events.pyi
@@ -342,8 +342,8 @@ class BaseEventLoop(AbstractEventLoop):
         async def create_datagram_endpoint(  # type: ignore[override]
             self,
             protocol_factory: Callable[[], _ProtocolT],
-            local_addr: tuple[str, int] | None = None,
-            remote_addr: tuple[str, int] | None = None,
+            local_addr: tuple[str, int] | str | None = None,
+            remote_addr: tuple[str, int] | str | None = None,
             *,
             family: int = 0,
             proto: int = 0,
@@ -351,6 +351,21 @@ class BaseEventLoop(AbstractEventLoop):
             reuse_port: bool | None = None,
             allow_broadcast: bool | None = None,
             sock: socket | None = None,
+        ) -> tuple[DatagramTransport, _ProtocolT]: ...
+    elif sys.version_info >= (3, 7):
+        async def create_datagram_endpoint(
+            self,
+            protocol_factory: Callable[[], _ProtocolT],
+            local_addr: tuple[str, int] | str | None = ...,
+            remote_addr: tuple[str, int] | str | None = ...,
+            *,
+            family: int = ...,
+            proto: int = ...,
+            flags: int = ...,
+            reuse_address: bool | None = ...,
+            reuse_port: bool | None = ...,
+            allow_broadcast: bool | None = ...,
+            sock: socket | None = ...,
         ) -> tuple[DatagramTransport, _ProtocolT]: ...
     else:
         async def create_datagram_endpoint(

--- a/stdlib/asyncio/base_events.pyi
+++ b/stdlib/asyncio/base_events.pyi
@@ -352,27 +352,12 @@ class BaseEventLoop(AbstractEventLoop):
             allow_broadcast: bool | None = None,
             sock: socket | None = None,
         ) -> tuple[DatagramTransport, _ProtocolT]: ...
-    elif sys.version_info >= (3, 7):
+    else:
         async def create_datagram_endpoint(
             self,
             protocol_factory: Callable[[], _ProtocolT],
             local_addr: tuple[str, int] | str | None = ...,
             remote_addr: tuple[str, int] | str | None = ...,
-            *,
-            family: int = ...,
-            proto: int = ...,
-            flags: int = ...,
-            reuse_address: bool | None = ...,
-            reuse_port: bool | None = ...,
-            allow_broadcast: bool | None = ...,
-            sock: socket | None = ...,
-        ) -> tuple[DatagramTransport, _ProtocolT]: ...
-    else:
-        async def create_datagram_endpoint(
-            self,
-            protocol_factory: Callable[[], _ProtocolT],
-            local_addr: tuple[str, int] | None = ...,
-            remote_addr: tuple[str, int] | None = ...,
             *,
             family: int = ...,
             proto: int = ...,

--- a/stdlib/asyncio/events.pyi
+++ b/stdlib/asyncio/events.pyi
@@ -512,8 +512,8 @@ class AbstractEventLoop:
         async def create_datagram_endpoint(
             self,
             protocol_factory: Callable[[], _ProtocolT],
-            local_addr: tuple[str, int] | None = None,
-            remote_addr: tuple[str, int] | None = None,
+            local_addr: tuple[str, int] | str | None = None,
+            remote_addr: tuple[str, int] | str | None = None,
             *,
             family: int = 0,
             proto: int = 0,

--- a/stdlib/asyncio/events.pyi
+++ b/stdlib/asyncio/events.pyi
@@ -491,38 +491,21 @@ class AbstractEventLoop:
     async def sendfile(
         self, transport: WriteTransport, file: IO[bytes], offset: int = 0, count: int | None = None, *, fallback: bool = True
     ) -> int: ...
-    if sys.version_info >= (3, 7):
-        @abstractmethod
-        async def create_datagram_endpoint(
-            self,
-            protocol_factory: Callable[[], _ProtocolT],
-            local_addr: tuple[str, int] | str | None = None,
-            remote_addr: tuple[str, int] | str | None = None,
-            *,
-            family: int = 0,
-            proto: int = 0,
-            flags: int = 0,
-            reuse_address: bool | None = None,
-            reuse_port: bool | None = None,
-            allow_broadcast: bool | None = None,
-            sock: socket | None = None,
-        ) -> tuple[DatagramTransport, _ProtocolT]: ...
-    else:
-        @abstractmethod
-        async def create_datagram_endpoint(
-            self,
-            protocol_factory: Callable[[], _ProtocolT],
-            local_addr: tuple[str, int] | str | None = None,
-            remote_addr: tuple[str, int] | str | None = None,
-            *,
-            family: int = 0,
-            proto: int = 0,
-            flags: int = 0,
-            reuse_address: bool | None = None,
-            reuse_port: bool | None = None,
-            allow_broadcast: bool | None = None,
-            sock: socket | None = None,
-        ) -> tuple[DatagramTransport, _ProtocolT]: ...
+    @abstractmethod
+    async def create_datagram_endpoint(
+        self,
+        protocol_factory: Callable[[], _ProtocolT],
+        local_addr: tuple[str, int] | str | None = None,
+        remote_addr: tuple[str, int] | str | None = None,
+        *,
+        family: int = 0,
+        proto: int = 0,
+        flags: int = 0,
+        reuse_address: bool | None = None,
+        reuse_port: bool | None = None,
+        allow_broadcast: bool | None = None,
+        sock: socket | None = None,
+    ) -> tuple[DatagramTransport, _ProtocolT]: ...
     # Pipes and subprocesses.
     @abstractmethod
     async def connect_read_pipe(

--- a/stdlib/asyncio/events.pyi
+++ b/stdlib/asyncio/events.pyi
@@ -491,21 +491,38 @@ class AbstractEventLoop:
     async def sendfile(
         self, transport: WriteTransport, file: IO[bytes], offset: int = 0, count: int | None = None, *, fallback: bool = True
     ) -> int: ...
-    @abstractmethod
-    async def create_datagram_endpoint(
-        self,
-        protocol_factory: Callable[[], _ProtocolT],
-        local_addr: tuple[str, int] | None = None,
-        remote_addr: tuple[str, int] | None = None,
-        *,
-        family: int = 0,
-        proto: int = 0,
-        flags: int = 0,
-        reuse_address: bool | None = None,
-        reuse_port: bool | None = None,
-        allow_broadcast: bool | None = None,
-        sock: socket | None = None,
-    ) -> tuple[DatagramTransport, _ProtocolT]: ...
+    if sys.version_info >= (3, 7):
+        @abstractmethod
+        async def create_datagram_endpoint(
+            self,
+            protocol_factory: Callable[[], _ProtocolT],
+            local_addr: tuple[str, int] | str | None = None,
+            remote_addr: tuple[str, int] | str | None = None,
+            *,
+            family: int = 0,
+            proto: int = 0,
+            flags: int = 0,
+            reuse_address: bool | None = None,
+            reuse_port: bool | None = None,
+            allow_broadcast: bool | None = None,
+            sock: socket | None = None,
+        ) -> tuple[DatagramTransport, _ProtocolT]: ...
+    else:
+        @abstractmethod
+        async def create_datagram_endpoint(
+            self,
+            protocol_factory: Callable[[], _ProtocolT],
+            local_addr: tuple[str, int] | None = None,
+            remote_addr: tuple[str, int] | None = None,
+            *,
+            family: int = 0,
+            proto: int = 0,
+            flags: int = 0,
+            reuse_address: bool | None = None,
+            reuse_port: bool | None = None,
+            allow_broadcast: bool | None = None,
+            sock: socket | None = None,
+        ) -> tuple[DatagramTransport, _ProtocolT]: ...
     # Pipes and subprocesses.
     @abstractmethod
     async def connect_read_pipe(


### PR DESCRIPTION
Since python 3.7, [`asyncio.loop.create_datagram_endpoint`](https://docs.python.org/3.8/library/asyncio-eventloop.html#asyncio.loop.create_datagram_endpoint) expects the arguments `local_addr` and `remote_addr` to be `str` or `None` when the argument `family` is `socket.AF_UNIX` (and if when `sock` is not `None`, it is also a unix socket). Here is a link to the relevant line in the standard library: https://github.com/python/cpython/blob/main/Lib/asyncio/base_events.py#L1319

Here is a link to the pull request on the cpython repository which effected this change: https://github.com/python/cpython/pull/3164

i'm not at all sure if I've made the changes correctly. is there a way to represent the dependency on the `family` argument that i'm missing?