### PR TITLE
Pin typing_extensions to 4.6.3

### DIFF
--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -21,7 +21,7 @@ stubdefaulter==0.1.0
 termcolor>=2.3
 tomli==2.0.1
 tomlkit==0.11.8
-typing-extensions
+typing-extensions==4.6.3
 
 # Type stubs used to type check our scripts.
 types-pyyaml>=6.0.12.7


### PR DESCRIPTION
Our CI is very red on `main` at the moment, due to the release of typing_extensions 4.6.3 (see #10383). #10344 is the fix for this, but that PR breaks pytype. For now, let's just pin to 4.6.3 to get CI green again.