### PR TITLE
CI: Pin Python to 3.7.16 for stubtest runs on macos

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -38,18 +38,28 @@ jobs:
         os: ["ubuntu-latest", "windows-latest", "macos-11"]
         # TODO: unpin the micro version of 3.7 when this issue is resolved:
         # https://github.com/actions/setup-python/issues/682
-        python-version: ["3.7.16", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
       fail-fast: false
 
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
+        if: ${{ matrix.os != 'macos-11' || matrix.python-version != '3.7' }}
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
           cache-dependency-path: requirements-tests.txt
           allow-prereleases: true
+        # Handle the py37 run on macos differently,
+        # to workaround https://github.com/actions/setup-python/issues/682
+      - name: Setup Python 3.7.16 on macos
+        if: ${{ matrix.os == 'macos-11' && matrix.python-version == '3.7' }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.7.16"
+          cache: pip
+          cache-dependency-path: requirements-tests.txt
       - name: Install dependencies
         run: pip install -r requirements-tests.txt
       - name: Run stubtest

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -36,8 +36,6 @@ jobs:
       matrix:
         # tkinter doesn't import on macOS-12
         os: ["ubuntu-latest", "windows-latest", "macos-11"]
-        # TODO: unpin the micro version of 3.7 when this issue is resolved:
-        # https://github.com/actions/setup-python/issues/682
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
       fail-fast: false
 

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -36,7 +36,9 @@ jobs:
       matrix:
         # tkinter doesn't import on macOS-12
         os: ["ubuntu-latest", "windows-latest", "macos-11"]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        # TODO: unpin the micro version of 3.7 when this issue is resolved:
+        # https://github.com/actions/setup-python/issues/682
+        python-version: ["3.7.16", "3.8", "3.9", "3.10", "3.11", "3.12"]
       fail-fast: false
 
     steps:
@@ -47,6 +49,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: pip
           cache-dependency-path: requirements-tests.txt
+          allow-prereleases: true
       - name: Install dependencies
         run: pip install -r requirements-tests.txt
       - name: Run stubtest

--- a/.github/workflows/stubtest_stdlib.yml
+++ b/.github/workflows/stubtest_stdlib.yml
@@ -32,20 +32,28 @@ jobs:
       matrix:
         # tkinter doesn't import on macOS 12
         os: ["ubuntu-latest", "windows-latest", "macos-11"]
-        # TODO: unpin the micro version of 3.7 when this issue is resolved:
-        # https://github.com/actions/setup-python/issues/682
-        python-version: ["3.7.16", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
       fail-fast: false
 
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
+        if: ${{ matrix.os != 'macos-11' || matrix.python-version != '3.7' }}
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
           cache-dependency-path: requirements-tests.txt
           allow-prereleases: true
+        # Handle the py37 run on macos differently,
+        # to workaround https://github.com/actions/setup-python/issues/682
+      - name: Setup Python 3.7.16 on macos
+        if: ${{ matrix.os == 'macos-11' && matrix.python-version == '3.7' }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.7.16"
+          cache: pip
+          cache-dependency-path: requirements-tests.txt
       - name: Install dependencies
         run: pip install -r requirements-tests.txt
       - name: Run stubtest

--- a/.github/workflows/stubtest_stdlib.yml
+++ b/.github/workflows/stubtest_stdlib.yml
@@ -32,7 +32,9 @@ jobs:
       matrix:
         # tkinter doesn't import on macOS 12
         os: ["ubuntu-latest", "windows-latest", "macos-11"]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
+        # TODO: unpin the micro version of 3.7 when this issue is resolved:
+        # https://github.com/actions/setup-python/issues/682
+        python-version: ["3.7.16", "3.8", "3.9", "3.10", "3.11", "3.12"]
       fail-fast: false
 
     steps:
@@ -43,6 +45,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: pip
           cache-dependency-path: requirements-tests.txt
+          allow-prereleases: true
       - name: Install dependencies
         run: pip install -r requirements-tests.txt
       - name: Run stubtest


### PR DESCRIPTION
Temporary workaround to resolve #10333.

Also, while we're here:
- Run stubtest on 3.12 as part of the daily tests, not just on PR runs
- Use the new `allow-prereleases` key with the setup-python action, so we won't need to manually drop the `-dev` suffix when 3.12.0 is released in the autumn.