### PR TITLE
Reverts aiofiles back to _typeshed Self

### DIFF
--- a/stubs/aiofiles/aiofiles/base.pyi
+++ b/stubs/aiofiles/aiofiles/base.pyi
@@ -1,7 +1,7 @@
+from _typeshed import Self
 from collections.abc import Coroutine, Generator, Iterator
 from types import CodeType, FrameType, TracebackType, coroutine
 from typing import Any, Generic, TypeVar
-from typing_extensions import Self
 
 _T = TypeVar("_T")
 _T_co = TypeVar("_T_co", covariant=True)
@@ -10,7 +10,7 @@ _T_contra = TypeVar("_T_contra", contravariant=True)
 
 class AsyncBase(Generic[_T]):
     def __init__(self, file: str, loop: Any, executor: Any) -> None: ...
-    def __aiter__(self) -> Self: ...
+    def __aiter__(self: Self) -> Self: ...
     async def __anext__(self) -> _T: ...
 
 class AiofilesContextManager(Generic[_T_co, _T_contra, _V_co]):


### PR DESCRIPTION
Hello,all.
This PR reverts those changes @AlexWaygood made about five days ago. After that I'd started getting this mypy error:
```
error: Self? has no attribute "__anext__"  [attr-defined]
```
It's quite similar to [#5725](https://github.com/python/typeshed/issues/5725), but the problem is typing_extensions.Self was not made to support an async iterator protocol.
So I've tried to rollback to an abstract type `Self` from `_typeshed` making a hot-hot fix just for now.

I'm not sure, maybe it's better to create an issue at typing_extensions for the occasion...