### PR TITLE
Improve pyright verification of third-party test cases in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -146,6 +146,12 @@ jobs:
           python-platform: ${{ matrix.python-platform }}
           python-version: ${{ matrix.python-version }}
           no-comments: ${{ matrix.python-version != '3.10' || matrix.python-platform != 'Linux' }} # Having each job create the same comment is too noisy.
+      - uses: jakebailey/pyright-action@v1
+        with:
+          version: ${{ steps.pyright_version.outputs.value }}
+          python-platform: ${{ matrix.python-platform }}
+          python-version: ${{ matrix.python-version }}
+          no-comments: ${{ matrix.python-version != '3.10' || matrix.python-platform != 'Linux' }} # Having each job create the same comment is too noisy.
           project: ./pyrightconfig.stricter.json
       - uses: jakebailey/pyright-action@v1
         with:
@@ -154,12 +160,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
           no-comments: ${{ matrix.python-version != '3.10' || matrix.python-platform != 'Linux' }} # Having each job create the same comment is too noisy.
           project: ./pyrightconfig.testcases.json
-      - uses: jakebailey/pyright-action@v1
-        with:
-          version: ${{ steps.pyright_version.outputs.value }}
-          python-platform: ${{ matrix.python-platform }}
-          python-version: ${{ matrix.python-version }}
-          no-comments: ${{ matrix.python-version != '3.10' || matrix.python-platform != 'Linux' }} # Having each job create the same comment is too noisy.
 
   stub-uploader:
     name: Run the stub_uploader tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -140,20 +140,23 @@ jobs:
         with:
           file: "pyproject.toml"
           field: "tool.typeshed.pyright_version"
-      - uses: jakebailey/pyright-action@v1
+      - name: Run pyright with basic settings on all the stubs
+        uses: jakebailey/pyright-action@v1
         with:
           version: ${{ steps.pyright_version.outputs.value }}
           python-platform: ${{ matrix.python-platform }}
           python-version: ${{ matrix.python-version }}
           no-comments: ${{ matrix.python-version != '3.10' || matrix.python-platform != 'Linux' }} # Having each job create the same comment is too noisy.
-      - uses: jakebailey/pyright-action@v1
+      - name: Run pyright with stricter settings on some of the stubs
+        uses: jakebailey/pyright-action@v1
         with:
           version: ${{ steps.pyright_version.outputs.value }}
           python-platform: ${{ matrix.python-platform }}
           python-version: ${{ matrix.python-version }}
           no-comments: ${{ matrix.python-version != '3.10' || matrix.python-platform != 'Linux' }} # Having each job create the same comment is too noisy.
           project: ./pyrightconfig.stricter.json
-      - uses: jakebailey/pyright-action@v1
+      - name: Run pyright on the test cases
+        uses: jakebailey/pyright-action@v1
         with:
           version: ${{ steps.pyright_version.outputs.value }}
           python-platform: ${{ matrix.python-platform }}

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -5,6 +5,10 @@
         "stdlib",
         "stubs",
     ],
+    "exclude": [
+        // test cases use a custom config file
+        "stubs/**/@tests/test_cases"
+    ],
     "typeCheckingMode": "basic",
     "strictListInference": true,
     "strictDictionaryInference": true,

