### PR TITLE
Fix typos in `extra_description` fields

### DIFF
--- a/stubs/appdirs/METADATA.toml
+++ b/stubs/appdirs/METADATA.toml
@@ -1,8 +1,8 @@
 version = "1.4.*"
 no_longer_updated = true
 extra_description = """\
-The `appdirs` package has been deprecated in favour of the `platformdirs`\
-package, which ships with a `py.typed` file. Users should migrate their\
-`appdirs` code to use `platformdirs` instead, which will remove the need for\
+The `appdirs` package has been deprecated in favour of the `platformdirs` \
+package, which ships with a `py.typed` file. Users should migrate their \
+`appdirs` code to use `platformdirs` instead, which will remove the need for \
 the `types-appdirs` package.\
 """

--- a/stubs/gdb/METADATA.toml
+++ b/stubs/gdb/METADATA.toml
@@ -3,7 +3,7 @@ extra_description = """\
   Type hints for GDB's \
   [Python API](https://sourceware.org/gdb/onlinedocs/gdb/Python-API.html). \
   Note that this API is available only when running Python scripts under GDB: \
-  is is not possible to install the `gdb` package separately, for instance \
+  it is not possible to install the `gdb` package separately, for instance \
   using `pip`.\
 """
 


### PR DESCRIPTION
As spotted by @Akuli in https://github.com/python/typeshed/pull/9877#discussion_r1135654570