### PR TITLE
Add `upstream_repository` to metadata for `s2clientprotocol`

### DIFF
--- a/stubs/s2clientprotocol/METADATA.toml
+++ b/stubs/s2clientprotocol/METADATA.toml
@@ -1,2 +1,3 @@
 version = "5.*"
+upstream_repository = "https://github.com/Blizzard/s2client-proto"
 requires = ["types-protobuf"]


### PR DESCRIPTION
These stubs were added yesterday in #10372, and I forgot that we had just added this new metadata field