### PR TITLE
Pillow: mark MAX_IMAGE_PIXELS as non-final

### DIFF
--- a/stubs/Pillow/PIL/Image.pyi
+++ b/stubs/Pillow/PIL/Image.pyi
@@ -3,7 +3,7 @@ from collections.abc import Callable, Iterable, Iterator, MutableMapping, Sequen
 from enum import IntEnum
 from pathlib import Path
 from typing import Any, ClassVar, Protocol, SupportsBytes
-from typing_extensions import Final, Literal, Self, TypeAlias, TypeGuard
+from typing_extensions import Literal, Self, TypeAlias, TypeGuard
 
 from PIL.PyAccess import PyAccess
 
@@ -43,7 +43,7 @@ class DecompressionBombError(Exception): ...
 # be altered at runtime. See
 #     https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.open
 # or the permalink
-#     https://github.com/python-pillow/Pillow/blob/10.0.0/docs/reference/Image.rst?plain=1#L54-L55 
+#     https://github.com/python-pillow/Pillow/blob/10.0.0/docs/reference/Image.rst?plain=1#L54-L55
 MAX_IMAGE_PIXELS: int | None
 
 USE_CFFI_ACCESS: bool

--- a/stubs/Pillow/PIL/Image.pyi
+++ b/stubs/Pillow/PIL/Image.pyi
@@ -39,7 +39,12 @@ class _Writeable(SupportsWrite[bytes], Protocol):
 class DecompressionBombWarning(RuntimeWarning): ...
 class DecompressionBombError(Exception): ...
 
-MAX_IMAGE_PIXELS: Final[int]
+# Despite the ALL_CAPS spelling, Pillow's docs mention that this threshold can
+# be altered at runtime. See
+#     https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.open
+# or the permalink
+#     https://github.com/python-pillow/Pillow/blob/10.0.0/docs/reference/Image.rst?plain=1#L54-L55 
+MAX_IMAGE_PIXELS: int | None
 
 USE_CFFI_ACCESS: bool
 


### PR DESCRIPTION
I don't think it was correct for #10411 to mark MAX_IMAGE_PIXELS as final. Quoting my reasoning from https://github.com/python/typeshed/pull/10411#discussion_r1261206232:

> According to [pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.open](https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.open):
>
>>    This threshold can be changed by setting [MAX_IMAGE_PIXELS](https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.MAX_IMAGE_PIXELS). It can be disabled by setting Image.MAX_IMAGE_PIXELS = None.
>
> I can't see any mention of this [MAX_IMAGE_PIXELS] in [pillow.readthedocs.io/en/stable/releasenotes/10.0.0.html](https://pillow.readthedocs.io/en/stable/releasenotes/10.0.0.html) either.