### PR TITLE
openpyxl: Class attributes set explicitly as another class'

### DIFF
--- a/stubs/openpyxl/openpyxl/cell/text.pyi
+++ b/stubs/openpyxl/openpyxl/cell/text.pyi
@@ -2,10 +2,13 @@ from _typeshed import Incomplete
 from typing import ClassVar
 from typing_extensions import Literal, TypeAlias
 
-from openpyxl.descriptors.base import Alias, Integer, NoneSet, Typed, _ConvertibleToInt
-from openpyxl.descriptors.nested import NestedString, NestedText
+from openpyxl.descriptors.base import Alias, Integer, NoneSet, Typed, _ConvertibleToBool, _ConvertibleToFloat, _ConvertibleToInt
+from openpyxl.descriptors.nested import NestedString, NestedText, _NestedNoneSetParam
 from openpyxl.descriptors.serialisable import Serialisable
-from openpyxl.styles.fonts import Font
+from openpyxl.styles.colors import Color
+from openpyxl.styles.fonts import Font, _FontScheme, _FontU, _FontVertAlign
+
+from ..xml._functions_overloads import _HasTagAndGet
 
 _PhoneticPropertiesType: TypeAlias = Literal["halfwidthKatakana", "fullwidthKatakana", "Hiragana", "noConversion"]
 _PhoneticPropertiesAlignment: TypeAlias = Literal["noControl", "left", "center", "distributed"]
@@ -35,38 +38,39 @@ class PhoneticText(Serialisable):
 class InlineFont(Font):
     tagname: ClassVar[str]
     rFont: NestedString[Literal[True]]
-    charset: Incomplete
-    family: Incomplete
-    b: Incomplete
-    i: Incomplete
-    strike: Incomplete
-    outline: Incomplete
-    shadow: Incomplete
-    condense: Incomplete
-    extend: Incomplete
-    color: Incomplete
-    sz: Incomplete
-    u: Incomplete
-    vertAlign: Incomplete
-    scheme: Incomplete
+    # Same as parent
+    # charset = Font.charset
+    # family = Font.family
+    # b = Font.b
+    # i = Font.i
+    # strike = Font.strike
+    # outline = Font.outline
+    # shadow = Font.shadow
+    # condense = Font.condense
+    # extend = Font.extend
+    # color = Font.color
+    # sz = Font.sz
+    # u = Font.u
+    # vertAlign = Font.vertAlign
+    # scheme = Font.scheme
     __elements__: ClassVar[tuple[str, ...]]
     def __init__(
         self,
         rFont: object = None,
-        charset: Incomplete | None = None,
-        family: Incomplete | None = None,
-        b: Incomplete | None = None,
-        i: Incomplete | None = None,
-        strike: Incomplete | None = None,
-        outline: Incomplete | None = None,
-        shadow: Incomplete | None = None,
-        condense: Incomplete | None = None,
-        extend: Incomplete | None = None,
-        color: Incomplete | None = None,
-        sz: Incomplete | None = None,
-        u: Incomplete | None = None,
-        vertAlign: Incomplete | None = None,
-        scheme: Incomplete | None = None,
+        charset: _HasTagAndGet[_ConvertibleToInt | None] | _ConvertibleToInt | None = None,
+        family: _HasTagAndGet[_ConvertibleToFloat | None] | _ConvertibleToFloat | None = None,
+        b: _HasTagAndGet[_ConvertibleToBool] | _ConvertibleToBool = None,
+        i: _HasTagAndGet[_ConvertibleToBool] | _ConvertibleToBool = None,
+        strike: _HasTagAndGet[_ConvertibleToBool | None] | _ConvertibleToBool | None = None,
+        outline: _HasTagAndGet[_ConvertibleToBool | None] | _ConvertibleToBool | None = None,
+        shadow: _HasTagAndGet[_ConvertibleToBool | None] | _ConvertibleToBool | None = None,
+        condense: _HasTagAndGet[_ConvertibleToBool | None] | _ConvertibleToBool | None = None,
+        extend: _HasTagAndGet[_ConvertibleToBool | None] | _ConvertibleToBool | None = None,
+        color: Color | None = None,
+        sz: _HasTagAndGet[_ConvertibleToFloat | None] | _ConvertibleToFloat | None = None,
+        u: _NestedNoneSetParam[_FontU] = None,
+        vertAlign: _NestedNoneSetParam[_FontVertAlign] = None,
+        scheme: _NestedNoneSetParam[_FontScheme] = None,
     ) -> None: ...
 
 class RichText(Serialisable):

--- a/stubs/openpyxl/openpyxl/chart/area_chart.pyi
+++ b/stubs/openpyxl/openpyxl/chart/area_chart.pyi
@@ -32,11 +32,12 @@ class _AreaChartBase(ChartBase):
 
 class AreaChart(_AreaChartBase):
     tagname: ClassVar[str]
