### PR TITLE
`pytype_test.py`: Fix typechecking errors

### DIFF
--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -16,5 +16,5 @@ termcolor>=2
 tomli==2.0.1
 tomlkit==0.11.6
 types-pyyaml>=6.0.12.7
-types-setuptools
+types-setuptools>=67.5.0.0
 typing-extensions

--- a/tests/pytype_test.py
+++ b/tests/pytype_test.py
@@ -161,9 +161,8 @@ def get_missing_modules(files_to_test: Sequence[str]) -> Iterable[str]:
         for pkg in read_dependencies(distribution).external_pkgs:
             # See https://stackoverflow.com/a/54853084
             top_level_file = os.path.join(
-                # Fixed in #9747
-                pkg_resources.get_distribution(pkg).egg_info,  # type: ignore[attr-defined]  # pyright: ignore[reportGeneralTypeIssues]
-                "top_level.txt",
+                pkg_resources.get_distribution(pkg).egg_info,  # type: ignore[arg-type]  # pyright: ignore[reportGeneralTypeIssues]
+                "top_level.txt",  # pyright: ignore[reportGeneralTypeIssues]
             )
             with open(top_level_file) as f:
                 missing_modules.update(f.read().splitlines())


### PR DESCRIPTION
The type checkers have changed their minds about why they don't like this snippet of code, following the new release of `types-setuptools`, following #9747

(Failing CI run here: https://github.com/python/typeshed/actions/runs/4346178794)

Cc. @Avasam