### PR TITLE
Add `__name__` to `_Wrapped` in functools

### DIFF
--- a/stdlib/functools.pyi
+++ b/stdlib/functools.pyi
@@ -72,6 +72,9 @@ WRAPPER_UPDATES: tuple[Literal["__dict__"]]
 class _Wrapped(Generic[_PWrapped, _RWrapped, _PWrapper, _RWapper]):
     __wrapped__: Callable[_PWrapped, _RWrapped]
     def __call__(self, *args: _PWrapper.args, **kwargs: _PWrapper.kwargs) -> _RWapper: ...
+    # as with ``Callable``, we'll assume that these attributes exist
+    __name__: str
+    __qualname__: str
 
 class _Wrapper(Generic[_PWrapped, _RWrapped]):
     def __call__(self, f: Callable[_PWrapper, _RWapper]) -> _Wrapped[_PWrapped, _RWrapped, _PWrapper, _RWapper]: ...

--- a/test_cases/stdlib/check_functools.py
+++ b/test_cases/stdlib/check_functools.py
@@ -1,10 +1,28 @@
 from __future__ import annotations
 
 import sys
+from functools import wraps
+from typing import Callable, ParamSpec, TypeVar
+from typing_extensions import ParamSpec, assert_type
+
+P = ParamSpec("P")
+T_co = TypeVar("T_co", covariant=True)
+
+
+def my_decorator(func: Callable[P, T_co]) -> Callable[P, T_co]:
+    func_name = func.__name__
+
+    @wraps(func)
+    def wrapper(*args: P.args, **kwargs: P.kwargs):
+        print(args)
+        return func(*args, **kwargs)
+
+    wrapper.__name__ = func_name
+    return wrapper
+
 
 if sys.version_info >= (3, 8):
     from functools import cached_property
-    from typing_extensions import assert_type
 
     class A:
         def __init__(self, x: int):

--- a/test_cases/stdlib/check_functools.py
+++ b/test_cases/stdlib/check_functools.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import sys
 from functools import wraps
-from typing import Callable, ParamSpec, TypeVar
+from typing import Callable, TypeVar
 from typing_extensions import ParamSpec, assert_type
 
 P = ParamSpec("P")

--- a/test_cases/stdlib/check_functools.py
+++ b/test_cases/stdlib/check_functools.py
@@ -10,14 +10,18 @@ T_co = TypeVar("T_co", covariant=True)
 
 
 def my_decorator(func: Callable[P, T_co]) -> Callable[P, T_co]:
-    func_name = func.__name__
 
     @wraps(func)
-    def wrapper(*args: P.args, **kwargs: P.kwargs):
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> T_co:
         print(args)
         return func(*args, **kwargs)
 
-    wrapper.__name__ = func_name
+    # verify that the wrapped function has all these attributes
+    wrapper.__annotations__ = func.__annotations__
+    wrapper.__doc__ = func.__doc__
+    wrapper.__module__ = func.__module__
+    wrapper.__name__ = func.__name__
+    wrapper.__qualname__ = func.__qualname__
     return wrapper
 
 

--- a/test_cases/stdlib/check_functools.py
+++ b/test_cases/stdlib/check_functools.py
@@ -10,7 +10,6 @@ T_co = TypeVar("T_co", covariant=True)
 
 
 def my_decorator(func: Callable[P, T_co]) -> Callable[P, T_co]:
-
     @wraps(func)
     def wrapper(*args: P.args, **kwargs: P.kwargs) -> T_co:
         print(args)


### PR DESCRIPTION
There can be scenarios where `__name__` isn't set, as pointed out here: https://github.com/python/mypy/pull/14815#issuecomment-1453509611 but the same is true for `Callable`, so this has precedent.