-    grouping: Incomplete
-    varyColors: Incomplete
-    ser: Incomplete
-    dLbls: Incomplete
-    dropLines: Incomplete
+    # Same as parent
+    # grouping = _AreaChartBase.grouping
+    # varyColors = _AreaChartBase.varyColors
+    # ser = _AreaChartBase.ser
+    # dLbls = _AreaChartBase.dLbls
+    # dropLines = _AreaChartBase.dropLines
     x_axis: Typed[TextAxis, Literal[False]]
     y_axis: Typed[NumericAxis, Literal[False]]
     extLst: Typed[ExtensionList, Literal[True]]
@@ -45,11 +46,12 @@ class AreaChart(_AreaChartBase):
 
 class AreaChart3D(AreaChart):
     tagname: ClassVar[str]
-    grouping: Incomplete
-    varyColors: Incomplete
-    ser: Incomplete
-    dLbls: Incomplete
-    dropLines: Incomplete
+    # Same as parent and grandparent
+    # grouping = _AreaChartBase.grouping
+    # varyColors = _AreaChartBase.varyColors
+    # ser = _AreaChartBase.ser
+    # dLbls = _AreaChartBase.dLbls
+    # dropLines = _AreaChartBase.dropLines
     gapDepth: Incomplete
     x_axis: Typed[TextAxis, Literal[False]]
     y_axis: Typed[NumericAxis, Literal[False]]

--- a/stubs/openpyxl/openpyxl/chart/axis.pyi
+++ b/stubs/openpyxl/openpyxl/chart/axis.pyi
@@ -164,22 +164,23 @@ class DisplayUnitsLabelList(Serialisable):
 
 class NumericAxis(_BaseAxis):
     tagname: ClassVar[str]
-    axId: Incomplete
-    scaling: Incomplete
-    delete: Incomplete
-    axPos: Incomplete
-    majorGridlines: Incomplete
-    minorGridlines: Incomplete
-    title: Incomplete
-    numFmt: Incomplete
-    majorTickMark: Incomplete
-    minorTickMark: Incomplete
-    tickLblPos: Incomplete
-    spPr: Incomplete
-    txPr: Incomplete
-    crossAx: Incomplete
-    crosses: Incomplete
-    crossesAt: Incomplete
+    # Same as parent
+    # axId = _BaseAxis.axId
+    # scaling = _BaseAxis.scaling
+    # delete = _BaseAxis.delete
+    # axPos = _BaseAxis.axPos
+    # majorGridlines = _BaseAxis.majorGridlines
+    # minorGridlines = _BaseAxis.minorGridlines
+    # title = _BaseAxis.title
+    # numFmt = _BaseAxis.numFmt
+    # majorTickMark = _BaseAxis.majorTickMark
+    # minorTickMark = _BaseAxis.minorTickMark
+    # tickLblPos = _BaseAxis.tickLblPos
+    # spPr = _BaseAxis.spPr
+    # txPr = _BaseAxis.txPr
+    # crossAx = _BaseAxis.crossAx
+    # crosses = _BaseAxis.crosses
+    # crossesAt = _BaseAxis.crossesAt
     crossBetween: NestedNoneSet[_NumericAxisCrossBetween]
     majorUnit: NestedFloat[Literal[True]]
     minorUnit: NestedFloat[Literal[True]]
@@ -200,22 +201,23 @@ class NumericAxis(_BaseAxis):
 
 class TextAxis(_BaseAxis):
     tagname: ClassVar[str]
-    axId: Incomplete
-    scaling: Incomplete
-    delete: Incomplete
-    axPos: Incomplete
-    majorGridlines: Incomplete
-    minorGridlines: Incomplete
-    title: Incomplete
-    numFmt: Incomplete
-    majorTickMark: Incomplete
-    minorTickMark: Incomplete
-    tickLblPos: Incomplete
-    spPr: Incomplete
-    txPr: Incomplete
-    crossAx: Incomplete
-    crosses: Incomplete
-    crossesAt: Incomplete
+    # Same as parent
+    # axId = _BaseAxis.axId
+    # scaling = _BaseAxis.scaling
+    # delete = _BaseAxis.delete
+    # axPos = _BaseAxis.axPos
+    # majorGridlines = _BaseAxis.majorGridlines
+    # minorGridlines = _BaseAxis.minorGridlines
+    # title = _BaseAxis.title
+    # numFmt = _BaseAxis.numFmt
+    # majorTickMark = _BaseAxis.majorTickMark
+    # minorTickMark = _BaseAxis.minorTickMark
+    # tickLblPos = _BaseAxis.tickLblPos
+    # spPr = _BaseAxis.spPr
+    # txPr = _BaseAxis.txPr
+    # crossAx = _BaseAxis.crossAx
+    # crosses = _BaseAxis.crosses
+    # crossesAt = _BaseAxis.crossesAt
     auto: NestedBool[Literal[True]]
     lblAlgn: NestedNoneSet[_TextAxisLblAlgn]
     lblOffset: NestedMinMax[float, Literal[False]]
@@ -238,22 +240,23 @@ class TextAxis(_BaseAxis):
 
 class DateAxis(TextAxis):
     tagname: ClassVar[str]
