### PR TITLE
Set HOMEBREW_NO_INSTALL_CLEANUP to speedup brew installs

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -18,6 +18,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  HOMEBREW_NO_INSTALL_CLEANUP: 1 # Speedup brew install. Environments are isolated, no need to cleanup old versions
+  NONINTERACTIVE: 1 # Required for brew install on CI
   PIP_DISABLE_PIP_VERSION_CHECK: 1
   FORCE_COLOR: 1
   TERM: xterm-256color # needed for FORCE_COLOR to work on mypy on Ubuntu, see https://github.com/python/mypy/issues/13817
@@ -81,7 +83,7 @@ jobs:
             PYTHON_EXECUTABLE="xvfb-run python"
           else
             if [ "${{ runner.os }}" = "macOS" ] && [ -n "$PACKAGES" ]; then
-              NONINTERACTIVE=1 brew install $PACKAGES
+              brew install $PACKAGES
             fi
 
             if [ "${{ runner.os }}" = "Windows" ] && [ -n "$PACKAGES" ]; then

--- a/.github/workflows/stubtest_third_party.yml
+++ b/.github/workflows/stubtest_third_party.yml
@@ -12,6 +12,8 @@ permissions:
   contents: read
 
 env:
+  HOMEBREW_NO_INSTALL_CLEANUP: 1 # Speedup brew install. Environments are isolated, no need to cleanup old versions
+  NONINTERACTIVE: 1 # Required for brew install on CI
   PIP_DISABLE_PIP_VERSION_CHECK: 1
   FORCE_COLOR: 1
   TERM: xterm-256color # needed for FORCE_COLOR to work on mypy on Ubuntu, see https://github.com/python/mypy/issues/13817
@@ -70,7 +72,7 @@ jobs:
             else
               if [ "${{ runner.os }}" = "macOS" ] && [ -n "$PACKAGES" ]; then
                 echo "Installing Homebrew packages: $PACKAGES"
-                NONINTERACTIVE=1 brew install $PACKAGES
+                brew install $PACKAGES
               fi
 
               if [ "${{ runner.os }}" = "Windows" ] && [ -n "$PACKAGES" ]; then


### PR DESCRIPTION
As the inline comment says: Speedup brew install. Environments are isolated, no need to cleanup old versions.
While working on a PR that touched pyaudio, I noticed this from runs like https://github.com/python/typeshed/actions/runs/4148676771/jobs/7176901691#step:5:54

I also moved the `NONINTERACTIVE` under `env`