### PR TITLE
Mark `types-appdirs` as no longer updated

### DIFF
--- a/stubs/appdirs/METADATA.toml
+++ b/stubs/appdirs/METADATA.toml
@@ -1,1 +1,8 @@
 version = "1.4.*"
+no_longer_updated = true
+extra_description = """\
+The `appdirs` package has been deprecated in favour of the `platformdirs`\
+package, which ships with a `py.typed` file. Users should migrate their\
+`appdirs` code to use `platformdirs` instead, which will remove the need for\
+the `types-appdirs` package.\
+"""


### PR DESCRIPTION
`appdirs` has officially been deprecated in favour of `platformdirs`, a fork of `appdirs` that is maintained and ships with a `py.typed` file.

See https://github.com/ActiveState/appdirs/commit/8734277956c1df3b85385e6b308e954910533884