-    axId: Incomplete
-    scaling: Incomplete
-    delete: Incomplete
-    axPos: Incomplete
-    majorGridlines: Incomplete
-    minorGridlines: Incomplete
-    title: Incomplete
-    numFmt: Incomplete
-    majorTickMark: Incomplete
-    minorTickMark: Incomplete
-    tickLblPos: Incomplete
-    spPr: Incomplete
-    txPr: Incomplete
-    crossAx: Incomplete
-    crosses: Incomplete
-    crossesAt: Incomplete
+    # Same as parent and grandparent
+    # axId = _BaseAxis.axId
+    # scaling = _BaseAxis.scaling
+    # delete = _BaseAxis.delete
+    # axPos = _BaseAxis.axPos
+    # majorGridlines = _BaseAxis.majorGridlines
+    # minorGridlines = _BaseAxis.minorGridlines
+    # title = _BaseAxis.title
+    # numFmt = _BaseAxis.numFmt
+    # majorTickMark = _BaseAxis.majorTickMark
+    # minorTickMark = _BaseAxis.minorTickMark
+    # tickLblPos = _BaseAxis.tickLblPos
+    # spPr = _BaseAxis.spPr
+    # txPr = _BaseAxis.txPr
+    # crossAx = _BaseAxis.crossAx
+    # crosses = _BaseAxis.crosses
+    # crossesAt = _BaseAxis.crossesAt
     auto: NestedBool[Literal[True]]
     lblOffset: NestedInteger[Literal[True]]  # type: ignore[assignment]
     baseTimeUnit: NestedNoneSet[_DateAxisTimeUnit]
@@ -278,22 +281,23 @@ class DateAxis(TextAxis):
 
 class SeriesAxis(_BaseAxis):
     tagname: ClassVar[str]
-    axId: Incomplete
-    scaling: Incomplete
-    delete: Incomplete
-    axPos: Incomplete
-    majorGridlines: Incomplete
-    minorGridlines: Incomplete
-    title: Incomplete
-    numFmt: Incomplete
-    majorTickMark: Incomplete
-    minorTickMark: Incomplete
-    tickLblPos: Incomplete
-    spPr: Incomplete
-    txPr: Incomplete
-    crossAx: Incomplete
-    crosses: Incomplete
-    crossesAt: Incomplete
+    # Same as parent
+    # axId = _BaseAxis.axId
+    # scaling = _BaseAxis.scaling
+    # delete = _BaseAxis.delete
+    # axPos = _BaseAxis.axPos
+    # majorGridlines = _BaseAxis.majorGridlines
+    # minorGridlines = _BaseAxis.minorGridlines
+    # title = _BaseAxis.title
+    # numFmt = _BaseAxis.numFmt
+    # majorTickMark = _BaseAxis.majorTickMark
+    # minorTickMark = _BaseAxis.minorTickMark
+    # tickLblPos = _BaseAxis.tickLblPos
+    # spPr = _BaseAxis.spPr
+    # txPr = _BaseAxis.txPr
+    # crossAx = _BaseAxis.crossAx
+    # crosses = _BaseAxis.crosses
+    # crossesAt = _BaseAxis.crossesAt
     tickLblSkip: NestedInteger[Literal[True]]
     tickMarkSkip: NestedInteger[Literal[True]]
     extLst: Typed[ExtensionList, Literal[True]]

--- a/stubs/openpyxl/openpyxl/chart/bar_chart.pyi
+++ b/stubs/openpyxl/openpyxl/chart/bar_chart.pyi
@@ -37,11 +37,12 @@ class _BarChartBase(ChartBase):
 
 class BarChart(_BarChartBase):
     tagname: ClassVar[str]
-    barDir: Incomplete
-    grouping: Incomplete
-    varyColors: Incomplete
-    ser: Incomplete
-    dLbls: Incomplete
+    # Same as parent
+    # barDir = _BarChartBase.barDir
+    # grouping = _BarChartBase.grouping
+    # varyColors = _BarChartBase.varyColors
+    # ser = _BarChartBase.ser
+    # dLbls = _BarChartBase.dLbls
     gapWidth: Incomplete
     overlap: Incomplete
     serLines: Typed[ChartLines, Literal[True]]
@@ -61,15 +62,16 @@ class BarChart(_BarChartBase):
 
 class BarChart3D(_BarChartBase, _3DBase):
     tagname: ClassVar[str]
-    barDir: Incomplete
-    grouping: Incomplete
-    varyColors: Incomplete
-    ser: Incomplete
-    dLbls: Incomplete
-    view3D: Incomplete
-    floor: Incomplete
-    sideWall: Incomplete
-    backWall: Incomplete
+    # Same as parents
+    # barDir = _BarChartBase.barDir
+    # grouping = _BarChartBase.grouping
+    # varyColors = _BarChartBase.varyColors
+    # ser = _BarChartBase.ser
+    # dLbls = _BarChartBase.dLbls
+    # view3D = _3DBase.view3D
+    # floor = _3DBase.floor
+    # sideWall = _3DBase.sideWall
+    # backWall = _3DBase.backWall
     gapWidth: Incomplete
     gapDepth: Incomplete
     shape: NestedNoneSet[_BarChart3DShape]

