### PR TITLE
[stubsabot] Bump jsonschema to 4.18.*

### DIFF
--- a/stubs/jsonschema/METADATA.toml
+++ b/stubs/jsonschema/METADATA.toml
@@ -1,4 +1,4 @@
-version = "4.17.*"
+version = "4.18.*"
 upstream_repository = "https://github.com/python-jsonschema/jsonschema"
 partial_stub = true
 


### PR DESCRIPTION
Release: https://pypi.org/pypi/jsonschema/4.18.4
Homepage: https://github.com/python-jsonschema/jsonschema
Repository: https://github.com/python-jsonschema/jsonschema
Changelog: https://github.com/python-jsonschema/jsonschema/blob/main/CHANGELOG.rst
Diff: https://github.com/python-jsonschema/jsonschema/compare/v4.17.3...v4.18.4

Stubsabot analysis of the diff between the two releases:
 - 3 public Python files have been added: `jsonschema/benchmarks/unused_registry.py`, `jsonschema/benchmarks/validator_creation.py`, `noxfile.py`.
 - 0 files included in typeshed's stubs have been deleted.
 - 10 files included in typeshed's stubs have been modified or renamed.
 - Total lines of Python code added: 1544.
 - Total lines of Python code deleted: 1151.

If stubtest fails for this PR:
- Leave this PR open (as a reminder, and to prevent stubsabot from opening another PR)
- Fix stubtest failures in another PR, then close this PR

Note that you will need to close and re-open the PR in order to trigger CI
