### PR TITLE
unittest.mock.__version__ was removed in 3.9

### DIFF
--- a/stdlib/unittest/mock.pyi
+++ b/stdlib/unittest/mock.pyi
@@ -47,7 +47,8 @@ else:
         "seal",
     )
 
-__version__: Final[str]
+if sys.version_info < (3, 9):
+    __version__: Final[str]
 
 FILTER_DIR: Any
 


### PR DESCRIPTION
See the first entry in https://docs.python.org/3/whatsnew/3.9.html#removed