--- a/stubs/openpyxl/openpyxl/chart/chartspace.pyi
+++ b/stubs/openpyxl/openpyxl/chart/chartspace.pyi
@@ -2,6 +2,7 @@ from _typeshed import Incomplete, Unused
 from typing import ClassVar, overload
 from typing_extensions import Literal, TypeAlias
 
+from openpyxl.chart._3d import Surface, View3D
 from openpyxl.chart.legend import Legend
 from openpyxl.chart.pivot import PivotSource
 from openpyxl.chart.plotarea import PlotArea
@@ -24,10 +25,13 @@ class ChartContainer(Serialisable):
     title: Typed[Title, Literal[True]]
     autoTitleDeleted: NestedBool[Literal[True]]
     pivotFmts: Incomplete
-    view3D: Incomplete
-    floor: Incomplete
-    sideWall: Incomplete
-    backWall: Incomplete
+
+    # Same as _3DBase
+    view3D: Typed[View3D, Literal[True]]
+    floor: Typed[Surface, Literal[True]]
+    sideWall: Typed[Surface, Literal[True]]
+    backWall: Typed[Surface, Literal[True]]
+
     plotArea: Typed[PlotArea, Literal[False]]
     legend: Typed[Legend, Literal[True]]
     plotVisOnly: NestedBool[Literal[False]]
@@ -40,10 +44,10 @@ class ChartContainer(Serialisable):
         title: Title | None = None,
         autoTitleDeleted: _HasTagAndGet[_ConvertibleToBool | None] | _ConvertibleToBool | None = None,
         pivotFmts=(),
-        view3D: Incomplete | None = None,
-        floor: Incomplete | None = None,
-        sideWall: Incomplete | None = None,
-        backWall: Incomplete | None = None,
+        view3D: View3D | None = None,
+        floor: Surface | None = None,
+        sideWall: Surface | None = None,
+        backWall: Surface | None = None,
         plotArea: PlotArea | None = None,
         legend: Legend | None = None,
         plotVisOnly: _HasTagAndGet[_ConvertibleToBool] | _ConvertibleToBool = True,

--- a/stubs/openpyxl/openpyxl/chart/label.pyi
+++ b/stubs/openpyxl/openpyxl/chart/label.pyi
@@ -51,19 +51,20 @@ class _DataLabelBase(Serialisable):
 class DataLabel(_DataLabelBase):
     tagname: ClassVar[str]
     idx: NestedInteger[Literal[False]]
-    numFmt: Incomplete
-    spPr: Incomplete
-    txPr: Incomplete
-    dLblPos: Incomplete
-    showLegendKey: Incomplete
-    showVal: Incomplete
-    showCatName: Incomplete
-    showSerName: Incomplete
-    showPercent: Incomplete
-    showBubbleSize: Incomplete
-    showLeaderLines: Incomplete
-    separator: Incomplete
-    extLst: Incomplete
+    # Same as parent
+    # numFmt = _DataLabelBase.numFmt
+    # spPr = _DataLabelBase.spPr
+    # txPr = _DataLabelBase.txPr
+    # dLblPos = _DataLabelBase.dLblPos
+    # showLegendKey = _DataLabelBase.showLegendKey
+    # showVal = _DataLabelBase.showVal
+    # showCatName = _DataLabelBase.showCatName
+    # showSerName = _DataLabelBase.showSerName
+    # showPercent = _DataLabelBase.showPercent
+    # showBubbleSize = _DataLabelBase.showBubbleSize
+    # showLeaderLines = _DataLabelBase.showLeaderLines
+    # separator = _DataLabelBase.separator
+    # extLst = _DataLabelBase.extLst
     __elements__: ClassVar[tuple[str, ...]]
     def __init__(self, idx: _HasTagAndGet[_ConvertibleToInt] | _ConvertibleToInt = 0, **kw) -> None: ...
 
@@ -71,19 +72,20 @@ class DataLabelList(_DataLabelBase):
     tagname: ClassVar[str]
     dLbl: Incomplete
     delete: NestedBool[Literal[True]]
