### PR TITLE
Further improve non-types dependency handling in `pytype_test.py`

### DIFF
--- a/.github/workflows/typecheck_typeshed_code.yml
+++ b/.github/workflows/typecheck_typeshed_code.yml
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.9"
           cache: pip
           cache-dependency-path: requirements-tests.txt
       - run: pip install -r requirements-tests.txt
@@ -66,5 +66,5 @@ jobs:
         with:
           version: ${{ steps.pyright_version.outputs.value }}
           python-platform: ${{ matrix.python-platform }}
-          python-version: "3.10"
+          python-version: "3.9"
           project: ./pyrightconfig.scripts_and_tests.json

--- a/tests/README.md
+++ b/tests/README.md
@@ -19,7 +19,7 @@ objects at runtime.
 in the `tests` and `scripts` directories.
 
 To run the tests, follow the [setup instructions](../CONTRIBUTING.md#preparing-the-environment)
-in the `CONTRIBUTING.md` document. In particular, you have to run with Python 3.10+.
+in the `CONTRIBUTING.md` document. In particular, you have to run with Python 3.9+.
 
 In order for `pytype_test` and `pyright_test` to work correctly, some third-party stubs
 may require extra dependencies external to typeshed to be installed in your virtual environment
@@ -72,7 +72,7 @@ for this script.
 
 Note: this test cannot be run on Windows
 systems unless you are using Windows Subsystem for Linux.
-It can currently only be run on Python 3.10 as pytype does not yet support
+It also requires a Python version < 3.11 as pytype does not yet support
 Python 3.11 and above.
 
 Run using:

--- a/tests/typecheck_typeshed.py
+++ b/tests/typecheck_typeshed.py
@@ -13,7 +13,7 @@ from utils import colored, print_error
 ReturnCode: TypeAlias = int
 
 SUPPORTED_PLATFORMS = ("linux", "darwin", "win32")
-SUPPORTED_VERSIONS = ("3.12", "3.11", "3.10")
+SUPPORTED_VERSIONS = ("3.12", "3.11", "3.10", "3.9")
 LOWEST_SUPPORTED_VERSION = min(SUPPORTED_VERSIONS, key=lambda x: int(x.split(".")[1]))
 DIRECTORIES_TO_TEST = ("scripts", "tests")
 EMPTY: list[str] = []
@@ -63,6 +63,8 @@ def run_mypy_as_subprocess(directory: str, platform: str, version: str) -> Retur
         "possibly-undefined",
         "--enable-error-code",
         "redundant-expr",
+        "--custom-typeshed-dir",
+        ".",
     ]
     if directory == "tests" and platform == "win32":
         command.extend(["--exclude", "tests/pytype_test.py"])


### PR DESCRIPTION
Another attempt at resolving the pytype CI errors in #10389. I've done a lot of testing via GitHub Actions on my fork, and I'm _pretty_ sure this gets the CI green on #10389. I don't know why these importlib APIs seem to be able to find the packages associated with `Flask-SQLAlchemy` when `importlib.metadata.packages_distributions()` doesn't seem able to, but that does seem to be the case.

Happily, these changes mean that our test suite can once again be run on Python 3.9, which is a nice-to-have.