### PR TITLE
Mark stubs for backports.ssl_match_hostname as no longer updated

### DIFF
--- a/stubs/backports.ssl_match_hostname/METADATA.toml
+++ b/stubs/backports.ssl_match_hostname/METADATA.toml
@@ -1,1 +1,2 @@
 version = "3.7.*"
+no_longer_updated = true


### PR DESCRIPTION
See #9843 for discussion