### PR TITLE
Stubsabot: mark stubs as obsolete, even if the `py.typed` file was added in a micro version

### DIFF
--- a/scripts/stubsabot.py
+++ b/scripts/stubsabot.py
@@ -180,6 +180,10 @@ async def release_contains_py_typed(release_to_download: PypiReleaseDownload, *,
 
 
 async def find_first_release_with_py_typed(pypi_info: PypiInfo, *, session: aiohttp.ClientSession) -> PypiReleaseDownload | None:
+    """If the latest release is py.typed, return the first release that included a py.typed file.
+
+    If the latest release is not py.typed, return None.
+    """
     release_iter = (release for release in pypi_info.releases_in_descending_order() if not release.version.is_prerelease)
     latest_release = next(release_iter)
     # If the latest release is not py.typed, assume none are.
@@ -429,10 +433,10 @@ async def determine_action(stub_path: Path, session: aiohttp.ClientSession) -> U
     latest_release = pypi_info.get_latest_release()
     latest_version = latest_release.version
     spec = packaging.specifiers.SpecifierSet(f"=={stub_info.version_spec}")
-    if latest_version in spec:
+    obsolete_since = await find_first_release_with_py_typed(pypi_info, session=session)
+    if obsolete_since is None and latest_version in spec:
         return NoUpdate(stub_info.distribution, "up to date")
 
-    obsolete_since = await find_first_release_with_py_typed(pypi_info, session=session)
     relevant_version = obsolete_since.version if obsolete_since else latest_version
 
     project_urls = pypi_info.info["project_urls"] or {}


### PR DESCRIPTION
flake8-plugin-utils released a new version with a `py.typed` file yesterday. However, stubsabot didn't file a PR to mark our stubs for flake8-plugin-utils as obsolete, because the `py.typed` file was added in v1.3.3. Our stubs are pinned to `1.3.*`:

https://github.com/python/typeshed/blob/93b4060cd4a6bd45a48fc70c16adc4a69edc9114/stubs/flake8-plugin-utils/METADATA.toml#L1

This led stubsabot to conclude that our stubs were up to date with the runtime package, so stubsabot exited early from the `determine_action` function before it even got to the bit where we try to figure out if the stubs package is obsolete or not.