### PR TITLE
`subprocess.check_call`: `executable` defaults to `None`

### DIFF
--- a/stdlib/subprocess.pyi
+++ b/stdlib/subprocess.pyi
@@ -994,7 +994,7 @@ if sys.version_info >= (3, 11):
     def check_call(
         args: _CMD,
         bufsize: int = ...,
-        executable: StrOrBytesPath = ...,
+        executable: StrOrBytesPath | None = None,
         stdin: _FILE = ...,
         stdout: _FILE = ...,
         stderr: _FILE = ...,
@@ -1025,7 +1025,7 @@ elif sys.version_info >= (3, 10):
     def check_call(
         args: _CMD,
         bufsize: int = ...,
-        executable: StrOrBytesPath = ...,
+        executable: StrOrBytesPath | None = None,
         stdin: _FILE = ...,
         stdout: _FILE = ...,
         stderr: _FILE = ...,
@@ -1055,7 +1055,7 @@ elif sys.version_info >= (3, 9):
     def check_call(
         args: _CMD,
         bufsize: int = ...,
-        executable: StrOrBytesPath = ...,
+        executable: StrOrBytesPath | None = None,
         stdin: _FILE = ...,
         stdout: _FILE = ...,
         stderr: _FILE = ...,
@@ -1083,7 +1083,7 @@ else:
     def check_call(
         args: _CMD,
         bufsize: int = ...,
-        executable: StrOrBytesPath = ...,
+        executable: StrOrBytesPath | None = None,
         stdin: _FILE = ...,
         stdout: _FILE = ...,
         stderr: _FILE = ...,


### PR DESCRIPTION
This argument is forwarded on to `Popen.__init__`, like most of the other arguments. It can be `None`, just like the `executable` parameter for all the other `subprocess` functions:

```pycon
>>> import subprocess
>>> subprocess.check_call(["python", "-c", "1/1"], executable=None)
0
>>> subprocess.check_call(["python", "-c", "1/0"], executable=None)
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ZeroDivisionError: division by zero
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\alexw\AppData\Local\Programs\Python\Python310\lib\subprocess.py", line 369, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['python', '-c', '1/0']' returned non-zero exit status 1.
```