### PR TITLE
Fill in all missing `upstream_repository`

### DIFF
--- a/stubs/JACK-Client/METADATA.toml
+++ b/stubs/JACK-Client/METADATA.toml
@@ -1,4 +1,5 @@
 version = "0.5.*"
+upstream_repository = "https://github.com/spatialaudio/jackclient-python"
 # Requires a version of numpy with a `py.typed` file
 requires = ["numpy>=1.20", "types-cffi"]
 

--- a/stubs/WebOb/METADATA.toml
+++ b/stubs/WebOb/METADATA.toml
@@ -1,1 +1,2 @@
 version = "1.8.*"
+upstream_repository = "https://github.com/Pylons/webob"

--- a/stubs/beautifulsoup4/METADATA.toml
+++ b/stubs/beautifulsoup4/METADATA.toml
@@ -1,5 +1,5 @@
 version = "4.12.*"
-upstream_repository = "https://git.launchpad.net/beautifulsoup"
+upstream_repository = "https://git.launchpad.net/beautifulsoup/tree"
 requires = ["types-html5lib"]
 partial_stub = true
 

--- a/stubs/beautifulsoup4/METADATA.toml
+++ b/stubs/beautifulsoup4/METADATA.toml
@@ -1,4 +1,5 @@
 version = "4.12.*"
+upstream_repository = "https://git.launchpad.net/beautifulsoup"
 requires = ["types-html5lib"]
 partial_stub = true
 

--- a/stubs/braintree/METADATA.toml
+++ b/stubs/braintree/METADATA.toml
@@ -1,4 +1,5 @@
 version = "4.21.*"
+upstream_repository = "https://github.com/braintree/braintree_python"
 partial_stub = true
 
 [tool.stubtest]

--- a/stubs/cffi/METADATA.toml
+++ b/stubs/cffi/METADATA.toml
@@ -1,4 +1,5 @@
 version = "1.15.*"
+upstream_repository = "https://foss.heptapod.net/pypy/cffi"
 requires = ["types-setuptools"]
 
 [tool.stubtest]

--- a/stubs/docopt/METADATA.toml
+++ b/stubs/docopt/METADATA.toml
@@ -1,1 +1,2 @@
 version = "0.6.*"
+upstream_repository = "https://github.com/docopt/docopt"

--- a/stubs/docutils/METADATA.toml
+++ b/stubs/docutils/METADATA.toml
@@ -1,4 +1,5 @@
 version = "0.20.*"
+upstream_repository = "https://sourceforge.net/p/docutils/code"
 partial_stub = true
 
 [tool.stubtest]

--- a/stubs/gdb/METADATA.toml
+++ b/stubs/gdb/METADATA.toml
@@ -1,4 +1,7 @@
 version = "12.1.*"
+# This is the official web portal for GDB,
+# see https://sourceware.org/gdb/current/ for other ways of obtaining the source code.
+upstream_repository = "https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git"
 extra_description = """\
   Type hints for GDB's \
   [Python API](https://sourceware.org/gdb/onlinedocs/gdb/Python-API.html). \

--- a/stubs/gdb/METADATA.toml
+++ b/stubs/gdb/METADATA.toml
@@ -1,7 +1,7 @@
 version = "12.1.*"
 # This is the official web portal for GDB,
 # see https://sourceware.org/gdb/current/ for other ways of obtaining the source code.
-upstream_repository = "https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git"
+upstream_repository = "https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;a=tree"
 extra_description = """\
   Type hints for GDB's \
   [Python API](https://sourceware.org/gdb/onlinedocs/gdb/Python-API.html). \

--- a/stubs/hdbcli/METADATA.toml
+++ b/stubs/hdbcli/METADATA.toml
@@ -1,1 +1,2 @@
 version = "2.17.*"
+# upstream_repository = closed-source

--- a/stubs/humanfriendly/METADATA.toml
+++ b/stubs/humanfriendly/METADATA.toml
@@ -1,4 +1,5 @@
 version = "10.0.*"
+upstream_repository = "https://github.com/xolox/python-humanfriendly"
 
 [tool.stubtest]
 stubtest_requirements = ["docutils", "mock"]

--- a/stubs/ibm-db/METADATA.toml
+++ b/stubs/ibm-db/METADATA.toml
@@ -1,1 +1,2 @@
 version = "3.1.*"
+upstream_repository = "https://github.com/ibmdb/python-ibmdb"

--- a/stubs/inifile/METADATA.toml
+++ b/stubs/inifile/METADATA.toml
@@ -1,1 +1,2 @@
 version = "0.4.*"
