### PR TITLE
Remove redundant `reportUnnecessaryTypeIgnoreComment=true`

### DIFF
--- a/stubs/invoke/@tests/test_cases/check_task.py
+++ b/stubs/invoke/@tests/test_cases/check_task.py
@@ -1,4 +1,3 @@
-# pyright: reportUnnecessaryTypeIgnoreComment=true
 from __future__ import annotations
 
 from invoke import Context, task

--- a/stubs/protobuf/@tests/test_cases/check_struct.py
+++ b/stubs/protobuf/@tests/test_cases/check_struct.py
@@ -1,4 +1,3 @@
-# pyright: reportUnnecessaryTypeIgnoreComment=true
 from __future__ import annotations
 
 from google.protobuf.struct_pb2 import ListValue, Struct

--- a/stubs/regex/@tests/test_cases/check_finditer.py
+++ b/stubs/regex/@tests/test_cases/check_finditer.py
@@ -1,5 +1,3 @@
-# pyright: reportUnnecessaryTypeIgnoreComment=true
-
 from __future__ import annotations
 
 from typing import List

--- a/stubs/requests/@tests/test_cases/check_post.py
+++ b/stubs/requests/@tests/test_cases/check_post.py
@@ -1,5 +1,3 @@
-# pyright: reportUnnecessaryTypeIgnoreComment=true
-
 from __future__ import annotations
 
 from collections.abc import Iterable

--- a/tests/check_consistent.py
+++ b/tests/check_consistent.py
@@ -14,8 +14,8 @@ from pathlib import Path
 import yaml
 from packaging.requirements import Requirement
 from packaging.specifiers import SpecifierSet
-from parse_metadata import read_metadata
 
+from parse_metadata import read_metadata
 from utils import VERSIONS_RE, get_all_testcase_directories, get_gitignore_spec, spec_matches_path, strip_comments
 
 extension_descriptions = {".pyi": "stub", ".py": ".py"}

--- a/tests/check_consistent.py
+++ b/tests/check_consistent.py
@@ -75,14 +75,6 @@ def check_test_cases() -> None:
             with open(file, encoding="UTF-8") as f:
                 lines = {line.strip() for line in f}
             assert "from __future__ import annotations" in lines, "Test-case files should use modern typing syntax where possible"
-            if package_name != "stdlib":
-                pyright_setting_not_enabled_msg = (
-                    f'Third-party test-case file "{file}" must have '
-                    f'"# pyright: reportUnnecessaryTypeIgnoreComment=true" '
-                    f"at the top of the file"
-                )
-                has_pyright_setting_enabled = "# pyright: reportUnnecessaryTypeIgnoreComment=true" in lines
-                assert has_pyright_setting_enabled, pyright_setting_not_enabled_msg
 
 
 def check_no_symlinks() -> None:

--- a/tests/check_consistent.py
+++ b/tests/check_consistent.py
@@ -14,8 +14,8 @@ from pathlib import Path
 import yaml
 from packaging.requirements import Requirement
 from packaging.specifiers import SpecifierSet
-
 from parse_metadata import read_metadata
+
 from utils import VERSIONS_RE, get_all_testcase_directories, get_gitignore_spec, spec_matches_path, strip_comments
 
 extension_descriptions = {".pyi": "stub", ".py": ".py"}
@@ -67,7 +67,7 @@ def check_stubs() -> None:
 
 
 def check_test_cases() -> None:
-    for package_name, testcase_dir in get_all_testcase_directories():
+    for _package_name, testcase_dir in get_all_testcase_directories():
         assert_consistent_filetypes(testcase_dir, kind=".py", allowed={"README.md"}, allow_nonidentifier_filenames=True)
         bad_test_case_filename = 'Files in a `test_cases` directory must have names starting with "check_"; got "{}"'
         for file in testcase_dir.rglob("*.py"):


### PR DESCRIPTION
Seems pretty redundant since #9397 `reportUnnecessaryTypeIgnoreComment` is set to `error` in all configs