### PR TITLE
Add some missing py311+ constants to `sre_constants.pyi`

### DIFF
--- a/stdlib/sre_constants.pyi
+++ b/stdlib/sre_constants.pyi
@@ -79,6 +79,10 @@ REPEAT: _NamedIntConstant
 REPEAT_ONE: _NamedIntConstant
 SUBPATTERN: _NamedIntConstant
 MIN_REPEAT_ONE: _NamedIntConstant
+if sys.version_info >= (3, 11):
+    ATOMIC_GROUP: _NamedIntConstant
+    POSSESSIVE_REPEAT: _NamedIntConstant
+    POSSESSIVE_REPEAT_ONE: _NamedIntConstant
 RANGE_UNI_IGNORE: _NamedIntConstant
 GROUPREF_LOC_IGNORE: _NamedIntConstant
 GROUPREF_UNI_IGNORE: _NamedIntConstant


### PR DESCRIPTION
Stubtest will complain about these being missing once mypy 1.0 is released.

(On Python 3.11, these constants are _actually_ defined in `re/_constants.py`, and reexported from the deprecated-in-3.11 `sre_constants` module. But I'd rather not reflect that right now, as that will be a much larger and more complicated change.)