### PR TITLE
flake8: Enable F822

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -20,30 +20,24 @@
 #     E701   multiple statements on one line (colon) -- disallows "..." on the same line
 #     F401   imported but unused -- does not recognize re-exports
 #            https://github.com/PyCQA/pyflakes/issues/474
-#     F822   undefined name in __all__ -- flake8 does not recognize 'foo: Any'
-#            https://github.com/PyCQA/pyflakes/issues/533
 
 # Rules that are out of the control of stub authors:
 #     E741   ambiguous variable name
 #     F403   import *' used; unable to detect undefined names
 #     F405   defined from star imports
 
-# Ignored to workaround pyflakes issues with stub files
-# (the bugs this rule catches are caught by our other tests anyway):
-#     F821   undefined name
-
 [flake8]
 extend-ignore = A, D, N8, SIM, RST, TYP, E301, E302, E305, E501
 per-file-ignores =
   *.py: E203
-  *.pyi: B, E701, E741, F401, F403, F405, F822
+  *.pyi: B, E701, E741, F401, F403, F405
   # Since typing.pyi defines "overload" this is not recognized by flake8 as typing.overload.
   # Unfortunately, flake8 does not allow to "noqa" just a specific error inside the file itself.
   # https://github.com/PyCQA/flake8/issues/1079
   #     F811 redefinition of unused '...'
-  stdlib/typing.pyi: B, E701, E741, F401, F403, F405, F811, F822
+  stdlib/typing.pyi: B, E701, E741, F401, F403, F405, F811
   # Generated protobuf files include docstrings
-  # *_pb2.pyi: B, E701, E741, F401, F403, F405, F822, Y021, Y026, Y053, Y054
+  # *_pb2.pyi: B, E701, E741, F401, F403, F405, Y021, Y026, Y053, Y054
 
 # TODO: Re-enable flake8 on generated protobuf files
 # after https://github.com/nipunn1313/mypy-protobuf/issues/523 is resolved


### PR DESCRIPTION
Following https://github.com/PyCQA/flake8-pyi/pull/364, it seems like pyflakes's F822 check no longer has any false positives on stub files when flake8-pyi is installed!

Also, remove an outdated comment that I forgot to remove in #10143.