### PR TITLE
flake8: ignore pyflakes codes in `*_pb2.pyi` files that are ignored in all other `.pyi` files

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -39,7 +39,7 @@ per-file-ignores =
   #     F811 redefinition of unused '...'
   stdlib/typing.pyi: B, E701, E741, F401, F403, F405, F811, F822
   # Generated protobuf files include docstrings
-  *_pb2.pyi: B, E701, Y021, Y026
+  *_pb2.pyi: B, E701, E741, F401, F403, F405, F822, Y021, Y026
 
 exclude = .venv*,.git
 noqa_require_code = true


### PR DESCRIPTION
Several flake8 error codes are currently ignored for all `.pyi` files _except_ those ending with `_pb2.pyi`. This caused a bit of confusion in #9873. This PR makes it so that all codes ignored generally across typeshed are also ignored in `*_pb2.pyi` files