### PR TITLE
Add default arguments for termcolor 1

### DIFF
--- a/stubs/termcolor/termcolor.pyi
+++ b/stubs/termcolor/termcolor.pyi
@@ -8,7 +8,7 @@ COLORS: dict[str, int]
 HIGHLIGHTS: dict[str, int]
 RESET: str
 
-def colored(text: str, color: str | None = ..., on_color: str | None = ..., attrs: Iterable[str] | None = ...) -> str: ...
+def colored(text: str, color: str | None = None, on_color: str | None = None, attrs: Iterable[str] | None = None) -> str: ...
 def cprint(
-    text: str, color: str | None = ..., on_color: str | None = ..., attrs: Iterable[str] | None = ..., **kwargs: Any
+    text: str, color: str | None = None, on_color: str | None = None, attrs: Iterable[str] | None = None, **kwargs: Any
 ) -> None: ...


### PR DESCRIPTION
Follow up to https://github.com/python/typeshed/pull/9959#issuecomment-1485748287 CC @AlexWaygood

All defaults are `None`  https://github.com/termcolor/termcolor/blob/1.1.0/termcolor.py (also double-checked locally)