### PR TITLE
Fix stubtest of pyserial

### DIFF
--- a/stubs/pyserial/@tests/stubtest_allowlist_darwin.txt
+++ b/stubs/pyserial/@tests/stubtest_allowlist_darwin.txt
@@ -16,13 +16,6 @@ serial.serialposix.Serial.write
 serial.serialposix.PosixPollSerial.read
 serial.serialposix.VTIMESerial.read
 
-# Error: is missing from the stub
-# ===============================
-# Linux specific implementations not guaranteed to be available on other platforms. They
-# may be importable but this is only by chance and may break in the future.
-serial.tools.list_ports_linux.SysFS
-serial.tools.list_ports_linux.comports
-
 # intended to be private aliases
 serial.tools.list_ports_posix.plat
 serial.serialposix.plat

--- a/stubs/pyserial/@tests/stubtest_allowlist_darwin.txt
+++ b/stubs/pyserial/@tests/stubtest_allowlist_darwin.txt
@@ -6,8 +6,9 @@ serial.tools.list_ports_windows  # Windows only
 
 # Error: is inconsistent
 # ======================
-# These are positional only argument in the stub because they inherit from io.RawIOBase
-# but at runtime they are normal arguments that don't have consistent names.
+# Methods defined with positional-only argument in the stub because they inherit from
+# io.RawIOBase but at runtime they are normal arguments that don't have consistent
+# names.
 serial.PosixPollSerial.read
 serial.VTIMESerial.read
 serial.serialposix.Serial.read
@@ -17,7 +18,8 @@ serial.serialposix.VTIMESerial.read
 
 # Error: is missing from the stub
 # ===============================
-# TODO: maybe add these
+# Linux specific implementations not guaranteed to be available on other platforms. They
+# may be importable but this is only by chance and may break in the future.
 serial.tools.list_ports_linux.SysFS
 serial.tools.list_ports_linux.comports
 

--- a/stubs/pyserial/@tests/stubtest_allowlist_linux.txt
+++ b/stubs/pyserial/@tests/stubtest_allowlist_linux.txt
@@ -7,8 +7,9 @@ serial.tools.list_ports_windows  # Windows only
 
 # Error: is inconsistent
 # ======================
-# These are positional only argument in the stub because they inherit from io.RawIOBase
-# but at runtime they are normal arguments that don't have consistent names.
+# Methods defined with positional-only argument in the stub because they inherit from
+# io.RawIOBase but at runtime they are normal arguments that don't have consistent
+# names.
 serial.PosixPollSerial.read
 serial.VTIMESerial.read
 serial.serialposix.Serial.read

--- a/stubs/pyserial/@tests/stubtest_allowlist_win32.txt
+++ b/stubs/pyserial/@tests/stubtest_allowlist_win32.txt
@@ -6,23 +6,15 @@ serial.tools.list_ports_posix  # Posix only
 
 # Error: is inconsistent
 # ======================
-# These are positional only argument in the stub because they inherit from io.RawIOBase
-# but at runtime they are normal arguments that don't have consistent names.
+# Methods defined with positional-only argument in the stub because they inherit from
+# io.RawIOBase but at runtime they are normal arguments that don't have consistent
+# names.
 serial.serialwin32.Serial.read
 serial.serialwin32.Serial.write
 
-# Missing from the stub (TODO: add these)
-# =======================================
-serial.win32._SECURITY_ATTRIBUTES.\w+
-serial.win32._OVERLAPPED.\w+
-serial.win32._DCB.\w+
-serial.win32._COMSTAT.\w+
-serial.win32._COMMTIMEOUTS.\w+
-serial.win32.N11_OVERLAPPED4DOLLAR_48E.\w+
-serial.win32.N11_OVERLAPPED4DOLLAR_484DOLLAR_49E.\w+
-serial.win32.CreateEventW
-serial.win32.CreateFileW
+# Missing from the stub
+# =====================
+# Linux specific implementations not guaranteed to be available on other platforms. They
+# may be importable but this is only by chance and may break in the future.
 serial.tools.list_ports_linux.SysFS
 serial.tools.list_ports_linux.comports
-serial.tools.list_ports_windows.SP_DEVINFO_DATA.\w+
-serial.tools.list_ports_windows.GUID.\w+

--- a/stubs/pyserial/@tests/stubtest_allowlist_win32.txt
+++ b/stubs/pyserial/@tests/stubtest_allowlist_win32.txt
@@ -11,10 +11,3 @@ serial.tools.list_ports_posix  # Posix only
 # names.
 serial.serialwin32.Serial.read
 serial.serialwin32.Serial.write
-
-# Missing from the stub
-# =====================
-# Linux specific implementations not guaranteed to be available on other platforms. They
-# may be importable but this is only by chance and may break in the future.
-serial.tools.list_ports_linux.SysFS
-serial.tools.list_ports_linux.comports

--- a/stubs/pyserial/serial/tools/list_ports_linux.pyi
+++ b/stubs/pyserial/serial/tools/list_ports_linux.pyi
@@ -1,14 +1,11 @@
-import sys
-
 from serial.tools.list_ports_common import ListPortInfo
 
-if sys.platform == "linux":
-    class SysFS(ListPortInfo):
-        usb_device_path: str | None
-        device_path: str | None
-        subsystem: str | None
-        usb_interface_path: str | None
-        def __init__(self, device: str) -> None: ...
-        def read_line(self, *args: str) -> str | None: ...
+class SysFS(ListPortInfo):
+    usb_device_path: str | None
+    device_path: str | None
+    subsystem: str | None
+    usb_interface_path: str | None
+    def __init__(self, device: str) -> None: ...
+    def read_line(self, *args: str) -> str | None: ...
 
