### PR TITLE
add signal.SIGSTKFLT

### DIFF
--- a/stdlib/signal.pyi
+++ b/stdlib/signal.pyi
@@ -53,6 +53,8 @@ class Signals(IntEnum):
             SIGPWR: int
             SIGRTMAX: int
             SIGRTMIN: int
+            if sys.version_info >= (3, 11):
+                SIGSTKFLT: int
 
 class Handlers(IntEnum):
     SIG_DFL: int
@@ -147,6 +149,8 @@ else:
         SIGPWR: Signals
         SIGRTMAX: Signals
         SIGRTMIN: Signals
+        if sys.version_info >= (3, 11):
+            SIGSTKFLT: Signals
         @final
         class struct_siginfo(structseq[int], tuple[int, int, int, int, int, int, int]):
             if sys.version_info >= (3, 10):

--- a/tests/stubtest_allowlists/linux-py311.txt
+++ b/tests/stubtest_allowlists/linux-py311.txt
@@ -13,8 +13,6 @@ mmap.MAP_STACK
 (os|posix).eventfd_read
 (os|posix).eventfd_write
 (os|posix).splice
-signal.SIGSTKFLT
-signal.Signals.SIGSTKFLT
 signal.sigtimedwait
 signal.sigwaitinfo
 xxlimited.Xxo.x_exports


### PR DESCRIPTION
I hope I added it in the right spot. It was added with Python 3.11 is only available on Linux, not MacOS.