### PR TITLE
Added `url: str` to `http.client.HTTPResponse`

### DIFF
--- a/stdlib/http/client.pyi
+++ b/stdlib/http/client.pyi
@@ -103,7 +103,6 @@ class HTTPMessage(email.message.Message):
 def parse_headers(fp: io.BufferedIOBase, _class: Callable[[], email.message.Message] = ...) -> HTTPMessage: ...
 
 class HTTPResponse(io.BufferedIOBase, BinaryIO):  # type: ignore[misc]  # incompatible method definitions in the base classes
-    url: str
     msg: HTTPMessage
     headers: HTTPMessage
     version: int
@@ -137,6 +136,10 @@ class HTTPResponse(io.BufferedIOBase, BinaryIO):  # type: ignore[misc]  # incomp
     def geturl(self) -> str: ...
     def getcode(self) -> int: ...
     def begin(self) -> None: ...
+    # url is set on instances of the class in urllib.request.AbstractHTTPHandler.do_open
+    # to match urllib.response.addinfourl's interface.
+    # It's not set in HTTPResponse.__init__ or any other method on the class
+    url: str
 
 class HTTPConnection:
     auto_open: int  # undocumented

--- a/stdlib/http/client.pyi
+++ b/stdlib/http/client.pyi
@@ -103,6 +103,7 @@ class HTTPMessage(email.message.Message):
 def parse_headers(fp: io.BufferedIOBase, _class: Callable[[], email.message.Message] = ...) -> HTTPMessage: ...
 
 class HTTPResponse(io.BufferedIOBase, BinaryIO):  # type: ignore[misc]  # incompatible method definitions in the base classes
+    url: str
     msg: HTTPMessage
     headers: HTTPMessage
     version: int

--- a/stdlib/http/client.pyi
+++ b/stdlib/http/client.pyi
@@ -115,6 +115,10 @@ class HTTPResponse(io.BufferedIOBase, BinaryIO):  # type: ignore[misc]  # incomp
     chunk_left: int | None
     length: int | None
     will_close: bool
+    # url is set on instances of the class in urllib.request.AbstractHTTPHandler.do_open
+    # to match urllib.response.addinfourl's interface.
+    # It's not set in HTTPResponse.__init__ or any other method on the class
+    url: str
     def __init__(self, sock: socket, debuglevel: int = 0, method: str | None = None, url: str | None = None) -> None: ...
     def peek(self, n: int = -1) -> bytes: ...
     def read(self, amt: int | None = None) -> bytes: ...
@@ -136,10 +140,6 @@ class HTTPResponse(io.BufferedIOBase, BinaryIO):  # type: ignore[misc]  # incomp
     def geturl(self) -> str: ...
     def getcode(self) -> int: ...
     def begin(self) -> None: ...
-    # url is set on instances of the class in urllib.request.AbstractHTTPHandler.do_open
-    # to match urllib.response.addinfourl's interface.
-    # It's not set in HTTPResponse.__init__ or any other method on the class
-    url: str
 
 class HTTPConnection:
     auto_open: int  # undocumented


### PR DESCRIPTION
From https://docs.python.org/3/library/urllib.request.html#module-urllib.response:

> Functions defined by this module are used internally by the [urllib.request](https://docs.python.org/3/library/urllib.request.html#module-urllib.request) module. The typical response object is a [urllib.response.addinfourl](https://docs.python.org/3/library/urllib.request.html#urllib.response.addinfourl) instance:

The response of a [`urllib.request.urlopen`](https://docs.python.org/3/library/urllib.request.html#urllib.request.urlopen) for HTTP/HTTPS urls is a [`http.client.HTTPResponse`](https://docs.python.org/3/library/http.client.html#http.client.HTTPResponse).  Thus, I think `HTTPResponse` needs to conform to the interface of `addinfourl`.  Currently, `HTTPResponse` is missing the `url` field, which this PR adds.

Note that I placed `url: str` at the top of `HTTPResponse` to match `addinfourl`'s ordering.

Closes https://github.com/python/typeshed/issues/10494.