-    def comports(include_links: bool = ...) -> list[SysFS]: ...
+def comports(include_links: bool = ...) -> list[SysFS]: ...

--- a/stubs/pyserial/serial/tools/list_ports_windows.pyi
+++ b/stubs/pyserial/serial/tools/list_ports_windows.pyi
@@ -23,8 +23,17 @@ if sys.platform == "win32":
     ACCESS_MASK = DWORD
     REGSAM = ACCESS_MASK
 
-    class GUID(ctypes.Structure): ...
-    class SP_DEVINFO_DATA(ctypes.Structure): ...
+    class GUID(ctypes.Structure):
+        Data1: ctypes._CField
+        Data2: ctypes._CField
+        Data3: ctypes._CField
+        Data4: ctypes._CField
+
+    class SP_DEVINFO_DATA(ctypes.Structure):
+        cbSize: ctypes._CField
+        ClassGuid: ctypes._CField
+        DevInst: ctypes._CField
+        Reserved: ctypes._CField
     PSP_DEVINFO_DATA: type[ctypes._Pointer[SP_DEVINFO_DATA]]
     PSP_DEVICE_INTERFACE_DETAIL_DATA = ctypes.c_void_p
     setupapi: ctypes.WinDLL

--- a/stubs/pyserial/serial/win32.pyi
+++ b/stubs/pyserial/serial/win32.pyi
@@ -1,28 +1,84 @@
 import sys
-from ctypes import Structure, Union, _NamedFuncPointer, _Pointer, c_int64, c_ulong, c_void_p
+from ctypes import Structure, Union, _CField, _NamedFuncPointer, _Pointer, c_int64, c_ulong, c_void_p
 from ctypes.wintypes import DWORD
 from typing_extensions import TypeAlias
 
 if sys.platform == "win32":
     def is_64bit() -> bool: ...
 
-    ULONG_PTR: c_int64 | c_ulong
+    ULONG_PTR: type[c_int64 | c_ulong]
 
-    class _SECURITY_ATTRIBUTES(Structure): ...
+    class _SECURITY_ATTRIBUTES(Structure):
+        nLength: _CField
+        lpSecurityDescriptor: _CField
+        bInheritHandle: _CField
     LPSECURITY_ATTRIBUTES: type[_Pointer[_SECURITY_ATTRIBUTES]]
     CreateEvent: _NamedFuncPointer
     CreateFile: _NamedFuncPointer
+    # The following are included in __all__ but their existence is not guaranteed as
+    # they are defined in a try/except block. Their aliases above are always defined.
+    CreateEventW: _NamedFuncPointer
+    CreateFileW: _NamedFuncPointer
 
-    class _OVERLAPPED(Structure): ...
+    class _OVERLAPPED(Structure):
+        Internal: _CField
+        InternalHigh: _CField
+        Offset: _CField
+        OffsetHigh: _CField
+        Pointer: _CField
+        hEvent: _CField
     OVERLAPPED: TypeAlias = _OVERLAPPED
 
-    class _COMSTAT(Structure): ...
+    class _COMSTAT(Structure):
+        fCtsHold: _CField
+        fDsrHold: _CField
+        fRlsdHold: _CField
+        fXoffHold: _CField
+        fXoffSent: _CField
+        fEof: _CField
+        fTxim: _CField
+        fReserved: _CField
+        cbInQue: _CField
+        cbOutQue: _CField
     COMSTAT: TypeAlias = _COMSTAT
 
-    class _DCB(Structure): ...
+    class _DCB(Structure):
+        DCBlength: _CField
+        BaudRate: _CField
+        fBinary: _CField
+        fParity: _CField
+        fOutxCtsFlow: _CField
+        fOutxDsrFlow: _CField
+        fDtrControl: _CField
+        fDsrSensitivity: _CField
+        fTXContinueOnXoff: _CField
+        fOutX: _CField
+        fInX: _CField
+        fErrorChar: _CField
+        fNull: _CField
+        fRtsControl: _CField
+        fAbortOnError: _CField
+        fDummy2: _CField
+        wReserved: _CField
+        XonLim: _CField
+        XoffLim: _CField
+        ByteSize: _CField
+        Parity: _CField
+        StopBits: _CField
+        XonChar: _CField
+        XoffChar: _CField
+        ErrorChar: _CField
+        EofChar: _CField
+        EvtChar: _CField
+        wReserved1: _CField
     DCB: TypeAlias = _DCB
 
-    class _COMMTIMEOUTS(Structure): ...
+    class _COMMTIMEOUTS(Structure):
+        ReadIntervalTimeout: _CField
+        ReadTotalTimeoutMultiplier: _CField
+        ReadTotalTimeoutConstant: _CField
+        WriteTotalTimeoutMultiplier: _CField
+        WriteTotalTimeoutConstant: _CField
     COMMTIMEOUTS: TypeAlias = _COMMTIMEOUTS
 
     GetLastError: _NamedFuncPointer
@@ -94,6 +150,12 @@ if sys.platform == "win32":
     EV_BREAK: int
     PURGE_RXCLEAR: int
 
-    class N11_OVERLAPPED4DOLLAR_48E(Union): ...
-    class N11_OVERLAPPED4DOLLAR_484DOLLAR_49E(Structure): ...
+    class N11_OVERLAPPED4DOLLAR_48E(Union):
+        Offset: _CField
+        OffsetHigh: _CField
+        Pointer: _CField
+
+    class N11_OVERLAPPED4DOLLAR_484DOLLAR_49E(Structure):
+        Offset: _CField
+        OffsetHigh: _CField
     PVOID: TypeAlias = c_void_p


### PR DESCRIPTION
Stubtest was enabled for the pyserial stubs recently in #9692 and it surfaced some errors especially on Windows that were allow-listed temporarily to get the CI green. This is a fix for these errors.