### PR TITLE
Update ctypes stubs for Python3.12

### DIFF
--- a/stdlib/_ctypes.pyi
+++ b/stdlib/_ctypes.pyi
@@ -22,6 +22,9 @@ RTLD_LOCAL: int
 if sys.version_info >= (3, 11):
     CTYPES_MAX_ARGCOUNT: int
 
+if sys.version_info >= (3, 12):
+    SIZEOF_TIME_T: int
+
 if sys.platform == "win32":
     # Description, Source, HelpFile, HelpContext, scode
     _COMError_Details: TypeAlias = tuple[str | None, str | None, str | None, int | None, int | None]

--- a/stdlib/ctypes/__init__.pyi
+++ b/stdlib/ctypes/__init__.pyi
@@ -182,7 +182,7 @@ if sys.platform == "win32":
     class HRESULT(_SimpleCData[int]): ...  # TODO undocumented
 
 if sys.version_info >= (3, 12):
-    c_time_t: TypeAlias = c_int32 | c_int64  # noqa: Y042
+    c_time_t: type[c_int32 | c_int64]
 
 class py_object(_CanCastTo, _SimpleCData[_T]): ...
 class BigEndianStructure(Structure): ...

--- a/stdlib/ctypes/__init__.pyi
+++ b/stdlib/ctypes/__init__.pyi
@@ -181,6 +181,9 @@ class c_bool(_SimpleCData[bool]):
 if sys.platform == "win32":
     class HRESULT(_SimpleCData[int]): ...  # TODO undocumented
 
+if sys.version_info >= (3, 12):
+    c_time_t: TypeAlias = c_int32 | c_int64
+
 class py_object(_CanCastTo, _SimpleCData[_T]): ...
 class BigEndianStructure(Structure): ...
 class LittleEndianStructure(Structure): ...

--- a/stdlib/ctypes/__init__.pyi
+++ b/stdlib/ctypes/__init__.pyi
@@ -182,7 +182,7 @@ if sys.platform == "win32":
     class HRESULT(_SimpleCData[int]): ...  # TODO undocumented
 
 if sys.version_info >= (3, 12):
-    c_time_t: TypeAlias = c_int32 | c_int64
+    c_time_t: TypeAlias = c_int32 | c_int64  # noqa: Y042
 
 class py_object(_CanCastTo, _SimpleCData[_T]): ...
 class BigEndianStructure(Structure): ...

--- a/tests/stubtest_allowlists/py312.txt
+++ b/tests/stubtest_allowlists/py312.txt
@@ -1,5 +1,4 @@
 # Uncategorised, from Python 3.12
-_ctypes.SIZEOF_TIME_T
 argparse.BooleanOptionalAction.__init__
 array.array.__class_getitem__
 asyncio.BaseEventLoop.create_connection
@@ -22,7 +21,6 @@ collections.UserDict.get
 configparser.ParsingError.__init__
 configparser.RawConfigParser.readfp
 configparser.__all__
-ctypes.c_time_t
 datetime.__all__
 email.utils.localtime
 enum.Enum.__signature__

--- a/tests/stubtest_allowlists/py312.txt
+++ b/tests/stubtest_allowlists/py312.txt
@@ -21,6 +21,7 @@ collections.UserDict.get
 configparser.ParsingError.__init__
 configparser.RawConfigParser.readfp
 configparser.__all__
+ctypes.c_time_t
 datetime.__all__
 email.utils.localtime
 enum.Enum.__signature__
@@ -194,12 +195,6 @@ zipfile.Path.match
 zipfile.Path.relative_to
 zipfile.Path.rglob
 zoneinfo.ZoneInfo.from_file
-
-array.array.__release_buffer__
-builtins.bytearray.__release_buffer__
-builtins.memoryview.__release_buffer__
-mmap.mmap.__release_buffer__
-pickle.PickleBuffer.__release_buffer__
 
 # Errors that also existed on Python 3.11
 _collections_abc.AsyncGenerator.ag_await

--- a/tests/stubtest_allowlists/py312.txt
+++ b/tests/stubtest_allowlists/py312.txt
@@ -21,7 +21,6 @@ collections.UserDict.get
 configparser.ParsingError.__init__
 configparser.RawConfigParser.readfp
 configparser.__all__
-ctypes.c_time_t
 datetime.__all__
 email.utils.localtime
 enum.Enum.__signature__


### PR DESCRIPTION
Source: https://github.com/python/cpython/blob/3.12/Lib/ctypes/__init__.py#L572-L577

Basically, it depends on `SIZEOF_TIME_T` value to set a proper alias type.