### PR TITLE
Fix potentially unbound issues in stubsabot

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,9 @@ repos:
     rev: v2.1.3 # must match requirements-tests.txt
     hooks:
       - id: pycln
-        args: [--config=pyproject.toml, stubs, stdlib, tests, scripts]
+        args: [--config=pyproject.toml]
+        types: [file]
+        types_or: [python, pyi]
   - repo: https://github.com/psf/black
     rev: 23.1.0 # must match requirements-tests.txt
     hooks:
@@ -33,6 +35,8 @@ repos:
           - "flake8-bugbear==23.1.20" # must match requirements-tests.txt
           - "flake8-noqa==1.3.0" # must match requirements-tests.txt
           - "flake8-pyi==23.1.2" # must match requirements-tests.txt
+        types: [file]
+        types_or: [python, pyi]
 
 ci:
   autofix_commit_msg: "[pre-commit.ci] auto fixes from pre-commit.com hooks"

--- a/scripts/stubsabot.py
+++ b/scripts/stubsabot.py
@@ -173,7 +173,7 @@ async def release_contains_py_typed(release_to_download: PypiReleaseDownload, *,
 async def find_first_release_with_py_typed(
     pypi_info: PypiInfo, latest_release: PypiReleaseDownload, *, session: aiohttp.ClientSession
 ) -> PypiReleaseDownload | None:
-    if await release_contains_py_typed(latest_release, session=session):
+    if not (await release_contains_py_typed(latest_release, session=session)):
         return None
 
     release_iter = pypi_info.releases_in_descending_order()

--- a/scripts/stubsabot.py
+++ b/scripts/stubsabot.py
@@ -170,13 +170,12 @@ async def release_contains_py_typed(release_to_download: PypiReleaseDownload, *,
         raise AssertionError(f"Unknown package type: {packagetype!r}")
 
 
-async def find_first_release_with_py_typed(
-    pypi_info: PypiInfo, latest_release: PypiReleaseDownload, *, session: aiohttp.ClientSession
-) -> PypiReleaseDownload | None:
-    if not (await release_contains_py_typed(latest_release, session=session)):
+async def find_first_release_with_py_typed(pypi_info: PypiInfo, *, session: aiohttp.ClientSession) -> PypiReleaseDownload | None:
+    release_iter = pypi_info.releases_in_descending_order()
+    # If the latest release is not py.typed, assume none are.
+    if not (await release_contains_py_typed(release := next(release_iter), session=session)):
         return None
 
-    release_iter = pypi_info.releases_in_descending_order()
     first_release_with_py_typed: PypiReleaseDownload | None = None
     while await release_contains_py_typed(release := next(release_iter), session=session):
         if not release.version.is_prerelease:

--- a/scripts/stubsabot.py
+++ b/scripts/stubsabot.py
@@ -423,7 +423,7 @@ async def determine_action(stub_path: Path, session: aiohttp.ClientSession) -> U
     if latest_version in spec:
         return NoUpdate(stub_info.distribution, "up to date")
 
-    obsolete_since = await find_first_release_with_py_typed(pypi_info, latest_release, session=session)
+    obsolete_since = await find_first_release_with_py_typed(pypi_info, session=session)
     relevant_version = obsolete_since.version if obsolete_since else latest_version
 
     project_urls = pypi_info.info["project_urls"] or {}


### PR DESCRIPTION
Fixes "potentially unbound" type issues in stubsabot.
Simplify a bit the section about finding the first `py.typed` version and whether the stub is obsolete.