### PR TITLE
Alternative fix for pyright CI issues

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -125,15 +125,23 @@ jobs:
           python-version: "3.10"
           cache: pip
           cache-dependency-path: requirements-tests.txt
-      - name: Install external dependencies for 3rd-party stubs
+      - name: Install typeshed test-suite requirements
+        # Install these so we can run `get_external_stub_requirements.py`
+        run: pip install -r requirements-tests.txt
+      - name: Create an isolated venv for testing
+        run: python -m venv .venv
+      - name: Install 3rd-party stub dependencies
         run: |
-          pip install -r requirements-tests.txt
           DEPENDENCIES=$(python tests/get_external_stub_requirements.py)
           if [ -n "$DEPENDENCIES" ]; then
+            source .venv/bin/activate
             echo "Installing packages: $DEPENDENCIES"
             pip install $DEPENDENCIES
           fi
-      - run: pip freeze --all
+      - name: List 3rd-party stub dependencies installed
+        run: |
+          source .venv/bin/activate
+          pip freeze --all
       - name: Get pyright version
         uses: SebRollen/toml-action@v1.0.2
         id: pyright_version
@@ -147,6 +155,7 @@ jobs:
           python-platform: ${{ matrix.python-platform }}
           python-version: ${{ matrix.python-version }}
           no-comments: ${{ matrix.python-version != '3.10' || matrix.python-platform != 'Linux' }} # Having each job create the same comment is too noisy.
+          venv-path: .
       - name: Run pyright with stricter settings on some of the stubs
         uses: jakebailey/pyright-action@v1
         with:
@@ -154,6 +163,7 @@ jobs:
           python-platform: ${{ matrix.python-platform }}
           python-version: ${{ matrix.python-version }}
           no-comments: ${{ matrix.python-version != '3.10' || matrix.python-platform != 'Linux' }} # Having each job create the same comment is too noisy.
+          venv-path: .
           project: ./pyrightconfig.stricter.json
       - name: Run pyright on the test cases
         uses: jakebailey/pyright-action@v1
@@ -162,6 +172,7 @@ jobs:
           python-platform: ${{ matrix.python-platform }}
           python-version: ${{ matrix.python-version }}
           no-comments: ${{ matrix.python-version != '3.10' || matrix.python-platform != 'Linux' }} # Having each job create the same comment is too noisy.
+          venv-path: .
           project: ./pyrightconfig.testcases.json
 
   stub-uploader:

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,6 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/microsoft/pyright/main/packages/vscode-pyright/schemas/pyrightconfig.schema.json",
     "typeshedPath": ".",
+    "venv": ".venv",
     "include": [
         "stdlib",
         "stubs",

--- a/pyrightconfig.stricter.json
+++ b/pyrightconfig.stricter.json
@@ -1,6 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/microsoft/pyright/main/packages/vscode-pyright/schemas/pyrightconfig.schema.json",
     "typeshedPath": ".",
+    "venv": ".venv",
     "include": [
         "stdlib",
         "stubs",

--- a/pyrightconfig.testcases.json
+++ b/pyrightconfig.testcases.json
@@ -1,6 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/microsoft/pyright/main/packages/vscode-pyright/schemas/pyrightconfig.schema.json",
     "typeshedPath": ".",
+    "venv": ".venv",
     "include": [
         "test_cases",
         "stubs/**/@tests/test_cases"


### PR DESCRIPTION
Helps with https://github.com/python/typeshed/issues/10112 (an alternative fix to #10120). Install 3rd-party stub dependencies into an isolated environment, and use that for running pyright on typeshed, rather than installing the 3rd-party stub requirements into the same environment all our test requirements are installed in.

As with #10120, this doesn't fix the issue encountered in #9989 or #10090, but it does unblock #10058.