### PR TITLE
influxdb-client: fix stubtest

### DIFF
--- a/stubs/influxdb-client/@tests/stubtest_allowlist.txt
+++ b/stubs/influxdb-client/@tests/stubtest_allowlist.txt
@@ -1,2 +1,0 @@
-# Metaclass problem inherited from urllib3.
-influxdb_client.client.write.retry.WritesRetry

--- a/stubs/influxdb-client/METADATA.toml
+++ b/stubs/influxdb-client/METADATA.toml
@@ -1,5 +1,6 @@
 version = "1.36.*"
-requires = ["types-urllib3"]
+# Requires a version of urllib3 with a `py.typed` file
+requires = ["urllib3>=2.0.0"]
 
 [tool.stubtest]
 extras = ["extra"]

--- a/stubs/influxdb-client/METADATA.toml
+++ b/stubs/influxdb-client/METADATA.toml
@@ -1,6 +1,5 @@
 version = "1.36.*"
-# Requires a version of urllib3 with a `py.typed` file
-requires = ["urllib3>=2.0.0"]
+requires = ["types-urllib3"]
 
 [tool.stubtest]
 extras = ["extra"]


### PR DESCRIPTION
Fixes #10089. The error was caused by the release of `urllib3==2.0.0`, which includes a `py.typed` file and inline type hints