### PR TITLE
Some light reorganisation of stubtest allowlists

### DIFF
--- a/tests/stubtest_allowlists/py311.txt
+++ b/tests/stubtest_allowlists/py311.txt
@@ -31,9 +31,6 @@ multiprocessing.managers.SharedMemoryServer.release_segment
 multiprocessing.managers.SharedMemoryServer.shutdown
 multiprocessing.managers.SharedMemoryServer.track_segment
 multiprocessing.spawn._main
-platform.uname_result.__match_args__
-platform.uname_result.__new__
-platform.uname_result.processor  # platform.uname_result's processor field is now dynamically made to exist
 queue.SimpleQueue.__init__
 sys.UnraisableHookArgs  # Not exported from sys
 tkinter._VersionInfoType.__doc__
@@ -119,14 +116,19 @@ queue.SimpleQueue.__init__
 xml.etree.ElementTree.XMLParser.__init__
 xml.etree.cElementTree.XMLParser.__init__
 
-# Runtime has *args, **kwargs, but will error if any are supplied
-unittest.TestCase.__init_subclass__
-unittest.case.TestCase.__init_subclass__
-
 # Treated an alias of a typing class in the stubs,
 # they are generic to type checkers anyway.
 contextlib.AbstractAsyncContextManager.__class_getitem__
 contextlib.AbstractContextManager.__class_getitem__
+
+# platform.uname_result's processor field is now dynamically made to exist
+platform.uname_result.__match_args__
+platform.uname_result.__new__
+platform.uname_result.processor
+
+# Runtime has *args, **kwargs, but will error if any are supplied
+unittest.TestCase.__init_subclass__
+unittest.case.TestCase.__init_subclass__
 
 # Super-special typing primitives
 typing\._SpecialForm.*

--- a/tests/stubtest_allowlists/py311.txt
+++ b/tests/stubtest_allowlists/py311.txt
@@ -16,20 +16,14 @@ argparse._MutuallyExclusiveGroup.add_mutually_exclusive_group
 bz2.BZ2Decompressor.__init__  # function does not accept parameters but C signature is set
 configparser.LegacyInterpolation.__init__
 configparser.ParsingError.filename
-enum.Enum._generate_next_value_
 enum.Enum.__init__
-# TODO: The stub for enum.auto is nothing like the implementation
-enum.auto.__init__
-enum.auto.value
-fractions.Fraction.__new__  # overload is too complicated for stubtest to resolve
+enum.Enum._generate_next_value_
 ftplib.FTP.trust_server_pasv_ipv4_address
-functools.cached_property.__set__  # Stub is a white lie; see comments in the stub
-functools._lru_cache_wrapper.cache_parameters  # Cannot be detected statically
 importlib.abc.Finder.find_module
-ipaddress.IPv4Interface.hostmask
-ipaddress.IPv6Interface.hostmask
 ipaddress._BaseNetwork.broadcast_address
 ipaddress._BaseNetwork.hostmask
+ipaddress.IPv4Interface.hostmask
+ipaddress.IPv6Interface.hostmask
 multiprocessing.managers.SharedMemoryServer.create
 multiprocessing.managers.SharedMemoryServer.list_segments
 multiprocessing.managers.SharedMemoryServer.public
@@ -37,27 +31,16 @@ multiprocessing.managers.SharedMemoryServer.release_segment
 multiprocessing.managers.SharedMemoryServer.shutdown
 multiprocessing.managers.SharedMemoryServer.track_segment
 multiprocessing.spawn._main
-# platform.uname_result's processor field is now dynamically made to exist
 platform.uname_result.__match_args__
 platform.uname_result.__new__
-platform.uname_result.processor
+platform.uname_result.processor  # platform.uname_result's processor field is now dynamically made to exist
 queue.SimpleQueue.__init__
 sys.UnraisableHookArgs  # Not exported from sys
 tkinter._VersionInfoType.__doc__
+typing_extensions\.get_original_bases
 typing.NewType.__call__
 typing.NewType.__mro_entries__
 weakref.WeakValueDictionary.update
-typing_extensions\.get_original_bases
-
-# Runtime has *args, **kwargs, but will error if any are supplied
-unittest.TestCase.__init_subclass__
-unittest.case.TestCase.__init_subclass__
-
-# Exist at runtime for internal reasons, no need to put them in the stub
-typing_extensions\.TypeAliasType\.__call__
-typing_extensions\.TypeAliasType\.__init_subclass__
-# We call them read-only properties, runtime implementation is slightly different
-typing_extensions\.TypeAliasType\.__(parameters|type_params|name|module|value)__
 
 # ==========
 # Related to positional-only arguments
@@ -97,19 +80,29 @@ os.path.join
 # Allowlist entries that cannot or should not be fixed
 # ==========
 
+_ast.ImportFrom.level  # None on the class, but never None on instances
 _collections_abc.AsyncGenerator.athrow  # async at runtime, deliberately not in the stub, see #7491. Pos-only differences also.
 _weakref.ProxyType.__reversed__  # Doesn't really exist
+ast.ImportFrom.level  # None on the class, but never None on instances
+asyncio.base_events.BaseEventLoop.subprocess_exec # BaseEventLoop adds several parameters and stubtest fails on the difference if we add them
+asyncio.BaseEventLoop.subprocess_exec # BaseEventLoop adds several parameters and stubtest fails on the difference if we add them
 builtins.property.__set_name__  # Doesn't actually exist
+dataclasses.KW_ONLY  # white lies around defaults
+enum.auto.__init__  # The stub for enum.auto is nothing like the implementation
+enum.auto.value  # The stub for enum.auto is nothing like the implementation
+fractions.Fraction.__new__  # overload is too complicated for stubtest to resolve
+functools._lru_cache_wrapper.cache_parameters  # Cannot be detected statically
+functools.cached_property.__set__  # Stub is a white lie; see comments in the stub
 hmac.new  # Stub is a white lie; see comments in the stub
 http.HTTPMethod.description  # mutable instance attribute at runtime but we pretend it's a property
