### PR TITLE
Make CVE-2020-10735 allowlist entries Windows-only

### DIFF
--- a/tests/stubtest_allowlists/py3_common.txt
+++ b/tests/stubtest_allowlists/py3_common.txt
@@ -608,8 +608,3 @@ typing.IO.__iter__  # See https://github.com/python/typeshed/commit/97bc450acd60
 # LC_MESSAGES is sometimes present in __all__, sometimes not,
 # so stubtest will sometimes complain about exported names being different at runtime to the exported names in the stub
 (locale.__all__)?
-
-# Added in a patch release, backported to all security branches,
-# but have yet to find their way to all GitHub Actions images
-(sys.get_int_max_str_digits)?
-(sys.set_int_max_str_digits)?

--- a/tests/stubtest_allowlists/win32.txt
+++ b/tests/stubtest_allowlists/win32.txt
@@ -66,3 +66,8 @@ tty
 # pathlib functions that rely on modules that don't exist on Windows
 pathlib.Path.owner
 pathlib.Path.group
+
+# Added in a patch release, backported to all security branches,
+# but have yet to find their way to all GitHub Actions images
+(sys.get_int_max_str_digits)?
+(sys.set_int_max_str_digits)?


### PR DESCRIPTION
It looks like the GitHub runners on MacOS and Linux now consistently get Python versions that include the CVE-2020-10735 patches, but the GitHub runners on Windows still don't.