### PR TITLE
Change `ignore_missing_stub` default to `false`

### DIFF
--- a/scripts/create_baseline_stubs.py
+++ b/scripts/create_baseline_stubs.py
@@ -71,14 +71,7 @@ def create_metadata(stub_dir: str, version: str) -> None:
         return
     print(f"Writing {filename}")
     with open(filename, "w", encoding="UTF-8") as file:
-        file.write(
-            f"""\
-version = "{version}.*"
-
-[tool.stubtest]
-ignore_missing_stub = false
-"""
-        )
+        file.write(f'version = "{version}.*"')
 
 
 def add_pyright_exclusion(stub_dir: str) -> None:

--- a/stubs/D3DShot/METADATA.toml
+++ b/stubs/D3DShot/METADATA.toml
@@ -2,6 +2,7 @@ version = "0.1.*"
 requires = ["types-Pillow"]
 
 [tool.stubtest]
+ignore_missing_stub = true
 # TODO: figure out how to run stubtest for this package
 # (the package pins Pillow in a problematic way)
 skip = true

--- a/stubs/DateTimeRange/METADATA.toml
+++ b/stubs/DateTimeRange/METADATA.toml
@@ -1,6 +1,3 @@
 version = "2.0.*"
 requires = ["types-python-dateutil"]
 obsolete_since = "2.1.0" # Released on 2023-02-19
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/Deprecated/METADATA.toml
+++ b/stubs/Deprecated/METADATA.toml
@@ -1,5 +1,2 @@
 version = "1.2.*"
 requires = []
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/ExifRead/METADATA.toml
+++ b/stubs/ExifRead/METADATA.toml
@@ -1,4 +1,1 @@
 version = "3.0.*"
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/Flask-Cors/METADATA.toml
+++ b/stubs/Flask-Cors/METADATA.toml
@@ -1,3 +1,6 @@
 version = "3.0.*"
 # Requires a version of flask with a `py.typed` file
 requires = ["Flask>=2.0.0"]
+
+[tool.stubtest]
+ignore_missing_stub = true

--- a/stubs/Flask-Migrate/METADATA.toml
+++ b/stubs/Flask-Migrate/METADATA.toml
@@ -1,3 +1,6 @@
 version = "4.0.*"
 # Requires a version of flask with a `py.typed` file
 requires = ["Flask>=2.0.0", "types-Flask-SQLAlchemy"]
+
+[tool.stubtest]
+ignore_missing_stub = true

--- a/stubs/Flask-SQLAlchemy/METADATA.toml
+++ b/stubs/Flask-SQLAlchemy/METADATA.toml
@@ -1,3 +1,6 @@
 version = "2.5.*"
 requires = ["types-SQLAlchemy"]
 obsolete_since = "3.0.1" # Released on 2022-10-11
+
+[tool.stubtest]
+ignore_missing_stub = true

--- a/stubs/JACK-Client/METADATA.toml
+++ b/stubs/JACK-Client/METADATA.toml
@@ -1,11 +1,10 @@
 version = "0.5.*"
 # Requires a version of numpy with a `py.typed` file
-requires = ["types-cffi", "numpy>=1.20"]
+requires = ["numpy>=1.20", "types-cffi"]
 
 [tool.stubtest]
-ignore_missing_stub = false
 # darwin and win32 are equivalent
-platforms = ["linux", "darwin"]
+platforms = ["darwin", "linux"]
 apt_dependencies = ["libjack-dev"]
 brew_dependencies = ["jack"]
 # No need to install on the CI. Leaving here as information for Windows contributors.

--- a/stubs/Markdown/METADATA.toml
+++ b/stubs/Markdown/METADATA.toml
@@ -1,1 +1,4 @@
 version = "3.4.*"
+
+[tool.stubtest]
+ignore_missing_stub = true

--- a/stubs/Pillow/METADATA.toml
+++ b/stubs/Pillow/METADATA.toml
@@ -1,1 +1,4 @@
 version = "9.4.*"
+
+[tool.stubtest]
+ignore_missing_stub = true

--- a/stubs/PyAutoGUI/METADATA.toml
+++ b/stubs/PyAutoGUI/METADATA.toml
@@ -1,5 +1,2 @@
 version = "0.9.*"
-requires = ["types-PyScreeze", "types-Pillow"]
-
-[tool.stubtest]
-ignore_missing_stub = false
+requires = ["types-Pillow", "types-PyScreeze"]

--- a/stubs/PyMySQL/METADATA.toml
+++ b/stubs/PyMySQL/METADATA.toml
@@ -1,1 +1,4 @@
 version = "1.0.*"
+
+[tool.stubtest]
+ignore_missing_stub = true