+inspect._ParameterKind.description  # Still exists, but stubtest can't see it
+os.PathLike.__class_getitem__  # PathLike is a protocol; we don't expect all PathLike classes to implement class_getitem
 pickle.Pickler.reducer_override  # implemented in C pickler
+types.CodeType.replace  # stubtest thinks default values are None but None doesn't work at runtime
 types.GenericAlias.__call__  # Would be complicated to fix properly, Any could silence problems. #6392
 types.GenericAlias.__getattr__
 types.GenericAlias.__mro_entries__
 weakref.ProxyType.__reversed__  # Doesn't really exist
-inspect._ParameterKind.description  # Still exists, but stubtest can't see it
-asyncio.BaseEventLoop.subprocess_exec # BaseEventLoop adds several parameters and stubtest fails on the difference if we add them
-asyncio.base_events.BaseEventLoop.subprocess_exec # BaseEventLoop adds several parameters and stubtest fails on the difference if we add them
 
 # C signature is broader than what is actually accepted
 ast.Bytes.__new__
@@ -126,10 +119,9 @@ queue.SimpleQueue.__init__
 xml.etree.ElementTree.XMLParser.__init__
 xml.etree.cElementTree.XMLParser.__init__
 
-os.PathLike.__class_getitem__  # PathLike is a protocol; we don't expect all PathLike classes to implement class_getitem
-types.CodeType.replace  # stubtest thinks default values are None but None doesn't work at runtime
-_ast.ImportFrom.level  # None on the class, but never None on instances
-ast.ImportFrom.level  # None on the class, but never None on instances
+# Runtime has *args, **kwargs, but will error if any are supplied
+unittest.TestCase.__init_subclass__
+unittest.case.TestCase.__init_subclass__
 
 # Treated an alias of a typing class in the stubs,
 # they are generic to type checkers anyway.
@@ -153,13 +145,16 @@ typing\.NamedTuple
 typing\.LiteralString
 typing\.Annotated
 
-# White lies around defaults
-dataclasses.KW_ONLY
-
 # We pretend it's a read-only property for forward compatibility with 3.12
 typing.ParamSpec(Args|Kwargs).__origin__
 typing\.TypeVar\.__.*__
 typing\.ParamSpec\.__.*__
+
+# Exist at runtime for internal reasons, no need to put them in the stub
+typing_extensions\.TypeAliasType\.__call__
+typing_extensions\.TypeAliasType\.__init_subclass__
+# We call them read-only properties, runtime implementation is slightly different
+typing_extensions\.TypeAliasType\.__(parameters|type_params|name|module|value)__
 
 # We lie about the existence of these methods
 .*.__buffer__

--- a/tests/stubtest_allowlists/py312.txt
+++ b/tests/stubtest_allowlists/py312.txt
@@ -280,17 +280,11 @@ _csv.Writer
 argparse._MutuallyExclusiveGroup.add_mutually_exclusive_group
 configparser.LegacyInterpolation.__init__
 enum.Enum.__init__
-# TODO: The stub for enum.auto is nothing like the implementation
-enum.auto.__init__
-enum.auto.value
-fractions.Fraction.__new__  # overload is too complicated for stubtest to resolve
 ftplib.FTP.trust_server_pasv_ipv4_address
-functools.cached_property.__set__  # Stub is a white lie; see comments in the stub
-functools._lru_cache_wrapper.cache_parameters  # Cannot be detected statically
-ipaddress.IPv4Interface.hostmask
-ipaddress.IPv6Interface.hostmask
 ipaddress._BaseNetwork.broadcast_address
 ipaddress._BaseNetwork.hostmask
+ipaddress.IPv4Interface.hostmask
+ipaddress.IPv6Interface.hostmask
 multiprocessing.managers.SharedMemoryServer.create
 multiprocessing.managers.SharedMemoryServer.list_segments
 multiprocessing.managers.SharedMemoryServer.public
@@ -298,20 +292,15 @@ multiprocessing.managers.SharedMemoryServer.release_segment
 multiprocessing.managers.SharedMemoryServer.shutdown
 multiprocessing.managers.SharedMemoryServer.track_segment
 multiprocessing.spawn._main
-# platform.uname_result's processor field is now dynamically made to exist
 platform.uname_result.__match_args__
 platform.uname_result.__new__
-platform.uname_result.processor
+platform.uname_result.processor  # platform.uname_result's processor field is now dynamically made to exist
 queue.SimpleQueue.__init__
 sys.UnraisableHookArgs  # Not exported from sys
 tkinter._VersionInfoType.__doc__
 typing.NewType.__call__
 typing.NewType.__mro_entries__
 weakref.WeakValueDictionary.update
-
-# Runtime has *args, **kwargs, but will error if any are supplied
-unittest.TestCase.__init_subclass__
-unittest.case.TestCase.__init_subclass__
 
 # ==========
 # Related to positional-only arguments
@@ -351,19 +340,29 @@ os.path.join
 # Allowlist entries that cannot or should not be fixed
 # ==========
 
+_ast.ImportFrom.level  # None on the class, but never None on instances
 _collections_abc.AsyncGenerator.athrow  # async at runtime, deliberately not in the stub, see #7491. Pos-only differences also.
 _weakref.ProxyType.__reversed__  # Doesn't really exist
+ast.ImportFrom.level  # None on the class, but never None on instances
+asyncio.base_events.BaseEventLoop.subprocess_exec # BaseEventLoop adds several parameters and stubtest fails on the difference if we add them
+asyncio.BaseEventLoop.subprocess_exec # BaseEventLoop adds several parameters and stubtest fails on the difference if we add them
 builtins.property.__set_name__  # Doesn't actually exist
