### PR TITLE
Pillow: Add `tuple[int, int]` to `_Color` TypeAlias

### DIFF
--- a/stubs/Pillow/PIL/Image.pyi
+++ b/stubs/Pillow/PIL/Image.pyi
@@ -29,7 +29,7 @@ _ConversionMatrix: TypeAlias = (
 # `str` values are only accepted if mode="RGB" for an `Image` object
 # `float` values are only accepted for certain modes such as "F"
 # See https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.new
-_Color: TypeAlias = int | tuple[int] | tuple[int, int, int] | tuple[int, int, int, int] | str | float | tuple[float]
+_Color: TypeAlias = int | tuple[int] | tuple[int, int] | tuple[int, int, int] | tuple[int, int, int, int] | str | float | tuple[float]
 
 class _Writeable(SupportsWrite[bytes], Protocol):
     def seek(self, __offset: int) -> Any: ...


### PR DESCRIPTION
The `color` value can be a `tuple[int, int]` as seen in the test case [1] from the Pillow project.

For example when using the `LA` mode in a call to `PIL.Image.new()`:
  PIL.Image.new("LA", size=(200, 200), color=(0xFF, 0))

`color` can be a `tuple[int, int]`

[1] https://github.com/python-pillow/Pillow/blob/3ee925915085ee0f7ad72fbede5d9a9e6ea902a7/Tests/test_image_access.py#L376