### PR TITLE
add `_is_text_encoding` attribute of CodecInfo (3.4+)

### DIFF
--- a/stdlib/codecs.pyi
+++ b/stdlib/codecs.pyi
@@ -96,6 +96,7 @@ class _IncrementalDecoder(Protocol):
     def __call__(self, errors: str = ...) -> IncrementalDecoder: ...
 
 class CodecInfo(tuple[_Encoder, _Decoder, _StreamReader, _StreamWriter]):
+    _is_text_encoding: bool
     @property
     def encode(self) -> _Encoder: ...
     @property


### PR DESCRIPTION
introduced in https://bugs.python.org/issue19619