### PR TITLE
Update `inspect` for Python3.12

### DIFF
--- a/stdlib/inspect.pyi
+++ b/stdlib/inspect.pyi
@@ -25,7 +25,7 @@ from types import (
     TracebackType,
     WrapperDescriptorType,
 )
-from typing import Any, ClassVar, NamedTuple, Protocol, TypeVar, overload, AsyncGenerator
+from typing import Any, AsyncGenerator, ClassVar, NamedTuple, Protocol, TypeVar, overload
 from typing_extensions import Literal, ParamSpec, Self, TypeAlias, TypeGuard
 
 if sys.version_info >= (3, 11):
@@ -376,12 +376,14 @@ class _ParameterKind(enum.IntEnum):
         def description(self) -> str: ...
 
 if sys.version_info >= (3, 12):
-    AGEN_CREATED: Literal['AGEN_CREATED']
-    AGEN_RUNNING: Literal['AGEN_RUNNING']
-    AGEN_SUSPENDED: Literal['AGEN_SUSPENDED']
-    AGEN_CLOSED: Literal['AGEN_CLOSED']
+    AGEN_CREATED: Literal["AGEN_CREATED"]
+    AGEN_RUNNING: Literal["AGEN_RUNNING"]
+    AGEN_SUSPENDED: Literal["AGEN_SUSPENDED"]
+    AGEN_CLOSED: Literal["AGEN_CLOSED"]
 
-    def getasyncgenstate(agen: AsyncGenerator[Any, Any]) -> Literal['AGEN_CREATED', 'AGEN_RUNNING', 'AGEN_SUSPENDED', 'AGEN_CLOSED']: ...
+    def getasyncgenstate(
+        agen: AsyncGenerator[Any, Any]
+    ) -> Literal["AGEN_CREATED", "AGEN_RUNNING", "AGEN_SUSPENDED", "AGEN_CLOSED"]: ...
     def getasyncgenlocals(agen: AsyncGeneratorType[Any, Any]) -> dict[str, Any]: ...
 
 class Parameter:

--- a/stdlib/inspect.pyi
+++ b/stdlib/inspect.pyi
@@ -137,6 +137,7 @@ if sys.version_info >= (3, 11):
             "AGEN_SUSPENDED",
             "getasyncgenlocals",
             "getasyncgenstate",
+            "BufferFlags",
         ]
 
 _P = ParamSpec("_P")

--- a/stdlib/inspect.pyi
+++ b/stdlib/inspect.pyi
@@ -25,7 +25,7 @@ from types import (
     TracebackType,
     WrapperDescriptorType,
 )
-from typing import Any, ClassVar, NamedTuple, Protocol, TypeVar, overload
+from typing import Any, ClassVar, NamedTuple, Protocol, TypeVar, overload, AsyncGenerator
 from typing_extensions import Literal, ParamSpec, Self, TypeAlias, TypeGuard
 
 if sys.version_info >= (3, 11):
@@ -128,8 +128,20 @@ if sys.version_info >= (3, 11):
         "walktree",
     ]
 
+    if sys.version_info >= (3, 12):
+        __all__ += [
+            "markcoroutinefunction",
+            "AGEN_CLOSED",
+            "AGEN_CREATED",
+            "AGEN_RUNNING",
+            "AGEN_SUSPENDED",
+            "getasyncgenlocals",
+            "getasyncgenstate",
+        ]
+
 _P = ParamSpec("_P")
 _T = TypeVar("_T")
+_F = TypeVar("_F", bound=Callable[..., Any])
 _T_cont = TypeVar("_T_cont", contravariant=True)
 _V_cont = TypeVar("_V_cont", contravariant=True)
 
@@ -183,6 +195,9 @@ def ismodule(object: object) -> TypeGuard[ModuleType]: ...
 def isclass(object: object) -> TypeGuard[type[Any]]: ...
 def ismethod(object: object) -> TypeGuard[MethodType]: ...
 def isfunction(object: object) -> TypeGuard[FunctionType]: ...
+
+if sys.version_info >= (3, 12):
+    def markcoroutinefunction(func: _F) -> _F: ...
 
 if sys.version_info >= (3, 8):
     @overload
@@ -359,6 +374,15 @@ class _ParameterKind(enum.IntEnum):
     if sys.version_info >= (3, 8):
         @property
         def description(self) -> str: ...
+
+if sys.version_info >= (3, 12):
+    AGEN_CREATED: Literal['AGEN_CREATED']
+    AGEN_RUNNING: Literal['AGEN_RUNNING']
+    AGEN_SUSPENDED: Literal['AGEN_SUSPENDED']
+    AGEN_CLOSED: Literal['AGEN_CLOSED']
+
+    def getasyncgenstate(agen: AsyncGenerator[Any, Any]) -> Literal['AGEN_CREATED', 'AGEN_RUNNING', 'AGEN_SUSPENDED', 'AGEN_CLOSED']: ...
+    def getasyncgenlocals(agen: AsyncGeneratorType[Any, Any]) -> dict[str, Any]: ...
 
 class Parameter:
     def __init__(self, name: str, kind: _ParameterKind, *, default: Any = ..., annotation: Any = ...) -> None: ...

--- a/stdlib/inspect.pyi
+++ b/stdlib/inspect.pyi
@@ -25,7 +25,7 @@ from types import (
     TracebackType,
     WrapperDescriptorType,
 )
-from typing import Any, AsyncGenerator, ClassVar, NamedTuple, Protocol, TypeVar, overload
+from typing import Any, ClassVar, NamedTuple, Protocol, TypeVar, overload
 from typing_extensions import Literal, ParamSpec, Self, TypeAlias, TypeGuard
 
 if sys.version_info >= (3, 11):

--- a/tests/stubtest_allowlists/py312.txt
+++ b/tests/stubtest_allowlists/py312.txt
@@ -53,14 +53,6 @@ importlib.resources.files
 importlib.util.module_for_loader
 importlib.util.set_loader
 importlib.util.set_package
-inspect.AGEN_CLOSED
-inspect.AGEN_CREATED
-inspect.AGEN_RUNNING
-inspect.AGEN_SUSPENDED
-inspect.__all__
-inspect.getasyncgenlocals
-inspect.getasyncgenstate
-inspect.markcoroutinefunction
 logging.Logger.getChildren
 logging.__all__
 logging.getHandlerByName


### PR DESCRIPTION
Source: https://github.com/python/cpython/blob/3.12/Lib/inspect.py