### PR TITLE
Fix misnamed parameter in stubtest_third_party

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -91,7 +91,7 @@ jobs:
             PYTHON_EXECUTABLE="python"
           fi
 
-          $PYTHON_EXECUTABLE tests/stubtest_third_party.py --specified-stubs-only --num-shards 4 --shard-index ${{ matrix.shard-index }}
+          $PYTHON_EXECUTABLE tests/stubtest_third_party.py --specified-platforms-only --num-shards 4 --shard-index ${{ matrix.shard-index }}
   stub-uploader:
     name: Run the stub_uploader tests
     runs-on: ubuntu-latest

--- a/.github/workflows/stubtest_third_party.yml
+++ b/.github/workflows/stubtest_third_party.yml
@@ -81,7 +81,7 @@ jobs:
               PYTHON_EXECUTABLE="python"
             fi
 
-            $PYTHON_EXECUTABLE tests/stubtest_third_party.py --specified-stubs-only $STUBS
+            $PYTHON_EXECUTABLE tests/stubtest_third_party.py --specified-platforms-only $STUBS
           else
             echo "Nothing to test"
           fi

--- a/tests/stubtest_third_party.py
+++ b/tests/stubtest_third_party.py
@@ -15,7 +15,7 @@ from parse_metadata import get_recursive_requirements, read_metadata
 from utils import colored, get_mypy_req, make_venv, print_error, print_success_msg
 
 
-def run_stubtest(dist: Path, *, verbose: bool = False, specified_stubs_only: bool = False) -> bool:
+def run_stubtest(dist: Path, *, verbose: bool = False, specified_platforms_only: bool = False) -> bool:
     dist_name = dist.name
     metadata = read_metadata(dist_name)
     print(f"{dist_name}... ", end="")
@@ -26,7 +26,7 @@ def run_stubtest(dist: Path, *, verbose: bool = False, specified_stubs_only: boo
         return True
 
     if sys.platform not in stubtest_settings.platforms:
-        if specified_stubs_only:
+        if specified_platforms_only:
             print(colored("skipping (platform not specified in METADATA.toml)", "yellow"))
             return True
         print(colored(f"Note: {dist_name} is not currently tested on {sys.platform} in typeshed's CI.", "yellow"))
@@ -155,7 +155,7 @@ def main() -> NoReturn:
     parser.add_argument("--num-shards", type=int, default=1)
     parser.add_argument("--shard-index", type=int, default=0)
     parser.add_argument(
-        "--specified-stubs-only",
+        "--specified-platforms-only",
         action="store_true",
         help="skip the test if the current platform is not specified in METADATA.toml/tool.stubtest.platforms",
     )
@@ -172,7 +172,7 @@ def main() -> NoReturn:
     for i, dist in enumerate(dists):
         if i % args.num_shards != args.shard_index:
             continue
-        if not run_stubtest(dist, verbose=args.verbose, specified_stubs_only=args.specified_stubs_only):
+        if not run_stubtest(dist, verbose=args.verbose, specified_platforms_only=args.specified_platforms_only):
             result = 1
     sys.exit(result)
 


### PR DESCRIPTION
I spotted this a while ago, but then forgot about it again.
Seems like when I introduced this in #9173 we totally glanced over that the name of the parameter is completely wrong, it's not specified "stubs", but specified "platforms" (in METADATA.toml)