### PR TITLE
`stubtest_stdlib.py`: suppress output from pip

### DIFF
--- a/tests/stubtest_stdlib.py
+++ b/tests/stubtest_stdlib.py
@@ -23,7 +23,7 @@ def run_stubtest(typeshed_dir: Path) -> int:
     combined_allowlist = f"{sys.platform}-py{sys.version_info.major}{sys.version_info.minor}.txt"
     with tempfile.TemporaryDirectory() as tmp:
         venv_dir = Path(tmp)
-        print("Setting up an isolated virtual environment...")
+        print("Setting up an isolated virtual environment...", file=sys.stderr)
         try:
             pip_exe, python_exe = make_venv(venv_dir)
         except Exception:
@@ -33,17 +33,17 @@ def run_stubtest(typeshed_dir: Path) -> int:
         # Install the same mypy version as in "requirements-tests.txt"
         try:
             install_command = [pip_exe, "install", get_mypy_req()]
-            ret = subprocess.run(install_command, check=True, text=True, capture_output=True)
+            subprocess.run(install_command, check=True, text=True, capture_output=True)
         except subprocess.CalledProcessError as e:
-            print(e.stderr)
+            print(e.stderr, file=sys.stderr)
             raise
 
         # Uninstall setuptools from the venv so we can test stdlib's distutils
         try:
             uninstall_command = [pip_exe, "uninstall", "-y", "setuptools"]
-            ret = subprocess.run(uninstall_command, check=True, text=True, capture_output=True)
+            subprocess.run(uninstall_command, check=True, text=True, capture_output=True)
         except subprocess.CalledProcessError as e:
-            print(e.stderr)
+            print(e.stderr, file=sys.stderr)
             raise
 
         cmd = [


### PR DESCRIPTION
Following #9734, there's now some fairly noisy output from pip if you run `stubtest_stdlib.py` locally, which I do quite a lot. This makes the output of the script hard to read. This PR suppresses the output from pip.

Prior to this PR:

```
(.venv) C:\Users\alexw\coding\typeshed>python tests/stubtest_stdlib.py
Collecting mypy==1.0
  Using cached mypy-1.0.0-cp311-cp311-win_amd64.whl (8.8 MB)
Collecting typing-extensions>=3.10
  Using cached typing_extensions-4.5.0-py3-none-any.whl (27 kB)
Collecting mypy-extensions>=0.4.3
  Using cached mypy_extensions-1.0.0-py3-none-any.whl (4.7 kB)
Installing collected packages: typing-extensions, mypy-extensions, mypy
Successfully installed mypy-1.0.0 mypy-extensions-1.0.0 typing-extensions-4.5.0

[notice] A new release of pip available: 22.3.1 -> 23.0.1
[notice] To update, run: C:\Users\alexw\AppData\Local\Temp\tmp86thq0va\Scripts\python.exe -m pip install --upgrade pip
Found existing installation: setuptools 65.5.0
Uninstalling setuptools-65.5.0:
  Successfully uninstalled setuptools-65.5.0
C:\Users\alexw\AppData\Local\Temp\tmp86thq0va\Scripts\python.exe -m mypy.stubtest --check-typeshed --custom-typeshed-dir . --allowlist tests\stubtest_allowlists\py3_common.txt --allowlist tests\stubtest_allowlists\py311.txt --allowlist tests\stubtest_allowlists\win32.txt --allowlist tests\stubtest_allowlists\win32-py311.txt
Success: no issues found in 484 modules
stubtest succeeded
```

With this PR applied:

```
(.venv) C:\Users\alexw\coding\typeshed>python tests/stubtest_stdlib.py
Setting up an isolated virtual environment...
C:\Users\alexw\AppData\Local\Temp\tmp1bkull8d\Scripts\python.exe -m mypy.stubtest --check-typeshed --custom-typeshed-dir . --allowlist tests\stubtest_allowlists\py3_common.txt --allowlist tests\stubtest_allowlists\py311.txt --allowlist tests\stubtest_allowlists\win32.txt --allowlist tests\stubtest_allowlists\win32-py311.txt
Success: no issues found in 484 modules
stubtest succeeded
```