### PR TITLE
Update _thread.pyi for Python3.12

### DIFF
--- a/stdlib/_thread.pyi
+++ b/stdlib/_thread.pyi
@@ -43,3 +43,6 @@ if sys.version_info >= (3, 8):
         @property
         def thread(self) -> Thread | None: ...
     _excepthook: Callable[[_ExceptHookArgs], Any]
+
+if sys.version_info >= (3, 12):
+    def daemon_threads_allowed() -> bool: ...

--- a/tests/stubtest_allowlists/py312.txt
+++ b/tests/stubtest_allowlists/py312.txt
@@ -1,6 +1,5 @@
 # Uncategorised, from Python 3.12
 _ctypes.SIZEOF_TIME_T
-_thread.daemon_threads_allowed
 argparse.BooleanOptionalAction.__init__
 array.array.__class_getitem__
 asyncio.BaseEventLoop.create_connection


### PR DESCRIPTION
```python
>>> import _thread
>>> _thread.daemon_threads_allowed
<built-in function daemon_threads_allowed>
>>> _thread.daemon_threads_allowed()
True
```

Source: https://github.com/python/cpython/blob/e830289c52cecd99e5e2291972d648e9b3452a51/Modules/_threadmodule.c#L1105