### PR TITLE
`dataclasses.make_dataclass` has a new parameter in 3.12

### DIFF
--- a/stdlib/dataclasses.pyi
+++ b/stdlib/dataclasses.pyi
@@ -247,7 +247,27 @@ class InitVar(Generic[_T], metaclass=_InitVarMeta):
         @overload
         def __class_getitem__(cls, type: Any) -> InitVar[Any]: ...
 
-if sys.version_info >= (3, 11):
+if sys.version_info >= (3, 12):
+    def make_dataclass(
+        cls_name: str,
+        fields: Iterable[str | tuple[str, type] | tuple[str, type, Any]],
+        *,
+        bases: tuple[type, ...] = (),
+        namespace: dict[str, Any] | None = None,
+        init: bool = True,
+        repr: bool = True,
+        eq: bool = True,
+        order: bool = False,
+        unsafe_hash: bool = False,
+        frozen: bool = False,
+        match_args: bool = True,
+        kw_only: bool = False,
+        slots: bool = False,
+        weakref_slot: bool = False,
+        module: str | None = None,
+    ) -> type: ...
+
+elif sys.version_info >= (3, 11):
     def make_dataclass(
         cls_name: str,
         fields: Iterable[str | tuple[str, type] | tuple[str, type, Any]],


### PR DESCRIPTION
Source https://github.com/python/cpython/blob/810d365b5eb2cf3043957ca2971f6e7a7cd87d0d/Lib/dataclasses.py#L1403