### PR TITLE
Bump pyright to 1.1.300

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,4 +62,4 @@ all = true
 disable_all_dunder_policy = true
 
 [tool.typeshed]
-pyright_version = "1.1.299"
+pyright_version = "1.1.300"


### PR DESCRIPTION
There's a lot of new errors; opening a draft PR so that we can see exactly what they are and analyze/fix them where possible. Some may be bugs in pyright rather than typeshed.