### PR TITLE
Improve a few version-dependent tkinter functions

### DIFF
--- a/stdlib/_tkinter.pyi
+++ b/stdlib/_tkinter.pyi
@@ -107,15 +107,27 @@ TK_VERSION: str
 class TkttType:
     def deletetimerhandler(self): ...
 
-def create(
-    __screenName: str | None = ...,
-    __baseName: str | None = ...,
-    __className: str = ...,
-    __interactive: bool = ...,
-    __wantobjects: bool = ...,
-    __wantTk: bool = ...,
-    __sync: bool = ...,
-    __use: str | None = ...,
-): ...
+if sys.version_info >= (3, 8):
+    def create(
+        __screenName: str | None = None,
+        __baseName: str = "",
+        __className: str = "Tk",
+        __interactive: bool = False,
+        __wantobjects: bool = False,
+        __wantTk: bool = True,
+        __sync: bool = False,
+        __use: str | None = None,
+    ): ...
+else:
+    def create(
+        __screenName: str | None = None,
+        __baseName: str | None = None,
+        __className: str = "Tk",
+        __interactive: bool = False,
+        __wantobjects: bool = False,
+        __wantTk: bool = True,
+        __sync: bool = False,
+        __use: str | None = None,
+    ): ...
 def getbusywaitinterval(): ...
 def setbusywaitinterval(__new_val): ...

--- a/stdlib/_tkinter.pyi
+++ b/stdlib/_tkinter.pyi
@@ -118,6 +118,7 @@ if sys.version_info >= (3, 8):
         __sync: bool = False,
         __use: str | None = None,
     ): ...
+
 else:
     def create(
         __screenName: str | None = None,
@@ -129,5 +130,6 @@ else:
         __sync: bool = False,
         __use: str | None = None,
     ): ...
+
 def getbusywaitinterval(): ...
 def setbusywaitinterval(__new_val): ...

--- a/stdlib/tkinter/__init__.pyi
+++ b/stdlib/tkinter/__init__.pyi
@@ -728,29 +728,18 @@ class _ExceptionReportingCallback(Protocol):
 
 class Tk(Misc, Wm):
     master: None
-    # Make sure to keep __init__ in sync with other functions that use the same args.
-    # Use `git grep screenName` to find them
-    if sys.version_info >= (3, 9):
-        def __init__(
-            self,
-            screenName: str | None = None,
-            baseName: str | None = None,
-            className: str = "Tk",
-            useTk: bool = True,
-            sync: bool = False,
-            use: str | None = None,
-        ) -> None: ...
-    else:
-        def __init__(
-            self,
-            screenName: str | None = None,
-            baseName: str | None = None,
-            className: str = "Tk",
-            useTk: bool = ...,
-            sync: bool = ...,
-            use: str | None = None,
-        ) -> None: ...
-
+    def __init__(
+        # Make sure to keep in sync with other functions that use the same
+        # args.
+        # use `git grep screenName` to find them
+        self,
+        screenName: str | None = None,
+        baseName: str | None = None,
+        className: str = "Tk",
+        useTk: bool = True,
+        sync: bool = False,
+        use: str | None = None,
+    ) -> None: ...
     @overload
     def configure(
         self,
@@ -811,11 +800,7 @@ class Tk(Misc, Wm):
     def wantobjects(self, *args, **kwargs): ...
     def willdispatch(self): ...
 
-if sys.version_info >= (3, 9):
-    def Tcl(screenName: str | None = None, baseName: str | None = None, className: str = "Tk", useTk: bool = False) -> Tk: ...
-
-else:
-    def Tcl(screenName: str | None = None, baseName: str | None = None, className: str = "Tk", useTk: bool = ...) -> Tk: ...
+def Tcl(screenName: str | None = None, baseName: str | None = None, className: str = "Tk", useTk: bool = False) -> Tk: ...
 
 _InMiscTotal = TypedDict("_InMiscTotal", {"in": Misc})
 _InMiscNonTotal = TypedDict("_InMiscNonTotal", {"in": Misc}, total=False)

--- a/stdlib/tkinter/__init__.pyi
+++ b/stdlib/tkinter/__init__.pyi
@@ -728,18 +728,28 @@ class _ExceptionReportingCallback(Protocol):
 
 class Tk(Misc, Wm):
     master: None
-    def __init__(
-        # Make sure to keep in sync with other functions that use the same
-        # args.
-        # use `git grep screenName` to find them
-        self,
-        screenName: str | None = None,
-        baseName: str | None = None,
-        className: str = "Tk",
-        useTk: bool = ...,
-        sync: bool = ...,
-        use: str | None = None,
-    ) -> None: ...
+    # Make sure to keep __init__ in sync with other functions that use the same args.
+    # Use `git grep screenName` to find them
+    if sys.version_info >= (3, 9):
+        def __init__(
+            self,
+            screenName: str | None = None,
+            baseName: str | None = None,
+            className: str = "Tk",
+            useTk: bool = True,
+            sync: bool = False,
+            use: str | None = None,
+        ) -> None: ...
+    else:
+        def __init__(
+            self,
+            screenName: str | None = None,
+            baseName: str | None = None,
+            className: str = "Tk",
+            useTk: bool = ...,
+            sync: bool = ...,
+            use: str | None = None,
+        ) -> None: ...
     @overload
     def configure(
         self,
@@ -800,7 +810,10 @@ class Tk(Misc, Wm):
     def wantobjects(self, *args, **kwargs): ...
     def willdispatch(self): ...
 
-def Tcl(screenName: str | None = None, baseName: str | None = None, className: str = "Tk", useTk: bool = ...) -> Tk: ...
+if sys.version_info >= (3, 9):
+    def Tcl(screenName: str | None = None, baseName: str | None = None, className: str = "Tk", useTk: bool = False) -> Tk: ...
+else:
+    def Tcl(screenName: str | None = None, baseName: str | None = None, className: str = "Tk", useTk: bool = ...) -> Tk: ...
 
 _InMiscTotal = TypedDict("_InMiscTotal", {"in": Misc})
 _InMiscNonTotal = TypedDict("_InMiscNonTotal", {"in": Misc}, total=False)

--- a/stdlib/tkinter/__init__.pyi
+++ b/stdlib/tkinter/__init__.pyi
@@ -750,6 +750,7 @@ class Tk(Misc, Wm):
             sync: bool = ...,
             use: str | None = None,
         ) -> None: ...
+
     @overload
     def configure(
         self,
@@ -812,6 +813,7 @@ class Tk(Misc, Wm):
 
 if sys.version_info >= (3, 9):
     def Tcl(screenName: str | None = None, baseName: str | None = None, className: str = "Tk", useTk: bool = False) -> Tk: ...
+
 else:
     def Tcl(screenName: str | None = None, baseName: str | None = None, className: str = "Tk", useTk: bool = ...) -> Tk: ...
 


### PR DESCRIPTION
On 3.8+, the second argument of `_tkinter.create` defaults to `""` rather than `None`, and `TypeError` is raised if a non-`str` is passed in:

```pycon
>>> import _tkinter
>>> _tkinter.create("foo", None)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: create() argument 2 must be str, not None
```

Meanwhile, on 3.9+, `tkinter.Tk.__init__` and `tkinter.Tcl` have `bool` defaults, which can be added to the stub. But on <=3.8, these functions have `int` defaults, which can't be added to the stub (since the parameters are annotated with `bool`, and I don't think we should change that).