### PR TITLE
Add comments when subclassing Any

### DIFF
--- a/stdlib/distutils/command/check.pyi
+++ b/stdlib/distutils/command/check.pyi
@@ -6,6 +6,8 @@ from ..cmd import Command
 _Reporter: TypeAlias = Any  # really docutils.utils.Reporter
 
 # Only defined if docutils is installed.
+# Depends on a third-party stub. Since distutils is deprecated anyway,
+# it's easier to just suppress the "any subclassing" error.
 class SilentReporter(_Reporter):
     messages: Any
     def __init__(

--- a/stdlib/unittest/mock.pyi
+++ b/stdlib/unittest/mock.pyi
@@ -101,6 +101,8 @@ class _CallList(list[_Call]):
 class Base:
     def __init__(self, *args: Any, **kwargs: Any) -> None: ...
 
+# We subclass with "Any" because mocks are explicitly designed to stand in for other types,
+# something that can't be expressed with our static type system.
 class NonCallableMock(Base, Any):
     def __new__(__cls, *args: Any, **kw: Any) -> Self: ...
     def __init__(

--- a/stubs/Pillow/PIL/ImageQt.pyi
+++ b/stubs/Pillow/PIL/ImageQt.pyi
@@ -3,7 +3,10 @@ from typing_extensions import Literal, TypeAlias
 
 from .Image import Image
 
-_QImage: TypeAlias = Any  # imported from either of {PyQt6,PySide6,PyQt5,PySide2}.QtGui
+# imported from either of {PyQt6,PySide6,PyQt5,PySide2}.QtGui
+# These are way too complex, with 4 different possible sources (2 deprecated)
+# And we don't want to force the user to install PyQt or Pyside when they may not even use it.
+_QImage: TypeAlias = Any
 _QPixmap: TypeAlias = Any
 
 qt_versions: Any

--- a/stubs/mock/mock/mock.pyi
+++ b/stubs/mock/mock/mock.pyi
@@ -81,6 +81,8 @@ class _CallList(list[_Call]):
 class Base:
     def __init__(self, *args: Any, **kwargs: Any) -> None: ...
 
+# We subclass with "Any" because mocks are explicitly designed to stand in for other types,
+# something that can't be expressed with our static type system.
 class NonCallableMock(Base, Any):
     def __new__(
         cls: type[Self],

--- a/tests/mypy_test.py
+++ b/tests/mypy_test.py
@@ -263,7 +263,9 @@ def run_mypy(
             # Stub completion is checked by pyright (--allow-*-defs)
             "--allow-untyped-defs",
             "--allow-incomplete-defs",
-            "--allow-subclassing-any",  # See #9491
+            # See https://github.com/python/typeshed/pull/9491#issuecomment-1381574946
+            # for discussion and reasoning to keep "--allow-subclassing-any"
+            "--allow-subclassing-any",
             "--enable-error-code",
             "ignore-without-code",
             "--config-file",


### PR DESCRIPTION
Since maintainers seems to be in favor of keeping `--allow-subclassing-any`, this adds a few comments on the few cases left and closes #9491
Everything else have been completed in different PRs (except one, but I'm fine closing #9491 with 1 left)