### PR TITLE
Remove unneeded ignore in `.flake8`

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -23,12 +23,9 @@
 #            Currently can't be enabled due to a few lingering bugs in mypy regarding
 #            PEP 604 type aliases (see #4819).
 
-# A bugbear rule that has many false positives:
-#     B028   consider using the `!r` conversion flag instead of manually surrounding things in quotes
-
 [flake8]
 per-file-ignores =
-  *.py: B028, E203, E301, E302, E305, E501
+  *.py: E203, E301, E302, E305, E501
   *.pyi: B, E301, E302, E305, E501, E701, E741, F401, F403, F405, F822, Y037
   # Since typing.pyi defines "overload" this is not recognized by flake8 as typing.overload.
   # Unfortunately, flake8 does not allow to "noqa" just a specific error inside the file itself.


### PR DESCRIPTION
B028 was renamed as B907, and we don't have any of the B9 rules enabled for this repo (they're all off by default)