### PR TITLE
Auto-add upstream URLs in `create_baseline_stubs.py`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ extra_standard_library = [
     "opcode",
     "pyexpat",
 ]
-known_first_party = ["utils", "parse_metadata"]
+known_first_party = ["utils", "parse_metadata", "stubsabot"]
 
 [tool.ruff]
 line-length = 130

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ extra_standard_library = [
     "opcode",
     "pyexpat",
 ]
-known_first_party = ["utils", "parse_metadata", "stubsabot"]
+known_first_party = ["utils", "parse_metadata"]
 
 [tool.ruff]
 line-length = 130

--- a/scripts/create_baseline_stubs.py
+++ b/scripts/create_baseline_stubs.py
@@ -78,6 +78,7 @@ async def get_project_urls_from_pypi(project: str, session: aiohttp.ClientSessio
     pypi_root = f"https://pypi.org/pypi/{urllib.parse.quote(project)}"
     async with session.get(f"{pypi_root}/json") as response:
         response.raise_for_status()
+        j: dict[str, dict[str, dict[str, str]]]
         j = await response.json()
         if project_urls := j["info"].get("project_urls"):
             assert isinstance(project_urls, dict)

--- a/scripts/create_baseline_stubs.py
+++ b/scripts/create_baseline_stubs.py
@@ -19,6 +19,7 @@ import sys
 import urllib.parse
 
 import aiohttp
+
 from stubsabot import fetch_pypi_info, get_github_api_headers
 
 if sys.version_info >= (3, 8):

--- a/scripts/create_baseline_stubs.py
+++ b/scripts/create_baseline_stubs.py
@@ -10,7 +10,6 @@ Run with -h for more help.
 
 from __future__ import annotations
 
-import aiohttp
 import argparse
 import asyncio
 import os
@@ -19,6 +18,7 @@ import subprocess
 import sys
 import urllib.parse
 
+import aiohttp
 from stubsabot import fetch_pypi_info, get_github_api_headers
 
 if sys.version_info >= (3, 8):

--- a/scripts/create_baseline_stubs.py
+++ b/scripts/create_baseline_stubs.py
@@ -16,10 +16,10 @@ import os
 import re
 import subprocess
 import sys
-import termcolor
 import urllib.parse
 
 import aiohttp
+import termcolor
 
 if sys.version_info >= (3, 8):
     from importlib.metadata import distribution

--- a/scripts/create_baseline_stubs.py
+++ b/scripts/create_baseline_stubs.py
@@ -131,8 +131,8 @@ def create_metadata(project: str, stub_dir: str, version: str) -> None:
     upstream_repo_url = asyncio.run(get_upstream_repo_url(project))
     if upstream_repo_url is None:
         warning = (
-            f"\nDid not succeed in finding a URL pointing to the upstream repo for {project!r}.\n"
-            f"Please add it manually to the `stubs/{project}/METADATA.toml` file, if possible!\n"
+            f"\nDid not succeed in finding a URL pointing to the source code for {project!r}.\n"
+            f"Please add it as `upstream_repository` to `stubs/{project}/METADATA.toml`, if possible!\n"
         )
         print(termcolor.colored(warning, "red"))
     else:

--- a/scripts/create_baseline_stubs.py
+++ b/scripts/create_baseline_stubs.py
@@ -131,7 +131,7 @@ def create_metadata(project: str, stub_dir: str, version: str) -> None:
     upstream_repo_url = asyncio.run(get_upstream_repo_url(project))
     if upstream_repo_url is None:
         warning = (
-            f"\nDid not succeed in finding a URL pointing to the source code for {project!r}.\n"
+            f"\nCould not find a URL pointing to the source code for {project!r}.\n"
             f"Please add it as `upstream_repository` to `stubs/{project}/METADATA.toml`, if possible!\n"
         )
         print(termcolor.colored(warning, "red"))


### PR DESCRIPTION
Using a slightly-tweaked version of @Akuli's script from #10489 (which was itself a slightly tweaked version of @srittau's script from #10488!).