### PR TITLE
Fix typechecking of our own test suite following change to `dict.get`

### DIFF
--- a/tests/check_consistent.py
+++ b/tests/check_consistent.py
@@ -168,7 +168,7 @@ def get_precommit_requirements() -> dict[str, SpecifierSet]:
         package_rev = repo["rev"].removeprefix("v")
         package_specifier = SpecifierSet(f"=={package_rev}")
         precommit_requirements[package_name] = package_specifier
-        for additional_req in hook.get("additional_dependencies", []):
+        for additional_req in hook.get("additional_dependencies", ()):
             req = Requirement(additional_req)
             precommit_requirements[req.name] = req.specifier
     return precommit_requirements


### PR DESCRIPTION
Following https://github.com/python/typeshed/commit/e86c61da86f564b39a8c4415a2d513758e62b0fd, pyright now complains that the second argument to `hook.get` is of type `list[Unknown]`, because we have extremely strict pyright settings in CI for checking our own test suite.