### PR TITLE
Revert "babel: Mark babel as obsolete since 2.12.0"

### DIFF
--- a/stubs/babel/METADATA.toml
+++ b/stubs/babel/METADATA.toml
@@ -1,6 +1,5 @@
 version = "2.11.*"
 requires = ["types-pytz"]
-obsolete_since = "2.12.0" # Released on 2023-02-28
 
 [tool.stubtest]
 ignore_missing_stub = true


### PR DESCRIPTION
Reverts python/typeshed#9830. We shouldn't mark the stubs as obsolete until the upstream package includes a `py.typed` file in wheels published to PyPI.

(A `py.typed` file exists on the GitHub `master` branch and in the tag for the latest release, but there's a packaging bug in `babel`: see https://github.com/python-babel/babel/pull/975.)