### PR TITLE
Type `argparse.HelpFormatter._Section`

### DIFF
--- a/stdlib/argparse.pyi
+++ b/stdlib/argparse.pyi
@@ -2,7 +2,7 @@ import sys
 from collections.abc import Callable, Generator, Iterable, Sequence
 from re import Pattern
 from typing import IO, Any, Generic, NewType, NoReturn, Protocol, TypeVar, overload
-from typing_extensions import Literal, TypeAlias
+from typing_extensions import Literal, Self, TypeAlias
 
 __all__ = [
     "ArgumentParser",
@@ -236,11 +236,19 @@ class HelpFormatter:
     _current_indent: int
     _level: int
     _action_max_length: int
-    _root_section: Any
-    _current_section: Any
+    _root_section: _Section
+    _current_section: _Section
     _whitespace_matcher: Pattern[str]
     _long_break_matcher: Pattern[str]
-    _Section: type[Any]  # Nested class
+
+    class _Section:
+        formatter: HelpFormatter
+        heading: str | None
+        parent: Self | None
+        items: list[tuple[Callable[..., str], Iterable[Any]]]
+        def __init__(self, formatter: HelpFormatter, parent: Self | None, heading: str | None = None) -> None: ...
+        def format_help(self) -> str: ...
+
     def __init__(self, prog: str, indent_increment: int = 2, max_help_position: int = 24, width: int | None = None) -> None: ...
     def _indent(self) -> None: ...
     def _dedent(self) -> None: ...


### PR DESCRIPTION
The python type system doesn't provide a way to fully express the type of `self.NestedClass` with inheritance but this change is still an improvement over the `Any` annotations. The usage of `_Section` is rare and subclassing it is even rarer so this shouldn't cause trouble.