### PR TITLE
Fix an unnecessary allowlist entry in `ssl.pyi`

### DIFF
--- a/stdlib/ssl.pyi
+++ b/stdlib/ssl.pyi
@@ -291,11 +291,14 @@ ALERT_DESCRIPTION_UNSUPPORTED_CERTIFICATE: AlertDescription
 ALERT_DESCRIPTION_UNSUPPORTED_EXTENSION: AlertDescription
 ALERT_DESCRIPTION_USER_CANCELLED: AlertDescription
 
-class _ASN1Object(NamedTuple):
+class _ASN1ObjectBase(NamedTuple):
     nid: int
     shortname: str
     longname: str
     oid: str
+
+class _ASN1Object(_ASN1ObjectBase):
+    def __new__(cls, oid: str) -> Self: ...
     @classmethod
     def fromnid(cls, nid: int) -> Self: ...
     @classmethod

--- a/tests/stubtest_allowlists/py3_common.txt
+++ b/tests/stubtest_allowlists/py3_common.txt
@@ -169,8 +169,7 @@ socketserver.BaseServer.RequestHandlerClass  # is defined as a property, because
 socketserver.BaseServer.fileno  # implemented in derived classes
 socketserver.BaseServer.get_request  # implemented in derived classes
 socketserver.BaseServer.server_bind  # implemented in derived classes
-ssl.Purpose.__new__  # You cannot override __new__ in NamedTuple and runtime uses namedtuple.
-ssl._ASN1Object.__new__  # You cannot override __new__ in NamedTuple and runtime uses namedtuple.
+ssl.Purpose.__new__  # the multiple inheritance confuses mypy
 (sys.get_int_max_str_digits)?  # Added in a patch release, backported to all security branches, but has yet to find its way to all GitHub Actions images
 sys.implementation  # Actually SimpleNamespace but then you wouldn't have convenient attributes
 (sys.set_int_max_str_digits)?  # Added in a patch release, backported to all security branches, but has yet to find its way to all GitHub Actions images


### PR DESCRIPTION
The comment in the allowlist is incorrect: `ssl._ASN1Object` isn't actually a namedtuple class at runtime. It's a *subclass* of a namedtuple class at runtime, and it's fine to override `__new__` in a subclass of a namedtuple class. https://github.com/python/cpython/blob/95f4e2ca03efbe020ae590108c022219008bbaf3/Lib/ssl.py#L452