### PR TITLE
Manually add missing symbols to `tabulate`

### DIFF
--- a/stubs/tabulate/tabulate/__init__.pyi
+++ b/stubs/tabulate/tabulate/__init__.pyi
@@ -1,15 +1,15 @@
 from collections.abc import Callable, Container, Iterable, Mapping, Sequence
 from typing import Any, NamedTuple
-from typing_extensions import TypeAlias
+from typing_extensions import Final, Self, TypeAlias
 
-__version__: str
+from .version import __version__ as __version__
 
-LATEX_ESCAPE_RULES: dict[str, str]
-MIN_PADDING: int
-PRESERVE_WHITESPACE: bool
-WIDE_CHARS_MODE: bool
-multiline_formats: dict[str, str]
-tabulate_formats: list[str]
+__all__ = ["tabulate", "tabulate_formats", "simple_separated_format"]
+
+MIN_PADDING: Final = 2
+PRESERVE_WHITESPACE: Final = False
+WIDE_CHARS_MODE: Final[bool]
+SEPARATING_LINE: Final = "\001"
 
 class Line(NamedTuple):
     begin: str
@@ -35,6 +35,10 @@ class TableFormat(NamedTuple):
     padding: int
     with_header_hide: Container[str] | None
 
+LATEX_ESCAPE_RULES: Final[dict[str, str]]
+tabulate_formats: list[str]
+multiline_formats: dict[str, str]
+
 def simple_separated_format(separator: str) -> TableFormat: ...
 def tabulate(
     tabular_data: Mapping[str, Iterable[Any]] | Iterable[Iterable[Any]],
@@ -52,3 +56,7 @@ def tabulate(
     rowalign: str | Iterable[str] | None = ...,
     maxheadercolwidths: int | Iterable[int] | None = ...,
 ) -> str: ...
+
+class JupyterHTMLStr(str):
+    @property
+    def str(self) -> Self: ...

--- a/stubs/tabulate/tabulate/__init__.pyi
+++ b/stubs/tabulate/tabulate/__init__.pyi
@@ -6,10 +6,13 @@ from .version import __version__ as __version__
 
 __all__ = ["tabulate", "tabulate_formats", "simple_separated_format"]
 
-MIN_PADDING: Final = 2
-PRESERVE_WHITESPACE: Final = False
-WIDE_CHARS_MODE: Final[bool]
-SEPARATING_LINE: Final = "\001"
+# These constants are meant to be configurable
+# https://github.com/astanin/python-tabulate#text-formatting
+PRESERVE_WHITESPACE: bool
+MIN_PADDING: int
+# https://github.com/astanin/python-tabulate#wide-fullwidth-cjk-symbols
+WIDE_CHARS_MODE: bool
+SEPARATING_LINE: str
 
 class Line(NamedTuple):
     begin: str

--- a/stubs/tabulate/tabulate/version.pyi
+++ b/stubs/tabulate/tabulate/version.pyi
@@ -1,3 +1,6 @@
-version: str
-version_tuple: tuple[int, int, int]
-__version_tuple__: tuple[int, int, int]
+from typing_extensions import Final
+
+version: Final[str]
+__version__: Final[str]
+version_tuple: Final[tuple[int, int, int]]
+__version_tuple__: Final[tuple[int, int, int]]


### PR DESCRIPTION
Reran stubgen, then I still had to manually add missing constants to resolve #9700