### PR TITLE
`_bisect`: Remove incorrect `= ...`s for several overloads

### DIFF
--- a/stdlib/_bisect.pyi
+++ b/stdlib/_bisect.pyi
@@ -17,7 +17,7 @@ if sys.version_info >= (3, 10):
         lo: int = 0,
         hi: int | None = None,
         *,
-        key: Callable[[_T], SupportsRichComparisonT] = ...,
+        key: Callable[[_T], SupportsRichComparisonT],
     ) -> int: ...
     @overload
     def bisect_right(
@@ -30,7 +30,7 @@ if sys.version_info >= (3, 10):
         lo: int = 0,
         hi: int | None = None,
         *,
-        key: Callable[[_T], SupportsRichComparisonT] = ...,
+        key: Callable[[_T], SupportsRichComparisonT],
     ) -> int: ...
     @overload
     def insort_left(
@@ -43,7 +43,7 @@ if sys.version_info >= (3, 10):
     ) -> None: ...
     @overload
     def insort_left(
-        a: MutableSequence[_T], x: _T, lo: int = 0, hi: int | None = None, *, key: Callable[[_T], SupportsRichComparisonT] = ...
+        a: MutableSequence[_T], x: _T, lo: int = 0, hi: int | None = None, *, key: Callable[[_T], SupportsRichComparisonT]
     ) -> None: ...
     @overload
     def insort_right(
@@ -56,7 +56,7 @@ if sys.version_info >= (3, 10):
     ) -> None: ...
     @overload
     def insort_right(
-        a: MutableSequence[_T], x: _T, lo: int = 0, hi: int | None = None, *, key: Callable[[_T], SupportsRichComparisonT] = ...
+        a: MutableSequence[_T], x: _T, lo: int = 0, hi: int | None = None, *, key: Callable[[_T], SupportsRichComparisonT]
     ) -> None: ...
 
 else:


### PR DESCRIPTION
Refs #9608

- If no value is provided for the `key` parameter by the user, we actually want the type checker to specify the first overload (not this overload, which is the second overload). Specifying a default value for this parameter in this overload is confusing.
- If the type checker did select this overload, the `_T` TypeVar would go unsolved if no value was specified for the key parameter.
- If we try to add the default value for this parameter (`None`), mypy will (correctly) complain that we're using an implicit optional type for the type annotation.