### PR TITLE
Add missing `TCP_USER_TIMEOUT` to `socket` module

### DIFF
--- a/stdlib/socket.pyi
+++ b/stdlib/socket.pyi
@@ -201,9 +201,10 @@ if sys.platform != "win32" and sys.platform != "darwin":
         TCP_LINGER2 as TCP_LINGER2,
         TCP_QUICKACK as TCP_QUICKACK,
         TCP_SYNCNT as TCP_SYNCNT,
-        TCP_USER_TIMEOUT as TCP_USER_TIMEOUT,
         TCP_WINDOW_CLAMP as TCP_WINDOW_CLAMP,
     )
+    if sys.version_info >= (3, 6):
+        from _socket import TCP_USER_TIMEOUT as TCP_USER_TIMEOUT
 if sys.platform != "win32":
     from _socket import (
         CMSG_LEN as CMSG_LEN,

--- a/stdlib/socket.pyi
+++ b/stdlib/socket.pyi
@@ -203,6 +203,7 @@ if sys.platform != "win32" and sys.platform != "darwin":
         TCP_SYNCNT as TCP_SYNCNT,
         TCP_WINDOW_CLAMP as TCP_WINDOW_CLAMP,
     )
+
     if sys.version_info >= (3, 6):
         from _socket import TCP_USER_TIMEOUT as TCP_USER_TIMEOUT
 if sys.platform != "win32":

--- a/stdlib/socket.pyi
+++ b/stdlib/socket.pyi
@@ -204,7 +204,7 @@ if sys.platform != "win32" and sys.platform != "darwin":
         TCP_WINDOW_CLAMP as TCP_WINDOW_CLAMP,
     )
 
-    if sys.version_info >= (3, 6):
+    if sys.version_info >= (3, 6, 7):
         from _socket import TCP_USER_TIMEOUT as TCP_USER_TIMEOUT
 if sys.platform != "win32":
     from _socket import (

--- a/stdlib/socket.pyi
+++ b/stdlib/socket.pyi
@@ -201,11 +201,9 @@ if sys.platform != "win32" and sys.platform != "darwin":
         TCP_LINGER2 as TCP_LINGER2,
         TCP_QUICKACK as TCP_QUICKACK,
         TCP_SYNCNT as TCP_SYNCNT,
+        TCP_USER_TIMEOUT as TCP_USER_TIMEOUT,
         TCP_WINDOW_CLAMP as TCP_WINDOW_CLAMP,
     )
-
-    if sys.version_info >= (3, 6, 7):
-        from _socket import TCP_USER_TIMEOUT as TCP_USER_TIMEOUT
 if sys.platform != "win32":
     from _socket import (
         CMSG_LEN as CMSG_LEN,

--- a/stdlib/socket.pyi
+++ b/stdlib/socket.pyi
@@ -202,6 +202,7 @@ if sys.platform != "win32" and sys.platform != "darwin":
         TCP_QUICKACK as TCP_QUICKACK,
         TCP_SYNCNT as TCP_SYNCNT,
         TCP_WINDOW_CLAMP as TCP_WINDOW_CLAMP,
+        TCP_USER_TIMEOUT as TCP_USER_TIMEOUT,
     )
 if sys.platform != "win32":
     from _socket import (

--- a/stdlib/socket.pyi
+++ b/stdlib/socket.pyi
@@ -201,8 +201,8 @@ if sys.platform != "win32" and sys.platform != "darwin":
         TCP_LINGER2 as TCP_LINGER2,
         TCP_QUICKACK as TCP_QUICKACK,
         TCP_SYNCNT as TCP_SYNCNT,
-        TCP_WINDOW_CLAMP as TCP_WINDOW_CLAMP,
         TCP_USER_TIMEOUT as TCP_USER_TIMEOUT,
+        TCP_WINDOW_CLAMP as TCP_WINDOW_CLAMP,
     )
 if sys.platform != "win32":
     from _socket import (


### PR DESCRIPTION
PR moved from https://github.com/python/mypy/pull/15811

Looks like this was backported from 3.7 to 3.6: https://bugs.python.org/issue26273 and https://github.com/python/cpython/blob/46366ca0486d07fe94c70d00771482c8ef1546fc/Doc/whatsnew/3.6.rst