### PR TITLE
Bump isort to 5.12.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
       - id: black
         language_version: python3.10
   - repo: https://github.com/pycqa/isort
-    rev: 5.11.4 # must match requirements-tests.txt
+    rev: 5.12.0 # must match requirements-tests.txt
     hooks:
       - id: isort
         name: isort (python)

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -4,7 +4,7 @@ flake8==6.0.0; python_version >= "3.8"            # must match .pre-commit-confi
 flake8-bugbear==23.1.14; python_version >= "3.8"  # must match .pre-commit-config.yaml
 flake8-noqa==1.3.0; python_version >= "3.8"       # must match .pre-commit-config.yaml
 flake8-pyi==23.1.1; python_version >= "3.8"       # must match .pre-commit-config.yaml
-isort==5.11.4                                     # must match .pre-commit-config.yaml
+isort==5.12.0; python_version >= "3.8"            # must match .pre-commit-config.yaml
 mypy==0.991
 packaging==23.0
 pathspec>=0.10.3


### PR DESCRIPTION
Fixes the CI failure seen in #9616 (see https://github.com/PyCQA/isort/issues/2077 for an explanation of the issue, fixed in the latest isort release)