### PR TITLE
Ignore flake8 extensions stubbed by typeshed

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,13 @@
+# The following rules come from plugins that are not used by typeshed.
+# Since typeshed stubs them, they can still be expected to be found in a
+# developer's venv for intellisense and reference reasons
+#     A      flake8-builtins
+#     D      flake8-docstrings
+#     N8     pep8-naming
+#     SIM    flake8-simplify
+#     RST    flake8-rst-docstrings
+#     TYP    flake8-typing-imports
+
 # The following rules are incompatible with or enforced by black:
 #     E203   whitespace before ':' -- scripts only
 #     E301   expected 1 blank line
@@ -19,16 +29,17 @@
 #     F405   defined from star imports
 
 [flake8]
+extend-ignore = A, D, N8, SIM, RST, TYP, E301, E302, E305, E501
 per-file-ignores =
-  *.py: E203, E301, E302, E305, E501
-  *.pyi: B, E301, E302, E305, E501, E701, E741, F401, F403, F405, F822
+  *.py: E203
+  *.pyi: B, E701, E741, F401, F403, F405, F822
   # Since typing.pyi defines "overload" this is not recognized by flake8 as typing.overload.
   # Unfortunately, flake8 does not allow to "noqa" just a specific error inside the file itself.
   # https://github.com/PyCQA/flake8/issues/1079
   #     F811 redefinition of unused '...'
-  stdlib/typing.pyi: B, E301, E302, E305, E501, E701, E741, F401, F403, F405, F811, F822
+  stdlib/typing.pyi: B, E701, E741, F401, F403, F405, F811, F822
   # Generated protobuf files include docstrings
-  *_pb2.pyi: B, E301, E302, E305, E501, E701, Y021, Y026
+  *_pb2.pyi: B, E701, Y021, Y026
 
 exclude = .venv*,.git
 noqa_require_code = true


### PR DESCRIPTION
The in-code comment explains the rationale:
Some flake8 plugins are stubbed by typeshed. When working on a stub, it is useful to install it in your venv for intellisense and reference reasons. Because of this, it can be expected to find said plugins in the local python environment, which are automatically picked-up by flake8. Resulting in a bunch of extra flake8 errors that only appear locally.

Also simplified configs a bit by de-duplicating violations that are ignored in all files.