### PR TITLE
Add some ruff autofixes to CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,11 @@ repos:
     hooks:
       - id: black
         language_version: python3.10
+  - repo: https://github.com/pycqa/isort
+    rev: 5.12.0 # must match requirements-tests.txt
+    hooks:
+      - id: isort
+        name: isort (python)
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.0.278  # must match requirements-tests.txt
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,11 +21,11 @@ repos:
     hooks:
       - id: black
         language_version: python3.10
-  - repo: https://github.com/pycqa/isort
-    rev: 5.12.0 # must match requirements-tests.txt
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.0.278  # must match requirements-tests.txt
     hooks:
-      - id: isort
-        name: isort (python)
+      - id: ruff
+        args: [--exit-non-zero-on-fix]
   - repo: https://github.com/pycqa/flake8
     rev: 6.0.0 # must match requirements-tests.txt
     hooks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ it takes a bit longer. For more details, read below.
 Typeshed runs continuous integration (CI) on all pull requests. This means that
 if you file a pull request (PR), our full test suite -- including our linter,
 `flake8` -- is run on your PR. It also means that bots will automatically apply
-changes to your PR (using `pycln`, `black` and `isort`) to fix any formatting issues.
+changes to your PR (using `pycln`, `black` and `ruff`) to fix any formatting issues.
 This frees you up to ignore all local setup on your side, focus on the
 code and rely on the CI to fix everything, or point you to the places that
 need fixing.
@@ -84,7 +84,7 @@ terminal to install all non-pytype requirements:
 
 ## Code formatting
 
