### PR TITLE
Bump `pyright` version to `1.1.318`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,4 +62,4 @@ all = true
 disable_all_dunder_policy = true
 
 [tool.typeshed]
-pyright_version = "1.1.317"
+pyright_version = "1.1.318"


### PR DESCRIPTION
It was just released: https://github.com/microsoft/pyright/releases/tag/1.1.318