### PR TITLE
Add `__orig_bases__` to `TypedDict` classes

### DIFF
--- a/stdlib/typing.pyi
+++ b/stdlib/typing.pyi
@@ -870,6 +870,10 @@ class _TypedDict(Mapping[str, object], metaclass=ABCMeta):
     if sys.version_info >= (3, 9):
         __required_keys__: ClassVar[frozenset[str]]
         __optional_keys__: ClassVar[frozenset[str]]
+    # __orig_bases__ sometimes exists on <3.12, but not consistently,
+    # so we only add it to the stub on 3.12+
+    if sys.version_info >= (3, 12):
+        __orig_bases__: ClassVar[tuple[Any, ...]]
     def copy(self) -> typing_extensions.Self: ...
     # Using Never so that only calls using mypy plugin hook that specialize the signature
     # can go through.

--- a/stdlib/typing_extensions.pyi
+++ b/stdlib/typing_extensions.pyi
@@ -148,6 +148,7 @@ class _TypedDict(Mapping[str, object], metaclass=abc.ABCMeta):
     __required_keys__: ClassVar[frozenset[str]]
     __optional_keys__: ClassVar[frozenset[str]]
     __total__: ClassVar[bool]
+    __orig_bases__: ClassVar[tuple[Any, ...]]
     def copy(self) -> Self: ...
     # Using Never so that only calls using mypy plugin hook that specialize the signature
     # can go through.


### PR DESCRIPTION
I'm deliberately updating `typing.TypedDict` and `typing_extensions.TypedDict`, but not `mypy_extensions.TypedDict`. The runtime implementation of `mypy_extensions.TypedDict` does not have the `__orig_bases__` attribute (and is quite out of date with the CPython `main` implementation in several other ways, as well).