### PR TITLE
Revert "[stubsabot] Mark pyvmomi as obsolete since 8.0.1.0 (#10148)"

### DIFF
--- a/stubs/pyvmomi/METADATA.toml
+++ b/stubs/pyvmomi/METADATA.toml
@@ -1,5 +1,4 @@
 version = "8.0.0.*"
-obsolete_since = "8.0.1.0" # Released on 2023-05-05
 partial_stub = true
 
 [tool.stubtest]


### PR DESCRIPTION
This reverts commit 853d01d55ef5b5c7f0733e62c2e214be1d472657.

As per https://github.com/python/typeshed/issues/10149#issuecomment-1542015902, it seems like the stubs bundled with the upstream `pyvmomi` package aren't currently usable due to syntax errors. Given that marking the stubs as obsolete causes a line to be added to the PyPI description instructing users to uninstall `types-pyvmomi`, it seems like we should probably _not_ mark the stubs as obsolete until the upstream types are free of syntax errors.