### PR TITLE
Update dis.pyi and opcode.pyi for Python3.12

### DIFF
--- a/stdlib/dis.pyi
+++ b/stdlib/dis.pyi
@@ -29,9 +29,12 @@ __all__ = [
     "opmap",
     "HAVE_ARGUMENT",
     "EXTENDED_ARG",
-    "hasnargs",
     "stack_effect",
 ]
+if sys.version_info >= (3, 12):
+    __all__ += ["hasarg", "hasexc"]
+else:
+    __all__ += ["hasnargs"]
 
 # Strictly this should not have to include Callable, but mypy doesn't use FunctionType
 # for functions (python/mypy#3171)

--- a/stdlib/opcode.pyi
+++ b/stdlib/opcode.pyi
@@ -14,9 +14,12 @@ __all__ = [
     "opmap",
     "HAVE_ARGUMENT",
     "EXTENDED_ARG",
-    "hasnargs",
     "stack_effect",
 ]
+if sys.version_info >= (3, 12):
+    __all__ += ["hasarg", "hasexc"]
+else:
+    __all__ += ["hasnargs"]
 
 if sys.version_info >= (3, 9):
     cmp_op: tuple[Literal["<"], Literal["<="], Literal["=="], Literal["!="], Literal[">"], Literal[">="]]
@@ -42,6 +45,11 @@ hasjabs: list[int]
 haslocal: list[int]
 hascompare: list[int]
 hasfree: list[int]
+if sys.version_info >= (3, 12):
+    hasarg: list[int]
+    hasexc: list[int]
+else:
+    hasnargs: list[int]
 opname: list[str]
 
 opmap: dict[str, int]
@@ -53,5 +61,3 @@ if sys.version_info >= (3, 8):
 
 else:
     def stack_effect(__opcode: int, __oparg: int | None = None) -> int: ...
-
-hasnargs: list[int]

--- a/tests/stubtest_allowlists/py312.txt
+++ b/tests/stubtest_allowlists/py312.txt
@@ -25,10 +25,6 @@ configparser.RawConfigParser.readfp
 configparser.__all__
 ctypes.c_time_t
 datetime.__all__
-dis.__all__
-dis.hasarg
-dis.hasexc
-dis.hasnargs
 email.utils.localtime
 enum.Enum.__signature__
 enum.EnumMeta.__call__

--- a/tests/stubtest_allowlists/py312.txt
+++ b/tests/stubtest_allowlists/py312.txt
@@ -88,10 +88,6 @@ multiprocessing.queues.Queue.__class_getitem__
 ntpath.__all__
 ntpath.isjunction
 ntpath.splitroot
-opcode.__all__
-opcode.hasarg
-opcode.hasexc
-opcode.hasnargs
 os.DirEntry.is_junction
 os.path.__all__
 os.path.isjunction


### PR DESCRIPTION
Demo:

```python
>>> import opcode
>>> opcode.hasarg
[90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 149, 150, 151, 152, 155, 156, 157, 162, 163, 164, 165, 168, 169, 170, 171, 172, 173, 174, 175, 176, 230, 237, 238, 239, 240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 260, 261, 262, 263, 264, 265, 266]
>>> opcode.hasexc
[256, 257, 258]
>>> opcode.hasnargs
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'opcode' has no attribute 'hasnargs'. Did you mean: 'hasarg'?
```

Source: https://github.com/python/cpython/blob/3.12/Lib/opcode.py