### PR TITLE
Update vscode recommended settings

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,35 +1,41 @@
 // ⚠ Disclaimer: The typeshed team doesn't commit to maintaining this file. It exists purely for your ease of use.
-
 // Keep in alphabetical order
 {
-  "recommendations": [
-    "bierner.github-markdown-preview",
-    "bungcip.better-toml",
-    "editorconfig.editorconfig",
-    "ms-python.black-formatter",
-    "ms-python.flake8",
-    "ms-python.isort",
-    "ms-python.python",
-    "ms-python.vscode-pylance",
-    "redhat.vscode-yaml",
-],
-"unwantedRecommendations": [
-    /*
-     * Don't recommend by default for this workspace
-    */
-    "christian-kohler.npm-intellisense",
-    /*
-     * Must disable in this workspace
-     * https://github.com/microsoft/vscode/issues/40239
-    */
-    // We use black
-    "ms-python.autopep8",
-    // Not using pylint
-    "ms-python.pylint",
-    // VSCode has implemented an optimized version
-    "coenraads.bracket-pair-colorizer",
-    "coenraads.bracket-pair-colorizer-2",
-    // Obsoleted by Pylance
-    "ms-pyright.pyright",
-  ],
+    "recommendations": [
+        "bierner.github-markdown-preview",
+        "editorconfig.editorconfig",
+        "ms-python.black-formatter",
+        "ms-python.flake8",
+        "ms-python.isort",
+        "ms-python.mypy-type-checker",
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "tamasfe.even-better-toml",
+        "redhat.vscode-yaml",
+    ],
+    "unwantedRecommendations": [
+        /*
+         * Don't recommend by default for this workspace
+        */
+        "christian-kohler.npm-intellisense",
+        /*
+         * Must disable in this workspace
+         * https://github.com/microsoft/vscode/issues/40239
+        */
+        // even-better-toml has format on save
+        "bungcip.better-toml",
+        // Don't use two mypy extensions simultaneously
+        "matangover.mypy",
+        // We use black
+        "ms-python.autopep8",
+        // Not using pylint
+        "ms-python.pylint",
+        // Not using Ruff
+        "charliermarsh.ruff",
+        // VSCode has implemented an optimized version
+        "coenraads.bracket-pair-colorizer",
+        "coenraads.bracket-pair-colorizer-2",
+        // Obsoleted by Pylance
+        "ms-pyright.pyright",
+    ],
 }

--- a/.vscode/settings.default.json
+++ b/.vscode/settings.default.json
@@ -5,6 +5,7 @@
  *
  * ⚠ Disclaimer: The typeshed team doesn't commit to maintaining this file. It exists purely for your ease of use.
 */
