### PR TITLE
Pyserial: remove apparently invalid method signature

### DIFF
--- a/stubs/pyserial/serial/serialutil.pyi
+++ b/stubs/pyserial/serial/serialutil.pyi
@@ -63,7 +63,6 @@ class SerialBase(io.RawIOBase):
         inter_byte_timeout: float | None = ...,
         exclusive: float | None = ...,
     ) -> None: ...
-    def read(self, __size: int = ...) -> bytes: ...  # same as io.RawIOBase.read but always returns bytes
     @property
     def port(self) -> str | None: ...
     @port.setter


### PR DESCRIPTION
Apologies in advance if I'm off-base, this is my first attempt at Python typing.

running `mypy` on an application built on top of `pyserial` complains:
> Unexpected keyword argument "size" for "read" of "SerialBase"  [call-arg]

This is because the stub file shows `__size` as a keyword argument.
` def read(self, __size: int = ...) -> bytes: ...  # same as io.RawIOBase.read but always returns bytes`

When I look at the actual [`pyserial` code](https://github.com/pyserial/pyserial/blob/31fa4807d73ed4eb9891a88a15817b439c4eea2d/serial/serialutil.py#L253), there is no `read()` method defined.  Instead, `SerialBase` inherits it from `io.RawIOBase` in the standard library.  According to the [documentation](https://github.com/pyserial/pyserial/blob/31fa4807d73ed4eb9891a88a15817b439c4eea2d/serial/serialutil.py#L253), `read()` accepts a `size` parameter and returns `bytes` (or `None`).

Presumably this line was added in the stub file for the `None` case?  But even then I see no reason to use `__size` instead of `size`.   I think the line should be either deleted altogether, or changed to 
` def read(self, size: int = ...) -> bytes: ...  # same as io.RawIOBase.read but always returns bytes`