### PR TITLE
pytype_test.py: Use importlib.metadata instead of pkg_resources

### DIFF
--- a/.github/workflows/typecheck_typeshed_code.yml
+++ b/.github/workflows/typecheck_typeshed_code.yml
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "3.10"
           cache: pip
           cache-dependency-path: requirements-tests.txt
       - run: pip install -r requirements-tests.txt
@@ -66,5 +66,5 @@ jobs:
         with:
           version: ${{ steps.pyright_version.outputs.value }}
           python-platform: ${{ matrix.python-platform }}
-          python-version: "3.9"
+          python-version: "3.10"
           project: ./pyrightconfig.scripts_and_tests.json

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -25,4 +25,3 @@ typing-extensions==4.6.3
 
 # Type stubs used to type check our scripts.
 types-pyyaml>=6.0.12.7
-types-setuptools>=67.5.0.0

--- a/tests/README.md
+++ b/tests/README.md
@@ -72,7 +72,7 @@ for this script.
 
 Note: this test cannot be run on Windows
 systems unless you are using Windows Subsystem for Linux.
-It also requires a Python version < 3.11 as pytype does not yet support
+It can currently only be run on Python 3.10 as pytype does not yet support
 Python 3.11 and above.
 
 Run using:

--- a/tests/README.md
+++ b/tests/README.md
@@ -19,7 +19,7 @@ objects at runtime.
 in the `tests` and `scripts` directories.
 
 To run the tests, follow the [setup instructions](../CONTRIBUTING.md#preparing-the-environment)
-in the `CONTRIBUTING.md` document. In particular, you have to run with Python 3.9+.
+in the `CONTRIBUTING.md` document. In particular, you have to run with Python 3.10+.
 
 In order for `pytype_test` and `pyright_test` to work correctly, some third-party stubs
 may require extra dependencies external to typeshed to be installed in your virtual environment

--- a/tests/pytype_test.py
+++ b/tests/pytype_test.py
@@ -169,7 +169,7 @@ def get_missing_modules(files_to_test: Sequence[str]) -> Iterable[str]:
     dist_to_pkg_map = defaultdict(list)
     for dist, pkg_list in importlib.metadata.packages_distributions().items():
         for pkg in pkg_list:
-            dist_to_pkg_map[dist].append(pkg)
+            dist_to_pkg_map[pkg].append(dist)
 
     missing_modules = set()
     for distribution in stub_distributions:

--- a/tests/pytype_test.py
+++ b/tests/pytype_test.py
@@ -24,6 +24,8 @@ from collections.abc import Iterable, Sequence
 
 from parse_metadata import read_dependencies
 
+from packaging.requirements import Requirement
+
 if sys.platform == "win32":
     print("pytype does not support Windows.", file=sys.stderr)
     sys.exit(1)
@@ -173,7 +175,8 @@ def get_missing_modules(files_to_test: Sequence[str]) -> Iterable[str]:
 
     missing_modules = set()
     for distribution in stub_distributions:
-        for pkg in read_dependencies(distribution).external_pkgs:
+        for external_req in read_dependencies(distribution).external_pkgs:
+            pkg = Requirement(external_req).name
             missing_modules.update(dist_to_pkg_map[pkg])
 
     test_dir = os.path.dirname(__file__)

--- a/tests/pytype_test.py
+++ b/tests/pytype_test.py
@@ -29,8 +29,8 @@ from parse_metadata import read_dependencies
 if sys.platform == "win32":
     print("pytype does not support Windows.", file=sys.stderr)
     sys.exit(1)
-if sys.version_info >= (3, 11):
-    print("pytype does not support Python 3.11+ yet.", file=sys.stderr)
+if sys.version_info[:2] != (3, 10):
+    print("pytype_test.py can currently only be run on Python 3.10.", file=sys.stderr)
     sys.exit(1)
 
 # pytype is not py.typed https://github.com/google/pytype/issues/1325

--- a/tests/typecheck_typeshed.py
+++ b/tests/typecheck_typeshed.py
@@ -13,7 +13,7 @@ from utils import colored, print_error
 ReturnCode: TypeAlias = int
 
 SUPPORTED_PLATFORMS = ("linux", "darwin", "win32")
-SUPPORTED_VERSIONS = ("3.12", "3.11", "3.10", "3.9")
+SUPPORTED_VERSIONS = ("3.12", "3.11", "3.10")
 LOWEST_SUPPORTED_VERSION = min(SUPPORTED_VERSIONS, key=lambda x: int(x.split(".")[1]))
 DIRECTORIES_TO_TEST = ("scripts", "tests")
 EMPTY: list[str] = []


### PR DESCRIPTION
My hope is that this will resolve the pytype failures in #10389. It's probably a good idea to do this anyway, though, since `pkg_resources` is deprecated.