### PR TITLE
`textwrap.{wrap, fill}`: `max_lines` defaults to `None`

### DIFF
--- a/stdlib/textwrap.pyi
+++ b/stdlib/textwrap.pyi
@@ -64,7 +64,7 @@ def wrap(
     break_long_words: bool = ...,
     break_on_hyphens: bool = ...,
     drop_whitespace: bool = ...,
-    max_lines: int = ...,
+    max_lines: int | None = None,
     placeholder: str = ...,
 ) -> list[str]: ...
 def fill(
@@ -80,7 +80,7 @@ def fill(
     break_long_words: bool = ...,
     break_on_hyphens: bool = ...,
     drop_whitespace: bool = ...,
-    max_lines: int = ...,
+    max_lines: int | None = None,
     placeholder: str = ...,
 ) -> str: ...
 def shorten(


### PR DESCRIPTION
All keyword arguments are delegated to `TextWrapper.__init__`: https://github.com/python/cpython/blob/59e86caca812fc993c5eb7dc8ccd1508ffccba86/Lib/textwrap.py#L373-L396