### PR TITLE
Fix CI, use new `termcolor` version

### DIFF
--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -12,7 +12,7 @@ pre-commit-hooks==4.4.0                           # must match .pre-commit-confi
 pycln==2.1.3                                      # must match .pre-commit-config.yaml
 pytype==2023.4.11; platform_system != "Windows" and python_version < "3.11"
 pyyaml==6.0
-termcolor>=2
+termcolor>=2.3
 tomli==2.0.1
 tomlkit==0.11.7
 types-pyyaml>=6.0.12.7

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -19,7 +19,7 @@ try:
     from termcolor import colored as colored
 except ImportError:
 
-    def colored(text: str, color: str | None = None, on_color: str | None = None, attrs: Iterable[str] | None = None) -> str:
+    def colored(text: str, color: str | None = None, on_color: str | None = None, attrs: Iterable[str] | None = None, *, no_color: bool | None = None, force_color: bool | None = None) -> str:
         return text
 
 


### PR DESCRIPTION
I've noticed that CI fails on `main`. See https://github.com/python/typeshed/actions/runs/4785737701/jobs/8508816903?pr=10078

Looks like it happens because of:

```
scripts/runtests.py:17: error: All conditional function variants must have
identical signatures  [misc]
        def colored(text: str, color: str | None = None, on_color: str | N...
        ^
scripts/runtests.py:17: note: Original:
scripts/runtests.py:17: note:     def colored(text: str, color: Optional[str] = ..., on_color: Optional[str] = ..., attrs: Optional[Iterable[str]] = ..., *, no_color: Optional[bool] = ..., force_color: Optional[bool] = ...) -> str
scripts/runtests.py:17: note: Redefinition:
scripts/runtests.py:17: note:     def colored(text: str, color: Optional[str] = ..., on_color: Optional[str] = ..., attrs: Optional[Iterable[str]] = ...) -> str
```

Source of new `termcolor` version: https://github.com/termcolor/termcolor/blob/0e016d928a1d6eff69ff46a6abdc6058dd412f4c/src/termcolor/termcolor.py#L135-L136

So, here's the fix.
