### PR TITLE
lru_cache.cache_info().maxsize can be None for infinite cache size

### DIFF
--- a/stdlib/functools.pyi
+++ b/stdlib/functools.pyi
@@ -67,7 +67,7 @@ def reduce(function: Callable[[_T, _T], _T], sequence: Iterable[_T]) -> _T: ...
 class _CacheInfo(NamedTuple):
     hits: int
     misses: int
-    maxsize: int
+    maxsize: int | None
     currsize: int
 
 @final


### PR DESCRIPTION
Docs are here: https://docs.python.org/3/library/functools.html#functools.lru_cache