### PR TITLE
Fix paramiko client parameter types

### DIFF
--- a/stubs/paramiko/paramiko/client.pyi
+++ b/stubs/paramiko/paramiko/client.pyi
@@ -12,7 +12,12 @@ from .transport import _SocketLike
 
 class _TransportFactory(Protocol):
     def __call__(
-        self, __sock: _SocketLike, *, gss_kex: bool, gss_deleg_creds: bool, disabled_algorithms: Mapping[str, Iterable[str]] | None
+        self,
+        __sock: _SocketLike,
+        *,
+        gss_kex: bool,
+        gss_deleg_creds: bool,
+        disabled_algorithms: Mapping[str, Iterable[str]] | None,
     ) -> Transport: ...
 
 class SSHClient(ClosingContextManager):

--- a/stubs/paramiko/paramiko/client.pyi
+++ b/stubs/paramiko/paramiko/client.pyi
@@ -12,7 +12,7 @@ from .transport import _SocketLike
 
 class _TransportFactory(Protocol):
     def __call__(
-        self, __sock: _SocketLike, *, gss_kex: bool, gss_deleg_creds: bool, disabled_algorithms: dict[str, Iterable[str]] | None
+        self, __sock: _SocketLike, *, gss_kex: bool, gss_deleg_creds: bool, disabled_algorithms: Mapping[str, Iterable[str]] | None
     ) -> Transport: ...
 
 class SSHClient(ClosingContextManager):
@@ -44,7 +44,7 @@ class SSHClient(ClosingContextManager):
         auth_timeout: float | None = None,
         gss_trust_dns: bool = True,
         passphrase: str | None = None,
-        disabled_algorithms: dict[str, Iterable[str]] | None = None,
+        disabled_algorithms: Mapping[str, Iterable[str]] | None = None,
         transport_factory: _TransportFactory | None = None,
     ) -> None: ...
     def close(self) -> None: ...
@@ -54,7 +54,7 @@ class SSHClient(ClosingContextManager):
         bufsize: int = -1,
         timeout: float | None = None,
         get_pty: bool = False,
-        environment: dict[str, str] | None = None,
+        environment: Mapping[str, str] | None = None,
     ) -> tuple[ChannelStdinFile, ChannelFile, ChannelStderrFile]: ...
     def invoke_shell(
         self,

--- a/stubs/paramiko/paramiko/transport.pyi
+++ b/stubs/paramiko/paramiko/transport.pyi
@@ -1,4 +1,4 @@
-from collections.abc import Callable, Iterable, Sequence
+from collections.abc import Callable, Iterable, Mapping Sequence
 from logging import Logger
 from socket import socket
 from threading import Condition, Event, Lock, Thread
@@ -64,7 +64,7 @@ class Transport(Thread, ClosingContextManager):
     banner_timeout: float
     handshake_timeout: float
     auth_timeout: float
-    disabled_algorithms: dict[str, Iterable[str]] | None
+    disabled_algorithms: Mapping[str, Iterable[str]] | None
     server_mode: bool
     server_object: ServerInterface | None
     server_key_dict: dict[str, PKey]
@@ -79,7 +79,7 @@ class Transport(Thread, ClosingContextManager):
         default_max_packet_size: int = 32768,
         gss_kex: bool = False,
         gss_deleg_creds: bool = True,
-        disabled_algorithms: dict[str, Iterable[str]] | None = None,
+        disabled_algorithms: Mapping[str, Iterable[str]] | None = None,
         server_sig_algs: bool = True,
     ) -> None: ...
     @property

--- a/stubs/paramiko/paramiko/transport.pyi
+++ b/stubs/paramiko/paramiko/transport.pyi
@@ -1,4 +1,4 @@
-from collections.abc import Callable, Iterable, Mapping Sequence
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from logging import Logger
 from socket import socket
 from threading import Condition, Event, Lock, Thread


### PR DESCRIPTION
Use Mapping instead of dict for better covariance.

Right now, mypy rejects a `dict[str, list[str]]` for the `disabled_algorithms` parameter of `connect`, because of the invariance of the `dict` type.