+dataclasses.KW_ONLY  # white lies around defaults
+enum.auto.__init__  # The stub for enum.auto is nothing like the implementation
+enum.auto.value  # The stub for enum.auto is nothing like the implementation
+fractions.Fraction.__new__  # overload is too complicated for stubtest to resolve
+functools._lru_cache_wrapper.cache_parameters  # Cannot be detected statically
+functools.cached_property.__set__  # Stub is a white lie; see comments in the stub
 hmac.new  # Stub is a white lie; see comments in the stub
 http.HTTPMethod.description  # mutable instance attribute at runtime but we pretend it's a property
+inspect._ParameterKind.description  # Still exists, but stubtest can't see it
+os.PathLike.__class_getitem__  # PathLike is a protocol; we don't expect all PathLike classes to implement class_getitem
 pickle.Pickler.reducer_override  # implemented in C pickler
+types.CodeType.replace  # stubtest thinks default values are None but None doesn't work at runtime
 types.GenericAlias.__call__  # Would be complicated to fix properly, Any could silence problems. #6392
 types.GenericAlias.__getattr__
 types.GenericAlias.__mro_entries__
 weakref.ProxyType.__reversed__  # Doesn't really exist
-inspect._ParameterKind.description  # Still exists, but stubtest can't see it
-asyncio.BaseEventLoop.subprocess_exec # BaseEventLoop adds several parameters and stubtest fails on the difference if we add them
-asyncio.base_events.BaseEventLoop.subprocess_exec # BaseEventLoop adds several parameters and stubtest fails on the difference if we add them
 
 # C signature is broader than what is actually accepted
 ast.Bytes.__new__
@@ -380,10 +379,9 @@ queue.SimpleQueue.__init__
 xml.etree.ElementTree.XMLParser.__init__
 xml.etree.cElementTree.XMLParser.__init__
 
-os.PathLike.__class_getitem__  # PathLike is a protocol; we don't expect all PathLike classes to implement class_getitem
-types.CodeType.replace  # stubtest thinks default values are None but None doesn't work at runtime
-_ast.ImportFrom.level  # None on the class, but never None on instances
-ast.ImportFrom.level  # None on the class, but never None on instances
+# Runtime has *args, **kwargs, but will error if any are supplied
+unittest.TestCase.__init_subclass__
+unittest.case.TestCase.__init_subclass__
 
 # Treated an alias of a typing class in the stubs,
 # they are generic to type checkers anyway.
@@ -406,6 +404,3 @@ typing_extensions\.Final
 typing\.NamedTuple
 typing\.LiteralString
 typing\.Annotated
-
-# White lies around defaults
-dataclasses.KW_ONLY

--- a/tests/stubtest_allowlists/py312.txt
+++ b/tests/stubtest_allowlists/py312.txt
@@ -292,9 +292,6 @@ multiprocessing.managers.SharedMemoryServer.release_segment
 multiprocessing.managers.SharedMemoryServer.shutdown
 multiprocessing.managers.SharedMemoryServer.track_segment
 multiprocessing.spawn._main
-platform.uname_result.__match_args__
-platform.uname_result.__new__
-platform.uname_result.processor  # platform.uname_result's processor field is now dynamically made to exist
 queue.SimpleQueue.__init__
 sys.UnraisableHookArgs  # Not exported from sys
 tkinter._VersionInfoType.__doc__
@@ -379,14 +376,19 @@ queue.SimpleQueue.__init__
 xml.etree.ElementTree.XMLParser.__init__
 xml.etree.cElementTree.XMLParser.__init__
 
-# Runtime has *args, **kwargs, but will error if any are supplied
-unittest.TestCase.__init_subclass__
-unittest.case.TestCase.__init_subclass__
-
 # Treated an alias of a typing class in the stubs,
 # they are generic to type checkers anyway.
 contextlib.AbstractAsyncContextManager.__class_getitem__
 contextlib.AbstractContextManager.__class_getitem__
+
+# platform.uname_result's processor field is now dynamically made to exist
+platform.uname_result.__match_args__
+platform.uname_result.__new__
+platform.uname_result.processor
+
+# Runtime has *args, **kwargs, but will error if any are supplied
+unittest.TestCase.__init_subclass__
+unittest.case.TestCase.__init_subclass__
 
 # Super-special typing primitives
 typing\._SpecialForm.*

--- a/tests/stubtest_allowlists/py3_common.txt
+++ b/tests/stubtest_allowlists/py3_common.txt
@@ -4,59 +4,12 @@
 
 # Please keep sorted alphabetically
 
-# Coroutine and Generator properties are added programmatically
-_collections_abc.Coroutine.cr_await
-_collections_abc.Coroutine.cr_code
-_collections_abc.Coroutine.cr_frame
-_collections_abc.Coroutine.cr_running
-_collections_abc.Generator.gi_code
-_collections_abc.Generator.gi_frame
-_collections_abc.Generator.gi_running
-_collections_abc.Generator.gi_yieldfrom
-_collections_abc.Mapping.__reversed__  # set to None at runtime for a better error message
-_collections_abc.Mapping.get  # Adding None to the Union messed up mypy
-_collections_abc.Sequence.index  # Supporting None in end is not mandatory
-
-# Adding these reflected dunders to `typing.AbstractSet` causes a large number of false-positives. See #7414.
-_collections_abc.Set.__rand__
-_collections_abc.Set.__ror__
-_collections_abc.Set.__rsub__
-_collections_abc.Set.__rxor__
-
 _csv.Dialect.__init__  # C __init__ signature is inaccurate
 _ctypes.CFuncPtr  # stubtest erroneously thinks it can't be subclassed
 _threading_local.local.__new__
