### PR TITLE
Add `setuptools.pkg_resources.Requirement.url`

### DIFF
--- a/stubs/setuptools/pkg_resources/__init__.pyi
+++ b/stubs/setuptools/pkg_resources/__init__.pyi
@@ -77,6 +77,7 @@ class Requirement:
     key: str
     extras: tuple[str, ...]
     specs: list[tuple[str, str]]
+    url: str
     # TODO: change this to packaging.markers.Marker | None once we can import
     #       packaging.markers
     marker: Incomplete | None

--- a/stubs/setuptools/pkg_resources/__init__.pyi
+++ b/stubs/setuptools/pkg_resources/__init__.pyi
@@ -77,7 +77,7 @@ class Requirement:
     key: str
     extras: tuple[str, ...]
     specs: list[tuple[str, str]]
-    url: str
+    url: str | None
     # TODO: change this to packaging.markers.Marker | None once we can import
     #       packaging.markers
     marker: Incomplete | None


### PR DESCRIPTION
Hi,

First, thanks a lot for maintaining mypy, typeshed, and friends!

Now, I realize that the setuptools and pkg_resources stubs need a bit more work (I just found a work-in-progress change I had forgotten about that was supposed to fix some of the Distribution fields and methods), but what do you think about this simple first step? The `pkg_resources.Requirement.parse()` method has been able to parse PEP508 dependency specifications containing a "@ url" part ever since setuptools-20.2, so I guess it ought to be safe to add it unconditionally.

Thanks in advance, and keep up the great work!

G'luck,
Peter
