### PR TITLE
Pillow: Add missing enums from 9.1.0

### DIFF
--- a/stubs/Pillow/PIL/BlpImagePlugin.pyi
+++ b/stubs/Pillow/PIL/BlpImagePlugin.pyi
@@ -1,15 +1,31 @@
+from enum import IntEnum
 from typing import Any, ClassVar
 from typing_extensions import Literal
 
 from .ImageFile import ImageFile, PyDecoder
 
-BLP_FORMAT_JPEG: int
-BLP_ENCODING_UNCOMPRESSED: int
-BLP_ENCODING_DXT: int
-BLP_ENCODING_UNCOMPRESSED_RAW_BGRA: int
-BLP_ALPHA_ENCODING_DXT1: int
-BLP_ALPHA_ENCODING_DXT3: int
-BLP_ALPHA_ENCODING_DXT5: int
+class Format(IntEnum):
+    JPEG: int
+
+BLP_FORMAT_JPEG: Literal[Format.JPEG]
+
+class Encoding(IntEnum):
+    UNCOMPRESSED: int
+    DXT: int
+    UNCOMPRESSED_RAW_BGRA: int
+
+BLP_ENCODING_UNCOMPRESSED: Literal[Encoding.UNCOMPRESSED]
+BLP_ENCODING_DXT: Literal[Encoding.DXT]
+BLP_ENCODING_UNCOMPRESSED_RAW_BGRA: Literal[Encoding.UNCOMPRESSED_RAW_BGRA]
+
+class AlphaEncoding(IntEnum):
+    DXT1: int
+    DXT3: int
+    DXT5: int
+
+BLP_ALPHA_ENCODING_DXT1: Literal[AlphaEncoding.DXT1]
+BLP_ALPHA_ENCODING_DXT3: Literal[AlphaEncoding.DXT3]
+BLP_ALPHA_ENCODING_DXT5: Literal[AlphaEncoding.DXT5]
 
 def unpack_565(i): ...
 def decode_dxt1(data, alpha: bool = ...): ...

--- a/stubs/Pillow/PIL/FtexImagePlugin.pyi
+++ b/stubs/Pillow/PIL/FtexImagePlugin.pyi
@@ -1,11 +1,17 @@
+from enum import IntEnum
 from typing import ClassVar
 from typing_extensions import Literal
 
 from .ImageFile import ImageFile
 
 MAGIC: bytes
-FORMAT_DXT1: int
-FORMAT_UNCOMPRESSED: int
+
+class Format(IntEnum):
+    DXT1: int
+    UNCOMPRESSED: int
+
+FORMAT_DXT1: Literal[Format.DXT1]
+FORMAT_UNCOMPRESSED: Literal[Format.UNCOMPRESSED]
 
 class FtexImageFile(ImageFile):
     format: ClassVar[Literal["FTEX"]]

--- a/stubs/Pillow/PIL/Image.pyi
+++ b/stubs/Pillow/PIL/Image.pyi
@@ -42,9 +42,9 @@ class DecompressionBombError(Exception): ...
 
 MAX_IMAGE_PIXELS: int | None
 
-LINEAR: Literal[2]  # deprecated
-CUBIC: Literal[3]  # deprecated
-ANTIALIAS: Literal[1]  # deprecated
+LINEAR: Literal[Resampling.BILINEAR]  # deprecated
+CUBIC: Literal[Resampling.BICUBIC]  # deprecated
+ANTIALIAS: Literal[Resampling.LANCZOS]  # deprecated
 
 class Transpose(IntEnum):
     FLIP_LEFT_RIGHT: Literal[0]