-_weakref.ref.*  # Alias for _weakref.ReferenceType, problems should be fixed there
-_weakref.CallableProxyType.__getattr__  # Should have all attributes of proxy
-_weakref.ProxyType.__getattr__  # Should have all attributes of proxy
-_weakref.ReferenceType.__call__  # C function default annotation is wrong
-_weakref.ReferenceType.__init__  # Runtime defines __new__ but stubtest thinks __init__ is also defined.
-argparse.ArgumentParser.__init__  # stubtest doesn't recognise the runtime default (a class) as being compatible with a callback protocol (the stub annotation)
-argparse.Namespace.__getattr__  # The whole point of this class is its attributes are dynamic
-# Condition functions are exported in __init__
-asyncio.Condition.acquire
-asyncio.Condition.locked
-asyncio.Condition.release
-# Condition functions are exported in __init__
-asyncio.locks.Condition.acquire
-asyncio.locks.Condition.locked
-asyncio.locks.Condition.release
-asyncio.proactor_events.BaseProactorEventLoop.sock_recv # nbytes parameter has different name 'n' in implementation
-asyncio.selector_events.BaseSelectorEventLoop.sock_recv # nbytes parameter has different name 'n' in implementation
-builtins.OSError.characters_written  # GetSetDescriptor that always raises AttributeError
 builtins.dict.get
 builtins.ellipsis  # type is not exposed anywhere
 builtins.function
-builtins.memoryview.__contains__  # C type that implements __getitem__
-builtins.object.__init__  # default C signature is incorrect
-builtins.type.__dict__  # read-only but not actually a property; stubtest thinks it's a mutable attribute.
-# The following CodecInfo properties are added in __new__
-codecs.CodecInfo.decode
-codecs.CodecInfo.encode
-codecs.CodecInfo.incrementaldecoder
-codecs.CodecInfo.incrementalencoder
-codecs.CodecInfo.streamreader
-codecs.CodecInfo.streamwriter
 collections.ChainMap.get  # Adding None to the underlying Mapping Union messed up mypy
 collections.ChainMap.fromkeys  # Runtime has *args which can really only be one argument
 collections.UserList.sort  # Runtime has *args but will error if any are supplied
@@ -66,25 +19,11 @@ configparser.SectionProxy.getboolean
 configparser.SectionProxy.getfloat
 configparser.SectionProxy.getint
 copy.PyStringMap  # defined only in Jython
-# The Dialect properties are initialized as None in Dialect but their values are enforced in _Dialect
-csv.Dialect.delimiter
-csv.Dialect.doublequote
-csv.Dialect.lineterminator
-csv.Dialect.quoting
-csv.Dialect.skipinitialspace
-csv.DictReader.__init__  # runtime sig has *args but will error if more than 5 positional args are supplied
-csv.DictWriter.__init__  # runtime sig has *args but will error if more than 5 positional args are supplied
-ctypes.Array._type_  # _type_ and _length_ are abstract, https://github.com/python/typeshed/pull/6361
-_ctypes.Array._type_
-ctypes.Array._length_
-_ctypes.Array._length_
 ctypes.CDLL._FuncPtr  # None at class level but initialized in __init__ to this value
 ctypes.memmove  # CFunctionType
 ctypes.memset  # CFunctionType
 ctypes.string_at  # docstring argument name is wrong
 ctypes.wstring_at  # docstring argument name is wrong
-hashlib.sha3_\d+  # Can be a class or a built-in function, can't be subclassed at runtime
-hashlib.shake_\d+  # Can be a class or a built-in function, can't be subclassed at runtime
 http.HTTPStatus.description  # set in __new__
 http.HTTPStatus.phrase  # set in __new__
 http.client.HTTPConnection.response_class  # the actual type at runtime is abc.ABCMeta
@@ -94,8 +33,6 @@ importlib.abc.Loader.exec_module  # See Lib/importlib/_abc.py. Might be defined 
 importlib.abc.MetaPathFinder.find_spec  # Not defined on the actual class, but expected to exist.
 importlib.abc.PathEntryFinder.find_spec  # Not defined on the actual class, but expected to exist.
 importlib.machinery.ExtensionFileLoader.get_filename  # Wrapped with _check_name decorator which changes runtime signature
-inspect.Parameter.empty  # set as private marker _empty
-inspect.Signature.empty  # set as private marker _empty
 io.BufferedRandom.truncate
 io.BufferedReader.seek
 io.BufferedReader.truncate
@@ -126,9 +63,6 @@ lib2to3.pytree.BasePattern.__new__
 lib2to3.pytree.BasePattern.type
 lib2to3.pytree.NegatedPattern.match
 lib2to3.pytree.NegatedPattern.match_seq
-# LC_MESSAGES is sometimes present in __all__, sometimes not,
-# so stubtest will sometimes complain about exported names being different at runtime to the exported names in the stub
-(locale.__all__)?
 multiprocessing.JoinableQueue
 multiprocessing.Queue
 multiprocessing.SimpleQueue
@@ -148,10 +82,6 @@ multiprocessing.synchronize.SemLock.acquire
 multiprocessing.synchronize.SemLock.release
 numbers.Number.__hash__  # typeshed marks this as abstract but code just sets this as None
 optparse.Values.__getattr__  # Some attributes are set in __init__ using setattr
-pickle.Pickler.persistent_id  # C pickler persistent_id is an attribute
-pickle.Unpickler.persistent_load  # C unpickler persistent_load is an attribute
-pickle._Unpickler\..*  # Best effort typing for undocumented internals
-pickle._Pickler\..*  # Best effort typing for undocumented internals
 poplib.POP3_SSL.stls  # bad declaration of inherited function. See poplib.pyi
 pyexpat.expat_CAPI
 select.poll  # Depends on configuration
@@ -161,53 +91,21 @@ socketserver.BaseServer.fileno  # implemented in derived classes
 socketserver.BaseServer.get_request  # implemented in derived classes
 socketserver.BaseServer.server_bind  # implemented in derived classes
 ssl.Purpose.__new__  # the multiple inheritance confuses mypy
