### PR TITLE
move some stuffs related to `Structure` and `Union` from `ctypes/__init__.pyi` to `_ctypes.pyi`, as at runtime.

### DIFF
--- a/stdlib/ctypes/__init__.pyi
+++ b/stdlib/ctypes/__init__.pyi
@@ -3,9 +3,14 @@ from _ctypes import (
     RTLD_GLOBAL as RTLD_GLOBAL,
     RTLD_LOCAL as RTLD_LOCAL,
     Array as Array,
+    Structure as Structure,
+    Union as Union,
     _CData as _CData,
     _CDataMeta as _CDataMeta,
+    _CField as _CField,
     _SimpleCData as _SimpleCData,
+    _StructUnionBase as _StructUnionBase,
+    _StructUnionMeta as _StructUnionMeta,
 )
 from collections.abc import Callable, Sequence
 from typing import Any, ClassVar, Generic, TypeVar, overload
@@ -216,23 +221,5 @@ if sys.platform == "win32":
     class HRESULT(_SimpleCData[int]): ...  # TODO undocumented
 
 class py_object(_CanCastTo, _SimpleCData[_T]): ...
-
-class _CField:
-    offset: int
-    size: int
-
-class _StructUnionMeta(_CDataMeta):
-    _fields_: Sequence[tuple[str, type[_CData]] | tuple[str, type[_CData], int]]
-    _pack_: int
-    _anonymous_: Sequence[str]
-    def __getattr__(self, name: str) -> _CField: ...
-
-class _StructUnionBase(_CData, metaclass=_StructUnionMeta):
-    def __init__(self, *args: Any, **kw: Any) -> None: ...
-    def __getattr__(self, name: str) -> Any: ...
-    def __setattr__(self, name: str, value: Any) -> None: ...
-
-class Union(_StructUnionBase): ...
-class Structure(_StructUnionBase): ...
 class BigEndianStructure(Structure): ...
 class LittleEndianStructure(Structure): ...

--- a/tests/stubtest_allowlists/py3_common.txt
+++ b/tests/stubtest_allowlists/py3_common.txt
@@ -339,8 +339,6 @@ _ctypes.POINTER
 _ctypes.PyObj_FromPtr
 _ctypes.Py_DECREF
 _ctypes.Py_INCREF
-_ctypes.Structure
-_ctypes.Union
 _ctypes.addressof
 _ctypes.alignment
 _ctypes.buffer_info


### PR DESCRIPTION
related to #8633 and https://github.com/python/typeshed/issues/8571#issuecomment-1221316973

As in #10118, I would change the typestub definitions to the equivalent location as runtime.

I moved stuffs related to `Structure` and `Union`.