### PR TITLE
Add entries to `pika`'s stubtest_requirements

### DIFF
--- a/stubs/pika/@tests/stubtest_allowlist.txt
+++ b/stubs/pika/@tests/stubtest_allowlist.txt
@@ -2,11 +2,6 @@
 pika.compat.StringIO.seek
 pika.compat.StringIO.truncate
 
-# Requires external libraries to be installed.
-pika\.adapters\.gevent_connection.*
-pika\.adapters\.tornado_connection.*
-pika\.adapters\.twisted_connection.*
-
 # Stubtest doesn't understand that a property alias is also read-only.
 pika.BlockingConnection.basic_nack
 pika.BlockingConnection.consumer_cancel_notify

--- a/stubs/pika/METADATA.toml
+++ b/stubs/pika/METADATA.toml
@@ -4,3 +4,6 @@ extra_description = """\
 The `types-pika` package contains alternate, more complete type stubs, that \
 are maintained outside of typeshed.\
 """
+
+[tool.stubtest]
+stubtest_requirements = ["gevent", "tornado", "twisted"]

--- a/stubs/pika/pika/adapters/twisted_connection.pyi
+++ b/stubs/pika/pika/adapters/twisted_connection.pyi
@@ -5,12 +5,12 @@ from typing_extensions import TypeAlias
 import pika.connection
 from pika.adapters.utils import nbio_interface
 
-DeferredQueue: TypeAlias = Any  # TODO: twisted.internet.defer.DeferredQueue
-Protocol: TypeAlias = Any  # TODO: twisted.internet.protocol.Protocol
+_DeferredQueue: TypeAlias = Any  # TODO: twisted.internet.defer.DeferredQueue
+_Protocol: TypeAlias = Any  # TODO: twisted.internet.protocol.Protocol
 
 LOGGER: Incomplete
 
-class ClosableDeferredQueue(DeferredQueue):
+class ClosableDeferredQueue(_DeferredQueue):
     closed: Incomplete
     def __init__(self, size: Incomplete | None = ..., backlog: Incomplete | None = ...) -> None: ...
     def put(self, obj): ...
@@ -107,7 +107,7 @@ class _TwistedConnectionAdapter(pika.connection.Connection):
     def connection_lost(self, error) -> None: ...
     def data_received(self, data) -> None: ...
 
-class TwistedProtocolConnection(Protocol):
+class TwistedProtocolConnection(_Protocol):
     ready: Incomplete
     closed: Incomplete
     def __init__(self, parameters: Incomplete | None = ..., custom_reactor: Incomplete | None = ...) -> None: ...


### PR DESCRIPTION
Split off from #9494 , these changes are beneficial on their own, and necessitate less review.