-The code is formatted using `black` and `isort`. Unused imports are also
+The code is formatted using `black` and `ruff`. Unused imports are also
 auto-removed using `pycln`.
 
 The repository is equipped with a [`pre-commit.ci`](https://pre-commit.ci/)
@@ -93,11 +93,11 @@ run the code formatters. When you push a commit, a bot will run those for you
 right away and add a commit to your PR.
 
 That being said, if you *want* to run the checks locally when you commit,
-you're free to do so. Either run `pycln`, `black` and `isort` manually...
+you're free to do so. Either run `pycln`, `black` and `ruff` manually...
 
 ```bash
 $ pycln --config=pyproject.toml .
-$ isort .
+$ ruff .
 $ black .
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ it takes a bit longer. For more details, read below.
 Typeshed runs continuous integration (CI) on all pull requests. This means that
 if you file a pull request (PR), our full test suite -- including our linter,
 `flake8` -- is run on your PR. It also means that bots will automatically apply
-changes to your PR (using `pycln`, `black` and `ruff`) to fix any formatting issues.
+changes to your PR (using `pycln`, `black`, `isort` and `ruff`) to fix any formatting issues.
 This frees you up to ignore all local setup on your side, focus on the
 code and rely on the CI to fix everything, or point you to the places that
 need fixing.
@@ -84,8 +84,8 @@ terminal to install all non-pytype requirements:
 
 ## Code formatting
 
-The code is formatted using `black` and `ruff`. Unused imports are also
-auto-removed using `pycln`.
+The code is formatted using `black` and `isort`. Unused imports are also
+auto-removed using `pycln`, and various other autofixes are performed by `ruff`.
 
 The repository is equipped with a [`pre-commit.ci`](https://pre-commit.ci/)
 configuration file. This means that you don't *need* to do anything yourself to
@@ -93,10 +93,11 @@ run the code formatters. When you push a commit, a bot will run those for you
 right away and add a commit to your PR.
 
 That being said, if you *want* to run the checks locally when you commit,
-you're free to do so. Either run `pycln`, `black` and `ruff` manually...
+you're free to do so. Either run `pycln`, `isort`, `black` and `ruff` manually...
 
 ```bash
 $ pycln --config=pyproject.toml .
+$ isort .
 $ ruff .
 $ black .
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,12 +7,48 @@ skip_magic_trailing_comma = true
 # for just these files, but doesn't seem possible yet.
 force-exclude = ".*_pb2.pyi"
 
-[tool.isort]
-profile = "black"
-combine_as_imports = true
-line_length = 130
-skip = [".git", ".github", ".venv"]
-extra_standard_library = [
+[tool.ruff]
+line-length = 130
+target-version = "py37"
+fix = true
+exclude = [
+    # We're only interested in autofixes for our stubs
+    "*.py",
+    # Ignore generated protobuf stubs
+    "*_pb2.pyi",
+    # virtual environment, cache directories, etc.:
+    "env",
+    ".env",
+    ".venv",
+    ".git",
+    ".mypy_cache",
+    ".pytype",
+]
+
+# Only enable rules that have safe autofixes;
+# only enable rules that are relevant to stubs
+select = [
+    "I001",  # isort
+    "UP004",  # Remove explicit `object` inheritance
+    "UP006",  # PEP-585 autofixes
+    "UP007",  # PEP-604 autofixes
+    "UP013",  # Class-based syntax for TypedDicts
+    "UP014",  # Class-based syntax for NamedTuples
+    "UP019",  # Use str over typing.Text
+    "UP035",  # import from typing, not typing_extensions, wherever possible
+    "UP039",  # don't use parens after a class definition with no bases
+    "PYI009",  # use `...`, not `pass`, in empty class bodies
+    "PYI010",  # function bodies must be empty
+    "PYI012",  # class bodies must not contain `pass`
+    "PYI013",  # non-empty class bodies must not contain `...`
+    "PYI020",  # quoted annotations are always unnecessary in stubs
+    "PYI025",  # always alias `collections.abc.Set` as `AbstractSet` when importing it
+    "PYI032",  # use `object`, not `Any`, as the second parameter to `__eq__`
+]
+
+[tool.ruff.isort]
+combine-as-imports = true
+extra-standard-library = [
     "typing_extensions",
     "_typeshed",
     # Extra modules not recognized by isort
@@ -55,7 +91,7 @@ extra_standard_library = [
     "opcode",
     "pyexpat",
 ]
-known_first_party = ["utils", "parse_metadata"]
+known-first-party = ["utils", "parse_metadata"]
 
 [tool.pycln]
 all = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,48 +7,12 @@ skip_magic_trailing_comma = true
 # for just these files, but doesn't seem possible yet.
 force-exclude = ".*_pb2.pyi"
 
-[tool.ruff]
-line-length = 130
-target-version = "py37"
-fix = true
-exclude = [
-    # We're only interested in autofixes for our stubs
-    "*.py",
-    # Ignore generated protobuf stubs
-    "*_pb2.pyi",
-    # virtual environment, cache directories, etc.:
-    "env",
-    ".env",
-    ".venv",
-    ".git",
-    ".mypy_cache",
-    ".pytype",
-]
-
-# Only enable rules that have safe autofixes;
-# only enable rules that are relevant to stubs
-select = [
-    "I001",  # isort
-    "UP004",  # Remove explicit `object` inheritance
-    "UP006",  # PEP-585 autofixes
-    "UP007",  # PEP-604 autofixes
-    "UP013",  # Class-based syntax for TypedDicts
-    "UP014",  # Class-based syntax for NamedTuples
-    "UP019",  # Use str over typing.Text
-    "UP035",  # import from typing, not typing_extensions, wherever possible
-    "UP039",  # don't use parens after a class definition with no bases
-    "PYI009",  # use `...`, not `pass`, in empty class bodies
-    "PYI010",  # function bodies must be empty
-    "PYI012",  # class bodies must not contain `pass`
-    "PYI013",  # non-empty class bodies must not contain `...`
-    "PYI020",  # quoted annotations are always unnecessary in stubs
-    "PYI025",  # always alias `collections.abc.Set` as `AbstractSet` when importing it
-    "PYI032",  # use `object`, not `Any`, as the second parameter to `__eq__`
-]
-
-[tool.ruff.isort]
-combine-as-imports = true
-extra-standard-library = [
+[tool.isort]
+profile = "black"
+combine_as_imports = true
+line_length = 130
+skip = [".git", ".github", ".venv"]
+extra_standard_library = [
     "typing_extensions",
     "_typeshed",
     # Extra modules not recognized by isort
@@ -91,7 +55,45 @@ extra-standard-library = [
     "opcode",
     "pyexpat",
 ]
-known-first-party = ["utils", "parse_metadata"]
+known_first_party = ["utils", "parse_metadata"]
+
+[tool.ruff]
+line-length = 130
+target-version = "py37"
+fix = true
+exclude = [
+    # We're only interested in autofixes for our stubs
+    "*.py",
+    # Ignore generated protobuf stubs
+    "*_pb2.pyi",
+    # virtual environment, cache directories, etc.:
+    "env",
+    ".env",
+    ".venv",
+    ".git",
+    ".mypy_cache",
+    ".pytype",
+]
+
+# Only enable rules that have safe autofixes;
+# only enable rules that are relevant to stubs
+select = [
+    "UP004",  # Remove explicit `object` inheritance
+    "UP006",  # PEP-585 autofixes
+    "UP007",  # PEP-604 autofixes
+    "UP013",  # Class-based syntax for TypedDicts
+    "UP014",  # Class-based syntax for NamedTuples
+    "UP019",  # Use str over typing.Text
+    "UP035",  # import from typing, not typing_extensions, wherever possible
+    "UP039",  # don't use parens after a class definition with no bases
+    "PYI009",  # use `...`, not `pass`, in empty class bodies
+    "PYI010",  # function bodies must be empty
+    "PYI012",  # class bodies must not contain `pass`
+    "PYI013",  # non-empty class bodies must not contain `...`
+    "PYI020",  # quoted annotations are always unnecessary in stubs
+    "PYI025",  # always alias `collections.abc.Set` as `AbstractSet` when importing it
+    "PYI032",  # use `object`, not `Any`, as the second parameter to `__eq__`
+]
 
 [tool.pycln]
 all = true

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -6,6 +6,7 @@ flake8==6.0.0; python_version >= "3.8"            # must match .pre-commit-confi
 flake8-bugbear==23.6.5; python_version >= "3.8"   # must match .pre-commit-config.yaml
 flake8-noqa==1.3.2; python_version >= "3.8"       # must match .pre-commit-config.yaml
 flake8-pyi==23.6.0; python_version >= "3.8"       # must match .pre-commit-config.yaml
+isort==5.12.0; python_version >= "3.8"            # must match .pre-commit-config.yaml
 mypy==1.4.1
 pre-commit-hooks==4.4.0                           # must match .pre-commit-config.yaml
 pycln==2.1.5                                      # must match .pre-commit-config.yaml

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -6,11 +6,11 @@ flake8==6.0.0; python_version >= "3.8"            # must match .pre-commit-confi
 flake8-bugbear==23.6.5; python_version >= "3.8"   # must match .pre-commit-config.yaml
 flake8-noqa==1.3.2; python_version >= "3.8"       # must match .pre-commit-config.yaml
 flake8-pyi==23.6.0; python_version >= "3.8"       # must match .pre-commit-config.yaml
-isort==5.12.0; python_version >= "3.8"            # must match .pre-commit-config.yaml
 mypy==1.4.1
 pre-commit-hooks==4.4.0                           # must match .pre-commit-config.yaml
 pycln==2.1.5                                      # must match .pre-commit-config.yaml
 pytype==2023.6.16; platform_system != "Windows" and python_version < "3.11"
+ruff==0.0.278                                     # must match .pre-commit-config.yaml
 
 # Libraries used by our various scripts.
 aiohttp==3.8.4; python_version < "3.12"           # aiohttp can't be installed on 3.12 yet

--- a/scripts/create_baseline_stubs.py
+++ b/scripts/create_baseline_stubs.py
@@ -60,9 +60,9 @@ def run_black(stub_dir: str) -> None:
     subprocess.run(["black", stub_dir])
 
 
-def run_isort(stub_dir: str) -> None:
-    print(f"Running isort: isort {stub_dir}")
-    subprocess.run([sys.executable, "-m", "isort", stub_dir])
+def run_ruff(stub_dir: str) -> None:
+    print(f"Running ruff: ruff {stub_dir}")
+    subprocess.run([sys.executable, "-m", "ruff", stub_dir])
 
 
 def create_metadata(stub_dir: str, version: str) -> None:
@@ -110,7 +110,7 @@ def add_pyright_exclusion(stub_dir: str) -> None:
 def main() -> None:
     parser = argparse.ArgumentParser(
         description="""Generate baseline stubs automatically for an installed pip package
-                       using stubgen. Also run black and isort. If the name of
+                       using stubgen. Also run black and ruff. If the name of
                        the project is different from the runtime Python package name, you may
                        need to use --package (example: --package yaml PyYAML)."""
     )
@@ -159,7 +159,7 @@ def main() -> None:
     run_stubgen(package, stub_dir)
     run_stubdefaulter(stub_dir)
 
-    run_isort(stub_dir)
+    run_ruff(stub_dir)
     run_black(stub_dir)
 
     create_metadata(stub_dir, version)

--- a/scripts/create_baseline_stubs.py
+++ b/scripts/create_baseline_stubs.py
@@ -164,8 +164,8 @@ def main() -> None:
     run_stubgen(package, stub_dir)
     run_stubdefaulter(stub_dir)
 
-    run_isort(stub_dir)
     run_ruff(stub_dir)
+    run_isort(stub_dir)
     run_black(stub_dir)
 
     create_metadata(stub_dir, version)

--- a/scripts/create_baseline_stubs.py
+++ b/scripts/create_baseline_stubs.py
@@ -60,6 +60,11 @@ def run_black(stub_dir: str) -> None:
     subprocess.run(["black", stub_dir])
 
 
+def run_isort(stub_dir: str) -> None:
+    print(f"Running isort: isort {stub_dir}")
+    subprocess.run([sys.executable, "-m", "isort", stub_dir])
+
+
 def run_ruff(stub_dir: str) -> None:
     print(f"Running ruff: ruff {stub_dir}")
     subprocess.run([sys.executable, "-m", "ruff", stub_dir])
@@ -110,7 +115,7 @@ def add_pyright_exclusion(stub_dir: str) -> None:
 def main() -> None:
     parser = argparse.ArgumentParser(
         description="""Generate baseline stubs automatically for an installed pip package
-                       using stubgen. Also run black and ruff. If the name of
+                       using stubgen. Also run black, isort and ruff. If the name of
                        the project is different from the runtime Python package name, you may
                        need to use --package (example: --package yaml PyYAML)."""
     )
@@ -159,6 +164,7 @@ def main() -> None:
     run_stubgen(package, stub_dir)
     run_stubdefaulter(stub_dir)
 
+    run_isort(stub_dir)
     run_ruff(stub_dir)
     run_black(stub_dir)
 

--- a/scripts/generate_proto_stubs.sh
+++ b/scripts/generate_proto_stubs.sh
@@ -45,7 +45,7 @@ PYTHON_PROTOBUF_DIR="protobuf-$PYTHON_PROTOBUF_VERSION"
 VENV=venv
 python3 -m venv "$VENV"
 source "$VENV/bin/activate"
-pip install -r "$REPO_ROOT/requirements-tests.txt"  # for black and ruff
+pip install -r "$REPO_ROOT/requirements-tests.txt"  # for black and isort
 
 # Install mypy-protobuf
 pip install "git+https://github.com/dropbox/mypy-protobuf@$MYPY_PROTOBUF_VERSION"
@@ -73,7 +73,7 @@ PROTO_FILES=$(grep "GenProto.*google" $PYTHON_PROTOBUF_DIR/python/setup.py | \
 # shellcheck disable=SC2086
 protoc_install/bin/protoc --proto_path="$PYTHON_PROTOBUF_DIR/src" --mypy_out="relax_strict_optional_primitives:$REPO_ROOT/stubs/protobuf" $PROTO_FILES
 
-ruff "$REPO_ROOT/stubs/protobuf"
+isort "$REPO_ROOT/stubs/protobuf"
 black "$REPO_ROOT/stubs/protobuf"
 
 sed -i "" "s/mypy-protobuf [^\"]*/mypy-protobuf ${MYPY_PROTOBUF_VERSION}/" "$REPO_ROOT/stubs/protobuf/METADATA.toml"

--- a/scripts/generate_proto_stubs.sh
+++ b/scripts/generate_proto_stubs.sh
@@ -45,7 +45,7 @@ PYTHON_PROTOBUF_DIR="protobuf-$PYTHON_PROTOBUF_VERSION"
 VENV=venv
 python3 -m venv "$VENV"
 source "$VENV/bin/activate"
-pip install -r "$REPO_ROOT/requirements-tests.txt"  # for black and isort
+pip install -r "$REPO_ROOT/requirements-tests.txt"  # for black and ruff
 
 # Install mypy-protobuf
 pip install "git+https://github.com/dropbox/mypy-protobuf@$MYPY_PROTOBUF_VERSION"
@@ -73,7 +73,7 @@ PROTO_FILES=$(grep "GenProto.*google" $PYTHON_PROTOBUF_DIR/python/setup.py | \
 # shellcheck disable=SC2086
 protoc_install/bin/protoc --proto_path="$PYTHON_PROTOBUF_DIR/src" --mypy_out="relax_strict_optional_primitives:$REPO_ROOT/stubs/protobuf" $PROTO_FILES
 
-isort "$REPO_ROOT/stubs/protobuf"
+ruff "$REPO_ROOT/stubs/protobuf"
 black "$REPO_ROOT/stubs/protobuf"
 
 sed -i "" "s/mypy-protobuf [^\"]*/mypy-protobuf ${MYPY_PROTOBUF_VERSION}/" "$REPO_ROOT/stubs/protobuf/METADATA.toml"

--- a/scripts/runtests.py
+++ b/scripts/runtests.py
@@ -79,6 +79,8 @@ def main() -> None:
     subprocess.run([sys.executable, "-m", "pycln", path, "--config=pyproject.toml"])
     print("\nRunning ruff...")
     subprocess.run([sys.executable, "-m", "ruff", path])
+    print("\nRunning isort...")
+    subprocess.run([sys.executable, "-m", "isort", path])
     print("\nRunning Black...")
     black_result = subprocess.run([sys.executable, "-m", "black", path])
     if black_result.returncode == 123:

--- a/scripts/runtests.py
+++ b/scripts/runtests.py
@@ -77,8 +77,8 @@ def main() -> None:
     # Run formatters first. Order matters.
     print("\nRunning pycln...")
     subprocess.run([sys.executable, "-m", "pycln", path, "--config=pyproject.toml"])
-    print("\nRunning isort...")
-    subprocess.run([sys.executable, "-m", "isort", path])
+    print("\nRunning ruff...")
+    subprocess.run([sys.executable, "-m", "ruff", path])
     print("\nRunning Black...")
     black_result = subprocess.run([sys.executable, "-m", "black", path])
     if black_result.returncode == 123:

--- a/stdlib/typing_extensions.pyi
+++ b/stdlib/typing_extensions.pyi
@@ -113,7 +113,7 @@ __all__ = [
 
 _T = typing.TypeVar("_T")
 _F = typing.TypeVar("_F", bound=Callable[..., Any])
-_TC = typing.TypeVar("_TC", bound=Type[object])
+_TC = typing.TypeVar("_TC", bound=type[object])
 
 # unfortunately we have to duplicate this class definition from typing.pyi or we break pytype
 class _SpecialForm:

--- a/tests/check_consistent.py
+++ b/tests/check_consistent.py
@@ -23,7 +23,7 @@ extension_descriptions = {".pyi": "stub", ".py": ".py"}
 
 # These type checkers and linters must have exact versions in the requirements file to ensure
 # consistent CI runs.
-linters = {"black", "flake8", "flake8-bugbear", "flake8-noqa", "flake8-pyi", "ruff", "mypy", "pycln", "pytype"}
+linters = {"black", "flake8", "flake8-bugbear", "flake8-noqa", "flake8-pyi", "isort", "ruff", "mypy", "pycln", "pytype"}
 
 
 def assert_consistent_filetypes(

--- a/tests/check_consistent.py
+++ b/tests/check_consistent.py
@@ -23,7 +23,7 @@ extension_descriptions = {".pyi": "stub", ".py": ".py"}
 
 # These type checkers and linters must have exact versions in the requirements file to ensure
 # consistent CI runs.
-linters = {"black", "flake8", "flake8-bugbear", "flake8-noqa", "flake8-pyi", "isort", "mypy", "pycln", "pytype"}
+linters = {"black", "flake8", "flake8-bugbear", "flake8-noqa", "flake8-pyi", "ruff", "mypy", "pycln", "pytype"}
 
 
 def assert_consistent_filetypes(
@@ -191,6 +191,9 @@ def check_precommit_requirements() -> None:
     precommit_requirements = get_precommit_requirements()
     no_txt_entry_msg = "All pre-commit requirements must also be listed in `requirements-tests.txt` (missing {requirement!r})"
     for requirement, specifier in precommit_requirements.items():
+        # annoying: the ruff repo for pre-commit is different to the name in requirements-tests.txt
+        if requirement == "ruff-pre-commit":
+            requirement = "ruff"
         assert requirement in requirements_txt_requirements, no_txt_entry_msg.format(requirement=requirement)
         specifier_mismatch = (
             f'Specifier "{specifier}" for {requirement!r} in `.pre-commit-config.yaml` '


### PR DESCRIPTION
The aim of this PR is to make it easier for new contributors to typeshed to comply with our -- at times fairly stringent! -- style guide. For large PRs (e.g. #10446, or #10355), this can be quite difficult. Ruff has a number of autofixes that we can use to help out with this task, and it's extremely fast.

Unlike most projects, we're not likely to ever _switch_ from flake8 to ruff -- even if ruff implemented the full set of flake8-pyi rules and had exactly the same behaviour as flake8-pyi for all of them, it's useful for us to be able to add new rules to our own linter whenver we want to. However, there's nothing stopping us from having ruff as part of our CI _as well as_ flake8.

Since (in my opinion) we're _only_ interested in the autofixes here, I've only enabled a few rules that have relatively safe autofixes relevant to stub files.

Since ruff includes isort as one of its autofixes, having isort as a test dependency is now redundant, so I've removed it in favour of ruff's I001 rule.