### PR TITLE
Stubsabot: Fix incorrect diff link when a `py.typed` was added in a micro version

### DIFF
--- a/scripts/stubsabot.py
+++ b/scripts/stubsabot.py
@@ -298,7 +298,7 @@ async def get_diff_info(
         return None
 
     try:
-        old_version = max(version for version in versions_to_tags if version in curr_specifier)
+        old_version = max(version for version in versions_to_tags if version in curr_specifier and version < pypi_version)
     except ValueError:
         return None
     else:


### PR DESCRIPTION
https://github.com/python/typeshed/pull/10374 has an incorrect diff link in the PR body. This PR fixes that bug.