### PR TITLE
Bump various test dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: mixed-line-ending
       - id: check-case-conflict
   - repo: https://github.com/hadialqattan/pycln
-    rev: v2.1.6 # must match requirements-tests.txt
+    rev: v2.1.5 # must match requirements-tests.txt
     hooks:
       - id: pycln
         args: [--config=pyproject.toml]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,14 +10,14 @@ repos:
       - id: mixed-line-ending
       - id: check-case-conflict
   - repo: https://github.com/hadialqattan/pycln
-    rev: v2.1.5 # must match requirements-tests.txt
+    rev: v2.1.6 # must match requirements-tests.txt
     hooks:
       - id: pycln
         args: [--config=pyproject.toml]
         types: [file]
         types_or: [python, pyi]
   - repo: https://github.com/psf/black
-    rev: 23.3.0 # must match requirements-tests.txt
+    rev: 23.7.0 # must match requirements-tests.txt
     hooks:
       - id: black
         language_version: python3.10
@@ -36,7 +36,7 @@ repos:
     hooks:
       - id: flake8
         additional_dependencies:
-          - "flake8-bugbear==23.6.5" # must match requirements-tests.txt
+          - "flake8-bugbear==23.7.10" # must match requirements-tests.txt
           - "flake8-noqa==1.3.2" # must match requirements-tests.txt
           - "flake8-pyi==23.6.0" # must match requirements-tests.txt
         types: [file]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: mixed-line-ending
       - id: check-case-conflict
   - repo: https://github.com/hadialqattan/pycln
-    rev: v2.1.5 # must match requirements-tests.txt
+    rev: v2.1.6 # must match requirements-tests.txt
     hooks:
       - id: pycln
         args: [--config=pyproject.toml]

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -9,8 +9,8 @@ flake8-pyi==23.6.0; python_version >= "3.8"       # must match .pre-commit-confi
 isort==5.12.0; python_version >= "3.8"            # must match .pre-commit-config.yaml
 mypy==1.4.1
 pre-commit-hooks==4.4.0                           # must match .pre-commit-config.yaml
-pycln==2.1.5                                      # must match .pre-commit-config.yaml
-pytype==2023.7.12; platform_system != "Windows" and python_version < "3.11"
+pycln==2.1.6                                      # must match .pre-commit-config.yaml
+pytype==2023.6.16; platform_system != "Windows" and python_version < "3.11"
 ruff==0.0.278                                     # must match .pre-commit-config.yaml
 
 # Libraries used by our various scripts.

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,7 +1,7 @@
 # Type checkers and other linters that we test our stubs against. These should always
 # be pinned to a specific version to make failure reproducible. See also the
 # "tool.typeshed" section in pyproject.toml for additional type checkers.
-black==23.7.0                                     # must match .pre-commit-config.yaml
+black==23.7.0; python_version >= "3.8"            # must match .pre-commit-config.yaml
 flake8==6.0.0; python_version >= "3.8"            # must match .pre-commit-config.yaml
 flake8-bugbear==23.7.10; python_version >= "3.8"  # must match .pre-commit-config.yaml
 flake8-noqa==1.3.2; python_version >= "3.8"       # must match .pre-commit-config.yaml
@@ -9,7 +9,7 @@ flake8-pyi==23.6.0; python_version >= "3.8"       # must match .pre-commit-confi
 isort==5.12.0; python_version >= "3.8"            # must match .pre-commit-config.yaml
 mypy==1.4.1
 pre-commit-hooks==4.4.0                           # must match .pre-commit-config.yaml
-pycln==2.1.6                                      # must match .pre-commit-config.yaml
+pycln==2.1.5                                      # must match .pre-commit-config.yaml
 pytype==2023.7.12; platform_system != "Windows" and python_version < "3.11"
 ruff==0.0.278                                     # must match .pre-commit-config.yaml
 

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,23 +1,23 @@
 # Type checkers and other linters that we test our stubs against. These should always
 # be pinned to a specific version to make failure reproducible. See also the
 # "tool.typeshed" section in pyproject.toml for additional type checkers.
-black==23.3.0                                     # must match .pre-commit-config.yaml
+black==23.7.0                                     # must match .pre-commit-config.yaml
 flake8==6.0.0; python_version >= "3.8"            # must match .pre-commit-config.yaml
-flake8-bugbear==23.6.5; python_version >= "3.8"   # must match .pre-commit-config.yaml
+flake8-bugbear==23.7.10; python_version >= "3.8"  # must match .pre-commit-config.yaml
 flake8-noqa==1.3.2; python_version >= "3.8"       # must match .pre-commit-config.yaml
 flake8-pyi==23.6.0; python_version >= "3.8"       # must match .pre-commit-config.yaml
 isort==5.12.0; python_version >= "3.8"            # must match .pre-commit-config.yaml
 mypy==1.4.1
 pre-commit-hooks==4.4.0                           # must match .pre-commit-config.yaml
-pycln==2.1.5                                      # must match .pre-commit-config.yaml
-pytype==2023.6.16; platform_system != "Windows" and python_version < "3.11"
+pycln==2.1.6                                      # must match .pre-commit-config.yaml
+pytype==2023.7.12; platform_system != "Windows" and python_version < "3.11"
 ruff==0.0.278                                     # must match .pre-commit-config.yaml
 
 # Libraries used by our various scripts.
-aiohttp==3.8.4; python_version < "3.12"           # aiohttp can't be installed on 3.12 yet
+aiohttp==3.8.5; python_version < "3.12"           # aiohttp can't be installed on 3.12 yet
 packaging==23.1
 pathspec>=0.11.1
-pyyaml==6.0
+pyyaml==6.0.1
 stubdefaulter==0.1.0
 termcolor>=2.3
 tomli==2.0.1


### PR DESCRIPTION
The `aiohttp` bump in particular resolves a security advisory warning we currently have for this repo: https://github.com/python/typeshed/security/dependabot/2