### PR TITLE
Fix stubtest for py312b3

### DIFF
--- a/stdlib/enum.pyi
+++ b/stdlib/enum.pyi
@@ -4,7 +4,7 @@ import types
 from _typeshed import SupportsKeysAndGetItem, Unused
 from abc import ABCMeta
 from builtins import property as _builtins_property
-from collections.abc import Iterable, Iterator, Mapping
+from collections.abc import Callable, Iterable, Iterator, Mapping
 from typing import Any, Generic, TypeVar, overload
 from typing_extensions import Literal, Self, TypeAlias
 
@@ -33,6 +33,9 @@ if sys.version_info >= (3, 11):
         "property",
         "verify",
     ]
+
+if sys.version_info >= (3, 12):
+    __all__ += ["pickle_by_enum_name", "pickle_by_global_name"]
 
 _EnumMemberT = TypeVar("_EnumMemberT")
 _EnumerationT = TypeVar("_EnumerationT", bound=type[Enum])
@@ -289,3 +292,7 @@ class auto(IntFlag):
     @_magic_enum_attr
     def value(self) -> Any: ...
     def __new__(cls) -> Self: ...
+
+if sys.version_info >= (3, 12):
+    def pickle_by_global_name(self: Enum, proto: int) -> str: ...
+    def pickle_by_enum_name(self: _EnumMemberT, proto: int) -> tuple[Callable[..., Any], tuple[type[_EnumMemberT], str]]: ...

--- a/tests/stubtest_allowlists/py312.txt
+++ b/tests/stubtest_allowlists/py312.txt
@@ -52,7 +52,6 @@ importlib.metadata._meta.PackageMetadata.get
 importlib.metadata._meta.SimplePath.__truediv__
 importlib.metadata._meta.SimplePath.parent
 importlib.resources.files
-importlib.util.allowing_all_extensions
 importlib.util.module_for_loader
 importlib.util.set_loader
 importlib.util.set_package


### PR DESCRIPTION
`enum` added a few new things; an allowlist entry is now unused