### PR TITLE
Remove unnecessary per-file-ignores in .flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -20,7 +20,7 @@
 
 [flake8]
 per-file-ignores =
-  *.py: E203, E301, E302, E305, E501
+  *.py: E501
   *.pyi: B, E301, E302, E305, E501, E701, E741, F401, F403, F405, F822
   # Since typing.pyi defines "overload" this is not recognized by flake8 as typing.overload.
   # Unfortunately, flake8 does not allow to "noqa" just a specific error inside the file itself.


### PR DESCRIPTION
The remove ignores were for `.pyi` files not `.py`.