### PR TITLE
Treat entries on pytype_exclude_list as missing modules for pytype_test.

### DIFF
--- a/tests/pytype_test.py
+++ b/tests/pytype_test.py
@@ -177,7 +177,7 @@ def get_missing_modules(files_to_test: Sequence[str]) -> Iterable[str]:
                 # Skips comments, empty lines, and stdlib files, which are in
                 # the exclude list because pytype has its own version.
                 continue
-            unused_stubs_prefix, unused_pkg, mod_path = fi.split(os.path.sep, 2)  # pyright: ignore [reportUnusedVariable]
+            unused_stubs_prefix, unused_pkg, mod_path = fi.split("/", 2)  # pyright: ignore [reportUnusedVariable]
             missing_modules.add(os.path.splitext(mod_path)[0])
     return missing_modules
 

--- a/tests/pytype_test.py
+++ b/tests/pytype_test.py
@@ -177,7 +177,7 @@ def get_missing_modules(files_to_test: Sequence[str]) -> Iterable[str]:
                 # Skips comments, empty lines, and stdlib files, which are in
                 # the exclude list because pytype has its own version.
                 continue
-            unused_stubs_prefix, unused_pkg, mod_path = fi.split(os.path.sep, 2)
+            unused_stubs_prefix, unused_pkg, mod_path = fi.split(os.path.sep, 2)  # pyright: ignore [reportUnusedVariable]
             missing_modules.add(os.path.splitext(mod_path)[0])
     return missing_modules
 

--- a/tests/pytype_test.py
+++ b/tests/pytype_test.py
@@ -173,7 +173,7 @@ def get_missing_modules(files_to_test: Sequence[str]) -> Iterable[str]:
     with open(exclude_list) as f:
         excluded_files = f.readlines()
         for fi in excluded_files:
-            if not fi.startswith(f"stubs/"):
+            if not fi.startswith("stubs/"):
                 # Skips comments, empty lines, and stdlib files, which are in
                 # the exclude list because pytype has its own version.
                 continue

--- a/tests/pytype_test.py
+++ b/tests/pytype_test.py
@@ -173,7 +173,7 @@ def get_missing_modules(files_to_test: Sequence[str]) -> Iterable[str]:
     with open(exclude_list) as f:
         excluded_files = f.readlines()
         for fi in excluded_files:
-            if not fi.startswith(f"stubs{os.path.sep}"):
+            if not fi.startswith(f"stubs/"):
                 # Skips comments, empty lines, and stdlib files, which are in
                 # the exclude list because pytype has its own version.
                 continue


### PR DESCRIPTION
This works around the pytype errors in https://github.com/python/typeshed/pull/10122.