--- a/stubs/PyScreeze/METADATA.toml
+++ b/stubs/PyScreeze/METADATA.toml
@@ -1,5 +1,2 @@
 version = "0.1.*"
 requires = ["types-Pillow"]
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/PyYAML/METADATA.toml
+++ b/stubs/PyYAML/METADATA.toml
@@ -1,4 +1,1 @@
 version = "6.0.*"
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/Pygments/METADATA.toml
+++ b/stubs/Pygments/METADATA.toml
@@ -1,2 +1,5 @@
 version = "2.14.*"
 requires = ["types-docutils", "types-setuptools"]
+
+[tool.stubtest]
+ignore_missing_stub = true

--- a/stubs/SQLAlchemy/METADATA.toml
+++ b/stubs/SQLAlchemy/METADATA.toml
@@ -4,3 +4,6 @@ extra_description = """\
   includes a mypy plugin for more precise types.\
 """
 obsolete_since = "2.0.0" # Released on 2023-01-26
+
+[tool.stubtest]
+ignore_missing_stub = true

--- a/stubs/Send2Trash/METADATA.toml
+++ b/stubs/Send2Trash/METADATA.toml
@@ -1,1 +1,4 @@
 version = "1.8.*"
+
+[tool.stubtest]
+ignore_missing_stub = true

--- a/stubs/aiofiles/METADATA.toml
+++ b/stubs/aiofiles/METADATA.toml
@@ -1,6 +1,5 @@
 version = "22.1.*"
 
 [tool.stubtest]
-ignore_missing_stub = false
 # linux and darwin are equivalent
 platforms = ["linux", "win32"]

--- a/stubs/annoy/METADATA.toml
+++ b/stubs/annoy/METADATA.toml
@@ -1,5 +1,2 @@
 version = "1.17.*"
 requires = []
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/appdirs/METADATA.toml
+++ b/stubs/appdirs/METADATA.toml
@@ -1,4 +1,1 @@
 version = "1.4.*"
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/aws-xray-sdk/METADATA.toml
+++ b/stubs/aws-xray-sdk/METADATA.toml
@@ -1,1 +1,4 @@
 version = "2.11.*"
+
+[tool.stubtest]
+ignore_missing_stub = true

--- a/stubs/babel/METADATA.toml
+++ b/stubs/babel/METADATA.toml
@@ -1,2 +1,5 @@
 version = "2.11.*"
 requires = ["types-pytz"]
+
+[tool.stubtest]
+ignore_missing_stub = true

--- a/stubs/backports.ssl_match_hostname/METADATA.toml
+++ b/stubs/backports.ssl_match_hostname/METADATA.toml
@@ -1,4 +1,1 @@
 version = "3.7.*"
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/beautifulsoup4/METADATA.toml
+++ b/stubs/beautifulsoup4/METADATA.toml
@@ -2,4 +2,5 @@ version = "4.11.*"
 requires = ["types-html5lib"]
 
 [tool.stubtest]
-extras = ["lxml", "html5lib"]
+ignore_missing_stub = true
+extras = ["html5lib", "lxml"]

--- a/stubs/bleach/METADATA.toml
+++ b/stubs/bleach/METADATA.toml
@@ -1,1 +1,4 @@
 version = "6.0.*"
+
+[tool.stubtest]
+ignore_missing_stub = true

--- a/stubs/boto/METADATA.toml
+++ b/stubs/boto/METADATA.toml
@@ -1,2 +1,5 @@
 version = "2.49.*"
 requires = []
+
+[tool.stubtest]
+ignore_missing_stub = true

--- a/stubs/braintree/METADATA.toml
+++ b/stubs/braintree/METADATA.toml
@@ -1,1 +1,4 @@
 version = "4.18.*"
+
+[tool.stubtest]
+ignore_missing_stub = true

--- a/stubs/cachetools/METADATA.toml
+++ b/stubs/cachetools/METADATA.toml
@@ -1,4 +1,1 @@
 version = "5.3.*"
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/caldav/METADATA.toml
+++ b/stubs/caldav/METADATA.toml
@@ -1,3 +1,6 @@
 version = "1.0.*"
 # also types-lxml and types-icalendar when those stubs are added
 requires = ["types-requests", "types-vobject"]
+
+[tool.stubtest]
+ignore_missing_stub = true

--- a/stubs/cffi/METADATA.toml
+++ b/stubs/cffi/METADATA.toml
@@ -1,6 +1,5 @@
 version = "1.15.*"
 
 [tool.stubtest]
-ignore_missing_stub = false
 # linux and darwin are mostly equivalent, except for a single `RTLD_DEEPBIND` variable
 platforms = ["linux", "win32"]

--- a/stubs/chardet/METADATA.toml
+++ b/stubs/chardet/METADATA.toml
@@ -1,2 +1,5 @@
 version = "5.0.*"
 obsolete_since = "5.1.0" # Released on 2022-12-01
+
+[tool.stubtest]
+ignore_missing_stub = true

