### PR TITLE
Add missing field to `typed_ast.ast3.TypeIgnore`

### DIFF
--- a/stubs/typed-ast/typed_ast/ast3.pyi
+++ b/stubs/typed-ast/typed_ast/ast3.pyi
@@ -388,3 +388,4 @@ class withitem(AST):
 
 class TypeIgnore(AST):
     lineno: int
+    tag: str


### PR DESCRIPTION
```pycon
>>> import typed_ast.ast3 as ast3
>>> x = ast3.parse('def foo(): ... # type: ignore[attr-defined]')
>>> ast3.dump(x)
"Module(body=[FunctionDef(name='foo', args=arguments(args=[], vararg=None, kwonlyargs=[], kw_defaults=[], kwarg=None, defaults=[]), body=[Expr(value=Ellipsis())], decorator_list=[], returns=None, type_comment=None)], type_ignores=[TypeIgnore(lineno=1, tag='[attr-defined]')])"
>>> y = ast3.parse('def foo(): ... # type: ignore')
>>> ast3.dump(y)
"Module(body=[FunctionDef(name='foo', args=arguments(args=[], vararg=None, kwonlyargs=[], kw_defaults=[], kwarg=None, defaults=[]), body=[Expr(value=Ellipsis())], decorator_list=[], returns=None, type_comment=None)], type_ignores=[TypeIgnore(lineno=1, tag='')])"
```