### PR TITLE
Improve how we run mypy on the py312 stubs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,7 +85,7 @@ jobs:
     strategy:
       matrix:
         platform: ["linux", "win32", "darwin"]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
       fail-fast: false
     steps:
       - uses: actions/checkout@v3
@@ -96,6 +96,26 @@ jobs:
           cache-dependency-path: requirements-tests.txt
       - run: pip install -r requirements-tests.txt
       - run: python ./tests/mypy_test.py --platform=${{ matrix.platform }} --python-version=${{ matrix.python-version }}
+
+  # Run mypy slightly differently on the py312 stubs,
+  # as mypyc doesn't work on Python 3.12 yet
+  # (and various non-types dependencies can't be installed on Python 3.12 yet)
+  mypy-312:
+    name: Run mypy against the stubs (3.12)
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform: ["linux", "win32", "darwin"]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: requirements-tests.txt
+      - run: pip install -r requirements-tests.txt
+      - run: python ./tests/mypy_test.py --platform=${{ matrix.platform }} --python-version=3.12
 
   regression-tests:
     name: Run mypy on the test cases


### PR DESCRIPTION
Mypyc doesn't support Python 3.12 yet, meaning we're using uncompiled mypy in CI when we're running mypy on our py312 stubs. This is incredibly slow -- `mypy_test.py` is taking 8-10 minutes on Python 3.12, compared to <3 minutes on the other Python versions we test in CI. We can speed it up by special-casing the py312 check -- we can run the check using Python 3.11, but with the `--python-version=3.12` flag. (For a refresher on why we generally _don't_ do this for the older Python versions, see #9499.) 

As well as speeding things up, this also resolves the `mypy_test.py` errors in #9989, which are caused because some dependencies-of-non-types-dependencies can't currently be installed on Python 3.12.