### PR TITLE
Add Markdown.ESCAPED_CHARS to Markdown stubs

### DIFF
--- a/stubs/Markdown/markdown/core.pyi
+++ b/stubs/Markdown/markdown/core.pyi
@@ -32,6 +32,7 @@ class Markdown:
     tab_length: int
     block_level_elements: list[str]
     registeredExtensions: list[Extension]
+    ESCAPED_CHARS: list[str]
     def __init__(
         self,
         *,


### PR DESCRIPTION
This instance variable is part of the API.
Changing it is [tested by Markdown's own test suite](https://github.com/Python-Markdown/markdown/blob/07b8b2c90a92c20fb0740d5527c6a219d2afb7ae/tests/test_apis.py#L884-L893) and used by [an included extension](https://github.com/Python-Markdown/markdown/blob/07b8b2c90a92c20fb0740d5527c6a219d2afb7ae/markdown/extensions/tables.py#L229-L230). It is also used by third-party extensions, for example by [pymdown-extensions](https://github.com/facelessuser/pymdown-extensions/blob/a8fb9666566dfb7e86094082860b5616885d35f4/pymdownx/util.py#L87-L100).