### PR TITLE
Add missing `TCP_CONNECTION_INFO` to `socket` module

### DIFF
--- a/stdlib/socket.pyi
+++ b/stdlib/socket.pyi
@@ -468,6 +468,8 @@ if sys.version_info >= (3, 12):
             ETHERTYPE_IPV6 as ETHERTYPE_IPV6,
             ETHERTYPE_VLAN as ETHERTYPE_VLAN,
         )
+if sys.version_info >= (3, 11) and sys.platform == "darwin":
+    from _socket import TCP_CONNECTION_INFO as TCP_CONNECTION_INFO
 
 # Re-exported from errno
 EBADF: int

--- a/tests/stubtest_allowlists/darwin-py311.txt
+++ b/tests/stubtest_allowlists/darwin-py311.txt
@@ -1,9 +1,6 @@
 _?curses.color_pair
 xxlimited.Xxo.x_exports
 
-# Exists at runtime, missing from stub
-socket.TCP_CONNECTION_INFO
-
 (dbm.gnu)?
 (locale.bind_textdomain_codeset)?
 (locale.bindtextdomain)?

--- a/tests/stubtest_allowlists/darwin-py312.txt
+++ b/tests/stubtest_allowlists/darwin-py312.txt
@@ -13,7 +13,6 @@ posix.PRIO_DARWIN_BG
 posix.PRIO_DARWIN_NONUI
 posix.PRIO_DARWIN_PROCESS
 posix.PRIO_DARWIN_THREAD
-socket.TCP_CONNECTION_INFO
 syslog.LOG_MASK
 syslog.LOG_UPTO
 syslog.setlogmask


### PR DESCRIPTION
```
Python 3.11.3 (main, Jun 21 2023, 16:11:30) [Clang 14.0.3 (clang-1403.0.22.14.1)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import socket
>>> socket.TCP_CONNECTION_INFO
262
```