### PR TITLE
Fix return type of start_tls()

### DIFF
--- a/stdlib/asyncio/base_events.pyi
+++ b/stdlib/asyncio/base_events.pyi
@@ -263,7 +263,7 @@ class BaseEventLoop(AbstractEventLoop):
             server_hostname: str | None = None,
             ssl_handshake_timeout: float | None = None,
             ssl_shutdown_timeout: float | None = None,
-        ) -> Transport: ...
+        ) -> Transport | None: ...
         async def connect_accepted_socket(
             self,
             protocol_factory: Callable[[], _ProtocolT],
@@ -317,7 +317,7 @@ class BaseEventLoop(AbstractEventLoop):
             server_side: bool = False,
             server_hostname: str | None = None,
             ssl_handshake_timeout: float | None = None,
-        ) -> Transport: ...
+        ) -> Transport | None: ...
         async def connect_accepted_socket(
             self,
             protocol_factory: Callable[[], _ProtocolT],

--- a/stdlib/asyncio/events.pyi
+++ b/stdlib/asyncio/events.pyi
@@ -358,7 +358,7 @@ class AbstractEventLoop:
             server_hostname: str | None = None,
             ssl_handshake_timeout: float | None = None,
             ssl_shutdown_timeout: float | None = None,
-        ) -> Transport: ...
+        ) -> Transport | None: ...
         async def create_unix_server(
             self,
             protocol_factory: _ProtocolFactory,
@@ -418,7 +418,7 @@ class AbstractEventLoop:
             server_side: bool = False,
             server_hostname: str | None = None,
             ssl_handshake_timeout: float | None = None,
-        ) -> Transport: ...
+        ) -> Transport | None: ...
         async def create_unix_server(
             self,
             protocol_factory: _ProtocolFactory,


### PR DESCRIPTION
This just returns `_app_transport`:
https://github.com/python/cpython/blob/dba72175116373c1d15e25d84c88b516daf9f5c4/Lib/asyncio/base_events.py#L1288
Which will be set to `None` on init and after connection lost:
https://github.com/python/cpython/blob/dba72175116373c1d15e25d84c88b516daf9f5c4/Lib/asyncio/sslproto.py#L412

Related bug report:
https://github.com/aio-libs/aiohttp/issues/3355