### PR TITLE
psutil: sconn.pid can be None

### DIFF
--- a/stubs/psutil/psutil/_common.pyi
+++ b/stubs/psutil/psutil/_common.pyi
@@ -117,7 +117,7 @@ class sconn(NamedTuple):
     laddr: addr | tuple[()]
     raddr: addr | tuple[()]
     status: str
-    pid: int
+    pid: int | None
 
 class snicaddr(NamedTuple):
     family: AddressFamily


### PR DESCRIPTION
Found out about this the hard way.

The code path that allows None is here: https://github.com/giampaolo/psutil/blob/2da99502238852f18f74db05304e67a01ee77005/psutil/_pslinux.py#L923