### PR TITLE
bisect: don't require Sequences

### DIFF
--- a/stdlib/_bisect.pyi
+++ b/stdlib/_bisect.pyi
@@ -1,6 +1,6 @@
 import sys
-from _typeshed import SupportsRichComparisonT
-from collections.abc import Callable, MutableSequence, Sequence
+from _typeshed import SupportsLenAndGetItem, SupportsRichComparisonT
+from collections.abc import Callable, MutableSequence
 from typing import TypeVar, overload
 
 _T = TypeVar("_T")
@@ -8,11 +8,16 @@ _T = TypeVar("_T")
 if sys.version_info >= (3, 10):
     @overload
     def bisect_left(
-        a: Sequence[SupportsRichComparisonT], x: SupportsRichComparisonT, lo: int = 0, hi: int | None = None, *, key: None = None
+        a: SupportsLenAndGetItem[SupportsRichComparisonT],
+        x: SupportsRichComparisonT,
+        lo: int = 0,
+        hi: int | None = None,
+        *,
+        key: None = None,
     ) -> int: ...
     @overload
     def bisect_left(
-        a: Sequence[_T],
+        a: SupportsLenAndGetItem[_T],
         x: SupportsRichComparisonT,
         lo: int = 0,
         hi: int | None = None,
@@ -21,11 +26,16 @@ if sys.version_info >= (3, 10):
     ) -> int: ...
     @overload
     def bisect_right(
-        a: Sequence[SupportsRichComparisonT], x: SupportsRichComparisonT, lo: int = 0, hi: int | None = None, *, key: None = None
+        a: SupportsLenAndGetItem[SupportsRichComparisonT],
+        x: SupportsRichComparisonT,
+        lo: int = 0,
+        hi: int | None = None,
+        *,
+        key: None = None,
     ) -> int: ...
     @overload
     def bisect_right(
-        a: Sequence[_T],
+        a: SupportsLenAndGetItem[_T],
         x: SupportsRichComparisonT,
         lo: int = 0,
         hi: int | None = None,
@@ -61,10 +71,10 @@ if sys.version_info >= (3, 10):
 
 else:
     def bisect_left(
-        a: Sequence[SupportsRichComparisonT], x: SupportsRichComparisonT, lo: int = 0, hi: int | None = None
+        a: SupportsLenAndGetItem[SupportsRichComparisonT], x: SupportsRichComparisonT, lo: int = 0, hi: int | None = None
     ) -> int: ...
     def bisect_right(
-        a: Sequence[SupportsRichComparisonT], x: SupportsRichComparisonT, lo: int = 0, hi: int | None = None
+        a: SupportsLenAndGetItem[SupportsRichComparisonT], x: SupportsRichComparisonT, lo: int = 0, hi: int | None = None
     ) -> int: ...
     def insort_left(
         a: MutableSequence[SupportsRichComparisonT], x: SupportsRichComparisonT, lo: int = 0, hi: int | None = None


### PR DESCRIPTION
This PR changes the type of the first argument of `bisect_left` and `bisect_right` (and by design `bisect` as well) from the `bisect` module.

Indeed, a full `Sequence` is not needed, only the following is needed:
 - If the `hi` parameter is `None`, only `__getitem__` and `__len__`
 - Else, only `__getitem__`

I'm asking for `SupportsLenAndGetItem` instead of only `SupportsGetItem` in the second case to avoid an exponential number of `@overload`.

---

You can check that only these attributes are needed with the following code:
```py
from bisect import bisect, bisect_left, bisect_right


class Minimal:
    content = 'abbbbcd'

    def __len__(self):
        return len(self.content)
    
    def __getitem__(self, pos):
        return self.content[pos]

obj = Minimal()

assert bisect(obj, 'b') == 5
assert bisect_left(obj, 'b') == 1
assert bisect_right(obj, 'b') == 5
```