### PR TITLE
Fix wrong connection argument name

### DIFF
--- a/stubs/hdbcli/hdbcli/dbapi.pyi
+++ b/stubs/hdbcli/hdbcli/dbapi.pyi
@@ -18,7 +18,7 @@ class Connection:
         self,
         address: str,
         port: int,
-        username: str,
+        user: str,
         password: str,
         autocommit: bool = ...,
         packetsize: int | None = ...,


### PR DESCRIPTION
The name should be user and not username