-    numFmt: Incomplete
-    spPr: Incomplete
-    txPr: Incomplete
-    dLblPos: Incomplete
-    showLegendKey: Incomplete
-    showVal: Incomplete
-    showCatName: Incomplete
-    showSerName: Incomplete
-    showPercent: Incomplete
-    showBubbleSize: Incomplete
-    showLeaderLines: Incomplete
-    separator: Incomplete
-    extLst: Incomplete
+    # Same as parent
+    # numFmt = _DataLabelBase.numFmt
+    # spPr = _DataLabelBase.spPr
+    # txPr = _DataLabelBase.txPr
+    # dLblPos = _DataLabelBase.dLblPos
+    # showLegendKey = _DataLabelBase.showLegendKey
+    # showVal = _DataLabelBase.showVal
+    # showCatName = _DataLabelBase.showCatName
+    # showSerName = _DataLabelBase.showSerName
+    # showPercent = _DataLabelBase.showPercent
+    # showBubbleSize = _DataLabelBase.showBubbleSize
+    # showLeaderLines = _DataLabelBase.showLeaderLines
+    # separator = _DataLabelBase.separator
+    # extLst = _DataLabelBase.extLst
     __elements__: ClassVar[tuple[str, ...]]
     def __init__(
         self, dLbl=(), delete: _HasTagAndGet[_ConvertibleToBool | None] | _ConvertibleToBool | None = None, **kw

--- a/stubs/openpyxl/openpyxl/chart/line_chart.pyi
+++ b/stubs/openpyxl/openpyxl/chart/line_chart.pyi
@@ -34,11 +34,12 @@ class _LineChartBase(ChartBase):
 
 class LineChart(_LineChartBase):
     tagname: ClassVar[str]
-    grouping: Incomplete
-    varyColors: Incomplete
-    ser: Incomplete
-    dLbls: Incomplete
-    dropLines: Incomplete
+    # Same as parent
+    # grouping = _LineChartBase.grouping
+    # varyColors = _LineChartBase.varyColors
+    # ser = _LineChartBase.ser
+    # dLbls = _LineChartBase.dLbls
+    # dropLines = _LineChartBase.dropLines
     hiLowLines: Typed[ChartLines, Literal[True]]
     upDownBars: Typed[UpDownBars, Literal[True]]
     marker: NestedBool[Literal[True]]
@@ -59,11 +60,12 @@ class LineChart(_LineChartBase):
 
 class LineChart3D(_LineChartBase):
     tagname: ClassVar[str]
-    grouping: Incomplete
-    varyColors: Incomplete
-    ser: Incomplete
-    dLbls: Incomplete
-    dropLines: Incomplete
+    # Same as parent
+    # grouping = _LineChartBase.grouping
+    # varyColors = _LineChartBase.varyColors
+    # ser = _LineChartBase.ser
+    # dLbls = _LineChartBase.dLbls
+    # dropLines = _LineChartBase.dropLines
     gapDepth: Incomplete
     hiLowLines: Typed[ChartLines, Literal[True]]
     upDownBars: Typed[UpDownBars, Literal[True]]

--- a/stubs/openpyxl/openpyxl/chart/pie_chart.pyi
+++ b/stubs/openpyxl/openpyxl/chart/pie_chart.pyi
@@ -30,9 +30,10 @@ class _PieChartBase(ChartBase):
 
 class PieChart(_PieChartBase):
     tagname: ClassVar[str]
-    varyColors: Incomplete
-    ser: Incomplete
-    dLbls: Incomplete
+    # Same as parent
+    # varyColors = _PieChartBase.varyColors
+    # ser = _PieChartBase.ser
+    # dLbls = _PieChartBase.dLbls
     firstSliceAng: NestedMinMax[float, Literal[False]]
     extLst: Typed[ExtensionList, Literal[True]]
     __elements__: ClassVar[tuple[str, ...]]
@@ -42,17 +43,19 @@ class PieChart(_PieChartBase):
 
 class PieChart3D(_PieChartBase):
     tagname: ClassVar[str]
-    varyColors: Incomplete
-    ser: Incomplete
-    dLbls: Incomplete
+    # Same as parent
+    # varyColors = _PieChartBase.varyColors
+    # ser = _PieChartBase.ser
+    # dLbls = _PieChartBase.dLbls
     extLst: Typed[ExtensionList, Literal[True]]
     __elements__: ClassVar[tuple[str, ...]]
 
 class DoughnutChart(_PieChartBase):
     tagname: ClassVar[str]
-    varyColors: Incomplete
-    ser: Incomplete
-    dLbls: Incomplete
+    # Same as parent
+    # varyColors = _PieChartBase.varyColors
+    # ser = _PieChartBase.ser
+    # dLbls = _PieChartBase.dLbls
     firstSliceAng: NestedMinMax[float, Literal[False]]
     holeSize: NestedMinMax[float, Literal[True]]
     extLst: Typed[ExtensionList, Literal[True]]
@@ -73,9 +76,10 @@ class CustomSplit(Serialisable):
 
 class ProjectedPieChart(_PieChartBase):
     tagname: ClassVar[str]
-    varyColors: Incomplete
-    ser: Incomplete
-    dLbls: Incomplete
+    # Same as parent
+    # varyColors = _PieChartBase.varyColors
+    # ser = _PieChartBase.ser
+    # dLbls = _PieChartBase.dLbls
     ofPieType: NestedSet[_ProjectedPieChartOfPieType]
     type: Alias
     gapWidth: Incomplete

--- a/stubs/openpyxl/openpyxl/chart/series.pyi
+++ b/stubs/openpyxl/openpyxl/chart/series.pyi
@@ -85,18 +85,20 @@ class Series(Serialisable):
     def to_tree(self, tagname: str | None = None, idx: Incomplete | None = None): ...  # type: ignore[override]
 
 class XYSeries(Series):
-    idx: Incomplete
-    order: Incomplete
-    tx: Incomplete
-    spPr: Incomplete
-    dPt: Incomplete
-    dLbls: Incomplete
-    trendline: Incomplete
-    errBars: Incomplete
-    xVal: Incomplete
-    yVal: Incomplete
-    invertIfNegative: Incomplete
-    bubbleSize: Incomplete
-    bubble3D: Incomplete
-    marker: Incomplete
-    smooth: Incomplete
+    # Same as parent
+    # idx = Series.idx
+    # order = Series.order
+    # tx = Series.tx
+    # spPr = Series.spPr
+    # dPt = Series.dPt
+    # dLbls = Series.dLbls
+    # trendline = Series.trendline
+    # errBars = Series.errBars
+    # xVal = Series.xVal
+    # yVal = Series.yVal
+    # invertIfNegative = Series.invertIfNegative
+    # bubbleSize = Series.bubbleSize
+    # bubble3D = Series.bubble3D
+    # marker = Series.marker
+    # smooth = Series.smooth
+    ...

--- a/stubs/openpyxl/openpyxl/chart/surface_chart.pyi
+++ b/stubs/openpyxl/openpyxl/chart/surface_chart.pyi
@@ -44,9 +44,10 @@ class _SurfaceChartBase(ChartBase):
 
 class SurfaceChart3D(_SurfaceChartBase, _3DBase):
     tagname: ClassVar[str]
-    wireframe: Incomplete
-    ser: Incomplete
-    bandFmts: Incomplete
+    # Same as parent
+    # wireframe = _SurfaceChartBase.wireframe
+    # ser = _SurfaceChartBase.ser
+    # bandFmts = _SurfaceChartBase.bandFmts
     extLst: Typed[ExtensionList, Literal[True]]
     x_axis: Typed[TextAxis, Literal[False]]
     y_axis: Typed[NumericAxis, Literal[False]]
@@ -56,9 +57,10 @@ class SurfaceChart3D(_SurfaceChartBase, _3DBase):
 
 class SurfaceChart(SurfaceChart3D):
     tagname: ClassVar[str]
-    wireframe: Incomplete
-    ser: Incomplete
-    bandFmts: Incomplete
+    # Same as parent and grandparent
+    # wireframe = _SurfaceChartBase.wireframe
+    # ser = _SurfaceChartBase.ser
+    # bandFmts = _SurfaceChartBase.bandFmts
     extLst: Typed[ExtensionList, Literal[True]]
     __elements__: ClassVar[tuple[str, ...]]
     def __init__(self, **kw) -> None: ...

--- a/stubs/openpyxl/openpyxl/drawing/effect.pyi
+++ b/stubs/openpyxl/openpyxl/drawing/effect.pyi
@@ -1,4 +1,3 @@
-from _typeshed import Incomplete
 from typing import ClassVar, overload
 from typing_extensions import Literal, TypeAlias
 
@@ -117,12 +116,13 @@ class AlphaBiLevelEffect(Serialisable):
 
 class GlowEffect(ColorChoice):
     rad: Float[Literal[False]]
-    scrgbClr: Incomplete
-    srgbClr: Incomplete
-    hslClr: Incomplete
-    sysClr: Incomplete
-    schemeClr: Incomplete
-    prstClr: Incomplete
+    # Same as parent
+    # scrgbClr = ColorChoice.scrgbClr
+    # srgbClr = ColorChoice.srgbClr
+    # hslClr = ColorChoice.hslClr
+    # sysClr = ColorChoice.sysClr
+    # schemeClr = ColorChoice.schemeClr
+    # prstClr = ColorChoice.prstClr
     __elements__: ClassVar[tuple[str, ...]]
     def __init__(self, rad: _ConvertibleToFloat, **kw) -> None: ...
 
@@ -130,12 +130,13 @@ class InnerShadowEffect(ColorChoice):
     blurRad: Float[Literal[False]]
     dist: Float[Literal[False]]
     dir: Integer[Literal[False]]
-    scrgbClr: Incomplete
-    srgbClr: Incomplete
-    hslClr: Incomplete
-    sysClr: Incomplete
-    schemeClr: Incomplete
-    prstClr: Incomplete
+    # Same as parent
+    # scrgbClr = ColorChoice.scrgbClr
+    # srgbClr = ColorChoice.srgbClr
+    # hslClr = ColorChoice.hslClr
+    # sysClr = ColorChoice.sysClr
+    # schemeClr = ColorChoice.schemeClr
+    # prstClr = ColorChoice.prstClr
     __elements__: ClassVar[tuple[str, ...]]
     def __init__(self, blurRad: _ConvertibleToFloat, dist: _ConvertibleToFloat, dir: _ConvertibleToInt, **kw) -> None: ...
 
@@ -150,12 +151,13 @@ class OuterShadow(ColorChoice):
     ky: Integer[Literal[True]]
     algn: Set[_Algn]
     rotWithShape: Bool[Literal[True]]
-    scrgbClr: Incomplete
-    srgbClr: Incomplete
-    hslClr: Incomplete
-    sysClr: Incomplete
-    schemeClr: Incomplete
-    prstClr: Incomplete
+    # Same as parent
+    # scrgbClr = ColorChoice.scrgbClr
+    # srgbClr = ColorChoice.srgbClr
+    # hslClr = ColorChoice.hslClr
+    # sysClr = ColorChoice.sysClr
+    # schemeClr = ColorChoice.schemeClr
+    # prstClr = ColorChoice.prstClr
     __elements__: ClassVar[tuple[str, ...]]
     @overload
     def __init__(
@@ -191,12 +193,13 @@ class PresetShadowEffect(ColorChoice):
     prst: Set[_PresetShadowEffectPrst]
     dist: Float[Literal[False]]
     dir: Integer[Literal[False]]
-    scrgbClr: Incomplete
-    srgbClr: Incomplete
-    hslClr: Incomplete
-    sysClr: Incomplete
-    schemeClr: Incomplete
-    prstClr: Incomplete
+    # Same as parent
+    # scrgbClr = ColorChoice.scrgbClr
+    # srgbClr = ColorChoice.srgbClr
+    # hslClr = ColorChoice.hslClr
+    # sysClr = ColorChoice.sysClr
+    # schemeClr = ColorChoice.schemeClr
+    # prstClr = ColorChoice.prstClr
     __elements__: ClassVar[tuple[str, ...]]
     def __init__(self, prst: _PresetShadowEffectPrst, dist: _ConvertibleToFloat, dir: _ConvertibleToInt, **kw) -> None: ...
 

--- a/stubs/openpyxl/openpyxl/drawing/spreadsheet_drawing.pyi
+++ b/stubs/openpyxl/openpyxl/drawing/spreadsheet_drawing.pyi
@@ -56,13 +56,14 @@ class AbsoluteAnchor(_AnchorBase):
     tagname: ClassVar[str]
     pos: Typed[XDRPoint2D, Literal[False]]
     ext: Typed[XDRPositiveSize2D, Literal[False]]
-    sp: Incomplete
-    grpSp: Incomplete
-    graphicFrame: Incomplete
-    cxnSp: Incomplete
-    pic: Incomplete
-    contentPart: Incomplete
-    clientData: Incomplete
+    # Same as parent
+    # sp = _AnchorBase.sp
+    # grpSp = _AnchorBase.grpSp
+    # graphicFrame = _AnchorBase.graphicFrame
+    # cxnSp = _AnchorBase.cxnSp
+    # pic = _AnchorBase.pic
+    # contentPart = _AnchorBase.contentPart
+    # clientData = _AnchorBase.clientData
     __elements__: ClassVar[tuple[str, ...]]
     def __init__(self, pos: XDRPoint2D | None = None, ext: XDRPositiveSize2D | None = None, **kw) -> None: ...
 
@@ -70,13 +71,14 @@ class OneCellAnchor(_AnchorBase):
     tagname: ClassVar[str]
     _from: Typed[AnchorMarker, Literal[False]]  # Not private. Avoids name clash
     ext: Typed[XDRPositiveSize2D, Literal[False]]
-    sp: Incomplete
-    grpSp: Incomplete
-    graphicFrame: Incomplete
-    cxnSp: Incomplete
-    pic: Incomplete
-    contentPart: Incomplete
-    clientData: Incomplete
+    # Same as parent
+    # sp = _AnchorBase.sp
+    # grpSp = _AnchorBase.grpSp
+    # graphicFrame = _AnchorBase.graphicFrame
+    # cxnSp = _AnchorBase.cxnSp
+    # pic = _AnchorBase.pic
+    # contentPart = _AnchorBase.contentPart
+    # clientData = _AnchorBase.clientData
     __elements__: ClassVar[tuple[str, ...]]
     def __init__(self, _from: AnchorMarker | None = None, ext: XDRPositiveSize2D | None = None, **kw) -> None: ...
 
@@ -85,13 +87,14 @@ class TwoCellAnchor(_AnchorBase):
     editAs: NoneSet[_TwoCellAnchorEditAs]
     _from: Typed[AnchorMarker, Literal[False]]  # Not private. Avoids name clash
     to: Typed[AnchorMarker, Literal[False]]
-    sp: Incomplete
-    grpSp: Incomplete
-    graphicFrame: Incomplete
-    cxnSp: Incomplete
-    pic: Incomplete
-    contentPart: Incomplete
-    clientData: Incomplete
+    # Same as parent
+    # sp = _AnchorBase.sp
+    # grpSp = _AnchorBase.grpSp
+    # graphicFrame = _AnchorBase.graphicFrame
+    # cxnSp = _AnchorBase.cxnSp
+    # pic = _AnchorBase.pic
+    # contentPart = _AnchorBase.contentPart
+    # clientData = _AnchorBase.clientData
     __elements__: ClassVar[tuple[str, ...]]
     def __init__(
         self,

--- a/stubs/openpyxl/openpyxl/drawing/xdr.pyi
+++ b/stubs/openpyxl/openpyxl/drawing/xdr.pyi
@@ -1,24 +1,26 @@
-from _typeshed import Incomplete
 from typing import ClassVar
 
 from .geometry import Point2D, PositiveSize2D, Transform2D
 
 class XDRPoint2D(Point2D):
     namespace: ClassVar[None]  # type:ignore[assignment]
-    x: Incomplete
-    y: Incomplete
+    # Same as parent
+    # x = Point2D.x
+    # y = Point2D.y
 
 class XDRPositiveSize2D(PositiveSize2D):
     namespace: ClassVar[None]  # type:ignore[assignment]
-    cx: Incomplete
-    cy: Incomplete
+    # Same as parent
+    # cx = PositiveSize2D.cx
+    # cy = PositiveSize2D.cy
 
 class XDRTransform2D(Transform2D):
     namespace: ClassVar[None]  # type:ignore[assignment]
-    rot: Incomplete
-    flipH: Incomplete
-    flipV: Incomplete
-    off: Incomplete
-    ext: Incomplete
-    chOff: Incomplete
-    chExt: Incomplete
+    # Same as parent
+    # rot = Transform2D.rot
+    # flipH = Transform2D.flipH
+    # flipV = Transform2D.flipV
+    # off = Transform2D.off
+    # ext = Transform2D.ext
+    # chOff = Transform2D.chOff
+    # chExt = Transform2D.chExt

--- a/stubs/openpyxl/openpyxl/worksheet/_read_only.pyi
+++ b/stubs/openpyxl/openpyxl/worksheet/_read_only.pyi
@@ -5,10 +5,12 @@ from openpyxl.worksheet.worksheet import Worksheet
 def read_dimension(source): ...
 
 class ReadOnlyWorksheet:
-    cell: Incomplete
-    iter_rows: Incomplete
+    cell = Worksheet.cell
+    iter_rows = Worksheet.iter_rows
+    # Same as Worksheet.values
     @property
     def values(self): ...
+    # Same as Worksheet.rows
     @property
     def rows(self): ...
     __getitem__ = Worksheet.__getitem__

--- a/stubs/openpyxl/openpyxl/worksheet/_write_only.pyi
+++ b/stubs/openpyxl/openpyxl/worksheet/_write_only.pyi
@@ -1,20 +1,37 @@
 from _typeshed import Incomplete
+from collections.abc import Iterable
 
 from openpyxl.workbook.child import _WorkbookChild
+from openpyxl.worksheet.table import TableList
+from openpyxl.worksheet.worksheet import Worksheet
 
 class WriteOnlyWorksheet(_WorkbookChild):
-    mime_type: Incomplete
-    add_chart: Incomplete
-    add_image: Incomplete
-    add_table: Incomplete
+    mime_type = Worksheet.mime_type
+    add_chart = Worksheet.add_chart
+    add_image = Worksheet.add_image
+    add_table = Worksheet.add_table
+
+    # Same properties as Worksheet
     @property
-    def tables(self): ...
+    def tables(self) -> TableList: ...
     @property
-    def print_titles(self): ...
-    print_title_cols: Incomplete
-    print_title_rows: Incomplete
-    freeze_panes: Incomplete
-    print_area: Incomplete
+    def print_titles(self) -> str | None: ...
+    @property
+    def print_title_cols(self) -> str | None: ...
+    @print_title_cols.setter
+    def print_title_cols(self, cols: str | None) -> None: ...
+    @property
+    def print_title_rows(self) -> str | None: ...
+    @print_title_rows.setter
+    def print_title_rows(self, rows: str | None) -> None: ...
+    @property
+    def freeze_panes(self) -> str | None: ...
+    @freeze_panes.setter
+    def freeze_panes(self, topLeftCell: Incomplete | None = ...) -> None: ...
+    @property
+    def print_area(self) -> list[str]: ...
+    @print_area.setter
+    def print_area(self, value: str | Iterable[str]) -> None: ...
     @property
     def sheet_view(self): ...
     def __init__(self, parent, title) -> None: ...

--- a/stubs/openpyxl/openpyxl/worksheet/merge.pyi
+++ b/stubs/openpyxl/openpyxl/worksheet/merge.pyi
@@ -7,6 +7,7 @@ from .cell_range import CellRange
 
 class MergeCell(CellRange):
     tagname: ClassVar[str]
+    # Same as CellRange.coord
     @property
     def ref(self): ...
     __attrs__: ClassVar[tuple[str, ...]]

--- a/stubs/openpyxl/openpyxl/worksheet/pagebreak.pyi
+++ b/stubs/openpyxl/openpyxl/worksheet/pagebreak.pyi
@@ -42,9 +42,8 @@ PageBreak = RowBreak
 
 class ColBreak(RowBreak):
     tagname: ClassVar[str]
-    @property
-    def count(self): ...
-    @property
-    def manualBreakCount(self): ...
-    brk: Incomplete
+    # Same as parent
+    # count = RowBreak.count
+    # manualBreakCount = RowBreak.manualBreakCount
+    # brk = RowBreak.brk
     __attrs__: ClassVar[tuple[str, ...]]


### PR DESCRIPTION
Has overlap with #9511, so should reduce changes there.

I searched the openpyxl source code for instances of a class attribute being explicitly set as another class'.

In most cases, those will be descriptors, which pyright will have issues with re-assigning. Luckily, they'll also mostly refer to parent definitions. For typing purposes, this can be simplified to just not including them. I still left them in as comments to make it a bit more explicit.

Similarly, mypy has issues with re-assigning properties (see https://github.com/python/mypy/issues/13975) so I explicitly redefined those when they came from a non-parent class.