### PR TITLE
[stripe] Add type for PaymentLink

### DIFF
--- a/stubs/stripe/@tests/stubtest_allowlist.txt
+++ b/stubs/stripe/@tests/stubtest_allowlist.txt
@@ -6,4 +6,4 @@ stripe\.api_resources\.test_helpers\.TestClock\.advance
 stripe\.api_resources\..*\.SearchableAPIResource\.search  # Not defined on the actual class in v3, but expected to exist.
 stripe\.api_resources\..*\.SearchableAPIResource\.search_auto_paging_iter  # Not defined on the actual class in v3, but expected to exist.
 stripe\.api_resources\..*\.Session.expire
-stripe\.api_resources\..*\.PaymentLink.list_line_items
+stripe\.api_resources\.PaymentLink.list_line_items

--- a/stubs/stripe/@tests/stubtest_allowlist.txt
+++ b/stubs/stripe/@tests/stubtest_allowlist.txt
@@ -1,9 +1,9 @@
 # The following methods have custom classmethod decorators
 stripe\..*\.delete
 stripe\..*PaymentIntent\.confirm
+stripe\..*PaymentLink\.list_line_items
 stripe\.api_resources\.test_helpers\.test_clock\.TestClock\.advance
 stripe\.api_resources\.test_helpers\.TestClock\.advance
 stripe\.api_resources\..*\.SearchableAPIResource\.search  # Not defined on the actual class in v3, but expected to exist.
 stripe\.api_resources\..*\.SearchableAPIResource\.search_auto_paging_iter  # Not defined on the actual class in v3, but expected to exist.
 stripe\.api_resources\..*\.Session.expire
-stripe\.api_resources\.PaymentLink.list_line_items

--- a/stubs/stripe/@tests/stubtest_allowlist.txt
+++ b/stubs/stripe/@tests/stubtest_allowlist.txt
@@ -6,3 +6,4 @@ stripe\.api_resources\.test_helpers\.TestClock\.advance
 stripe\.api_resources\..*\.SearchableAPIResource\.search  # Not defined on the actual class in v3, but expected to exist.
 stripe\.api_resources\..*\.SearchableAPIResource\.search_auto_paging_iter  # Not defined on the actual class in v3, but expected to exist.
 stripe\.api_resources\..*\.Session.expire
+stripe\.api_resources\..*\.PaymentLink.list_line_items

--- a/stubs/stripe/stripe/api_resources/__init__.pyi
+++ b/stubs/stripe/stripe/api_resources/__init__.pyi
@@ -46,6 +46,7 @@ from stripe.api_resources.login_link import LoginLink as LoginLink
 from stripe.api_resources.mandate import Mandate as Mandate
 from stripe.api_resources.order import Order as Order
 from stripe.api_resources.payment_intent import PaymentIntent as PaymentIntent
+from stripe.api_resources.payment_link import PaymentLink as PaymentLink
 from stripe.api_resources.payment_method import PaymentMethod as PaymentMethod
 from stripe.api_resources.payout import Payout as Payout
 from stripe.api_resources.person import Person as Person

--- a/stubs/stripe/stripe/api_resources/payment_link.pyi
+++ b/stubs/stripe/stripe/api_resources/payment_link.pyi
@@ -11,7 +11,14 @@ class PaymentLink(CreateableAPIResource, ListableAPIResource, UpdateableAPIResou
 
     @overload
     @classmethod
-    def list_line_items(cls, payment_link, api_key=None, stripe_version=None, stripe_account=None, **params): ...
+    def list_line_items(
+        cls,
+        payment_link: str,
+        api_key: str | None = None,
+        stripe_version: str | None = None,
+        stripe_account: str | None = None,
+        **params,
+    ): ...
     @overload
     @classmethod
-    def list_line_items(cls, idempotency_key=None, **params): ...
+    def list_line_items(cls, idempotency_key: str | None = None, **params): ...

--- a/stubs/stripe/stripe/api_resources/payment_link.pyi
+++ b/stubs/stripe/stripe/api_resources/payment_link.pyi
@@ -1,3 +1,5 @@
+from typing import overload
+
 from stripe.api_resources.abstract import (
     CreateableAPIResource as CreateableAPIResource,
     ListableAPIResource as ListableAPIResource,
@@ -7,4 +9,9 @@ from stripe.api_resources.abstract import (
 class PaymentLink(CreateableAPIResource, ListableAPIResource, UpdateableAPIResource):
     OBJECT_NAME: str
 
-    def list_line_items(self, idempotency_key=None, **params): ...
+    @overload
+    @classmethod
+    def list_line_items(cls, payment_link, api_key=None, stripe_version=None, stripe_account=None, **params): ...
+    @overload
+    @classmethod
+    def list_line_items(cls, idempotency_key=None, **params): ...

--- a/stubs/stripe/stripe/api_resources/payment_link.pyi
+++ b/stubs/stripe/stripe/api_resources/payment_link.pyi
@@ -1,0 +1,10 @@
+from stripe.api_resources.abstract import (
+    CreateableAPIResource as CreateableAPIResource,
+    ListableAPIResource as ListableAPIResource,
+    UpdateableAPIResource as UpdateableAPIResource,
+)
+
+class PaymentLink(CreateableAPIResource, ListableAPIResource, UpdateableAPIResource):
+    OBJECT_NAME: str
+
+    def list_line_items(self, idempotency_key=None, **params): ...


### PR DESCRIPTION
Adds type checking for the [PaymentLink](https://stripe.com/docs/api/payment_links/payment_links) resource, which is defined in stripe-python [here](https://github.com/stripe/stripe-python/blob/4829b884cf817dacd4d3217e40560693e26a7f8f/stripe/api_resources/payment_link.py).

Similar to https://github.com/python/typeshed/pull/10323 and https://github.com/python/typeshed/pull/10416