+upstream_repository = "https://github.com/mitsuhiko/python-inifile"

--- a/stubs/paho-mqtt/METADATA.toml
+++ b/stubs/paho-mqtt/METADATA.toml
@@ -1,1 +1,2 @@
 version = "1.6.*"
+upstream_repository = "https://github.com/eclipse/paho.mqtt.python"

--- a/stubs/passlib/METADATA.toml
+++ b/stubs/passlib/METADATA.toml
@@ -1,1 +1,2 @@
 version = "1.7.*"
+upstream_repository = "https://foss.heptapod.net/python-libs/passlib"

--- a/stubs/pexpect/METADATA.toml
+++ b/stubs/pexpect/METADATA.toml
@@ -1,1 +1,2 @@
 version = "4.8.*"
+upstream_repository = "https://github.com/pexpect/pexpect"

--- a/stubs/protobuf/METADATA.toml
+++ b/stubs/protobuf/METADATA.toml
@@ -1,5 +1,6 @@
 version = "4.24.*"
-extra_description = "Generated with aid from mypy-protobuf v3.4.0"
+upstream_repository = "https://github.com/protocolbuffers/protobuf"
+extra_description = "Generated with aid from [mypy-protobuf](https://github.com/nipunn1313/mypy-protobuf) v3.4.0"
 partial_stub = true
 
 [tool.stubtest]

--- a/stubs/pyaudio/METADATA.toml
+++ b/stubs/pyaudio/METADATA.toml
@@ -1,8 +1,7 @@
 version = "0.2.*"
 # There is no web portal for the source, this is the official source link:
 # https://people.csail.mit.edu/hubert/pyaudio/#sources
-# https://people.csail.mit.edu/hubert/git/pyaudio.git
-# upstream_repository =
+upstream_repository = "https://people.csail.mit.edu/hubert/git/pyaudio.git"
 
 [tool.stubtest]
 # linux and win32 are equivalent

--- a/stubs/pyaudio/METADATA.toml
+++ b/stubs/pyaudio/METADATA.toml
@@ -1,4 +1,7 @@
 version = "0.2.*"
+# There is no web portal for the source, this is the official source link:
+# https://people.csail.mit.edu/hubert/pyaudio/#sources
+upstream_repository = "https://people.csail.mit.edu/hubert/git/pyaudio.git"
 
 [tool.stubtest]
 # linux and win32 are equivalent

--- a/stubs/pyaudio/METADATA.toml
+++ b/stubs/pyaudio/METADATA.toml
@@ -1,6 +1,8 @@
 version = "0.2.*"
-# There is no web portal for the source, this is the official source link
-upstream_repository = "https://people.csail.mit.edu/hubert/pyaudio/#sources"
+# There is no web portal for the source, this is the official source link:
+# https://people.csail.mit.edu/hubert/pyaudio/#sources
+# https://people.csail.mit.edu/hubert/git/pyaudio.git
+# upstream_repository =
 
 [tool.stubtest]
 # linux and win32 are equivalent

--- a/stubs/pyaudio/METADATA.toml
+++ b/stubs/pyaudio/METADATA.toml
@@ -1,7 +1,6 @@
 version = "0.2.*"
 # There is no web portal for the source, this is the official source link:
-# https://people.csail.mit.edu/hubert/pyaudio/#sources
-upstream_repository = "https://people.csail.mit.edu/hubert/git/pyaudio.git"
+# upstream_repository = "https://people.csail.mit.edu/hubert/pyaudio/#sources"
 
 [tool.stubtest]
 # linux and win32 are equivalent

--- a/stubs/pyaudio/METADATA.toml
+++ b/stubs/pyaudio/METADATA.toml
@@ -1,7 +1,6 @@
 version = "0.2.*"
-# There is no web portal for the source, this is the official source link:
-# https://people.csail.mit.edu/hubert/pyaudio/#sources
-upstream_repository = "https://people.csail.mit.edu/hubert/git/pyaudio.git"
+# There is no web portal for the source, this is the official source link
+upstream_repository = "https://people.csail.mit.edu/hubert/pyaudio/#sources"
 
 [tool.stubtest]
 # linux and win32 are equivalent

--- a/stubs/pycurl/METADATA.toml
+++ b/stubs/pycurl/METADATA.toml
@@ -1,4 +1,5 @@
 version = "7.45.2"
+upstream_repository = "https://github.com/pycurl/pycurl"
 
 [tool.stubtest]
 # Install on Windows requires building PycURL from source

