### PR TITLE
Fix optional USB attributes in pyserial's `ListPortInfo`

### DIFF
--- a/stubs/pyserial/serial/tools/list_ports_common.pyi
+++ b/stubs/pyserial/serial/tools/list_ports_common.pyi
@@ -8,20 +8,21 @@ class ListPortInfo:
     name: str
     description: str
     hwid: str
-    # USB specific data: the attributes below are specific to USB devices only and should be marked
-    # as Optional. Since the majority of the serial devices nowadays are USB devices, typing them
-    # as Optional will be unnecessarily annoying. We type them with as a Union of their original
-    # type and Any so that obvious typing errors like ListPortInfo.pid + "str" are flagged.
+    # USB specific data: the vid and pid attributes below are specific to USB devices only and
+    # should be marked as Optional. Since the majority of the serial devices nowadays are USB
+    # devices, typing them as Optional will be unnecessarily annoying. We type them with as
+    # `int | Any` so that obvious typing errors like ListPortInfo.pid + "str" are flagged.
     # As desired, this will cause a false negative if the value is ever None, but may also cause
-    # other false negatives from the Any proliferating.
+    # other false negatives from the Any proliferating. The other USB attributes are correctly
+    # typed as Optional because they may be `None` even for USB devices
     # Original discussion at https://github.com/python/typeshed/pull/9347#issuecomment-1358245865.
     vid: int | Any
     pid: int | Any
-    serial_number: str | Any
-    location: str | Any
-    manufacturer: str | Any
-    product: str | Any
-    interface: str | Any
+    serial_number: str | None
+    location: str | None
+    manufacturer: str | None
+    product: str | None
+    interface: str | None
     def __init__(self, device: str, skip_link_detection: bool = ...) -> None: ...
     def usb_description(self) -> str: ...
     def usb_info(self) -> str: ...


### PR DESCRIPTION
Some USB specific attributes in pyserial's [`serial.tools.list_port_common.ListPortInfo`](https://github.com/python/typeshed/blob/main/stubs/pyserial/serial/tools/list_ports_common.pyi#L11-L24) class are not always available and should be marked as optional. They depend on the USB device and its driver correctly reporting these attributes. I discovered this recently with a new device that does not report its serial number. Only the Vendor ID `vid` and Product ID `pid` are guaranteed (This can be seen [here](https://github.com/pyserial/pyserial/blob/master/serial/tools/list_ports_linux.py#L52-L62) where `vid` and `pid` are always cast as `int` while other attributes are left as `str | None` for USB devices).

This is a follow up to #9347 and the discussion at https://github.com/python/typeshed/pull/9347#issuecomment-1358245865 (CC. @hauntsaninja)