### PR TITLE
psutil: import platform-specific 'pio' definitions

### DIFF
--- a/stubs/psutil/psutil/__init__.pyi
+++ b/stubs/psutil/psutil/__init__.pyi
@@ -55,7 +55,6 @@ from psutil._common import (
     pcputimes,
     pctxsw,
     pgids,
-    pio,
     pionice,
     popenfile,
     pthread,
@@ -133,6 +132,13 @@ else:
     class svmem(Any): ...
 
     def sensors_battery(): ...
+
+if sys.platform == "linux":
+    from ._pslinux import pio
+elif sys.platform == "win32":
+    from ._pswindows import pio
+else:
+    from ._common import pio
 
 AF_LINK: int
 version_info: tuple[int, int, int]


### PR DESCRIPTION
The 'pio' named tuple is defined in tree variants: we import it depending on the platform so that io_counters() has the correct return type (following up on commit 85a6dd14e1e6c9c68d6de19294775b325ad903e1).