### PR TITLE
Bump `pytype` to 2023.2.17

### DIFF
--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -10,7 +10,7 @@ packaging==23.0
 pathspec>=0.10.3
 pre-commit-hooks==4.4.0                           # must match .pre-commit-config.yaml
 pycln==2.1.3                                      # must match .pre-commit-config.yaml
-pytype==2023.1.31; platform_system != "Windows" and python_version < "3.11"
+pytype==2023.2.17; platform_system != "Windows" and python_version < "3.11"
 pyyaml==6.0
 termcolor>=2
 tomli==2.0.1


### PR DESCRIPTION
Should fix a pytype issue in #9781 and #9642 thanks to https://github.com/google/pytype/commit/a7cd226ec76fe9f64487054e1d2e9cdb32fc9f3f / https://github.com/google/pytype/issues/1369