@@ -193,7 +193,7 @@ class Image:
     def quantize(
         self,
         colors: int = ...,
-        method: Literal[0, 1, 2, 3] | None = ...,
+        method: Quantize | Literal[0, 1, 2, 3] | None = ...,
         kmeans: int = ...,
         palette: Image | None = ...,
         dither: int = ...,

--- a/stubs/Pillow/PIL/ImageCms.pyi
+++ b/stubs/Pillow/PIL/ImageCms.pyi
@@ -1,18 +1,34 @@
+from enum import IntEnum
 from _typeshed import Incomplete
 from typing import Any
+from typing_extensions import Literal
 
 from .Image import ImagePointHandler
 
 DESCRIPTION: str
 VERSION: str
 core: Any
-INTENT_PERCEPTUAL: int
-INTENT_RELATIVE_COLORIMETRIC: int
-INTENT_SATURATION: int
-INTENT_ABSOLUTE_COLORIMETRIC: int
-DIRECTION_INPUT: int
-DIRECTION_OUTPUT: int
-DIRECTION_PROOF: int
+
+class Intent(IntEnum):
+    PERCEPTUAL: int
+    RELATIVE_COLORIMETRIC: int
+    SATURATION: int
+    ABSOLUTE_COLORIMETRIC: int
+
+INTENT_PERCEPTUAL: Literal[Intent.PERCEPTUAL]
+INTENT_RELATIVE_COLORIMETRIC: Literal[Intent.RELATIVE_COLORIMETRIC]
+INTENT_SATURATION: Literal[Intent.SATURATION]
+INTENT_ABSOLUTE_COLORIMETRIC: Literal[Intent.ABSOLUTE_COLORIMETRIC]
+
+class Direction(IntEnum):
+    INPUT: int
+    OUTPUT: int
+    PROOF: int
+
+DIRECTION_INPUT: Literal[Direction.INPUT]
+DIRECTION_OUTPUT: Literal[Direction.OUTPUT]
+DIRECTION_PROOF: Literal[Direction.PROOF]
+
 FLAGS: Any
 
 class ImageCmsProfile:

--- a/stubs/Pillow/PIL/ImageCms.pyi
+++ b/stubs/Pillow/PIL/ImageCms.pyi
@@ -1,5 +1,5 @@
-from enum import IntEnum
 from _typeshed import Incomplete
+from enum import IntEnum
 from typing import Any
 from typing_extensions import Literal
 

--- a/stubs/Pillow/PIL/ImageFont.pyi
+++ b/stubs/Pillow/PIL/ImageFont.pyi
@@ -1,7 +1,7 @@
-from enum import IntEnum
 from _typeshed import FileDescriptorOrPath, Incomplete, SupportsRead
-from typing import Any, Protocol
-from typing_extensions import Literal, TypeAlias
+from enum import IntEnum
+from typing import Protocol
+from typing_extensions import Literal
 
 class Layout(IntEnum):
     BASIC: Literal[0]

--- a/stubs/Pillow/PIL/ImageFont.pyi
+++ b/stubs/Pillow/PIL/ImageFont.pyi
@@ -1,9 +1,14 @@
+from enum import IntEnum
 from _typeshed import FileDescriptorOrPath, Incomplete, SupportsRead
 from typing import Any, Protocol
-from typing_extensions import Literal
+from typing_extensions import Literal, TypeAlias
 
-LAYOUT_BASIC: Literal[0]
-LAYOUT_RAQM: Literal[1]
+class Layout(IntEnum):
+    BASIC: Literal[0]
+    RAQM: Literal[1]
+
+LAYOUT_BASIC: Literal[Layout.BASIC]
+LAYOUT_RAQM: Literal[Layout.RAQM]
 
 class _Font(Protocol):
     def getmask(self, text: str | bytes, mode: str = ..., direction=..., features=...): ...
@@ -17,14 +22,14 @@ class FreeTypeFont:
     size: int
     index: int
     encoding: str
-    layout_engine: Any
+    layout_engine: Layout
     def __init__(
         self,
         font: str | bytes | SupportsRead[bytes] | None = ...,
         size: int = ...,
         index: int = ...,
         encoding: str = ...,
-        layout_engine: int | None = ...,
+        layout_engine: Layout | None = ...,
     ) -> None: ...
     def getname(self) -> tuple[str, str]: ...
     def getmetrics(self) -> tuple[int, int]: ...
@@ -97,7 +102,7 @@ class FreeTypeFont:
         size: int | None = ...,
         index: int | None = ...,
         encoding: str | None = ...,
-        layout_engine: int | None = ...,
+        layout_engine: Layout | None = ...,
     ) -> FreeTypeFont: ...
     def get_variation_names(self): ...
     def set_variation_by_name(self, name): ...
@@ -115,7 +120,7 @@ def truetype(
     size: int = ...,
     index: int = ...,
     encoding: str = ...,
-    layout_engine: int | None = ...,
+    layout_engine: Layout | None = ...,
 ) -> FreeTypeFont: ...
 def load_path(filename: str | bytes) -> ImageFont: ...
 def load_default() -> ImageFont: ...

--- a/stubs/Pillow/PIL/PngImagePlugin.pyi
+++ b/stubs/Pillow/PIL/PngImagePlugin.pyi
@@ -1,4 +1,5 @@
 from _typeshed import Incomplete
+from enum import IntEnum
 from typing import Any, ClassVar
 from typing_extensions import Literal
 
@@ -9,11 +10,22 @@ logger: Any
 is_cid: Any
 MAX_TEXT_CHUNK: Any
 MAX_TEXT_MEMORY: Any
-APNG_DISPOSE_OP_NONE: int
-APNG_DISPOSE_OP_BACKGROUND: int
-APNG_DISPOSE_OP_PREVIOUS: int
-APNG_BLEND_OP_SOURCE: int
-APNG_BLEND_OP_OVER: int
+
+class Disposal(IntEnum):
+    OP_NONE: int
+    OP_BACKGROUND: int
+    OP_PREVIOUS: int
+
+APNG_DISPOSE_OP_NONE: Literal[Disposal.OP_NONE]
+APNG_DISPOSE_OP_BACKGROUND: Literal[Disposal.OP_BACKGROUND]
+APNG_DISPOSE_OP_PREVIOUS: Literal[Disposal.OP_PREVIOUS]
+
+class Blend(IntEnum):
+    OP_SOURCE: int
+    OP_OVER: int
+
+APNG_BLEND_OP_SOURCE: Literal[Blend.OP_SOURCE]
+APNG_BLEND_OP_OVER: Literal[Blend.OP_OVER]
 
 class ChunkStream:
     fp: Any


### PR DESCRIPTION
https://pillow.readthedocs.io/en/stable/releasenotes/9.1.0.html#constants

Related:

- python-pillow/Pillow#5954
- #8419