### PR TITLE
Make `sys.UnraisableHookArgs` a Protocol

### DIFF
--- a/stdlib/sys.pyi
+++ b/stdlib/sys.pyi
@@ -321,7 +321,7 @@ if sys.version_info < (3, 9):
 
 if sys.version_info >= (3, 8):
     # Doesn't exist at runtime, but exported in the stubs so pytest etc. can annotate their code more easily.
-    class UnraisableHookArgs:
+    class UnraisableHookArgs(Protocol):
         exc_type: type[BaseException]
         exc_value: BaseException | None
         exc_traceback: TracebackType | None


### PR DESCRIPTION
With the previous stubs you could make a `sys.unraisablehook` function but you can't pass arguments to that function.

The most I can find about `unraisablehook` is [this post](https://vstinner.github.io/sys-unraisablehook-python38.html). Apparently the arguments are supposed to be extendable. I think `Protocol` would allow for what's been described, or at least it'd fix my current issue which is that I can't call `sys.unraisablehook` from my Python code without `# type: ignore[arg-type]`.

I can give examples of what I was trying to do, but a context manager that passes raised exceptions to `sys.unraisablehook` is pretty self-explanatory.