### PR TITLE
Update UUID is_safe default value

### DIFF
--- a/stdlib/uuid.pyi
+++ b/stdlib/uuid.pyi
@@ -23,7 +23,7 @@ class UUID:
         int: _Int | None = None,
         version: _Int | None = None,
         *,
-        is_safe: SafeUUID = ...,
+        is_safe: SafeUUID = SafeUUID.unknown,
     ) -> None: ...
     @property
     def is_safe(self) -> SafeUUID: ...


### PR DESCRIPTION
The `UUID` class `is_safe` parameter doesn't reflect the default value properly.
This is available in Python versions so I don't think this is a limitation, but a mismatch.

@AlexWaygood As it's related to https://github.com/python/typeshed/pull/9606 can you please check?