### PR TITLE
pyOpenSSL: Introduce PARTIAL_CHAIN constant

### DIFF
--- a/stubs/pyOpenSSL/OpenSSL/crypto.pyi
+++ b/stubs/pyOpenSSL/OpenSSL/crypto.pyi
@@ -159,6 +159,7 @@ class X509StoreFlags:
     NOTIFY_POLICY: int
     CHECK_SS_SIGNATURE: int
     CB_ISSUER_CHECK: int
+    PARTIAL_CHAIN: int
 
 class PKCS7:
     def get_type_name(self) -> str: ...


### PR DESCRIPTION
This value was added in v23.0.0:

 https://github.com/pyca/pyopenssl/commit/1cafac4d8fc5301d4e58bedbac45722bf7cdfd32

Signed-off-by: Andy Doan <andy@foundries.io>