### PR TITLE
Bump pyright version to 1.1.304

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,4 +62,4 @@ all = true
 disable_all_dunder_policy = true
 
 [tool.typeshed]
-pyright_version = "1.1.303"
+pyright_version = "1.1.304"


### PR DESCRIPTION
Mainly motivated to remove this [false positive](https://github.com/python/typeshed/pull/10052#discussion_r1167765606).