### PR TITLE
python-xlib: remove workaround for pytype

### DIFF
--- a/stubs/python-xlib/Xlib/xobject/resource.pyi
+++ b/stubs/python-xlib/Xlib/xobject/resource.pyi
@@ -1,13 +1,5 @@
-from typing import type_check_only
-
+from Xlib.display import _BaseDisplay
 from Xlib._typing import ErrorHandler
-from Xlib.protocol import display
-
-# Workaround for pytype crash. Should be Xlib.display._BaseDisplay
-@type_check_only
-class _BaseDisplay(display.Display):
-    def __init__(self, display: str | None = ...) -> None: ...
-    def get_atom(self, atomname: str, only_if_exists: bool = ...) -> int: ...
 
 class Resource:
     display: _BaseDisplay

--- a/stubs/python-xlib/Xlib/xobject/resource.pyi
+++ b/stubs/python-xlib/Xlib/xobject/resource.pyi
@@ -1,5 +1,5 @@
-from Xlib.display import _BaseDisplay
 from Xlib._typing import ErrorHandler
+from Xlib.display import _BaseDisplay
 
 class Resource:
     display: _BaseDisplay


### PR DESCRIPTION
Xlib/xobject/resource.pyi declared a fake `_BaseDisplay` class, marked as `@type_check_only`, used as the type of `Resource.display` instance attribute and the associated `display` parameter `Resource.__init__()`. An in-code comment indicated the reason for the incorrect class typing:
> Workaround for pytype crash. Should be Xlib.display._BaseDisplay

However, the workaround causes issues with `mypy` in code performing comparisons between `Xlib.xobject.drawable.Window.display` (affected by the workaround) and `Xlib.display.Display.display` (using the original, correct class) objects:

> error: Non-overlapping identity check (left operand type: "Xlib.xobject.resource._BaseDisplay", right operand type: "Xlib.display._BaseDisplay")  [comparison-overlap]

Also, I could not reproduce the mentioned crash using latest `pytype` v2023.01.17 under Python 3.8 in Ubuntu, so it was either already fixed upstream or it requires specific conditions or environment to trigger.

As such, I believe it's better to remove the workaround.

Later, proven it's still required, such conditions should be described in more details, reported as a bug in `pytype` and link back the report before reverting this removal so we have a way to properly track the need for this workaround.