### PR TITLE
fix: add missing distribution to distutils cmd

### DIFF
--- a/stdlib/distutils/cmd.pyi
+++ b/stdlib/distutils/cmd.pyi
@@ -5,6 +5,7 @@ from distutils.dist import Distribution
 from typing import Any
 
 class Command:
+    distribution: Distribution
     sub_commands: list[tuple[str, Callable[[Command], bool] | None]]
     def __init__(self, dist: Distribution) -> None: ...
     @abstractmethod

--- a/stubs/setuptools/setuptools/_distutils/cmd.pyi
+++ b/stubs/setuptools/setuptools/_distutils/cmd.pyi
@@ -7,6 +7,7 @@ from typing_extensions import Self
 from .dist import Distribution
 
 class Command:
+    distribution: Distribution
     sub_commands: ClassVar[list[tuple[str, Callable[[Self], bool] | None]]]
     def __init__(self, dist: Distribution) -> None: ...
     @abstractmethod


### PR DESCRIPTION
This is the first thing `__init__` does with distribution, and it was missing.
