### PR TITLE
fix: use correct base classes for classes in email.generator

### DIFF
--- a/stdlib/email/feedparser.pyi
+++ b/stdlib/email/feedparser.pyi
@@ -1,24 +1,25 @@
 from collections.abc import Callable
 from email.message import Message
 from email.policy import Policy
-from typing import Generic, TypeVar, overload
+from typing import Generic, Protocol, TypeVar, overload
 
 __all__ = ["FeedParser", "BytesFeedParser"]
 
 _MessageT = TypeVar("_MessageT", bound=Message)
+_T_contra = TypeVar("_T_contra", contravariant=True)
 
-class FeedParser(Generic[_MessageT]):
+class _SupportsFeed(Protocol[_T_contra]):
+    def feed(self, data: _T_contra) -> None: ...
+
+class FeedParser(Generic[_MessageT], _SupportsFeed[str]):
     @overload
     def __init__(self: FeedParser[Message], _factory: None = None, *, policy: Policy = ...) -> None: ...
     @overload
     def __init__(self, _factory: Callable[[], _MessageT], *, policy: Policy = ...) -> None: ...
-    def feed(self, data: str) -> None: ...
     def close(self) -> _MessageT: ...
 
-class BytesFeedParser(Generic[_MessageT]):
+class BytesFeedParser(FeedParser[_MessageT], _SupportsFeed[bytes | bytearray]):
     @overload
     def __init__(self: BytesFeedParser[Message], _factory: None = None, *, policy: Policy = ...) -> None: ...
     @overload
     def __init__(self, _factory: Callable[[], _MessageT], *, policy: Policy = ...) -> None: ...
-    def feed(self, data: bytes | bytearray) -> None: ...
-    def close(self) -> _MessageT: ...

--- a/stdlib/email/feedparser.pyi
+++ b/stdlib/email/feedparser.pyi
@@ -1,25 +1,24 @@
 from collections.abc import Callable
 from email.message import Message
 from email.policy import Policy
-from typing import Generic, Protocol, TypeVar, overload
+from typing import Generic, TypeVar, overload
 
 __all__ = ["FeedParser", "BytesFeedParser"]
 
 _MessageT = TypeVar("_MessageT", bound=Message)
-_T_contra = TypeVar("_T_contra", contravariant=True)
 
-class _SupportsFeed(Protocol[_T_contra]):
-    def feed(self, data: _T_contra) -> None: ...
-
-class FeedParser(Generic[_MessageT], _SupportsFeed[str]):
+class FeedParser(Generic[_MessageT]):
     @overload
     def __init__(self: FeedParser[Message], _factory: None = None, *, policy: Policy = ...) -> None: ...
     @overload
     def __init__(self, _factory: Callable[[], _MessageT], *, policy: Policy = ...) -> None: ...
+    def feed(self, data: str) -> None: ...
     def close(self) -> _MessageT: ...
 
-class BytesFeedParser(FeedParser[_MessageT], _SupportsFeed[bytes | bytearray]):
+class BytesFeedParser(Generic[_MessageT]):
     @overload
     def __init__(self: BytesFeedParser[Message], _factory: None = None, *, policy: Policy = ...) -> None: ...
     @overload
     def __init__(self, _factory: Callable[[], _MessageT], *, policy: Policy = ...) -> None: ...
+    def feed(self, data: bytes | bytearray) -> None: ...
+    def close(self) -> _MessageT: ...

--- a/stdlib/email/generator.pyi
+++ b/stdlib/email/generator.pyi
@@ -1,11 +1,12 @@
 from _typeshed import SupportsWrite
 from email.message import Message
 from email.policy import Policy
+from typing_extensions import Self
 
 __all__ = ["Generator", "DecodedGenerator", "BytesGenerator"]
 
 class Generator:
-    def clone(self, fp: SupportsWrite[str]) -> Generator: ...
+    def clone(self, fp: SupportsWrite[str]) -> Self: ...
     def write(self, s: str) -> None: ...
     def __init__(
         self,
@@ -17,9 +18,7 @@ class Generator:
     ) -> None: ...
     def flatten(self, msg: Message, unixfrom: bool = False, linesep: str | None = None) -> None: ...
 
-class BytesGenerator:
-    def clone(self, fp: SupportsWrite[bytes]) -> BytesGenerator: ...
-    def write(self, s: str) -> None: ...
+class BytesGenerator(Generator):
     def __init__(
         self,
         outfp: SupportsWrite[bytes],
@@ -28,7 +27,6 @@ class BytesGenerator:
         *,
         policy: Policy | None = None,
     ) -> None: ...
-    def flatten(self, msg: Message, unixfrom: bool = False, linesep: str | None = None) -> None: ...
 
 class DecodedGenerator(Generator):
     def __init__(


### PR DESCRIPTION
I noticed that `email.feedparser.BytesFeedParser` and `email.generator.BytesGenerator` do not inherit from `email.feedparser.FeedParser` and `email.generator.Generator`, respectively, although they do in the actual stdlib module implementation. This PR amends that.

Update: reverted changes in `email.feedparser`, will try it again in a different PR.