### PR TITLE
Stripe: add shipping_rate to `__init__.py`

### DIFF
--- a/stubs/stripe/stripe/api_resources/__init__.pyi
+++ b/stubs/stripe/stripe/api_resources/__init__.pyi
@@ -62,6 +62,7 @@ from stripe.api_resources.review import Review as Review
 from stripe.api_resources.search_result_object import SearchResultObject as SearchResultObject
 from stripe.api_resources.setup_attempt import SetupAttempt as SetupAttempt
 from stripe.api_resources.setup_intent import SetupIntent as SetupIntent
+from stripe.api_resources.shipping_rate import ShippingRate as ShippingRate
 from stripe.api_resources.sku import SKU as SKU
 from stripe.api_resources.source import Source as Source
 from stripe.api_resources.source_transaction import SourceTransaction as SourceTransaction


### PR DESCRIPTION
This is a quick follow up to #10323. I failed to add the new type to `__init__.py` preventing the new type to be exposed for type checking.