### PR TITLE
Fix signature of `http.client.HTTPSConnection` for Python3.12

### DIFF
--- a/stdlib/http/client.pyi
+++ b/stdlib/http/client.pyi
@@ -175,19 +175,31 @@ class HTTPConnection:
 class HTTPSConnection(HTTPConnection):
     # Can be `None` if `.connect()` was not called:
     sock: ssl.SSLSocket | Any
-    def __init__(
-        self,
-        host: str,
-        port: int | None = None,
-        key_file: str | None = None,
-        cert_file: str | None = None,
-        timeout: float | None = ...,
-        source_address: tuple[str, int] | None = None,
-        *,
-        context: ssl.SSLContext | None = None,
-        check_hostname: bool | None = None,
-        blocksize: int = 8192,
-    ) -> None: ...
+    if sys.version_info >= (3, 12):
+        def __init__(
+            self,
+            host: str,
+            port: str,
+            *,
+            timeout: float | None = ...,
+            source_address: tuple[str, int] | None = None,
+            context: ssl.SSLContext | None = None,
+            blocksize: int = 8192,
+        ) -> None: ...
+    else:
+        def __init__(
+            self,
+            host: str,
+            port: int | None = None,
+            key_file: str | None = None,
+            cert_file: str | None = None,
+            timeout: float | None = ...,
+            source_address: tuple[str, int] | None = None,
+            *,
+            context: ssl.SSLContext | None = None,
+            check_hostname: bool | None = None,
+            blocksize: int = 8192,
+        ) -> None: ...
 
 class HTTPException(Exception): ...
 

--- a/stdlib/http/client.pyi
+++ b/stdlib/http/client.pyi
@@ -180,7 +180,7 @@ class HTTPSConnection(HTTPConnection):
         def __init__(
             self,
             host: str,
-            port: str,
+            port: str : None = None,
             *,
             timeout: float | None = ...,
             source_address: tuple[str, int] | None = None,

--- a/stdlib/http/client.pyi
+++ b/stdlib/http/client.pyi
@@ -1,6 +1,7 @@
 import email.message
 import io
 import ssl
+import sys
 import types
 from _typeshed import ReadableBuffer, SupportsRead, WriteableBuffer
 from collections.abc import Callable, Iterable, Iterator, Mapping

--- a/stdlib/http/client.pyi
+++ b/stdlib/http/client.pyi
@@ -180,7 +180,7 @@ class HTTPSConnection(HTTPConnection):
         def __init__(
             self,
             host: str,
-            port: str : None = None,
+            port: str | None = None,
             *,
             timeout: float | None = ...,
             source_address: tuple[str, int] | None = None,

--- a/tests/stubtest_allowlists/py312.txt
+++ b/tests/stubtest_allowlists/py312.txt
@@ -30,7 +30,6 @@ genericpath.__all__
 genericpath.islink
 gzip.GzipFile.filename
 http.client.HTTPConnection.get_proxy_response_headers
-http.client.HTTPSConnection.__init__
 imaplib.IMAP4_SSL.__init__
 importlib.abc.Finder
 importlib.abc.Loader.module_repr


### PR DESCRIPTION
Source: https://github.com/python/cpython/blob/3.12/Lib/http/client.py#L1441-L1443

I will change `http.client.HTTPConnection.get_proxy_response_headers` after we will decide on https://github.com/python/cpython/pull/105628