### PR TITLE
Add a stub for sys.thread_info

### DIFF
--- a/stdlib/sys.pyi
+++ b/stdlib/sys.pyi
@@ -201,8 +201,8 @@ class _int_info(structseq[int], tuple[int, int, int, int]):
     @property
     def str_digits_check_threshold(self) -> int: ...
 
-_ThreadInfoName = Literal["nt", "pthread", "pthread-stubs", "solaris"]
-_ThreadInfoLock = Literal["semaphore", "mutex+cond"] | None
+_ThreadInfoName: TypeAlias = Literal["nt", "pthread", "pthread-stubs", "solaris"]
+_ThreadInfoLock: TypeAlias = Literal["semaphore", "mutex+cond"] | None
 
 @final
 class _thread_info(_UninstantiableStructseq, tuple[_ThreadInfoName, _ThreadInfoLock, str | None]):

--- a/stdlib/sys.pyi
+++ b/stdlib/sys.pyi
@@ -201,6 +201,20 @@ class _int_info(structseq[int], tuple[int, int, int, int]):
     @property
     def str_digits_check_threshold(self) -> int: ...
 
+_ThreadInfoName = Literal["nt", "pthread", "pthread-stubs", "solaris"]
+_ThreadInfoLock = Literal["semaphore", "mutex+cond"] | None
+
+@final
+class _thread_info(_UninstantiableStructseq, tuple[_ThreadInfoName, _ThreadInfoLock, str | None]):
+    @property
+    def name(self) -> _ThreadInfoName: ...
+    @property
+    def lock(self) -> _ThreadInfoLock: ...
+    @property
+    def version(self) -> str | None: ...
+
+thread_info: _thread_info
+
 @final
 class _version_info(_UninstantiableStructseq, tuple[int, int, int, str, int]):
     @property

--- a/tests/stubtest_allowlists/py3_common.txt
+++ b/tests/stubtest_allowlists/py3_common.txt
@@ -171,7 +171,6 @@ ssl.Purpose.__new__  # the multiple inheritance confuses mypy
 (sys.get_int_max_str_digits)?  # Added in a patch release, backported to all security branches, but has yet to find its way to all GitHub Actions images
 sys.implementation  # Actually SimpleNamespace but then you wouldn't have convenient attributes
 (sys.set_int_max_str_digits)?  # Added in a patch release, backported to all security branches, but has yet to find its way to all GitHub Actions images
-sys.thread_info
 tarfile.TarFile.errors  # errors is initialized for some reason as None even though it really only accepts str
 threading.Condition.acquire  # Condition functions are exported in __init__
 threading.Condition.release  # Condition functions are exported in __init__


### PR DESCRIPTION
Adds a stub for [sys.thread_info](https://docs.python.org/3/library/sys.html#sys.thread_info)

This property was added in 3.3, should I add a version check? I haven't found any check for versions this old..