### PR TITLE
Change `asyncio.Task.__init__` signature

### DIFF
--- a/stdlib/asyncio/tasks.pyi
+++ b/stdlib/asyncio/tasks.pyi
@@ -275,11 +275,10 @@ else:
     ) -> tuple[set[Task[_T]], set[Task[_T]]]: ...
     async def wait_for(fut: _FutureLike[_T], timeout: float | None, *, loop: AbstractEventLoop | None = None) -> _T: ...
 
-
 if sys.version_info >= (3, 12):
-    _TaskCompatibleCoro: TypeAlias =  Coroutine[Any, Any, _T_co]
+    _TaskCompatibleCoro: TypeAlias = Coroutine[Any, Any, _T_co]
 else:
-    _TaskCompatibleCoro: TypeAlias =  Generator[_TaskYieldType, None, _T_co] | Awaitable[_T_co]
+    _TaskCompatibleCoro: TypeAlias = Generator[_TaskYieldType, None, _T_co] | Awaitable[_T_co]
 
 # mypy and pyright complain that a subclass of an invariant class shouldn't be covariant.
 # While this is true in general, here it's sort-of okay to have a covariant subclass,
@@ -288,16 +287,10 @@ else:
 class Task(Future[_T_co], Generic[_T_co]):  # type: ignore[type-var]  # pyright: ignore[reportGeneralTypeIssues]
     if sys.version_info >= (3, 8):
         def __init__(
-            self,
-            coro: _TaskCompatibleCoro[_T_co],
-            *,
-            loop: AbstractEventLoop = ...,
-            name: str | None = ...,
+            self, coro: _TaskCompatibleCoro[_T_co], *, loop: AbstractEventLoop = ..., name: str | None = ...
         ) -> None: ...
     else:
-        def __init__(
-            self, coro: _TaskCompatibleCoro[_T_co], *, loop: AbstractEventLoop = ...
-        ) -> None: ...
+        def __init__(self, coro: _TaskCompatibleCoro[_T_co], *, loop: AbstractEventLoop = ...) -> None: ...
     if sys.version_info >= (3, 8):
         def get_coro(self) -> _TaskCompatibleCoro[_T_co]: ...
         def get_name(self) -> str: ...

--- a/stdlib/asyncio/tasks.pyi
+++ b/stdlib/asyncio/tasks.pyi
@@ -1,6 +1,6 @@
 import concurrent.futures
 import sys
-from collections.abc import Awaitable, Generator, Iterable, Iterator
+from collections.abc import Awaitable, Coroutine, Generator, Iterable, Iterator
 from types import FrameType
 from typing import Any, Generic, TextIO, TypeVar, overload
 from typing_extensions import Literal, TypeAlias
@@ -275,6 +275,12 @@ else:
     ) -> tuple[set[Task[_T]], set[Task[_T]]]: ...
     async def wait_for(fut: _FutureLike[_T], timeout: float | None, *, loop: AbstractEventLoop | None = None) -> _T: ...
 
+
+if sys.version_info >= (3, 12):
+    _TaskCompatibleCoro: TypeAlias =  Coroutine[Any, Any, _T_co]
+else:
+    _TaskCompatibleCoro: TypeAlias =  Generator[_TaskYieldType, None, _T_co] | Awaitable[_T_co]
+
 # mypy and pyright complain that a subclass of an invariant class shouldn't be covariant.
 # While this is true in general, here it's sort-of okay to have a covariant subclass,
 # since the only reason why `asyncio.Future` is invariant is the `set_result()` method,
@@ -283,17 +289,17 @@ class Task(Future[_T_co], Generic[_T_co]):  # type: ignore[type-var]  # pyright:
     if sys.version_info >= (3, 8):
         def __init__(
             self,
-            coro: Generator[_TaskYieldType, None, _T_co] | Awaitable[_T_co],
+            coro: _TaskCompatibleCoro[_T_co],
             *,
             loop: AbstractEventLoop = ...,
             name: str | None = ...,
         ) -> None: ...
     else:
         def __init__(
-            self, coro: Generator[_TaskYieldType, None, _T_co] | Awaitable[_T_co], *, loop: AbstractEventLoop = ...
+            self, coro: _TaskCompatibleCoro[_T_co], *, loop: AbstractEventLoop = ...
         ) -> None: ...
     if sys.version_info >= (3, 8):
-        def get_coro(self) -> Generator[_TaskYieldType, None, _T_co] | Awaitable[_T_co]: ...
+        def get_coro(self) -> _TaskCompatibleCoro[_T_co]: ...
         def get_name(self) -> str: ...
         def set_name(self, __value: object) -> None: ...
 


### PR DESCRIPTION
Previously it was possible to pass `Awaitable` objects and `Generator`s into `Task.__init__`:

```python
>>> from asyncio import Task
>>> def gen():
...    yield
... 
>>> Task(gen())
<stdin>:1: DeprecationWarning: There is no current event loop
<Task pending name='Task-1' coro=<gen() running at <stdin>:1>>
```

Starting from `3.12` Python does not allow anything but coroutines in `Task.__init__`.

Proof:

```python
Python 3.12.0a7+ (heads/main-dirty:3cba61f111, May 15 2023, 12:56:55) [Clang 11.0.0 (clang-1100.0.33.16)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from asyncio import Task
>>> def gen():
...    yield 
... 
>>> Task(gen())
<stdin>:1: DeprecationWarning: There is no current event loop
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: a coroutine was expected, got <generator object gen at 0x10bd47930>
```

Also changes:

```python
>>> Task(coro()).get_coro()
<coroutine object coro at 0x10bd47a00>
```

I am keeping this type alias local, because right now it is not used anywhere else. However, I see a clear difference between `Task.__init__` and `create_task()`, I think that we need to go deeper in the next PRs and find, which one is more correct.

Refs https://github.com/python/typeshed/issues/10116