### PR TITLE
Bump flake8-pyi to 23.5.0; re-enable F821

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -36,14 +36,16 @@
 extend-ignore = A, D, N8, SIM, RST, TYP, E301, E302, E305, E501
 per-file-ignores =
   *.py: E203
-  *.pyi: B, E701, E741, F401, F403, F405, F821, F822
+  *.pyi: B, E701, E741, F401, F403, F405, F822
   # Since typing.pyi defines "overload" this is not recognized by flake8 as typing.overload.
   # Unfortunately, flake8 does not allow to "noqa" just a specific error inside the file itself.
   # https://github.com/PyCQA/flake8/issues/1079
   #     F811 redefinition of unused '...'
-  stdlib/typing.pyi: B, E701, E741, F401, F403, F405, F811, F821, F822
+  stdlib/typing.pyi: B, E701, E741, F401, F403, F405, F811, F822
   # Generated protobuf files include docstrings
-  *_pb2.pyi: B, E701, E741, F401, F403, F405, F821, F822, Y021, Y026, Y053, Y054
+  # *_pb2.pyi: B, E701, E741, F401, F403, F405, F822, Y021, Y026, Y053, Y054
 
-exclude = .venv*,.git
+# TODO: Re-enable flake8 on generated protobuf files
+# after https://github.com/nipunn1313/mypy-protobuf/issues/523 is resolved
+exclude = .venv*,.git,*_pb2.pyi
 noqa_require_code = true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
         additional_dependencies:
           - "flake8-bugbear==23.3.23" # must match requirements-tests.txt
           - "flake8-noqa==1.3.1" # must match requirements-tests.txt
-          - "flake8-pyi==23.4.1" # must match requirements-tests.txt
+          - "flake8-pyi==23.5.0" # must match requirements-tests.txt
         types: [file]
         types_or: [python, pyi]
 

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -3,7 +3,7 @@ black==23.3.0                                     # must match .pre-commit-confi
 flake8==6.0.0; python_version >= "3.8"            # must match .pre-commit-config.yaml
 flake8-bugbear==23.3.23; python_version >= "3.8"  # must match .pre-commit-config.yaml
 flake8-noqa==1.3.1; python_version >= "3.8"       # must match .pre-commit-config.yaml
-flake8-pyi==23.4.1; python_version >= "3.8"       # must match .pre-commit-config.yaml
+flake8-pyi==23.5.0; python_version >= "3.8"       # must match .pre-commit-config.yaml
 isort==5.12.0; python_version >= "3.8"            # must match .pre-commit-config.yaml
 mypy==1.2.0
 packaging==23.1


### PR DESCRIPTION
- Bump flake8-pyi to 23.5.0
- Reenable pyflakes's F821 check. With the latest flake8-pyi updates, there's no longer any false positives from this check when checking stub files.
- Exclude generated protobuf files from flake8 for now, until https://github.com/nipunn1313/mypy-protobuf/issues/523 is fixed and our protobuf stubs are regenerated. (I've filed https://github.com/nipunn1313/mypy-protobuf/pull/525 to fix it.)