--- a/stubs/python-nmap/METADATA.toml
+++ b/stubs/python-nmap/METADATA.toml
@@ -1,1 +1,2 @@
 version = "0.7.*"
+upstream_repository = "https://bitbucket.org/xael/python-nmap"

--- a/stubs/pytz/METADATA.toml
+++ b/stubs/pytz/METADATA.toml
@@ -1,1 +1,3 @@
 version = "2023.3"
+# This is a mirror of https://git.launchpad.net/pytz, see https://pythonhosted.org/pytz/#latest-versions
+upstream_repository = "https://github.com/stub42/pytz"

--- a/stubs/pytz/METADATA.toml
+++ b/stubs/pytz/METADATA.toml
@@ -1,3 +1,3 @@
 version = "2023.3"
-# This is a mirror of https://git.launchpad.net/pytz, see https://pythonhosted.org/pytz/#latest-versions
+# This is a mirror of https://git.launchpad.net/pytz/tree, see https://pythonhosted.org/pytz/#latest-versions
 upstream_repository = "https://github.com/stub42/pytz"

--- a/stubs/untangle/METADATA.toml
+++ b/stubs/untangle/METADATA.toml
@@ -1,1 +1,2 @@
 version = "1.2.*"
+upstream_repository = "https://github.com/stchris/untangle"

--- a/tests/parse_metadata.py
+++ b/tests/parse_metadata.py
@@ -208,8 +208,8 @@ def read_metadata(distribution: str) -> StubMetadata:
         assert not parsed_url.netloc.startswith(
             "www."
         ), "`World Wide Web` subdomain (`www.`) should be removed from URLs in the upstream_repository field"
-        assert (
-            parsed_url.hostname not in QUERY_URL_ALLOWLIST and not parsed_url.query
+        assert parsed_url.hostname in QUERY_URL_ALLOWLIST or (
+            not parsed_url.query
         ), "Query params (`?`) should be removed from URLs in the upstream_repository field"
         assert not parsed_url.fragment, "Fragments (`#`) should be removed from URLs in the upstream_repository field"
         if parsed_url.netloc == "github.com":

--- a/tests/parse_metadata.py
+++ b/tests/parse_metadata.py
@@ -205,11 +205,13 @@ def read_metadata(distribution: str) -> StubMetadata:
     if isinstance(upstream_repository, str):
         parsed_url = urllib.parse.urlsplit(upstream_repository)
         assert parsed_url.scheme == "https", "URLs in the upstream_repository field should use https"
-        assert not parsed_url.netloc.startswith("www."), "`www.` should be removed from URLs in the upstream_repository field"
+        assert not parsed_url.netloc.startswith(
+            "www."
+        ), "`World Wide Web` subdomain (`www.`) should be removed from URLs in the upstream_repository field"
         assert (
             parsed_url.hostname not in QUERY_URL_ALLOWLIST and not parsed_url.query
-        ), "`?` should be removed from URLs in the upstream_repository field"
-        assert not parsed_url.fragment, "`#` should be removed from URLs in the upstream_repository field"
+        ), "Query params (`?`) should be removed from URLs in the upstream_repository field"
+        assert not parsed_url.fragment, "Fragments (`#`) should be removed from URLs in the upstream_repository field"
         if parsed_url.netloc == "github.com":
             cleaned_url_path = parsed_url.path.strip("/")
             num_url_path_parts = len(Path(cleaned_url_path).parts)

