### PR TITLE
Update `http/__init__.pyi` for Python3.12

### DIFF
--- a/stdlib/http/__init__.pyi
+++ b/stdlib/http/__init__.pyi
@@ -79,6 +79,17 @@ class HTTPStatus(IntEnum):
         EARLY_HINTS: Literal[103]
         IM_A_TEAPOT: Literal[418]
         TOO_EARLY: Literal[425]
+    if sys.version_info >= (3, 12):
+        @property
+        def is_informational(self) -> bool: ...
+        @property
+        def is_success(self) -> bool: ...
+        @property
+        def is_redirection(self) -> bool: ...
+        @property
+        def is_client_error(self) -> bool: ...
+        @property
+        def is_server_error(self) -> bool: ...
 
 if sys.version_info >= (3, 11):
     class HTTPMethod(StrEnum):

--- a/tests/stubtest_allowlists/py312.txt
+++ b/tests/stubtest_allowlists/py312.txt
@@ -30,11 +30,6 @@ enum.property.member
 genericpath.__all__
 genericpath.islink
 gzip.GzipFile.filename
-http.HTTPStatus.is_client_error
-http.HTTPStatus.is_informational
-http.HTTPStatus.is_redirection
-http.HTTPStatus.is_server_error
-http.HTTPStatus.is_success
 http.client.HTTPConnection.get_proxy_response_headers
 http.client.HTTPSConnection.__init__
 imaplib.IMAP4_SSL.__init__


### PR DESCRIPTION
I would prefer to leave `http.client` for later when https://github.com/python/cpython/pull/105628 is merged / rejected.

Source: https://github.com/python/cpython/blame/3.12/Lib/http/__init__.py#L34-L52