-(sys.get_int_max_str_digits)?  # Added in a patch release, backported to all security branches, but has yet to find its way to all GitHub Actions images
-sys.implementation  # Actually SimpleNamespace but then you wouldn't have convenient attributes
-(sys.set_int_max_str_digits)?  # Added in a patch release, backported to all security branches, but has yet to find its way to all GitHub Actions images
 tarfile.TarFile.errors  # errors is initialized for some reason as None even though it really only accepts str
-threading.Condition.acquire  # Condition functions are exported in __init__
-threading.Condition.release  # Condition functions are exported in __init__
 tkinter.simpledialog.[A-Z_]+
 tkinter.simpledialog.TclVersion
 tkinter.simpledialog.TkVersion
 tkinter.tix.[A-Z_]+
 tkinter.tix.TclVersion
 tkinter.tix.TkVersion
-multiprocessing.dummy.Condition.acquire
-multiprocessing.dummy.Condition.release
-threading.Lock  # A factory function that returns 'most efficient lock'. Marking it as a function will make it harder for users to mark the Lock type.
-threading.RLock  # Similar to above
-multiprocessing.dummy.Lock  # Similar to above
-multiprocessing.dummy.RLock  # Similar to above
-# alias for a class defined elsewhere, mypy infers the variable has type `(*args) -> ForkingPickler` but stubtest infers the runtime type as <class ForkingPickler>
-multiprocessing.reduction.AbstractReducer.ForkingPickler
-tkinter.Misc.grid_propagate  # The noarg placeholder is a set value list
-tkinter.Misc.pack_propagate  # The noarg placeholder is a set value list
-tkinter.Tk.eval  # from __getattr__
-tkinter.Tk.report_callback_exception  # A bit of a lie, since it's actually a method, but typing it as an attribute allows it to be assigned to
-tkinter.Wm.wm_iconphoto  # Default value of argument can't be used without runtime error
-tkinter.font.Font.__getitem__  # Argument name differs (doesn't matter for __dunder__ methods)
 traceback.TracebackException.from_exception  # explicitly expanding arguments going into TracebackException __init__
-types.MethodType.__closure__  # read-only but not actually a property; stubtest thinks it doesn't exist.
-types.MethodType.__defaults__  # read-only but not actually a property; stubtest thinks it doesn't exist.
-types.ModuleType.__dict__  # read-only but not actually a property; stubtest thinks it's a mutable attribute.
-types.ModuleType.__getattr__  # this doesn't exist at runtime
-types.SimpleNamespace.__init__  # class doesn't accept positional arguments but has default C signature
 typing.IO.__next__  # Added because IO streams are iterable. See https://github.com/python/typeshed/commit/97bc450acd60c1bcdafef3ce8fbe3b95a9c0cac3
 typing.type_check_only  # typing decorator that is not available at runtime
 unittest.mock.patch  # It's a complicated overload and I haven't been able to figure out why stubtest doesn't like it
 urllib.request.HTTPPasswordMgrWithPriorAuth.__init__  # Args are passed as is to super, so super args are specified
-weakref.CallableProxyType.__getattr__  # Should have all attributes of proxy
-weakref.ProxyType.__getattr__  # Should have all attributes of proxy
-weakref.ReferenceType.*  # Alias for _weakref.ReferenceType, problems should be fixed there
 weakref.WeakKeyDictionary.get
 weakref.WeakKeyDictionary.update
 weakref.WeakValueDictionary.get
-weakref.WeakValueDictionary.setdefault  # has a default value for the "default" argument, but always errors out if no value is supplied for the parameter by the user
-weakref.ref.*  # Alias for _weakref.ReferenceType, problems should be fixed there
-webbrowser.UnixBrowser.remote_action  # always overridden in inheriting class
-webbrowser.UnixBrowser.remote_action_newtab  # always overridden in inheriting class
-webbrowser.UnixBrowser.remote_action_newwin  # always overridden in inheriting class
 xml.parsers.expat.expat_CAPI
 
 # ==========
@@ -334,16 +232,54 @@ _ctypes.call_function
 # Allowlist entries that cannot or should not be fixed
 # ==========
 
-ctypes.Array.raw  # exists but stubtest can't see it; only available if _CT == c_char
-_ctypes.Array.raw
+# async at runtime, deliberately not in the stub, see #7491
+_collections_abc.AsyncGenerator.asend  # pos-only differences also.
+_collections_abc.AsyncGenerator.__anext__
+_collections_abc.AsyncGenerator.aclose
+_collections_abc.AsyncIterator.__anext__
 
-_collections_abc.AsyncGenerator.asend  # async at runtime, deliberately not in the stub, see #7491. Pos-only differences also.
-_collections_abc.AsyncGenerator.__anext__  # async at runtime, deliberately not in the stub, see #7491
-_collections_abc.AsyncGenerator.aclose  # async at runtime, deliberately not in the stub, see #7491
-_collections_abc.AsyncIterator.__anext__  # async at runtime, deliberately not in the stub, see #7491
+# Coroutine and Generator properties are added programmatically
+_collections_abc.Coroutine.cr_await
+_collections_abc.Coroutine.cr_code
+_collections_abc.Coroutine.cr_frame
+_collections_abc.Coroutine.cr_running
+_collections_abc.Generator.gi_code
+_collections_abc.Generator.gi_frame
+_collections_abc.Generator.gi_running
+_collections_abc.Generator.gi_yieldfrom
+_collections_abc.Mapping.__reversed__  # set to None at runtime for a better error message
+_collections_abc.Mapping.get  # Adding None to the Union messed up mypy
+_collections_abc.Sequence.index  # Supporting None in end is not mandatory
+
+# Adding these reflected dunders to `typing.AbstractSet` causes a large number of false-positives. See #7414.
+_collections_abc.Set.__rand__
+_collections_abc.Set.__ror__
+_collections_abc.Set.__rsub__
+_collections_abc.Set.__rxor__
+
+collections.abc.*  # Types are re-exported from _collections_abc, so errors should be fixed there
+
+_?ctypes.Array.raw  # exists but stubtest can't see it; only available if _CT == c_char
+_?ctypes.Array._type_  # _type_ is abstract, https://github.com/python/typeshed/pull/6361
+_?ctypes.Array._length_ # _length_ is abstract, https://github.com/python/typeshed/pull/6361
 _pydecimal.*  # See comments in file
