### PR TITLE
Add `cache_parameters` method to `_lru_cache_wrapper`

### DIFF
--- a/stdlib/functools.pyi
+++ b/stdlib/functools.pyi
@@ -45,7 +45,7 @@ class _CacheInfo(NamedTuple):
     misses: int
     maxsize: int | None
     currsize: int
-        
+
 if sys.version_info >= (3, 9):
     class _CacheParameters(TypedDict):
         maxsize: int
@@ -59,6 +59,7 @@ class _lru_cache_wrapper(Generic[_T]):
     def cache_clear(self) -> None: ...
     if sys.version_info >= (3, 9):
         def cache_parameters(self) -> _CacheParameters: ...
+
     def __copy__(self) -> _lru_cache_wrapper[_T]: ...
     def __deepcopy__(self, __memo: Any) -> _lru_cache_wrapper[_T]: ...
 

--- a/stdlib/functools.pyi
+++ b/stdlib/functools.pyi
@@ -3,7 +3,7 @@ import types
 from _typeshed import SupportsAllComparisons, SupportsItems
 from collections.abc import Callable, Hashable, Iterable, Sequence, Sized
 from typing import Any, Generic, NamedTuple, TypeVar, overload
-from typing_extensions import Literal, ParamSpec, Self, TypeAlias, final
+from typing_extensions import Literal, ParamSpec, Self, TypeAlias, TypedDict, final
 
 if sys.version_info >= (3, 9):
     from types import GenericAlias
@@ -45,6 +45,11 @@ class _CacheInfo(NamedTuple):
     misses: int
     maxsize: int | None
     currsize: int
+        
+if sys.version_info >= (3, 9):
+    class _CacheParameters(TypedDict):
+        maxsize: int
+        typed: bool
 
 @final
 class _lru_cache_wrapper(Generic[_T]):
@@ -52,6 +57,8 @@ class _lru_cache_wrapper(Generic[_T]):
     def __call__(self, *args: Hashable, **kwargs: Hashable) -> _T: ...
     def cache_info(self) -> _CacheInfo: ...
     def cache_clear(self) -> None: ...
+    if sys.version_info >= (3, 9):
+        def cache_parameters(self) -> _CacheParameters: ...
     def __copy__(self) -> _lru_cache_wrapper[_T]: ...
     def __deepcopy__(self, __memo: Any) -> _lru_cache_wrapper[_T]: ...
 

--- a/tests/stubtest_allowlists/py310.txt
+++ b/tests/stubtest_allowlists/py310.txt
@@ -17,6 +17,7 @@ contextlib.AbstractAsyncContextManager.__class_getitem__
 contextlib.AbstractContextManager.__class_getitem__
 fractions.Fraction.__new__  # overload is too complicated for stubtest to resolve
 functools.cached_property.__set__  # Stub is a while lie; see comments in the stub
+functools._lru_cache_wrapper.cache_parameters  # Cannot be detected statically
 gettext.install
 gettext.translation
 hmac.new  # Stub is a white lie; see comments in the stub

--- a/tests/stubtest_allowlists/py311.txt
+++ b/tests/stubtest_allowlists/py311.txt
@@ -21,6 +21,7 @@ enum.auto.value
 fractions.Fraction.__new__  # overload is too complicated for stubtest to resolve
 ftplib.FTP.trust_server_pasv_ipv4_address
 functools.cached_property.__set__  # Stub is a while lie; see comments in the stub
+functools._lru_cache_wrapper.cache_parameters  # Cannot be detected statically
 ipaddress.IPv4Interface.hostmask
 ipaddress.IPv6Interface.hostmask
 ipaddress._BaseNetwork.broadcast_address

--- a/tests/stubtest_allowlists/py39.txt
+++ b/tests/stubtest_allowlists/py39.txt
@@ -37,6 +37,7 @@ contextlib.AbstractContextManager.__class_getitem__
 distutils.command.bdist_wininst  # see #6523
 fractions.Fraction.__new__  # overload is too complicated for stubtest to resolve
 functools.cached_property.__set__  # Stub is a while lie; see comments in the stub
+functools._lru_cache_wrapper.cache_parameters  # Cannot be detected statically
 gettext.install
 gettext.translation
 hmac.new  # Stub is a white lie; see comments in the stub


### PR DESCRIPTION
The docs says that `cache_parameters()` function was added in 3.9: https://docs.python.org/3/library/functools.html#functools.lru_cache Source: https://github.com/python/cpython/blob/af530469954e8ad49f1e071ef31c844b9bfda414/Lib/functools.py#L512 But, `typeshed` does not have it.

Demo:

```python
>>> import functools
>>> functools.lru_cache(sum).cache_parameters()
{'maxsize': 128, 'typed': False}
```