### PR TITLE
colorama: Preserve input type for `wrap_stream`

### DIFF
--- a/stubs/colorama/colorama/initialise.pyi
+++ b/stubs/colorama/colorama/initialise.pyi
@@ -1,7 +1,9 @@
 from contextlib import AbstractContextManager
-from typing import Any, TextIO
+from typing import Any, TextIO, TypeVar
 
 from .ansitowin32 import StreamWrapper
+
+_TextIOT = TypeVar("_TextIOT", bound=TextIO)
 
 orig_stdout: TextIO | None
 orig_stderr: TextIO | None
@@ -16,6 +18,6 @@ def deinit() -> None: ...
 def colorama_text(*args: Any, **kwargs: Any) -> AbstractContextManager[None]: ...
 def reinit() -> None: ...
 def wrap_stream(
-    stream: TextIO, convert: bool | None, strip: bool | None, autoreset: bool, wrap: bool
-) -> TextIO | StreamWrapper: ...
+    stream: _TextIOT, convert: bool | None, strip: bool | None, autoreset: bool, wrap: bool
+) -> _TextIOT | StreamWrapper: ...
 def just_fix_windows_console() -> None: ...


### PR DESCRIPTION
Implementation looks like this:

```python
def wrap_stream(stream, convert, strip, autoreset, wrap):
    if wrap:
        wrapper = AnsiToWin32(stream,
            convert=convert, strip=strip, autoreset=autoreset)
        if wrapper.should_wrap():
            stream = wrapper.stream
    return stream
```