-_weakref.ProxyType.__bytes__  # Doesn't really exist
+argparse.ArgumentParser.__init__  # stubtest doesn't recognise the runtime default (a class) as being compatible with a callback protocol (the stub annotation)
+argparse.Namespace.__getattr__  # The whole point of this class is its attributes are dynamic
 ast.NodeVisitor.visit_\w+  # Methods are discovered dynamically, see #3796
+asyncio.proactor_events.BaseProactorEventLoop.sock_recv # nbytes parameter has different name 'n' in implementation
+asyncio.selector_events.BaseSelectorEventLoop.sock_recv # nbytes parameter has different name 'n' in implementation
+
+# Condition functions are exported in __init__
+asyncio.Condition.acquire
+asyncio.Condition.locked
+asyncio.Condition.release
+asyncio.locks.Condition.acquire
+asyncio.locks.Condition.locked
+asyncio.locks.Condition.release
+threading.Condition.acquire
+threading.Condition.release
+multiprocessing.dummy.Condition.acquire
+multiprocessing.dummy.Condition.release
 
 # Weird special builtins that are typed as functions, but aren't functions
 builtins.copyright
@@ -354,6 +290,12 @@ builtins.license
 builtins.quit
 
 builtins.float.__getformat__  # Internal method for CPython test suite
+builtins.memoryview.__contains__  # C type that implements __getitem__
+builtins.object.__init__  # default C signature is incorrect
+builtins.OSError.characters_written  # GetSetDescriptor that always raises AttributeError
+builtins.reveal_locals  # Builtins that type checkers pretends exist
+builtins.reveal_type  # Builtins that type checkers pretends exist
+builtins.type.__dict__  # read-only but not actually a property; stubtest thinks it's a mutable attribute.
 
 # These super() dunders don't seem to be particularly useful,
 # and having them pop up on autocomplete suggestions would be annoying
@@ -361,7 +303,42 @@ builtins.super.__self__
 builtins.super.__self_class__
 builtins.super.__thisclass__
 
-# These enums derive from (int, IntEnum) or (str, Enum).
+# The following CodecInfo properties are added in __new__
+codecs.CodecInfo.decode
+codecs.CodecInfo.encode
+codecs.CodecInfo.incrementaldecoder
+codecs.CodecInfo.incrementalencoder
+codecs.CodecInfo.streamreader
+codecs.CodecInfo.streamwriter
+
+# The Dialect properties are initialized as None in Dialect but their values are enforced in _Dialect
+csv.Dialect.delimiter
+csv.Dialect.doublequote
+csv.Dialect.lineterminator
+csv.Dialect.quoting
+csv.Dialect.skipinitialspace
+
+csv.DictReader.__init__  # runtime sig has *args but will error if more than 5 positional args are supplied
+csv.DictWriter.__init__  # runtime sig has *args but will error if more than 5 positional args are supplied
+
+# Removed undocumented and often mistakenly used _normalize parameter that was removed in 3.12
+# On 3.12, stubtest doesn't correctly combine the overload because parameter names mismatch
+fractions.Fraction.__new__
+
+contextvars.Context.__init__  # C signature is broader than what is actually accepted
+dataclasses.field  # White lies around defaults
+hashlib.sha3_\d+  # Can be a class or a built-in function, can't be subclassed at runtime
+hashlib.shake_\d+  # Can be a class or a built-in function, can't be subclassed at runtime
+hmac.HMAC.blocksize  # use block_size instead
+
+# We can't distinguish not having a default value from having a default value of inspect.Parameter.empty
+inspect.Parameter.__init__
+inspect.Signature.__init__
+
+inspect.Parameter.empty  # set as private marker _empty
+inspect.Signature.empty  # set as private marker _empty
+
+# These enums derive from (int, IntEnum) or (str, Enum)
 pstats.SortKey.__new__
 tkinter.EventType.__new__
 
@@ -381,22 +358,24 @@ multiprocessing.managers.DictProxy.keys
 multiprocessing.managers.DictProxy.popitem
 multiprocessing.managers.DictProxy.values
 
+multiprocessing.(dummy|managers).Namespace.__[gs]etattr__  # Any field can be set on Namespace
+# alias for a class defined elsewhere, mypy infers the variable has type `(*args) -> ForkingPickler` but stubtest infers the runtime type as <class ForkingPickler>
+multiprocessing.reduction.AbstractReducer.ForkingPickler
+
 # Items that depend on the existence and flags of SSL
 imaplib.IMAP4_SSL.ssl
 ssl.PROTOCOL_SSLv2
 ssl.PROTOCOL_SSLv3
 ssl.RAND_egd
 
-collections.abc.*  # Types are re-exported from _collections_abc, so errors should be fixed there
-hmac.HMAC.blocksize  # use block_size instead
+pickle._Pickler\..*  # Best effort typing for undocumented internals
+pickle._Unpickler\..*  # Best effort typing for undocumented internals
 pickle.Pickler.memo  # undocumented implementation detail, has different type in C/Python implementations
+pickle.Pickler.persistent_id  # C pickler persistent_id is an attribute
 pickle.Unpickler.memo  # undocumented implementation detail, has different type in C/Python implementations
