### PR TITLE
Improve `NamedTuple` stubs

### DIFF
--- a/stdlib/typing.pyi
+++ b/stdlib/typing.pyi
@@ -843,18 +843,21 @@ if sys.version_info >= (3, 11):
 
 class NamedTuple(tuple[Any, ...]):
     if sys.version_info < (3, 8):
-        _field_types: collections.OrderedDict[str, type]
+        _field_types: ClassVar[collections.OrderedDict[str, type]]
     elif sys.version_info < (3, 9):
-        _field_types: dict[str, type]
-    _field_defaults: dict[str, Any]
-    _fields: tuple[str, ...]
-    _source: str
+        _field_types: ClassVar[dict[str, type]]
+    _field_defaults: ClassVar[dict[str, Any]]
+    _fields: ClassVar[tuple[str, ...]]
+    # __orig_bases__ sometimes exists on <3.12, but not consistently
+    # So we only add it to the stub on 3.12+.
+    if sys.version_info >= (3, 12):
+        __orig_bases__: ClassVar[tuple[Any, ...]]
     @overload
     def __init__(self, typename: str, fields: Iterable[tuple[str, Any]] = ...) -> None: ...
     @overload
     def __init__(self, typename: str, fields: None = None, **kwargs: Any) -> None: ...
     @classmethod
-    def _make(cls: Type[_T], iterable: Iterable[Any]) -> _T: ...
+    def _make(cls, iterable: Iterable[Any]) -> typing_extensions.Self: ...
     if sys.version_info >= (3, 8):
         def _asdict(self) -> dict[str, Any]: ...
     else:

--- a/stdlib/typing_extensions.pyi
+++ b/stdlib/typing_extensions.pyi
@@ -275,12 +275,12 @@ else:
 
     class NamedTuple(tuple[Any, ...]):
         if sys.version_info < (3, 8):
-            _field_types: collections.OrderedDict[str, type]
+            _field_types: ClassVar[collections.OrderedDict[str, type]]
         elif sys.version_info < (3, 9):
-            _field_types: dict[str, type]
-        _field_defaults: dict[str, Any]
-        _fields: tuple[str, ...]
-        _source: str
+            _field_types: ClassVar[dict[str, type]]
+        _field_defaults: ClassVar[dict[str, Any]]
+        _fields: ClassVar[tuple[str, ...]]
+        __orig_bases__: ClassVar[tuple[Any, ...]]
         @overload
         def __init__(self, typename: str, fields: Iterable[tuple[str, Any]] = ...) -> None: ...
         @overload


### PR DESCRIPTION
- The `_source` attribute was removed in Python 3.7. Delete it from the stubs.
- A bunch of attributes should be marked as `ClassVar`s, but currently aren't
- Add the `__orig_bases__` attribute to `typing_extensions.NamedTuple`
- Add the `__orig_bases__` attribute to `typing.NamedTuple` on py312+. It sometimes exists on Python <=3.11, but not always, so it's only safe to directly access it on py312+.