### PR TITLE
Fix pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,6 +33,8 @@ repos:
           - "flake8-bugbear==23.1.20" # must match requirements-tests.txt
           - "flake8-noqa==1.3.0" # must match requirements-tests.txt
           - "flake8-pyi==23.1.2" # must match requirements-tests.txt
+        types: [file]
+        types_or: [python, pyi]
 
 ci:
   autofix_commit_msg: "[pre-commit.ci] auto fixes from pre-commit.com hooks"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,9 @@ repos:
     rev: v2.1.3 # must match requirements-tests.txt
     hooks:
       - id: pycln
-        args: [--config=pyproject.toml, stubs, stdlib, tests, scripts]
+        args: [--config=pyproject.toml]
+        types: [file]
+        types_or: [python, pyi]
   - repo: https://github.com/psf/black
     rev: 23.1.0 # must match requirements-tests.txt
     hooks:


### PR DESCRIPTION
Hi,

I found some areas of improvement in the `pre-commit` configuration.

- [ ] Fix `flake8` `pre-commit` hook which did not run on `.pyi` files.
- [ ] Fix `pycln` `pre-commit` hook which always ran on every file even if they were not modified. I suppose this was to run on `.pyi` files too by specifying the folders in the argument list to check because by default `pycln` does not run on `.pyi` files. So I removed the folders in the argument list and specified to run on `.pyi` files too.