+pickle.Unpickler.persistent_load  # C unpickler persistent_load is an attribute
 re.Pattern.scanner  # Undocumented and not useful. #6405
 tempfile._TemporaryFileWrapper.[\w_]+  # Dynamically specified by __getattr__, and thus don't exist on the class
-
-# Removed undocumented and often mistakenly used _normalize parameter that was removed in 3.12
-# On 3.12, stubtest doesn't correctly combine the overload because parameter names mismatch
-fractions.Fraction.__new__
 
 # Details of runtime definition don't need to be in stubs
 typing_extensions\._SpecialForm.*
@@ -453,6 +432,17 @@ typing_extensions.NewType.__call__
 typing_extensions\.deprecated
 typing_extensions\.override
 
+# Typing-related weirdness
+_collections_abc.Callable
+_typeshed.*  # Utility types for typeshed, doesn't exist at runtime
+typing._SpecialForm.__call__
+typing._SpecialForm.__init__
+
+# Pretend typing.ByteString is a Union, to better match its documented semantics.
+# As a side effect, this changes the definition of collections.abc.ByteString, which is okay,
+# because it's not an ABC that makes any sense and was deprecated in 3.12
+_collections_abc.ByteString
+
 # These are abstract properties at runtime,
 # but marking them as such in the stub breaks half the the typed-Python ecosystem (see #8726)
 typing.IO.closed
@@ -464,27 +454,11 @@ typing.TextIO.errors
 typing.TextIO.line_buffering
 typing.TextIO.newlines
 
-# Typing-related weirdness
-_collections_abc.Callable
-_typeshed.*  # Utility types for typeshed, doesn't exist at runtime
-typing._SpecialForm.__call__
-typing._SpecialForm.__init__
-
-# Builtins that type checkers pretends exist
-builtins.reveal_locals
-builtins.reveal_type
-
-# White lies around defaults
-dataclasses.field
-
-# We can't distinguish not having a default value from having a default value of inspect.Parameter.empty
-inspect.Parameter.__init__
-inspect.Signature.__init__
-
-# C signature is broader than what is actually accepted
-contextvars.Context.__init__
-
-multiprocessing.(dummy|managers).Namespace.__[gs]etattr__  # Any field can be set on Namespace
+types.MethodType.__closure__  # read-only but not actually a property; stubtest thinks it doesn't exist.
+types.MethodType.__defaults__  # read-only but not actually a property; stubtest thinks it doesn't exist.
+types.ModuleType.__dict__  # read-only but not actually a property; stubtest thinks it's a mutable attribute.
+types.ModuleType.__getattr__  # this doesn't exist at runtime
+types.SimpleNamespace.__init__  # class doesn't accept positional arguments but has default C signature
 
 # sys attributes that are not always defined
 sys.gettotalrefcount  # Available on python debug builds
@@ -495,21 +469,44 @@ sys.ps1
 sys.ps2
 sys.tracebacklimit
 
-# See comments in file. List out methods that are delegated by __getattr__ at runtime.
-# Used to make the relevant class satisfy BinaryIO interface.
-codecs.StreamReaderWriter.\w+
-codecs.StreamRecoder.\w+
-urllib.response.addbase.\w+
+sys.implementation  # Actually SimpleNamespace but then you wouldn't have convenient attributes
 
-weakref.ProxyType.__bytes__  # Doesn't actually exist
+# A factory function that returns 'most efficient lock'. Marking it as a function will make it harder for users to mark the Lock type.
+threading.Lock
+threading.RLock
+multiprocessing.dummy.Lock
+multiprocessing.dummy.RLock
 
 # Dynamically created, has unnecessary *args
 turtle.ScrolledCanvas.find_all
 turtle.ScrolledCanvas.select_clear
 turtle.ScrolledCanvas.select_item
 
-# Unnecessary re-export
-xml.dom.minidom.StringTypes
+# Always overridden in inheriting class
+webbrowser.UnixBrowser.remote_action
+webbrowser.UnixBrowser.remote_action_newtab
+webbrowser.UnixBrowser.remote_action_newwin
+
+# Undocumented and have a comment in the source code saying "State variables (don't mess with these)"
+wsgiref.handlers.BaseHandler.bytes_sent
+wsgiref.handlers.BaseHandler.headers
+wsgiref.handlers.BaseHandler.headers_sent
+wsgiref.handlers.BaseHandler.result
+wsgiref.handlers.BaseHandler.status
+
+(_?weakref.rf|_?weakref.ReferenceType).__call__  # C function default annotation is wrong
+(_?weakref.rf|_?weakref.ReferenceType).__init__  # Runtime defines __new__ but stubtest thinks __init__ is also defined.
+_?weakref.CallableProxyType.__getattr__  # Should have all attributes of proxy
+_?weakref.ProxyType.__bytes__  # Doesn't actually exist
+_?weakref.ProxyType.__getattr__  # Should have all attributes of proxy
+weakref.WeakValueDictionary.setdefault  # has a default value for the "default" argument, but always errors out if no value is supplied for the parameter by the user
+xml.dom.minidom.StringTypes  # Unnecessary re-export
+
+# See comments in file. List out methods that are delegated by __getattr__ at runtime.
+# Used to make the relevant class satisfy BinaryIO interface.
+codecs.StreamReaderWriter.\w+
+codecs.StreamRecoder.\w+
+urllib.response.addbase.\w+
 
 # __all__-related weirdness (see #6523)
 email.base64mime
@@ -573,6 +570,7 @@ tkinter.Tk.call
 tkinter.Tk.createcommand
 tkinter.Tk.createtimerhandler
 tkinter.Tk.dooneevent
+tkinter.Tk.eval
 tkinter.Tk.evalfile
 tkinter.Tk.exprboolean
 tkinter.Tk.exprdouble
@@ -588,12 +586,11 @@ tkinter.Tk.unsetvar
 tkinter.Tk.wantobjects
 tkinter.Tk.willdispatch
 
