### PR TITLE
Use ruff, not pycln, for removing unused imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,13 +9,6 @@ repos:
       - id: check-merge-conflict
       - id: mixed-line-ending
       - id: check-case-conflict
-  - repo: https://github.com/hadialqattan/pycln
-    rev: v2.1.6 # must match requirements-tests.txt
-    hooks:
-      - id: pycln
-        args: [--config=pyproject.toml]
-        types: [file]
-        types_or: [python, pyi]
   - repo: https://github.com/psf/black
     rev: 23.7.0 # must match requirements-tests.txt
     hooks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ it takes a bit longer. For more details, read below.
 Typeshed runs continuous integration (CI) on all pull requests. This means that
 if you file a pull request (PR), our full test suite -- including our linter,
 `flake8` -- is run on your PR. It also means that bots will automatically apply
-changes to your PR (using `pycln`, `black`, `isort` and `ruff`) to fix any formatting issues.
+changes to your PR (using `black`, `isort` and `ruff`) to fix any formatting issues.
 This frees you up to ignore all local setup on your side, focus on the
 code and rely on the CI to fix everything, or point you to the places that
 need fixing.
@@ -84,8 +84,8 @@ terminal to install all non-pytype requirements:
 
 ## Code formatting
 
-The code is formatted using `black` and `isort`. Unused imports are also
-auto-removed using `pycln`, and various other autofixes are performed by `ruff`.
+The code is formatted using `black` and `isort`. Various other autofixes are
+also performed by `ruff`.
 
 The repository is equipped with a [`pre-commit.ci`](https://pre-commit.ci/)
 configuration file. This means that you don't *need* to do anything yourself to
@@ -93,10 +93,9 @@ run the code formatters. When you push a commit, a bot will run those for you
 right away and add a commit to your PR.
 
 That being said, if you *want* to run the checks locally when you commit,
-you're free to do so. Either run `pycln`, `isort`, `black` and `ruff` manually...
+you're free to do so. Either run `isort`, `black` and `ruff` manually...
 
 ```bash
-$ pycln --config=pyproject.toml .
 $ isort .
 $ ruff .
 $ black .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ exclude = [
 # Only enable rules that have safe autofixes;
 # only enable rules that are relevant to stubs
 select = [
+    "F401",   # Remove unused imports
     "UP004",  # Remove explicit `object` inheritance
     "UP006",  # PEP-585 autofixes
     "UP007",  # PEP-604 autofixes
@@ -94,10 +95,6 @@ select = [
     "PYI025",  # always alias `collections.abc.Set` as `AbstractSet` when importing it
     "PYI032",  # use `object`, not `Any`, as the second parameter to `__eq__`
 ]
-
-[tool.pycln]
-all = true
-disable_all_dunder_policy = true
 
 [tool.typeshed]
 pyright_version = "1.1.318"

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -9,7 +9,6 @@ flake8-pyi==23.6.0; python_version >= "3.8"       # must match .pre-commit-confi
 isort==5.12.0; python_version >= "3.8"            # must match .pre-commit-config.yaml
 mypy==1.4.1
 pre-commit-hooks==4.4.0                           # must match .pre-commit-config.yaml
-pycln==2.1.6                                      # must match .pre-commit-config.yaml
 pytype==2023.6.16; platform_system != "Windows" and python_version < "3.11"
 ruff==0.0.278                                     # must match .pre-commit-config.yaml
 

--- a/scripts/runtests.py
+++ b/scripts/runtests.py
@@ -75,8 +75,6 @@ def main() -> None:
     pytype_result: subprocess.CompletedProcess[bytes] | None = None
 
     # Run formatters first. Order matters.
-    print("\nRunning pycln...")
-    subprocess.run([sys.executable, "-m", "pycln", path, "--config=pyproject.toml"])
     print("\nRunning ruff...")
     subprocess.run([sys.executable, "-m", "ruff", path])
     print("\nRunning isort...")

--- a/tests/check_consistent.py
+++ b/tests/check_consistent.py
@@ -23,7 +23,7 @@ extension_descriptions = {".pyi": "stub", ".py": ".py"}
 
 # These type checkers and linters must have exact versions in the requirements file to ensure
 # consistent CI runs.
-linters = {"black", "flake8", "flake8-bugbear", "flake8-noqa", "flake8-pyi", "isort", "ruff", "mypy", "pycln", "pytype"}
+linters = {"black", "flake8", "flake8-bugbear", "flake8-noqa", "flake8-pyi", "isort", "ruff", "mypy", "pytype"}
 
 
 def assert_consistent_filetypes(


### PR DESCRIPTION
Pycln pins its dependencies very tightly, which is annoying when you want to install all your tools into a single environment, as we do, and has caused us minor issues in the past.  It's currently blocking us from upgrading to the latest version of pytype (see https://github.com/python/typeshed/pull/10344#issuecomment-1646200943), which in turn is blocking us from updating our typing_extensions stubs.

Ruff also provides this autofix functionality, so let's stop using pycln and just enable the relevant ruff rule in CI.