### PR TITLE
Add more correct type annotations for `tomllib`

### DIFF
--- a/stdlib/tomllib.pyi
+++ b/stdlib/tomllib.pyi
@@ -1,10 +1,14 @@
 from _typeshed import SupportsRead
 from collections.abc import Callable
-from typing import Any
+from datetime import datetime, date, time
+from typing import Any, TypeAlias
 
 __all__ = ("loads", "load", "TOMLDecodeError")
 
 class TOMLDecodeError(ValueError): ...
 
-def load(__fp: SupportsRead[bytes], *, parse_float: Callable[[str], Any] = ...) -> dict[str, Any]: ...
-def loads(__s: str, *, parse_float: Callable[[str], Any] = ...) -> dict[str, Any]: ...
+TOMLValue: TypeAlias = int | float | str | bool | list['TOMLValue'] | \
+                       dict['TOMLValue', 'TOMLValue'] | datetime | date | time
+
+def load(__fp: SupportsRead[bytes], *, parse_float: Callable[[str], Any] = ...) -> dict[str, TOMLValue]: ...
+def loads(__s: str, *, parse_float: Callable[[str], Any] = ...) -> dict[str, TOMLValue]: ...

--- a/stdlib/tomllib.pyi
+++ b/stdlib/tomllib.pyi
@@ -1,14 +1,13 @@
 from _typeshed import SupportsRead
 from collections.abc import Callable
-from datetime import datetime, date, time
+from datetime import date, datetime, time
 from typing import Any, TypeAlias
 
 __all__ = ("loads", "load", "TOMLDecodeError")
 
 class TOMLDecodeError(ValueError): ...
 
-TOMLValue: TypeAlias = int | float | str | bool | list['TOMLValue'] | \
-                       dict['TOMLValue', 'TOMLValue'] | datetime | date | time
+TOMLValue: TypeAlias = int | float | str | bool | list["TOMLValue"] | dict["TOMLValue", "TOMLValue"] | datetime | date | time
 
 def load(__fp: SupportsRead[bytes], *, parse_float: Callable[[str], Any] = ...) -> dict[str, TOMLValue]: ...
 def loads(__s: str, *, parse_float: Callable[[str], Any] = ...) -> dict[str, TOMLValue]: ...

--- a/stdlib/tomllib.pyi
+++ b/stdlib/tomllib.pyi
@@ -1,13 +1,14 @@
 from _typeshed import SupportsRead
 from collections.abc import Callable
 from datetime import date, datetime, time
-from typing import Any, TypeAlias
+from typing import Any
+from typing_extensions import TypeAlias
 
 __all__ = ("loads", "load", "TOMLDecodeError")
 
 class TOMLDecodeError(ValueError): ...
 
-TOMLValue: TypeAlias = int | float | str | bool | list["TOMLValue"] | dict["TOMLValue", "TOMLValue"] | datetime | date | time
+_TOMLValue: TypeAlias = int | float | str | bool | list[_TOMLValue] | dict[_TOMLValue, _TOMLValue] | datetime | date | time
 
-def load(__fp: SupportsRead[bytes], *, parse_float: Callable[[str], Any] = ...) -> dict[str, TOMLValue]: ...
-def loads(__s: str, *, parse_float: Callable[[str], Any] = ...) -> dict[str, TOMLValue]: ...
+def load(__fp: SupportsRead[bytes], *, parse_float: Callable[[str], Any] = ...) -> dict[str, _TOMLValue]: ...
+def loads(__s: str, *, parse_float: Callable[[str], Any] = ...) -> dict[str, _TOMLValue]: ...


### PR DESCRIPTION
I've added more correct type annotations for `tomllib` module, because it was `Any`, but there is a [table](https://docs.python.org/3/library/tomllib.html#conversion-table) of types in [documentation](https://docs.python.org/3/library/tomllib.html).