--- a/stubs/chevron/METADATA.toml
+++ b/stubs/chevron/METADATA.toml
@@ -1,4 +1,3 @@
 version = "0.14.*"
 
 [tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/click-spinner/METADATA.toml
+++ b/stubs/click-spinner/METADATA.toml
@@ -1,4 +1,1 @@
 version = "0.1.*"
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/colorama/METADATA.toml
+++ b/stubs/colorama/METADATA.toml
@@ -1,5 +1,4 @@
 version = "0.4.*"
 
 [tool.stubtest]
-ignore_missing_stub = false
-platforms = ["win32", "linux"]
+platforms = ["linux", "win32"]

--- a/stubs/commonmark/METADATA.toml
+++ b/stubs/commonmark/METADATA.toml
@@ -1,1 +1,4 @@
 version = "0.9.*"
+
+[tool.stubtest]
+ignore_missing_stub = true

--- a/stubs/console-menu/METADATA.toml
+++ b/stubs/console-menu/METADATA.toml
@@ -1,4 +1,1 @@
 version = "0.7.*"
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/contextvars/METADATA.toml
+++ b/stubs/contextvars/METADATA.toml
@@ -1,4 +1,1 @@
 version = "2.4"
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/croniter/METADATA.toml
+++ b/stubs/croniter/METADATA.toml
@@ -1,4 +1,1 @@
 version = "1.3.*"
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/dateparser/METADATA.toml
+++ b/stubs/dateparser/METADATA.toml
@@ -1,5 +1,4 @@
 version = "1.1.*"
 
 [tool.stubtest]
-ignore_missing_stub = false
 extras = ["fasttext", "langdetect"]

--- a/stubs/decorator/METADATA.toml
+++ b/stubs/decorator/METADATA.toml
@@ -1,4 +1,1 @@
 version = "5.1.*"
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/dj-database-url/METADATA.toml
+++ b/stubs/dj-database-url/METADATA.toml
@@ -1,4 +1,1 @@
 version = "1.2.*"
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/dockerfile-parse/METADATA.toml
+++ b/stubs/dockerfile-parse/METADATA.toml
@@ -1,4 +1,1 @@
 version = "2.0.*"
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/docopt/METADATA.toml
+++ b/stubs/docopt/METADATA.toml
@@ -1,4 +1,1 @@
 version = "0.6.*"
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/docutils/METADATA.toml
+++ b/stubs/docutils/METADATA.toml
@@ -1,1 +1,4 @@
 version = "0.19.*"
+
+[tool.stubtest]
+ignore_missing_stub = true

--- a/stubs/editdistance/METADATA.toml
+++ b/stubs/editdistance/METADATA.toml
@@ -1,4 +1,1 @@
 version = "0.6.*"
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/emoji/METADATA.toml
+++ b/stubs/emoji/METADATA.toml
@@ -1,5 +1,2 @@
 version = "2.1.*"
 obsolete_since = "2.2.0" # Released on 2022-10-31
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/entrypoints/METADATA.toml
+++ b/stubs/entrypoints/METADATA.toml
@@ -1,4 +1,1 @@
 version = "0.4.*"
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/first/METADATA.toml
+++ b/stubs/first/METADATA.toml
@@ -1,4 +1,1 @@
 version = "2.0.*"
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/flake8-2020/METADATA.toml
+++ b/stubs/flake8-2020/METADATA.toml
@@ -1,4 +1,1 @@
 version = "1.7.*"
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/flake8-bugbear/METADATA.toml
+++ b/stubs/flake8-bugbear/METADATA.toml
@@ -1,1 +1,4 @@
 version = "23.2.13"
+
+[tool.stubtest]
+ignore_missing_stub = true

--- a/stubs/flake8-builtins/METADATA.toml
+++ b/stubs/flake8-builtins/METADATA.toml
@@ -1,1 +1,4 @@
 version = "2.1.*"
+
+[tool.stubtest]
+ignore_missing_stub = true

--- a/stubs/flake8-docstrings/METADATA.toml
+++ b/stubs/flake8-docstrings/METADATA.toml
@@ -1,1 +1,4 @@
 version = "1.7.*"
+
+[tool.stubtest]
+ignore_missing_stub = true

--- a/stubs/flake8-plugin-utils/METADATA.toml
+++ b/stubs/flake8-plugin-utils/METADATA.toml
@@ -1,1 +1,4 @@
 version = "1.3.*"
+
+[tool.stubtest]
+ignore_missing_stub = true

--- a/stubs/flake8-rst-docstrings/METADATA.toml
+++ b/stubs/flake8-rst-docstrings/METADATA.toml
@@ -1,1 +1,4 @@
 version = "0.3.*"
+
+[tool.stubtest]
+ignore_missing_stub = true

--- a/stubs/flake8-simplify/METADATA.toml
+++ b/stubs/flake8-simplify/METADATA.toml
@@ -1,1 +1,4 @@
 version = "0.19.*"
+
+[tool.stubtest]
+ignore_missing_stub = true

--- a/stubs/flake8-typing-imports/METADATA.toml
+++ b/stubs/flake8-typing-imports/METADATA.toml
@@ -1,1 +1,4 @@
 version = "1.14.*"
+
+[tool.stubtest]
+ignore_missing_stub = true

--- a/stubs/fpdf2/METADATA.toml
+++ b/stubs/fpdf2/METADATA.toml
@@ -1,5 +1,2 @@
 version = "2.6.1"
 requires = ["types-Pillow>=9.2.0"]
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/google-cloud-ndb/METADATA.toml
+++ b/stubs/google-cloud-ndb/METADATA.toml
@@ -1,1 +1,4 @@
 version = "2.1.*"
+
+[tool.stubtest]
+ignore_missing_stub = true

--- a/stubs/hdbcli/METADATA.toml
+++ b/stubs/hdbcli/METADATA.toml
@@ -1,4 +1,1 @@
 version = "2.15.*"
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/html5lib/METADATA.toml
+++ b/stubs/html5lib/METADATA.toml
@@ -1,4 +1,5 @@
 version = "1.1.*"
 
 [tool.stubtest]
+ignore_missing_stub = true
 extras = ["all"]

--- a/stubs/httplib2/METADATA.toml
+++ b/stubs/httplib2/METADATA.toml
@@ -1,4 +1,1 @@
 version = "0.21.*"
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/humanfriendly/METADATA.toml
+++ b/stubs/humanfriendly/METADATA.toml
@@ -1,4 +1,1 @@
 version = "10.0.*"
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/ibm-db/METADATA.toml
+++ b/stubs/ibm-db/METADATA.toml
@@ -1,4 +1,1 @@
 version = "3.1.*"
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/influxdb-client/METADATA.toml
+++ b/stubs/influxdb-client/METADATA.toml
@@ -2,5 +2,4 @@ version = "1.36.*"
 requires = ["types-urllib3"]
 
 [tool.stubtest]
-ignore_missing_stub = false
 extras = ["extra"]

--- a/stubs/invoke/METADATA.toml
+++ b/stubs/invoke/METADATA.toml
@@ -1,1 +1,4 @@
 version = "2.0.*"
+
+[tool.stubtest]
+ignore_missing_stub = true

--- a/stubs/jmespath/METADATA.toml
+++ b/stubs/jmespath/METADATA.toml
@@ -1,4 +1,1 @@
 version = "1.0.*"
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/jsonschema/METADATA.toml
+++ b/stubs/jsonschema/METADATA.toml
@@ -1,4 +1,5 @@
 version = "4.17.*"
 
 [tool.stubtest]
+ignore_missing_stub = true
 extras = ["format"]

--- a/stubs/keyboard/METADATA.toml
+++ b/stubs/keyboard/METADATA.toml
@@ -1,7 +1,6 @@
 version = "0.13.*"
 
-[tool.stubtest]
-ignore_missing_stub = false
+# [tool.stubtest]
 # While the stubs slightly differ on Windows vs Linux.
 # It's only by possible mouse buttons and event literal types.
 # As well as returning a tuple of int/long from keyboard.mouse.get_position

--- a/stubs/ldap3/METADATA.toml
+++ b/stubs/ldap3/METADATA.toml
@@ -2,6 +2,7 @@ version = "2.9.*"
 requires = ["types-pyasn1"]
 
 [tool.stubtest]
+ignore_missing_stub = true
 apt_dependencies = ["libkrb5-dev"]
 # No need to install on the CI. Leaving here as information for MacOs/Windows contributors.
 # brew_dependencies = ["krb5"]

--- a/stubs/mock/METADATA.toml
+++ b/stubs/mock/METADATA.toml
@@ -1,4 +1,1 @@
 version = "5.0.*"
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/mypy-extensions/METADATA.toml
+++ b/stubs/mypy-extensions/METADATA.toml
@@ -1,4 +1,1 @@
 version = "1.0.*"
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/mysqlclient/METADATA.toml
+++ b/stubs/mysqlclient/METADATA.toml
@@ -1,4 +1,1 @@
 version = "2.1.*"
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/netaddr/METADATA.toml
+++ b/stubs/netaddr/METADATA.toml
@@ -1,4 +1,1 @@
 version = "0.8.*"
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/oauthlib/METADATA.toml
+++ b/stubs/oauthlib/METADATA.toml
@@ -1,1 +1,4 @@
 version = "3.2.*"
+
+[tool.stubtest]
+ignore_missing_stub = true

--- a/stubs/openpyxl/METADATA.toml
+++ b/stubs/openpyxl/METADATA.toml
@@ -1,1 +1,4 @@
 version = "3.0.*"
+
+[tool.stubtest]
+ignore_missing_stub = true

--- a/stubs/opentracing/METADATA.toml
+++ b/stubs/opentracing/METADATA.toml
@@ -1,1 +1,4 @@
 version = "2.4.*"
+
+[tool.stubtest]
+ignore_missing_stub = true

--- a/stubs/paho-mqtt/METADATA.toml
+++ b/stubs/paho-mqtt/METADATA.toml
@@ -1,4 +1,1 @@
 version = "1.6.*"
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/paramiko/METADATA.toml
+++ b/stubs/paramiko/METADATA.toml
@@ -3,5 +3,6 @@ version = "3.0.*"
 requires = ["cryptography>=37.0.0"]
 
 [tool.stubtest]
+ignore_missing_stub = true
 # linux and darwin are equivalent
 platforms = ["linux", "win32"]

--- a/stubs/parsimonious/METADATA.toml
+++ b/stubs/parsimonious/METADATA.toml
@@ -1,4 +1,1 @@
 version = "0.10.*"
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/passlib/METADATA.toml
+++ b/stubs/passlib/METADATA.toml
@@ -1,4 +1,1 @@
 version = "1.7.*"
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/passpy/METADATA.toml
+++ b/stubs/passpy/METADATA.toml
@@ -1,4 +1,1 @@
 version = "1.0.*"
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/peewee/METADATA.toml
+++ b/stubs/peewee/METADATA.toml
@@ -1,4 +1,1 @@
 version = "3.15.*"
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/pep8-naming/METADATA.toml
+++ b/stubs/pep8-naming/METADATA.toml
@@ -1,1 +1,4 @@
 version = "0.13.*"
+
+[tool.stubtest]
+ignore_missing_stub = true

--- a/stubs/pika/METADATA.toml
+++ b/stubs/pika/METADATA.toml
@@ -1,9 +1,6 @@
 version = "1.3.*"
-stub_distribution = "types-pika-ts"  # https://github.com/python/typeshed/issues/9246
+stub_distribution = "types-pika-ts" # https://github.com/python/typeshed/issues/9246
 extra_description = """\
 The `types-pika` package contains alternate, more complete type stubs, that \
 are maintained outside of typeshed.\
 """
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/playsound/METADATA.toml
+++ b/stubs/playsound/METADATA.toml
@@ -1,4 +1,1 @@
 version = "1.3.*"
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/polib/METADATA.toml
+++ b/stubs/polib/METADATA.toml
@@ -1,4 +1,1 @@
 version = "1.1.*"
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/prettytable/METADATA.toml
+++ b/stubs/prettytable/METADATA.toml
@@ -1,5 +1,2 @@
 version = "3.4.*"
 obsolete_since = "3.5.0" # Released on 2022-10-28
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/protobuf/METADATA.toml
+++ b/stubs/protobuf/METADATA.toml
@@ -1,2 +1,5 @@
 version = "4.21.*"
 extra_description = "Generated with aid from mypy-protobuf v3.4.0"
+
+[tool.stubtest]
+ignore_missing_stub = true

--- a/stubs/psutil/METADATA.toml
+++ b/stubs/psutil/METADATA.toml
@@ -1,5 +1,4 @@
 version = "5.9.*"
 
 [tool.stubtest]
-ignore_missing_stub = false
-platforms = ["win32", "linux", "darwin"]
+platforms = ["darwin", "linux", "win32"]

--- a/stubs/psycopg2/METADATA.toml
+++ b/stubs/psycopg2/METADATA.toml
@@ -1,1 +1,4 @@
 version = "2.9.*"
+
+[tool.stubtest]
+ignore_missing_stub = true

--- a/stubs/pyOpenSSL/METADATA.toml
+++ b/stubs/pyOpenSSL/METADATA.toml
@@ -1,3 +1,6 @@
 version = "23.0.*"
 # Requires a version of cryptography with a `py.typed` file
 requires = ["cryptography>=35.0.0"]
+
+[tool.stubtest]
+ignore_missing_stub = true

--- a/stubs/pyRFC3339/METADATA.toml
+++ b/stubs/pyRFC3339/METADATA.toml
@@ -1,4 +1,1 @@
 version = "1.1"
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/pyasn1/METADATA.toml
+++ b/stubs/pyasn1/METADATA.toml
@@ -1,4 +1,1 @@
 version = "0.4.*"
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/pyaudio/METADATA.toml
+++ b/stubs/pyaudio/METADATA.toml
@@ -1,8 +1,7 @@
 version = "0.2.*"
 
 [tool.stubtest]
-ignore_missing_stub = false
 # linux and win32 are equivalent
-platforms = ["linux", "darwin"]
+platforms = ["darwin", "linux"]
 apt_dependencies = ["portaudio19-dev"]
 brew_dependencies = ["portaudio"]

--- a/stubs/pycocotools/METADATA.toml
+++ b/stubs/pycocotools/METADATA.toml
@@ -1,4 +1,1 @@
 version = "2.0.*"
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/pycurl/METADATA.toml
+++ b/stubs/pycurl/METADATA.toml
@@ -1,7 +1,6 @@
 version = "7.45.2"
 
 [tool.stubtest]
-ignore_missing_stub = false
 # Install on Windows requires building PycURL from source
 #
 # Install on MacOS is too complicated for the CI and does not work with stubtest:

--- a/stubs/pyfarmhash/METADATA.toml
+++ b/stubs/pyfarmhash/METADATA.toml
@@ -1,4 +1,1 @@
 version = "0.3.*"
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/pyflakes/METADATA.toml
+++ b/stubs/pyflakes/METADATA.toml
@@ -1,1 +1,4 @@
 version = "3.0.*"
+
+[tool.stubtest]
+ignore_missing_stub = true

--- a/stubs/pyinstaller/METADATA.toml
+++ b/stubs/pyinstaller/METADATA.toml
@@ -1,5 +1,2 @@
 version = "5.8.*"
 requires = ["types-setuptools"]
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/pynput/METADATA.toml
+++ b/stubs/pynput/METADATA.toml
@@ -1,5 +1,4 @@
 version = "1.7.*"
 
 [tool.stubtest]
-ignore_missing_stub = false
-platforms = ["linux", "darwin", "win32"]
+platforms = ["darwin", "linux", "win32"]

--- a/stubs/pyserial/METADATA.toml
+++ b/stubs/pyserial/METADATA.toml
@@ -1,6 +1,5 @@
 version = "3.5.*"
 
 [tool.stubtest]
-ignore_missing_stub = false
-platforms = ["linux", "win32", "darwin"]
+platforms = ["darwin", "linux", "win32"]
 extras = ["cp2110"]

--- a/stubs/pysftp/METADATA.toml
+++ b/stubs/pysftp/METADATA.toml
@@ -1,5 +1,2 @@
 version = "0.2.*"
 requires = ["types-paramiko"]
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/pytest-lazy-fixture/METADATA.toml
+++ b/stubs/pytest-lazy-fixture/METADATA.toml
@@ -1,4 +1,1 @@
 version = "0.6.*"
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/python-crontab/METADATA.toml
+++ b/stubs/python-crontab/METADATA.toml
@@ -1,4 +1,1 @@
 version = "2.7.*"
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/python-datemath/METADATA.toml
+++ b/stubs/python-datemath/METADATA.toml
@@ -1,3 +1,6 @@
 version = "1.5.*"
 # Requires a version of arrow with a `py.typed` file
 requires = ["arrow>=1.0.1"]
+
+[tool.stubtest]
+ignore_missing_stub = true

--- a/stubs/python-dateutil/METADATA.toml
+++ b/stubs/python-dateutil/METADATA.toml
@@ -1,1 +1,4 @@
 version = "2.8.*"
+
+[tool.stubtest]
+ignore_missing_stub = true

--- a/stubs/python-gflags/METADATA.toml
+++ b/stubs/python-gflags/METADATA.toml
@@ -1,4 +1,1 @@
 version = "3.1.*"
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/python-jose/METADATA.toml
+++ b/stubs/python-jose/METADATA.toml
@@ -1,5 +1,2 @@
 version = "3.3.*"
 requires = ["types-pyasn1"] # excluding pyrsa, cryptography until typing is available
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/python-nmap/METADATA.toml
+++ b/stubs/python-nmap/METADATA.toml
@@ -1,4 +1,1 @@
 version = "0.7.*"
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/python-slugify/METADATA.toml
+++ b/stubs/python-slugify/METADATA.toml
@@ -1,4 +1,1 @@
 version = "8.0.*"
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/python-xlib/METADATA.toml
+++ b/stubs/python-xlib/METADATA.toml
@@ -1,5 +1,2 @@
 version = "0.33.*"
 requires = ["types-Pillow"]
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/pytz/METADATA.toml
+++ b/stubs/pytz/METADATA.toml
@@ -1,4 +1,1 @@
 version = "2022.7.1"
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/pyvmomi/METADATA.toml
+++ b/stubs/pyvmomi/METADATA.toml
@@ -1,1 +1,4 @@
 version = "8.0.*"
+
+[tool.stubtest]
+ignore_missing_stub = true

--- a/stubs/pywin32/METADATA.toml
+++ b/stubs/pywin32/METADATA.toml
@@ -2,4 +2,3 @@ version = "305.*"
 
 [tool.stubtest]
 platforms = ["win32"]
-ignore_missing_stub = false

--- a/stubs/redis/METADATA.toml
+++ b/stubs/redis/METADATA.toml
@@ -1,6 +1,7 @@
 version = "4.5.1"
 # Requires a version of cryptography with a `py.typed` file
-requires = ["types-pyOpenSSL", "cryptography>=35.0.0"]
+requires = ["cryptography>=35.0.0", "types-pyOpenSSL"]
 
 [tool.stubtest]
+ignore_missing_stub = true
 extras = ["ocsp"]

--- a/stubs/regex/METADATA.toml
+++ b/stubs/regex/METADATA.toml
@@ -1,4 +1,1 @@
 version = "2022.10.31"
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/requests/METADATA.toml
+++ b/stubs/requests/METADATA.toml
@@ -2,5 +2,4 @@ version = "2.28.*"
 requires = ["types-urllib3<1.27"] # keep in sync with requests's setup.py
 
 [tool.stubtest]
-ignore_missing_stub = false
 extras = ["socks"]

--- a/stubs/retry/METADATA.toml
+++ b/stubs/retry/METADATA.toml
@@ -1,4 +1,1 @@
 version = "0.9.*"
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/setuptools/METADATA.toml
+++ b/stubs/setuptools/METADATA.toml
@@ -1,2 +1,5 @@
 version = "67.3.*"
 requires = ["types-docutils"]
+
+[tool.stubtest]
+ignore_missing_stub = true

--- a/stubs/simplejson/METADATA.toml
+++ b/stubs/simplejson/METADATA.toml
@@ -1,1 +1,4 @@
 version = "3.18.*"
+
+[tool.stubtest]
+ignore_missing_stub = true

--- a/stubs/singledispatch/METADATA.toml
+++ b/stubs/singledispatch/METADATA.toml
@@ -1,4 +1,1 @@
 version = "4.0.*"
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/six/METADATA.toml
+++ b/stubs/six/METADATA.toml
@@ -1,4 +1,1 @@
 version = "1.16.*"
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/slumber/METADATA.toml
+++ b/stubs/slumber/METADATA.toml
@@ -1,5 +1,2 @@
 version = "0.7.*"
 requires = ["types-requests"]
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/stdlib-list/METADATA.toml
+++ b/stubs/stdlib-list/METADATA.toml
@@ -1,4 +1,1 @@
 version = "0.8.*"
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/stripe/METADATA.toml
+++ b/stubs/stripe/METADATA.toml
@@ -1,1 +1,4 @@
 version = "3.5.*"
+
+[tool.stubtest]
+ignore_missing_stub = true

--- a/stubs/tabulate/METADATA.toml
+++ b/stubs/tabulate/METADATA.toml
@@ -1,4 +1,1 @@
 version = "0.9.*"
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/tensorflow/METADATA.toml
+++ b/stubs/tensorflow/METADATA.toml
@@ -1,3 +1,6 @@
 version = "2.11.*"
 # requires a version of numpy with a `py.typed` file
 requires = ["numpy>=1.20"]
+
+[tool.stubtest]
+ignore_missing_stub = true

--- a/stubs/termcolor/METADATA.toml
+++ b/stubs/termcolor/METADATA.toml
@@ -1,5 +1,2 @@
 version = "1.1.*"
 obsolete_since = "2.0.0" # Released on 2022-09-11
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/toml/METADATA.toml
+++ b/stubs/toml/METADATA.toml
@@ -1,4 +1,1 @@
 version = "0.10.*"
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/toposort/METADATA.toml
+++ b/stubs/toposort/METADATA.toml
@@ -1,4 +1,1 @@
 version = "1.9"
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/tqdm/METADATA.toml
+++ b/stubs/tqdm/METADATA.toml
@@ -1,5 +1,4 @@
 version = "4.64.*"
 
 [tool.stubtest]
-ignore_missing_stub = false
 extras = ["slack", "telegram"]

--- a/stubs/tree-sitter-languages/METADATA.toml
+++ b/stubs/tree-sitter-languages/METADATA.toml
@@ -1,5 +1,2 @@
 version = "1.5.*"
 requires = ["types-tree-sitter"]
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/tree-sitter/METADATA.toml
+++ b/stubs/tree-sitter/METADATA.toml
@@ -1,4 +1,1 @@
 version = "0.20.*"
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/ttkthemes/METADATA.toml
+++ b/stubs/ttkthemes/METADATA.toml
@@ -1,4 +1,1 @@
 version = "3.2.*"
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/typed-ast/METADATA.toml
+++ b/stubs/typed-ast/METADATA.toml
@@ -1,4 +1,1 @@
 version = "1.5.*"
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/tzlocal/METADATA.toml
+++ b/stubs/tzlocal/METADATA.toml
@@ -1,5 +1,2 @@
 version = "4.2"
 requires = ["types-pytz"]
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/ujson/METADATA.toml
+++ b/stubs/ujson/METADATA.toml
@@ -1,4 +1,1 @@
 version = "5.7.*"
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/untangle/METADATA.toml
+++ b/stubs/untangle/METADATA.toml
@@ -1,4 +1,1 @@
 version = "1.2.*"
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/urllib3/METADATA.toml
+++ b/stubs/urllib3/METADATA.toml
@@ -1,4 +1,5 @@
 version = "1.26.*"
 
 [tool.stubtest]
+ignore_missing_stub = true
 extras = ["socks"]

--- a/stubs/vobject/METADATA.toml
+++ b/stubs/vobject/METADATA.toml
@@ -1,4 +1,1 @@
 version = "0.9.*"
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/waitress/METADATA.toml
+++ b/stubs/waitress/METADATA.toml
@@ -2,5 +2,6 @@ version = "2.1.*"
 requires = []
 
 [tool.stubtest]
+ignore_missing_stub = true
 # linux and darwin are equivalent
 platforms = ["linux", "win32"]

--- a/stubs/whatthepatch/METADATA.toml
+++ b/stubs/whatthepatch/METADATA.toml
@@ -1,4 +1,1 @@
 version = "1.0.*"
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/xmltodict/METADATA.toml
+++ b/stubs/xmltodict/METADATA.toml
@@ -1,4 +1,1 @@
 version = "0.13.*"
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/xxhash/METADATA.toml
+++ b/stubs/xxhash/METADATA.toml
@@ -1,5 +1,2 @@
 version = "3.0.*"
 obsolete_since = "3.1.0" # Released on 2022-10-19
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/zstd/METADATA.toml
+++ b/stubs/zstd/METADATA.toml
@@ -1,4 +1,1 @@
 version = "1.5.*"
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/stubs/zxcvbn/METADATA.toml
+++ b/stubs/zxcvbn/METADATA.toml
@@ -1,4 +1,1 @@
 version = "4.4.*"
-
-[tool.stubtest]
-ignore_missing_stub = false

--- a/tests/README.md
+++ b/tests/README.md
@@ -170,16 +170,17 @@ By default, stubtest emits an error if a public object is present at runtime
 but missing from the stub. However, this behaviour can be disabled using the
 `--ignore-missing-stub` option.
 
-Many third-party stubs packages in typeshed are currently incomplete, and so by
-default, `stubtest_third_party.py` runs stubtest with the
+Most third-party stubs packages in typeshed are currently complete (as far as stubtest is
+concerned), and so by default, `stubtest_third_party.py` does not run stubtest with the
 `--ignore-missing-stub` option to test our third-party stubs. However, this
-option is not used if the distribution has `ignore_missing_stub = false` in the
+option is used if the distribution has `ignore_missing_stub = true` in the
 `tool.stubtest` section of its `tests/METADATA.toml` file. This setting
-indicates that the package is considered "complete", for example:
-https://github.com/python/typeshed/blob/6950c3237065e6e2a9b64810765fec716252d52a/stubs/emoji/METADATA.toml#L3-L4
+indicates that the package is considered "incomplete", for example:
+<!-- TODO: Change to permalink once this is merged -->
+<https://github.com/python/typeshed/blob/main/stubs/setuptools/METADATA.toml#L5>
 
-You can help make typeshed's stubs more complete by adding
-`ignore_missing_stub = false` to the `tests/METADATA.toml` file for a
+You can help make typeshed's stubs more complete by removing
+`ignore_missing_stub = true` from the `tests/METADATA.toml` file for a
 third-party stubs distribution, running stubtest, and then adding things that
 stubtest reports to be missing to the stub. However, note that not *everything*
 that stubtest reports to be missing should necessarily be added to the stub.

--- a/tests/README.md
+++ b/tests/README.md
@@ -170,14 +170,10 @@ By default, stubtest emits an error if a public object is present at runtime
 but missing from the stub. However, this behaviour can be disabled using the
 `--ignore-missing-stub` option.
 
-Most third-party stubs packages in typeshed are currently complete (as far as stubtest is
-concerned), and so by default, `stubtest_third_party.py` does not run stubtest with the
-`--ignore-missing-stub` option to test our third-party stubs. However, this
-option is used if the distribution has `ignore_missing_stub = true` in the
-`tool.stubtest` section of its `tests/METADATA.toml` file. This setting
-indicates that the package is considered "incomplete", for example:
-<!-- TODO: Change to permalink once this is merged -->
-<https://github.com/python/typeshed/blob/main/stubs/setuptools/METADATA.toml#L5>
+If a distribution has `ignore_missing_stub = true` in the `[tool.stubtest]` section of its
+`tests/METADATA.toml` file, `stubtest_third_party.py` will test that distribution with the
+`--ignore-missing-stub option`. This indicates that the stubs for this distribution are
+considered "incomplete".
 
 You can help make typeshed's stubs more complete by removing
 `ignore_missing_stub = true` from the `tests/METADATA.toml` file for a

--- a/tests/parse_metadata.py
+++ b/tests/parse_metadata.py
@@ -67,7 +67,7 @@ def read_stubtest_settings(distribution: str) -> StubtestSettings:
     brew_dependencies = data.get("brew_dependencies", [])
     choco_dependencies = data.get("choco_dependencies", [])
     extras = data.get("extras", [])
-    ignore_missing_stub = data.get("ignore_missing_stub", True)
+    ignore_missing_stub = data.get("ignore_missing_stub", False)
     specified_platforms = data.get("platforms", ["linux"])
 
     assert type(skipped) is bool


### PR DESCRIPTION
Closes #9538 which got lots of thumbs up, and hopefully I'm not misinterpreting @hauntsaninja 's comment in https://github.com/python/mypy/issues/14692#issuecomment-1428479005 saying he advocated against `--ignore-missing-stub` by default.

I wanted to wait until after mypy 1.0 (with its many stubtest fixes) for this. Should help promote complete stubs.

CC @AlexWaygood because this affects typeshed-stats (unless it reuses `parse_metadata.py`, idk how you implemented it)