### PR TITLE
Update OpenSSL/crypto.pyi

### DIFF
--- a/stubs/pyOpenSSL/OpenSSL/crypto.pyi
+++ b/stubs/pyOpenSSL/OpenSSL/crypto.pyi
@@ -16,6 +16,8 @@ FILETYPE_TEXT: int
 
 TYPE_RSA: int
 TYPE_DSA: int
+TYPE_DH: int
+TYPE_EC: int
 
 class _EllipticCurve:
     def __init__(self, lib: Incomplete | None, nid: int, name: str) -> None: ...


### PR DESCRIPTION
Adds typing for missing constants `TYPE_DH` and `TYPE_EC`

See https://github.com/pyca/pyopenssl/blob/main/src/OpenSSL/crypto.py#L94-L95