### PR TITLE
Add markdown.treeprocessors.UnescapeTreeprocessor

### DIFF
--- a/stubs/Markdown/markdown/treeprocessors.pyi
+++ b/stubs/Markdown/markdown/treeprocessors.pyi
@@ -1,5 +1,7 @@
 from _typeshed import Incomplete
-from typing import Any
+from re import Pattern
+from typing import Any, ClassVar
+from xml.etree.ElementTree import Element
 
 from . import util
 
@@ -7,7 +9,7 @@ def build_treeprocessors(md, **kwargs): ...
 def isString(s): ...
 
 class Treeprocessor(util.Processor):
-    def run(self, root) -> Any | None: ...
+    def run(self, root: Element) -> Element | None: ...
 
 class InlineProcessor(Treeprocessor):
     inlinePatterns: Any
@@ -15,6 +17,10 @@ class InlineProcessor(Treeprocessor):
     def __init__(self, md) -> None: ...
     stashed_nodes: Any
     parent_map: Any
-    def run(self, tree, ancestors: Incomplete | None = ...): ...
+    def run(self, tree: Element, ancestors: Incomplete | None = ...) -> Element: ...
 
 class PrettifyTreeprocessor(Treeprocessor): ...
+
+class UnescapeTreeprocessor(Treeprocessor):
+    RE: ClassVar[Pattern[str]]
+    def unescape(self, text: str) -> str: ...


### PR DESCRIPTION
This replaced the deprecated `markdown.postprocessors.UnescapePostprocessor` in https://github.com/Python-Markdown/markdown/pull/1272.