### PR TITLE
Mark `types-typed-ast` as no longer updated

### DIFF
--- a/stubs/typed-ast/METADATA.toml
+++ b/stubs/typed-ast/METADATA.toml
@@ -1,1 +1,2 @@
 version = "1.5.*"
+no_longer_updated = true


### PR DESCRIPTION
The [`typed-ast` repo](https://github.com/python/typed_ast) has been archived, and has a notice on its README saying that it is no longer maintained. Mypy no longer depends on typed-ast, and black is about to drop its dependency (https://github.com/psf/black/pull/3765).