-# Undocumented and have a comment in the source code saying "State variables (don't mess with these)"
-wsgiref.handlers.BaseHandler.bytes_sent
-wsgiref.handlers.BaseHandler.headers
-wsgiref.handlers.BaseHandler.headers_sent
-wsgiref.handlers.BaseHandler.result
-wsgiref.handlers.BaseHandler.status
+tkinter.font.Font.__getitem__  # Argument name differs (doesn't matter for __dunder__ methods)
+tkinter.Misc.grid_propagate  # The noarg placeholder is a set value list
+tkinter.Misc.pack_propagate  # The noarg placeholder is a set value list
+tkinter.Tk.report_callback_exception  # A bit of a lie, since it's actually a method, but typing it as an attribute allows it to be assigned to
+tkinter.Wm.wm_iconphoto  # Default value of argument can't be used without runtime error
 
 # Iterable classes that don't define __iter__ at runtime (usually iterable via __getitem__)
 # These would ideally be special-cased by type checkers; see https://github.com/python/mypy/issues/2220
@@ -605,7 +602,9 @@ xml.etree.ElementTree.Element.__iter__
 xml.etree.cElementTree.Element.__iter__
 typing.IO.__iter__  # See https://github.com/python/typeshed/commit/97bc450acd60c1bcdafef3ce8fbe3b95a9c0cac3
 
-# Pretend typing.ByteString is a Union, to better match its documented semantics.
-# As a side effect, this changes the definition of collections.abc.ByteString, which is okay,
-# because it's not an ABC that makes any sense and was deprecated in 3.12
-_collections_abc.ByteString
+# LC_MESSAGES is sometimes present in __all__, sometimes not,
+# so stubtest will sometimes complain about exported names being different at runtime to the exported names in the stub
+(locale.__all__)?
+
+(sys.get_int_max_str_digits)?  # Added in a patch release, backported to all security branches, but has yet to find its way to all GitHub Actions images
+(sys.set_int_max_str_digits)?  # Added in a patch release, backported to all security branches, but has yet to find its way to all GitHub Actions images

--- a/tests/stubtest_allowlists/py3_common.txt
+++ b/tests/stubtest_allowlists/py3_common.txt
@@ -359,7 +359,9 @@ multiprocessing.managers.DictProxy.popitem
 multiprocessing.managers.DictProxy.values
 
 multiprocessing.(dummy|managers).Namespace.__[gs]etattr__  # Any field can be set on Namespace
-# alias for a class defined elsewhere, mypy infers the variable has type `(*args) -> ForkingPickler` but stubtest infers the runtime type as <class ForkingPickler>
+# alias for a class defined elsewhere,
+# mypy infers the variable has type `(*args) -> ForkingPickler`
+# but stubtest infers the runtime type as <class ForkingPickler>
 multiprocessing.reduction.AbstractReducer.ForkingPickler
 
 # Items that depend on the existence and flags of SSL
@@ -471,7 +473,8 @@ sys.tracebacklimit
 
 sys.implementation  # Actually SimpleNamespace but then you wouldn't have convenient attributes
 
-# A factory function that returns 'most efficient lock'. Marking it as a function will make it harder for users to mark the Lock type.
+# A factory function that returns 'most efficient lock'.
+# Marking it as a function will make it impossible for users to use the Lock type as an annotation.
 threading.Lock
 threading.RLock
 multiprocessing.dummy.Lock
@@ -606,5 +609,7 @@ typing.IO.__iter__  # See https://github.com/python/typeshed/commit/97bc450acd60
 # so stubtest will sometimes complain about exported names being different at runtime to the exported names in the stub
 (locale.__all__)?
 
-(sys.get_int_max_str_digits)?  # Added in a patch release, backported to all security branches, but has yet to find its way to all GitHub Actions images
-(sys.set_int_max_str_digits)?  # Added in a patch release, backported to all security branches, but has yet to find its way to all GitHub Actions images
+# Added in a patch release, backported to all security branches,
+# but have yet to find their way to all GitHub Actions images
+(sys.get_int_max_str_digits)?
+(sys.set_int_max_str_digits)? 

--- a/tests/stubtest_allowlists/py3_common.txt
+++ b/tests/stubtest_allowlists/py3_common.txt
@@ -494,8 +494,8 @@ wsgiref.handlers.BaseHandler.headers_sent
 wsgiref.handlers.BaseHandler.result
 wsgiref.handlers.BaseHandler.status
 
-(_?weakref.rf|_?weakref.ReferenceType).__call__  # C function default annotation is wrong
-(_?weakref.rf|_?weakref.ReferenceType).__init__  # Runtime defines __new__ but stubtest thinks __init__ is also defined.
+(_?weakref.ref|_?weakref.ReferenceType).__call__  # C function default annotation is wrong
+(_?weakref.ref|_?weakref.ReferenceType).__init__  # Runtime defines __new__ but stubtest thinks __init__ is also defined.
 _?weakref.CallableProxyType.__getattr__  # Should have all attributes of proxy
 _?weakref.ProxyType.__bytes__  # Doesn't actually exist
 _?weakref.ProxyType.__getattr__  # Should have all attributes of proxy

--- a/tests/stubtest_allowlists/py3_common.txt
+++ b/tests/stubtest_allowlists/py3_common.txt
@@ -612,4 +612,4 @@ typing.IO.__iter__  # See https://github.com/python/typeshed/commit/97bc450acd60
 # Added in a patch release, backported to all security branches,
 # but have yet to find their way to all GitHub Actions images
 (sys.get_int_max_str_digits)?
-(sys.set_int_max_str_digits)? 
+(sys.set_int_max_str_digits)?


### PR DESCRIPTION
Mostly moves a bunch of things from the "should be fixed" to the "cannot be fixed" section and does some light alphabetisation