### PR TITLE
Silence subclassing `Any` error for `_NotImplementedType`

### DIFF
--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -1221,7 +1221,7 @@ class property:
     def __delete__(self, __instance: Any) -> None: ...
 
 @final
-class _NotImplementedType(Any):
+class _NotImplementedType(Any):  # type: ignore[misc]
     # A little weird, but typing the __call__ as NotImplemented makes the error message
     # for NotImplemented() much better
     __call__: NotImplemented  # type: ignore[valid-type]  # pyright: ignore[reportGeneralTypeIssues]


### PR DESCRIPTION
I somehow managed to encounter this issue bubbling up when using `mypy --strict` which enables `--disallow-subclassing-any`.

Am using the `pytest-mypy-plugins` package to test a new stubs-only package I'm writing, so I don't expect that this usually occurs in normal usage of `mypy` on the command line - at least it's been this way a long time and I've never seen it 🤔 

Example output:

```
.../tests/typecheck/test_all_imports.yml:3:
E   pytest_mypy_plugins.utils.TypecheckAssertionError: Output is not expected:
E   Actual:
E     .../lib/python3.11/site-packages/mypy/typeshed/stdlib/builtins.pyi:1114: error: Class cannot subclass "Any" (has type "Any")  [misc] (diff)
E   Expected:
E     (empty)
```

I've been working around this with the following:

```ini
[mypy]
strict = true
...

[mypy-builtins]
disallow_subclassing_any = false
```