+// TODO: Add charliermarsh.ruff to unrecommended extensions
 {
     // Don't format on save for formatters we don't explicitely control
     "editor.formatOnSave": false,
@@ -33,62 +34,97 @@
     "[json][jsonc][python]": {
         "editor.tabSize": 4
     },
-    "[markdown]": {
-        "editor.rulers": [
-            90,
-            130
-        ]
-    },
+    "editor.rulers": [
+        90,
+        130
+    ],
     "[git-commit]": {
         "editor.rulers": [
             72
         ]
     },
-    "[yaml]": {
-        "editor.defaultFormatter": "redhat.vscode-yaml",
-        "editor.formatOnSave": true,
-        "editor.codeActionsOnSave": {
-            "source.fixAll": true
-        }
-    },
-    "[python]": {
-        "editor.defaultFormatter": "ms-python.black-formatter",
-        "editor.rulers": [
-            130
-        ],
+    // Format on save for formatters we explicitely control
+    "[json][jsonc][yaml][python][toml]": {
         "editor.formatOnSave": true,
         "editor.codeActionsOnSave": {
             "source.fixAll": true,
-            "source.fixAll.unusedImports": true,
-            "source.fixAll.convertImportFormat": true,
             "source.organizeImports": true
         }
     },
-    "isort.check": true,
-    // Using the dedicated black extension
-    "black-formatter.importStrategy": "fromEnvironment",
+    "[json][jsonc]": {
+        "editor.defaultFormatter": "vscode.json-language-features"
+    },
+    "[yaml]": {
+        "editor.defaultFormatter": "redhat.vscode-yaml"
+    },
+    "[toml]": {
+        "editor.rulers": [
+            90
+        ],
+        "editor.defaultFormatter": "tamasfe.even-better-toml"
+    },
+    "[python]": {
+        "editor.rulers": [
+            130
+        ],
+        "editor.defaultFormatter": "ms-python.black-formatter"
+    },
+    // Use the new dedicated extensions instead
     "python.formatting.provider": "none",
-    // Important to follow the config in pyrightconfig.json
-    "python.analysis.useLibraryCodeForTypes": false,
-    "python.analysis.extraPaths": [
-        "tests"
-    ],
-    "python.linting.enabled": true,
-    "python.linting.mypyEnabled": true,
-    "python.linting.mypyArgs": [
-        "--show-column-numbers",
-        "--no-pretty",
-        "--custom-typeshed-dir=${workspaceFolder}",
-        "--python-version=3.7"
-    ],
-    "isort.importStrategy": "fromEnvironment",
-    // Not using bandit
-    "python.linting.banditEnabled": false,
-    // Using dedicated Flake8 extension
+    "python.linting.enabled": false,
+    "python.linting.mypyEnabled": false,
     "python.linting.flake8Enabled": false,
     "python.linting.pycodestyleEnabled": false,
     "python.linting.prospectorEnabled": false,
     "python.linting.pylamaEnabled": false,
-    // Use the new dedicated extensions instead (and we're not using pylint)
-    "python.linting.pylintEnabled": false
+    "python.linting.pylintEnabled": false,
+    // Not using bandit
+    "python.linting.banditEnabled": false,
+    // python.analysis is Pylance (pyright) configurations
+    "python.analysis.fixAll": [
+        "source.unusedImports"
+        // Explicitly omiting "source.convertImportFormat", some stubs use relative imports
+    ],
+    // Important to use `types-*` and flag untyped dependencies.
+    "python.analysis.useLibraryCodeForTypes": false,
+    "python.analysis.typeshedPaths": [
+        "${workspaceFolder}"
+    ],
+    "python.analysis.extraPaths": [
+        "tests"
+    ],
+    "mypy-type-checker.importStrategy": "fromEnvironment",
+    "mypy-type-checker.args": [
+        "--custom-typeshed-dir=${workspaceFolder}",
+        "--python-version=3.7",
+        "--strict"
+        // Needed because a library stubbed in typeshed won't necessarily be installed inthe dev's environment
+        // Currentyl broken in dmypy: https://github.com/python/mypy/issues/10709
+        // "--ignore-missing-imports"
+    ],
+    // Ensure typeshed's configs are used, and not user's VSCode settings
+    "flake8.args": [
+        "--config=.flake8"
+    ],
+    "flake8.importStrategy": "fromEnvironment",
+    "isort.check": true,
+    "isort.importStrategy": "fromEnvironment",
+    "black-formatter.importStrategy": "fromEnvironment",
+    "evenBetterToml.formatter.alignComments": false,
+    "evenBetterToml.formatter.alignEntries": false,
+    "evenBetterToml.formatter.allowedBlankLines": 1,
+    "evenBetterToml.formatter.arrayAutoCollapse": true,
+    "evenBetterToml.formatter.arrayAutoExpand": true,
+    "evenBetterToml.formatter.arrayTrailingComma": true,
+    "evenBetterToml.formatter.columnWidth": 90,
+    "evenBetterToml.formatter.compactArrays": true,
+    "evenBetterToml.formatter.compactEntries": false,
+    "evenBetterToml.formatter.compactInlineTables": false,
+    "evenBetterToml.formatter.indentEntries": false,
+    "evenBetterToml.formatter.indentTables": false,
+    "evenBetterToml.formatter.inlineTableExpand": false,
+    "evenBetterToml.formatter.reorderArrays": true,
+    "evenBetterToml.formatter.trailingNewline": true,
+    // We like keeping TOML keys in a certain non-alphabetical order that feels more natural
+    "evenBetterToml.formatter.reorderKeys": false
 }


### PR DESCRIPTION
It's been a while, and I've kept accumulating changes. I figured with the new `ms-python.mypy-type-checker` extension it might be a good time to provide an update to these recommendations.