### PR TITLE
[DO-NOT-MERGE] Checking to see if pyright verifies stdlib test cases against false negatives correctly

### DIFF
--- a/test_cases/stdlib/check_contextlib.py
+++ b/test_cases/stdlib/check_contextlib.py
@@ -5,7 +5,7 @@ from typing_extensions import assert_type
 
 
 # See issue #7961
-class Thing(ExitStack):
+class Thing(ExitStack):  # type: ignore
     pass
 
 


### PR DESCRIPTION
If our test-cases setup is working correctly, pyright should hopefully complain about this `type: ignore` being unused.