### PR TITLE
Fix some stubtest complaints before they happen

### DIFF
--- a/stdlib/lib2to3/pygram.pyi
+++ b/stdlib/lib2to3/pygram.pyi
@@ -110,4 +110,5 @@ class pattern_symbols(Symbols):
 
 python_grammar: Grammar
 python_grammar_no_print_statement: Grammar
+python_grammar_no_print_and_exec_statement: Grammar
 pattern_grammar: Grammar

--- a/stdlib/lib2to3/pygram.pyi
+++ b/stdlib/lib2to3/pygram.pyi
@@ -1,3 +1,4 @@
+import sys
 from lib2to3.pgen2.grammar import Grammar
 
 class Symbols:
@@ -110,5 +111,6 @@ class pattern_symbols(Symbols):
 
 python_grammar: Grammar
 python_grammar_no_print_statement: Grammar
-python_grammar_no_print_and_exec_statement: Grammar
+if sys.version_info >= (3, 8):
+    python_grammar_no_print_and_exec_statement: Grammar
 pattern_grammar: Grammar

--- a/stubs/decorator/decorator.pyi
+++ b/stubs/decorator/decorator.pyi
@@ -1,10 +1,11 @@
+import inspect
 from builtins import dict as _dict  # alias to avoid conflicts with attribute name
 from collections.abc import Callable, Iterator
 from contextlib import _GeneratorContextManager
 from inspect import Signature, getfullargspec as getfullargspec, iscoroutinefunction as iscoroutinefunction
 from re import Pattern
 from typing import Any, TypeVar
-from typing_extensions import ParamSpec
+from typing_extensions import Literal, ParamSpec
 
 _C = TypeVar("_C", bound=Callable[..., Any])
 _Func = TypeVar("_Func", bound=Callable[..., Any])
@@ -14,6 +15,7 @@ _P = ParamSpec("_P")
 def get_init(cls: type) -> None: ...
 
 DEF: Pattern[str]
+POS: Literal[inspect._ParameterKind.POSITIONAL_OR_KEYWORD]
 
 class FunctionMaker:
     args: list[str]

--- a/stubs/dockerfile-parse/dockerfile_parse/parser.pyi
+++ b/stubs/dockerfile-parse/dockerfile_parse/parser.pyi
@@ -1,8 +1,11 @@
+import logging
 from collections.abc import Mapping, Sequence
 from typing import IO, ClassVar
 from typing_extensions import TypedDict
 
 from .util import Context
+
+logger: logging.Logger
 
 class KeyValues(dict[str, str]):
     parser_attr: ClassVar[str | None]

--- a/stubs/playsound/playsound.pyi
+++ b/stubs/playsound/playsound.pyi
@@ -1,4 +1,7 @@
+import logging
 import pathlib
+
+logger: logging.Logger
 
 class PlaysoundException(Exception): ...
 

--- a/stubs/pyinstaller/PyInstaller/__main__.pyi
+++ b/stubs/pyinstaller/PyInstaller/__main__.pyi
@@ -1,4 +1,5 @@
 # https://pyinstaller.org/en/stable/usage.html#running-pyinstaller-from-python-code
+import logging
 from _typeshed import SupportsKeysAndGetItem
 from collections.abc import Iterable
 from typing_extensions import TypeAlias
@@ -7,5 +8,7 @@ from typing_extensions import TypeAlias
 _PyIConfig: TypeAlias = (
     SupportsKeysAndGetItem[str, bool | str | list[str] | None] | Iterable[tuple[str, bool | str | list[str] | None]]
 )
+
+logger: logging.Logger
 
 def run(pyi_args: Iterable[str] | None = ..., pyi_config: _PyIConfig | None = ...) -> None: ...

--- a/stubs/pyinstaller/PyInstaller/utils/hooks/__init__.pyi
+++ b/stubs/pyinstaller/PyInstaller/utils/hooks/__init__.pyi
@@ -1,5 +1,6 @@
 # https://pyinstaller.org/en/stable/hooks.html
 
+import logging
 from _typeshed import StrOrBytesPath, StrPath
 from collections.abc import Callable, Iterable
 from typing import Any
@@ -13,6 +14,7 @@ from PyInstaller.utils.hooks.win32 import get_pywin32_module_file_attribute as g
 
 conda_support = conda
 
+logger: logging.Logger
 PY_IGNORE_EXTENSIONS: set[str]
 hook_variables: dict[str, str]
 

--- a/stubs/retry/retry/api.pyi
+++ b/stubs/retry/retry/api.pyi
@@ -5,6 +5,8 @@ from typing import Any, TypeVar
 
 _R = TypeVar("_R")
 
+logging_logger: Logger
+
 def retry_call(
     f: Callable[..., _R],
     fargs: Sequence[Any] | None = ...,

--- a/stubs/vobject/vobject/base.pyi
+++ b/stubs/vobject/vobject/base.pyi
@@ -1,8 +1,10 @@
+import logging
 from _typeshed import Incomplete, SupportsWrite
 from collections.abc import Iterable, Iterator
 from typing import Any, TypeVar, overload
 from typing_extensions import Literal
 
+logger: logging.Logger
 DEBUG: bool
 CR: str
 LF: str


### PR DESCRIPTION
This adds some missing objects to various stdlib and third-party stubs. Stubtest doesn't complain about these now, but will do when mypy 1.0 is released; this should make upgrading to mypy 1.0 easier when that happens.