### PR TITLE
`nargs` could be `None` in `add_argument` method

### DIFF
--- a/stdlib/argparse.pyi
+++ b/stdlib/argparse.pyi
@@ -85,7 +85,7 @@ class _ActionsContainer:
         self,
         *name_or_flags: str,
         action: _ActionStr | type[Action] = ...,
-        nargs: int | _NArgsStr | _SUPPRESS_T | None = ...,
+        nargs: int | _NArgsStr | _SUPPRESS_T | None = None,
         const: Any = ...,
         default: Any = ...,
         type: Callable[[str], _T] | FileType = ...,

--- a/stdlib/argparse.pyi
+++ b/stdlib/argparse.pyi
@@ -85,7 +85,7 @@ class _ActionsContainer:
         self,
         *name_or_flags: str,
         action: _ActionStr | type[Action] = ...,
-        nargs: int | _NArgsStr | _SUPPRESS_T = ...,
+        nargs: int | _NArgsStr | _SUPPRESS_T | None = ...,
         const: Any = ...,
         default: Any = ...,
         type: Callable[[str], _T] | FileType = ...,


### PR DESCRIPTION
The argument `nargs` in stdlib `argparse.ArgumentParser.add_argument` could be `None`, according to the documentation
https://docs.python.org/3/library/argparse.html#nargs 

and also the source code https://github.com/python/cpython/blob/3.11/Lib/argparse.py 

The the absence of `None` cause false negative in code that is accepted