### PR TITLE
babel: Mark babel as obsolete since 2.12.0

### DIFF
--- a/stubs/babel/METADATA.toml
+++ b/stubs/babel/METADATA.toml
@@ -1,5 +1,6 @@
 version = "2.11.*"
 requires = ["types-pytz"]
+obsolete_since = "2.12.0" # Released on 2023-02-28
 
 [tool.stubtest]
 ignore_missing_stub = true


### PR DESCRIPTION
Babel now includes inline types with py.typed

Removal issue - #9829

Release: https://github.com/python-babel/babel/releases/tag/v2.12.0
Homepage: https://github.com/python-babel/babel
Diff: https://github.com/python-babel/babel/compare/v2.11.0...v2.12.0