### PR TITLE
Increase `mypy_primer` comment length

### DIFF
--- a/.github/workflows/mypy_primer_comment.yml
+++ b/.github/workflows/mypy_primer_comment.yml
@@ -50,9 +50,11 @@ jobs:
           script: |
             const fs = require('fs')
             let data = fs.readFileSync('fulldiff.txt', { encoding: 'utf8' })
-            // posting comment fails if too long, so truncate
-            if (data.length > 30000) {
-              let truncated_data = data.substring(0, 30000)
+
+            // Maximum comment length is 65536 characters. We need much less than 236 for extra text.
+            const MAX_LENGTH = 65300
+            if (data.length > MAX_LENGTH) {
+              let truncated_data = data.substring(0, MAX_LENGTH)
               let lines_truncated = data.split('\n').length - truncated_data.split('\n').length
               data = truncated_data + `\n\n... (truncated ${lines_truncated} lines) ...\n`
             }


### PR DESCRIPTION
To be exact, we only need to reserve 170 characters to truncate over a thousand lines. But I figured that `65300` was a nice round number with a good buffer.

Sources:
![image](https://user-images.githubusercontent.com/1350584/215264985-a88b17d8-9cbf-4847-9f3f-2b26390a9c23.png)
and https://github.com/orgs/community/discussions/27190#discussioncomment-3254953