--- a/pyrightconfig.stricter.json
+++ b/pyrightconfig.stricter.json
@@ -6,6 +6,8 @@
         "stubs",
     ],
     "exclude": [
+        // test cases use a custom pyrightconfig file
+        "stubs/**/@tests/test_cases",
         "stdlib/distutils/command",
         "stdlib/lib2to3/refactor.pyi",
         "stdlib/_tkinter.pyi",

--- a/pyrightconfig.testcases.json
+++ b/pyrightconfig.testcases.json
@@ -3,6 +3,7 @@
     "typeshedPath": ".",
     "include": [
         "test_cases",
+        "stubs/**/@tests/test_cases"
     ],
     "typeCheckingMode": "strict",
     // Using unspecific "type ignore" comments in test_cases.

--- a/stubs/invoke/@tests/test_cases/check_task.py
+++ b/stubs/invoke/@tests/test_cases/check_task.py
@@ -13,5 +13,5 @@ def docker_build(context: Context) -> None:
 
 
 @task(docker_build)
-def docker_push(context: Context) -> None:
+def docker_push(context: Context) -> None:  # type: ignore
     pass

--- a/stubs/invoke/@tests/test_cases/check_task.py
+++ b/stubs/invoke/@tests/test_cases/check_task.py
@@ -13,5 +13,5 @@ def docker_build(context: Context) -> None:
 
 
 @task(docker_build)
-def docker_push(context: Context) -> None:  # type: ignore
+def docker_push(context: Context) -> None:
     pass

--- a/stubs/invoke/@tests/test_cases/check_task.py
+++ b/stubs/invoke/@tests/test_cases/check_task.py
@@ -1,4 +1,3 @@
-# pyright: reportUnnecessaryTypeIgnoreComment=true
 from __future__ import annotations
 
 from invoke import Context, task

--- a/stubs/protobuf/@tests/test_cases/check_struct.py
+++ b/stubs/protobuf/@tests/test_cases/check_struct.py
@@ -1,4 +1,3 @@
-# pyright: reportUnnecessaryTypeIgnoreComment=true
 from __future__ import annotations
 
 from google.protobuf.struct_pb2 import ListValue, Struct

--- a/stubs/regex/@tests/test_cases/check_finditer.py
+++ b/stubs/regex/@tests/test_cases/check_finditer.py
@@ -1,5 +1,3 @@
-# pyright: reportUnnecessaryTypeIgnoreComment=true
-
 from __future__ import annotations
 
 from typing import List

--- a/stubs/requests/@tests/test_cases/check_post.py
+++ b/stubs/requests/@tests/test_cases/check_post.py
@@ -12,7 +12,7 @@ import requests
 # =================================================================================================
 
 
-url = "https://httpbin.org/post"  # type: ignore
+url = "https://httpbin.org/post"
 multiple_files = [
     ("images", ("foo.png", open("foo.png", "rb"), "image/png")),
     ("images", ("bar.png", open("bar.png", "rb"), "image/png")),

--- a/stubs/requests/@tests/test_cases/check_post.py
+++ b/stubs/requests/@tests/test_cases/check_post.py
@@ -1,5 +1,3 @@
-# pyright: reportUnnecessaryTypeIgnoreComment=true
-
 from __future__ import annotations
 
 from collections.abc import Iterable

--- a/stubs/requests/@tests/test_cases/check_post.py
+++ b/stubs/requests/@tests/test_cases/check_post.py
@@ -12,7 +12,7 @@ import requests
 # =================================================================================================
 
 
-url = "https://httpbin.org/post"
+url = "https://httpbin.org/post"  # type: ignore
 multiple_files = [
     ("images", ("foo.png", open("foo.png", "rb"), "image/png")),
     ("images", ("bar.png", open("bar.png", "rb"), "image/png")),

--- a/tests/check_consistent.py
+++ b/tests/check_consistent.py
@@ -65,9 +65,15 @@ def check_stubs() -> None:
         allowed = {"METADATA.toml", "README", "README.md", "README.rst", "@tests"}
         assert_consistent_filetypes(dist, kind=".pyi", allowed=allowed)
 
+        tests_dir = dist / "@tests"
+        if tests_dir.exists() and tests_dir.is_dir():
+            py_files_present = bool([file for file in tests_dir.iterdir() if file.suffix == ".py"])
+            error_message = "Test-case files must be in an `@tests/test_cases/` directory, not in the `@tests/` directory"
+            assert not py_files_present, error_message
+
 
 def check_test_cases() -> None:
-    for package_name, testcase_dir in get_all_testcase_directories():
+    for _, testcase_dir in get_all_testcase_directories():
         assert_consistent_filetypes(testcase_dir, kind=".py", allowed={"README.md"}, allow_nonidentifier_filenames=True)
         bad_test_case_filename = 'Files in a `test_cases` directory must have names starting with "check_"; got "{}"'
         for file in testcase_dir.rglob("*.py"):
@@ -75,14 +81,6 @@ def check_test_cases() -> None:
             with open(file, encoding="UTF-8") as f:
                 lines = {line.strip() for line in f}
             assert "from __future__ import annotations" in lines, "Test-case files should use modern typing syntax where possible"
-            if package_name != "stdlib":
-                pyright_setting_not_enabled_msg = (
-                    f'Third-party test-case file "{file}" must have '
-                    f'"# pyright: reportUnnecessaryTypeIgnoreComment=true" '
-                    f"at the top of the file"
-                )
-                has_pyright_setting_enabled = "# pyright: reportUnnecessaryTypeIgnoreComment=true" in lines
-                assert has_pyright_setting_enabled, pyright_setting_not_enabled_msg
 
 
 def check_no_symlinks() -> None:

--- a/tests/check_consistent.py
+++ b/tests/check_consistent.py
@@ -67,7 +67,7 @@ def check_stubs() -> None:
 
         tests_dir = dist / "@tests"
         if tests_dir.exists() and tests_dir.is_dir():
-            py_files_present = bool([file for file in tests_dir.iterdir() if file.suffix == ".py"])
+            py_files_present = any(file.suffix == ".py" for file in tests_dir.iterdir())
             error_message = "Test-case files must be in an `@tests/test_cases/` directory, not in the `@tests/` directory"
             assert not py_files_present, error_message
 


### PR DESCRIPTION
As seen in #9623, following some recent changes to our pyright config, pyright no longer verifies our checks against false-negative errors that we have in our third-party test cases. (Our standard-library test cases are fine.) Luckily, the latest release of pyright means that we can use the same pyright config for our third-party test cases as we do for our standard-library test cases, by using wildcards in `include` and `exclude` patterns. This means that we can remove a no-longer-necessary test from `check_consistent.py`, and it means that we no longer have to have `# pyright: reportUnnecessaryTypeIgnoreComment=true` comments at the top of every third-party test-case file.

Also in this PR:

- Add a new test to `check_consistent.py`, ensuring that `.py` files are only found in the `@tests/test_cases/` directory, and not at the top level of the `@tests/` directory. This isn't necessarily obvious, and caused confusion in #9323.
- Change the workflow file so that the pyright configs are run in a more logical order. The old order was: "strict config first on a subset of the stubs; then, if that succeeds, do the test-cases config on the stdlib test cases; then, if _that_ succeeds, run the basic config on all the stubs". The new order is: "run the basic config first on all the stubs; then, if that succeeds, run the strict config on a subset of the stubs; then, if _that_ succeeds, run the test-case config on the stdlib and third-party test cases".

Co-authored-by: Avasam <samuel.06@hotmail.com>