--- a/tests/parse_metadata.py
+++ b/tests/parse_metadata.py
@@ -32,7 +32,7 @@ __all__ = [
 
 _STUBTEST_PLATFORM_MAPPING: Final = {"linux": "apt_dependencies", "darwin": "brew_dependencies", "win32": "choco_dependencies"}
 # Some older websites have a bad pattern of using query params for navigation.
-QUERY_URL_ALLOWLIST = {"sourceware.org"}
+_QUERY_URL_ALLOWLIST = {"sourceware.org"}
 
 
 def _is_list_of_strings(obj: object) -> TypeGuard[list[str]]:
@@ -212,7 +212,7 @@ def read_metadata(distribution: str) -> StubMetadata:
         no_query_params_please = (
             f"{distribution}: Query params (`?`) should be removed from URLs in the upstream_repository field"
         )
-        assert parsed_url.hostname in QUERY_URL_ALLOWLIST or (not parsed_url.query), no_query_params_please
+        assert parsed_url.hostname in _QUERY_URL_ALLOWLIST or (not parsed_url.query), no_query_params_please
         no_fragments_please = f"{distribution}: Fragments (`#`) should be removed from URLs in the upstream_repository field"
         assert not parsed_url.fragment, no_fragments_please
         if parsed_url.netloc == "github.com":

--- a/tests/parse_metadata.py
+++ b/tests/parse_metadata.py
@@ -205,15 +205,16 @@ def read_metadata(distribution: str) -> StubMetadata:
     if isinstance(upstream_repository, str):
         parsed_url = urllib.parse.urlsplit(upstream_repository)
         assert parsed_url.scheme == "https", f"{distribution}: URLs in the upstream_repository field should use https"
-        assert not parsed_url.netloc.startswith(
-            "www."
-        ), f"{distribution}: `World Wide Web` subdomain (`www.`) should be removed from URLs in the upstream_repository field"
-        assert parsed_url.hostname in QUERY_URL_ALLOWLIST or (
-            not parsed_url.query
-        ), f"{distribution}: Query params (`?`) should be removed from URLs in the upstream_repository field"
-        assert (
-            not parsed_url.fragment
-        ), f"{distribution}: Fragments (`#`) should be removed from URLs in the upstream_repository field"
+        no_www_please = (
+            f"{distribution}: `World Wide Web` subdomain (`www.`) should be removed from URLs in the upstream_repository field"
+        )
+        assert not parsed_url.netloc.startswith("www."), no_www_please
+        no_query_params_please = (
+            f"{distribution}: Query params (`?`) should be removed from URLs in the upstream_repository field"
+        )
+        assert parsed_url.hostname in QUERY_URL_ALLOWLIST or (not parsed_url.query), no_query_params_please
+        no_fragments_please = f"{distribution}: Fragments (`#`) should be removed from URLs in the upstream_repository field"
+        assert not parsed_url.fragment, no_fragments_please
         if parsed_url.netloc == "github.com":
             cleaned_url_path = parsed_url.path.strip("/")
             num_url_path_parts = len(Path(cleaned_url_path).parts)

--- a/tests/parse_metadata.py
+++ b/tests/parse_metadata.py
@@ -31,8 +31,8 @@ __all__ = [
 
 
 _STUBTEST_PLATFORM_MAPPING: Final = {"linux": "apt_dependencies", "darwin": "brew_dependencies", "win32": "choco_dependencies"}
+# Some older websites have a bad pattern of using query params for navigation.
 QUERY_URL_ALLOWLIST = {"sourceware.org"}
-"""Some older websites have a bad pattern of using query params for navigation"""
 
 
 def _is_list_of_strings(obj: object) -> TypeGuard[list[str]]:
@@ -204,14 +204,16 @@ def read_metadata(distribution: str) -> StubMetadata:
     assert isinstance(upstream_repository, (str, type(None)))
     if isinstance(upstream_repository, str):
         parsed_url = urllib.parse.urlsplit(upstream_repository)
-        assert parsed_url.scheme == "https", "URLs in the upstream_repository field should use https"
+        assert parsed_url.scheme == "https", f"{distribution}: URLs in the upstream_repository field should use https"
         assert not parsed_url.netloc.startswith(
             "www."
-        ), "`World Wide Web` subdomain (`www.`) should be removed from URLs in the upstream_repository field"
+        ), f"{distribution}: `World Wide Web` subdomain (`www.`) should be removed from URLs in the upstream_repository field"
         assert parsed_url.hostname in QUERY_URL_ALLOWLIST or (
             not parsed_url.query
-        ), "Query params (`?`) should be removed from URLs in the upstream_repository field"
-        assert not parsed_url.fragment, "Fragments (`#`) should be removed from URLs in the upstream_repository field"
+        ), f"{distribution}: Query params (`?`) should be removed from URLs in the upstream_repository field"
+        assert (
+            not parsed_url.fragment
+        ), f"{distribution}: Fragments (`#`) should be removed from URLs in the upstream_repository field"
         if parsed_url.netloc == "github.com":
             cleaned_url_path = parsed_url.path.strip("/")
             num_url_path_parts = len(Path(cleaned_url_path).parts)


### PR DESCRIPTION
I was navigating https://alexwaygood.github.io/typeshed-stats/stats-csv/ for unrelated reasons and noticed a lot of missing upstream source / url, and decided it'd be fun to go on a hunt.

The only actually closed-source project seems to be SAP's hdbcli.
Most of these were linked in their docs (although sometimes very obscure). Except for python-ini which has no documentation and no link on PyPI. But it's the same author so I assume it's the right repository.

I've updated the `upstream_repository` field validation to make the GDB change pass. I believe this respects the original intent of avoiding extra query params and fragments that may have accidentally been copied. And added more detailed error messages.