### PR TITLE
Simplify `logging.config` type imports

### DIFF
--- a/stdlib/logging/config.pyi
+++ b/stdlib/logging/config.pyi
@@ -5,13 +5,9 @@ from configparser import RawConfigParser
 from re import Pattern
 from threading import Thread
 from typing import IO, Any
+from typing_extensions import Literal, TypedDict
 
 from . import _Level
-
-if sys.version_info >= (3, 8):
-    from typing import Literal, TypedDict
-else:
-    from typing_extensions import Literal, TypedDict
 
 DEFAULT_LOGGING_CONFIG_PORT: int
 RESET_ERROR: int  # undocumented


### PR DESCRIPTION
There's no need in `if sys.version` check here, all other places just use `typing_extensions` directly