### PR TITLE
Fix broken stubsabot logic in `find_first_release_with_py_typed`

### DIFF
--- a/scripts/stubsabot.py
+++ b/scripts/stubsabot.py
@@ -171,7 +171,10 @@ async def release_contains_py_typed(release_to_download: PypiReleaseDownload, *,
 
 
 async def find_first_release_with_py_typed(pypi_info: PypiInfo, *, session: aiohttp.ClientSession) -> PypiReleaseDownload | None:
-    release_iter = pypi_info.releases_in_descending_order()
+    release_iter = (
+        release for release in pypi_info.releases_in_descending_order()
+        if not release.version.is_prerelease
+    )
     latest_release = next(release_iter)
     # If the latest release is not py.typed, assume none are.
     if not (await release_contains_py_typed(latest_release, session=session)):
@@ -179,8 +182,7 @@ async def find_first_release_with_py_typed(pypi_info: PypiInfo, *, session: aioh
 
     first_release_with_py_typed = latest_release
     while await release_contains_py_typed(release := next(release_iter), session=session):
-        if not release.version.is_prerelease:
-            first_release_with_py_typed = release
+        first_release_with_py_typed = release
     return first_release_with_py_typed
 
 

--- a/scripts/stubsabot.py
+++ b/scripts/stubsabot.py
@@ -172,11 +172,12 @@ async def release_contains_py_typed(release_to_download: PypiReleaseDownload, *,
 
 async def find_first_release_with_py_typed(pypi_info: PypiInfo, *, session: aiohttp.ClientSession) -> PypiReleaseDownload | None:
     release_iter = pypi_info.releases_in_descending_order()
+    latest_release = next(release_iter)
     # If the latest release is not py.typed, assume none are.
-    if not (await release_contains_py_typed(release := next(release_iter), session=session)):
+    if not (await release_contains_py_typed(latest_release, session=session)):
         return None
 
-    first_release_with_py_typed: PypiReleaseDownload | None = None
+    first_release_with_py_typed = latest_release
     while await release_contains_py_typed(release := next(release_iter), session=session):
         if not release.version.is_prerelease:
             first_release_with_py_typed = release

--- a/scripts/stubsabot.py
+++ b/scripts/stubsabot.py
@@ -171,10 +171,7 @@ async def release_contains_py_typed(release_to_download: PypiReleaseDownload, *,
 
 
 async def find_first_release_with_py_typed(pypi_info: PypiInfo, *, session: aiohttp.ClientSession) -> PypiReleaseDownload | None:
-    release_iter = (
-        release for release in pypi_info.releases_in_descending_order()
-        if not release.version.is_prerelease
-    )
+    release_iter = (release for release in pypi_info.releases_in_descending_order() if not release.version.is_prerelease)
     latest_release = next(release_iter)
     # If the latest release is not py.typed, assume none are.
     if not (await release_contains_py_typed(latest_release, session=session)):


### PR DESCRIPTION
Fixes #9759

I tested this locally: with this patch, `DateTimeRange` is correctly marked as obsolete if I run it locally. Without it, stubsabot just tries to bump `DateTimeRange` to the latest version, without noticing that `DateTimeRange` added a `py.typed` file in the latest version, released in the last 24 hours.