### PR TITLE
Split requirements files into sections

### DIFF
--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,4 +1,6 @@
-aiohttp==3.8.4; python_version < "3.12"           # aiohttp can't be installed on 3.12 yet
+# Type checkers and other linters that we test our stubs against. These should always
+# be pinned to a specific version to make failure reproducible. See also the
+# "tool.typeshed" section in pyproject.toml for additional type checkers.
 black==23.3.0                                     # must match .pre-commit-config.yaml
 flake8==6.0.0; python_version >= "3.8"            # must match .pre-commit-config.yaml
 flake8-bugbear==23.5.9; python_version >= "3.8"   # must match .pre-commit-config.yaml
@@ -6,16 +8,23 @@ flake8-noqa==1.3.1; python_version >= "3.8"       # must match .pre-commit-confi
 flake8-pyi==23.5.0; python_version >= "3.8"       # must match .pre-commit-config.yaml
 isort==5.12.0; python_version >= "3.8"            # must match .pre-commit-config.yaml
 mypy==1.3.0
-packaging==23.1
-pathspec>=0.11.1
-pre-commit-hooks==4.4.0                           # must match .pre-commit-config.yaml
 pycln==2.1.5                                      # must match .pre-commit-config.yaml
 pytype==2023.6.2; platform_system != "Windows" and python_version < "3.11"
+
+# Git support.
+pre-commit-hooks==4.4.0                           # must match .pre-commit-config.yaml
+
+# Utilities used by our various scripts.
+aiohttp==3.8.4; python_version < "3.12"           # aiohttp can't be installed on 3.12 yet
+packaging==23.1
+pathspec>=0.11.1
 pyyaml==6.0
 stubdefaulter==0.1.0
 termcolor>=2.3
 tomli==2.0.1
 tomlkit==0.11.8
+typing-extensions
+
+# Type stubs used to type check our scripts.
 types-pyyaml>=6.0.12.7
 types-setuptools>=67.5.0.0
-typing-extensions


### PR DESCRIPTION
Also note that type checkers and linters should be pinned to a specific version.

See typeshed-internal/stub_uploader#96 for context.