### PR TITLE
Bump `tzlocal` to `5.0.1`

### DIFF
--- a/stubs/tzlocal/@tests/stubtest_allowlist.txt
+++ b/stubs/tzlocal/@tests/stubtest_allowlist.txt
@@ -1,3 +1,6 @@
 # Implementation details
 tzlocal.unix
 tzlocal.win32
+
+# Internal stuff:
+tzlocal.utils.log

--- a/stubs/tzlocal/METADATA.toml
+++ b/stubs/tzlocal/METADATA.toml
@@ -1,2 +1,2 @@
-version = "5.0"
+version = "5.0.1"
 requires = ["types-pytz"]


### PR DESCRIPTION
I don't see a reason to add stubs for this object: https://github.com/regebro/tzlocal/blob/2bd083aa15b642b23197ee55a82838877da481e6/tzlocal/utils.py#L15

It is not used, might be removed, should not be used by users of this lib.

Closes https://github.com/python/typeshed/pull/10186

