### PR TITLE
move some byref-related-stuffs from `ctypes/__init__.pyi` to `_ctypes.pyi`, as at runtime.

### DIFF
--- a/stdlib/_ctypes.pyi
+++ b/stdlib/_ctypes.pyi
@@ -2,7 +2,7 @@ import sys
 from _typeshed import ReadableBuffer, WriteableBuffer
 from abc import abstractmethod
 from collections.abc import Iterable, Iterator, Mapping, Sequence
-from ctypes import CDLL, _CArgObject
+from ctypes import CDLL
 from typing import Any, Generic, TypeVar, overload
 from typing_extensions import Self, TypeAlias
 
@@ -88,6 +88,10 @@ class _Pointer(Generic[_CT], _PointerLike, _CData):
 
 def POINTER(type: type[_CT]) -> type[_Pointer[_CT]]: ...
 def pointer(__arg: _CT) -> _Pointer[_CT]: ...
+
+class _CArgObject: ...
+
+def byref(obj: _CData, offset: int = ...) -> _CArgObject: ...
 
 class _CField:
     offset: int

--- a/stdlib/ctypes/__init__.pyi
+++ b/stdlib/ctypes/__init__.pyi
@@ -8,6 +8,7 @@ from _ctypes import (
     Structure as Structure,
     Union as Union,
     _CanCastTo as _CanCastTo,
+    _CArgObject as _CArgObject,
     _CData as _CData,
     _CDataMeta as _CDataMeta,
     _CField as _CField,
@@ -18,6 +19,7 @@ from _ctypes import (
     _StructUnionMeta as _StructUnionMeta,
     addressof as addressof,
     alignment as alignment,
+    byref as byref,
     get_errno as get_errno,
     pointer as pointer,
     resize as resize,
@@ -120,8 +122,6 @@ if sys.platform == "win32":
 
 def PYFUNCTYPE(restype: type[_CData] | None, *argtypes: type[_CData]) -> type[_FuncPointer]: ...
 
-class _CArgObject: ...
-
 # Any type that can be implicitly converted to c_void_p when passed as a C function argument.
 # (bytes is not included here, see below.)
 _CVoidPLike: TypeAlias = _PointerLike | Array[Any] | _CArgObject | int
@@ -130,8 +130,6 @@ _CVoidPLike: TypeAlias = _PointerLike | Array[Any] | _CArgObject | int
 # and non-const pointers), but it catches errors like memmove(b'foo', buf, 4)
 # when memmove(buf, b'foo', 4) was intended.
 _CVoidConstPLike: TypeAlias = _CVoidPLike | bytes
-
-def byref(obj: _CData, offset: int = ...) -> _CArgObject: ...
 
 _CastT = TypeVar("_CastT", bound=_CanCastTo)
 

--- a/tests/stubtest_allowlists/py3_common.txt
+++ b/tests/stubtest_allowlists/py3_common.txt
@@ -339,7 +339,6 @@ _ctypes.PyObj_FromPtr
 _ctypes.Py_DECREF
 _ctypes.Py_INCREF
 _ctypes.buffer_info
-_ctypes.byref
 _ctypes.call_cdeclfunction
 _ctypes.call_function
 


### PR DESCRIPTION
related to #8633 and https://github.com/python/typeshed/issues/8571#issuecomment-1221316973

As in #10118, I would change the typestub definitions to the equivalent location as runtime.

I moved some classes and functions. They are byref-related-stuffs.