### PR TITLE
Add a more precise signature for `AsyncMock.reset_mock()`

### DIFF
--- a/stdlib/unittest/mock.pyi
+++ b/stdlib/unittest/mock.pyi
@@ -389,7 +389,11 @@ if sys.version_info >= (3, 8):
     class AsyncMagicMixin(MagicMixin):
         def __init__(self, *args: Any, **kw: Any) -> None: ...
 
-    class AsyncMock(AsyncMockMixin, AsyncMagicMixin, Mock): ...
+    class AsyncMock(AsyncMockMixin, AsyncMagicMixin, Mock):
+        # Improving the `reset_mock` signature.
+        # It is defined on `AsyncMockMixin` with `*args, **kwargs`, which is not ideal.
+        # But, `NonCallableMock` super-class has the better version.
+        def reset_mock(self, visited: Any = None, *, return_value: bool = False, side_effect: bool = False) -> None: ...
 
 class MagicProxy:
     name: str

--- a/stubs/mock/mock/mock.pyi
+++ b/stubs/mock/mock/mock.pyi
@@ -329,6 +329,7 @@ class AsyncMockMixin(Base):
     __annotations__: dict[str, Any] | None  # type: ignore[assignment]
 
 class AsyncMagicMixin(MagicMixin): ...
+
 class AsyncMock(AsyncMockMixin, AsyncMagicMixin, Mock):
     # Improving the `reset_mock` signature.
     # It is defined on `AsyncMockMixin` with `*args, **kwargs`, which is not ideal.

--- a/stubs/mock/mock/mock.pyi
+++ b/stubs/mock/mock/mock.pyi
@@ -329,7 +329,11 @@ class AsyncMockMixin(Base):
     __annotations__: dict[str, Any] | None  # type: ignore[assignment]
 
 class AsyncMagicMixin(MagicMixin): ...
-class AsyncMock(AsyncMockMixin, AsyncMagicMixin, Mock): ...
+class AsyncMock(AsyncMockMixin, AsyncMagicMixin, Mock):
+    # Improving the `reset_mock` signature.
+    # It is defined on `AsyncMockMixin` with `*args, **kwargs`, which is not ideal.
+    # But, `NonCallableMock` super-class has the better version.
+    def reset_mock(self, visited: Any = None, *, return_value: bool = False, side_effect: bool = False) -> None: ...
 
 class MagicProxy(Base):
     name: str


### PR DESCRIPTION
Related https://github.com/python/typeshed/pull/10472