### PR TITLE
distutils/setuptools: Don't use wildcards for allowlist entries

### DIFF
--- a/stubs/setuptools/@tests/stubtest_allowlist.txt
+++ b/stubs/setuptools/@tests/stubtest_allowlist.txt
@@ -31,7 +31,27 @@ pkg_resources.EggMetadata.loader
 setuptools._distutils.dist.Distribution.get_command_obj
 
 # Dynamically created in __init__
-setuptools._distutils.dist.Distribution.get_.*
+setuptools._distutils.dist.Distribution.get_name
+setuptools._distutils.dist.Distribution.get_version
+setuptools._distutils.dist.Distribution.get_fullname
+setuptools._distutils.dist.Distribution.get_author
+setuptools._distutils.dist.Distribution.get_author_email
+setuptools._distutils.dist.Distribution.get_maintainer
+setuptools._distutils.dist.Distribution.get_maintainer_email
+setuptools._distutils.dist.Distribution.get_contact
+setuptools._distutils.dist.Distribution.get_contact_email
+setuptools._distutils.dist.Distribution.get_url
+setuptools._distutils.dist.Distribution.get_license
+setuptools._distutils.dist.Distribution.get_licence
+setuptools._distutils.dist.Distribution.get_description
+setuptools._distutils.dist.Distribution.get_long_description
+setuptools._distutils.dist.Distribution.get_keywords
+setuptools._distutils.dist.Distribution.get_platforms
+setuptools._distutils.dist.Distribution.get_classifiers
+setuptools._distutils.dist.Distribution.get_download_url
+setuptools._distutils.dist.Distribution.get_requires
+setuptools._distutils.dist.Distribution.get_provides
+setuptools._distutils.dist.Distribution.get_obsoletes
 
 # Uncomment once ignore_missing_stub is turned off
 # # Not supported by typeshed

--- a/tests/stubtest_allowlists/py3_common.txt
+++ b/tests/stubtest_allowlists/py3_common.txt
@@ -523,8 +523,27 @@ xml.etree
 xml.sax
 
 # Dynamically created
-distutils.dist.Distribution.get_.*
-distutils.core.Distribution.get_.*
+distutils.(dist|core).Distribution.get_name
+distutils.(dist|core).Distribution.get_version
+distutils.(dist|core).Distribution.get_fullname
+distutils.(dist|core).Distribution.get_author
+distutils.(dist|core).Distribution.get_author_email
+distutils.(dist|core).Distribution.get_maintainer
+distutils.(dist|core).Distribution.get_maintainer_email
+distutils.(dist|core).Distribution.get_contact
+distutils.(dist|core).Distribution.get_contact_email
+distutils.(dist|core).Distribution.get_url
+distutils.(dist|core).Distribution.get_license
+distutils.(dist|core).Distribution.get_licence
+distutils.(dist|core).Distribution.get_description
+distutils.(dist|core).Distribution.get_long_description
+distutils.(dist|core).Distribution.get_keywords
+distutils.(dist|core).Distribution.get_platforms
+distutils.(dist|core).Distribution.get_classifiers
+distutils.(dist|core).Distribution.get_download_url
+distutils.(dist|core).Distribution.get_requires
+distutils.(dist|core).Distribution.get_provides
+distutils.(dist|core).Distribution.get_obsoletes
 
 # Platform differences that cannot be captured by the type system
 os.O_[A-Z_]+


### PR DESCRIPTION
These entries are causing more functions to be allowlisted than was intended: for example, none of these methods are generated methods, but they're all currently included by the `distutils.dist.Distribution.get_.*` entry:

https://github.com/python/typeshed/blob/2d990ee2f714c1902620586efed576b4f7edaba7/stdlib/distutils/dist.pyi#L106-L108

This caused a bit of confusion for me, as I was fiddling around with a stubtest patch, and expected stubtest to emit an error if I deleted this allowlist entry:

https://github.com/python/typeshed/blob/2d990ee2f714c1902620586efed576b4f7edaba7/tests/stubtest_allowlists/py3_common.txt#L89

...But stubtest didn't emit an error, because `distutils.dist.Distribution.get_command_obj` was _still_ allowlisted, even with that entry deleted, due to these regex entries here.