### PR TITLE
Update `tqdm` stubs to 4.65.*

### DIFF
--- a/stubs/tqdm/METADATA.toml
+++ b/stubs/tqdm/METADATA.toml
@@ -1,4 +1,4 @@
-version = "4.64.*"
+version = "4.65.*"
 
 [tool.stubtest]
 extras = ["slack", "telegram"]

--- a/stubs/tqdm/tqdm/std.pyi
+++ b/stubs/tqdm/tqdm/std.pyi
@@ -83,7 +83,7 @@ class tqdm(Generic[_T], Iterable[_T], Comparable):
         position: int | None = ...,
         postfix: Mapping[str, object] | str | None = ...,
         unit_divisor: float = ...,
-        write_bytes: bool | None = ...,
+        write_bytes: bool = False,
         lock_args: tuple[bool | None, float | None] | tuple[bool | None] | None = ...,
         nrows: int | None = ...,
         colour: str | None = ...,
@@ -196,7 +196,6 @@ class tqdm(Generic[_T], Iterable[_T], Comparable):
     start_t: Incomplete
 
     def __bool__(self) -> bool: ...
-    def __nonzero__(self) -> bool: ...
     def __len__(self) -> int: ...
     def __reversed__(self) -> Iterator[_T]: ...
     def __contains__(self, item: object) -> bool: ...


### PR DESCRIPTION
Closes #9838

The diff between the two releases is here: https://github.com/tqdm/tqdm/compare/v4.64.1...v4.65.0