### PR TITLE
pytype_test.py: Fix typechecking errors following #9747

### DIFF
--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -16,5 +16,5 @@ termcolor>=2
 tomli==2.0.1
 tomlkit==0.11.6
 types-pyyaml>=6.0.12.7
-types-setuptools
+types-setuptools>=67.5.0.0
 typing-extensions

--- a/tests/pytype_test.py
+++ b/tests/pytype_test.py
@@ -159,12 +159,10 @@ def get_missing_modules(files_to_test: Sequence[str]) -> Iterable[str]:
     missing_modules = set()
     for distribution in stub_distributions:
         for pkg in read_dependencies(distribution).external_pkgs:
+            egg_info = pkg_resources.get_distribution(pkg).egg_info
+            assert isinstance(egg_info, str)
             # See https://stackoverflow.com/a/54853084
-            top_level_file = os.path.join(
-                # Fixed in #9747
-                pkg_resources.get_distribution(pkg).egg_info,  # type: ignore[attr-defined]  # pyright: ignore[reportGeneralTypeIssues]
-                "top_level.txt",
-            )
+            top_level_file = os.path.join(egg_info, "top_level.txt")
             with open(top_level_file) as f:
                 missing_modules.update(f.read().splitlines())
     return missing_modules


### PR DESCRIPTION
Follow up to #9747

Superseeds https://github.com/python/typeshed/pull/9847#discussion_r1126830446 ( Closes #9847 ) by fixing the potentially `None` type error in a more principled way. The code already implicitly made this assert assumption.

CC. @AlexWaygood 