### PR TITLE
Configure Ruff for VSCode

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,6 +3,7 @@
 {
     "recommendations": [
         "bierner.github-markdown-preview",
+        "charliermarsh.ruff",
         "editorconfig.editorconfig",
         "ms-python.black-formatter",
         "ms-python.flake8",
@@ -30,8 +31,6 @@
         "ms-python.autopep8",
         // Not using pylint
         "ms-python.pylint",
-        // Not using Ruff
-        "charliermarsh.ruff",
         // VSCode has implemented an optimized version
         "coenraads.bracket-pair-colorizer",
         "coenraads.bracket-pair-colorizer-2",

--- a/.vscode/settings.default.json
+++ b/.vscode/settings.default.json
@@ -5,7 +5,6 @@
  *
  * ⚠ Disclaimer: The typeshed team doesn't commit to maintaining this file. It exists purely for your ease of use.
 */
-// TODO: Add charliermarsh.ruff to unrecommended extensions
 {
     // Don't format on save for formatters we don't explicitely control
     "editor.formatOnSave": false,
@@ -22,7 +21,8 @@
         "pytype_exclude_list.txt": "properties"
     },
     "files.exclude": {
-        "**/.mypy_cache": true
+        "**/.*_cache": true, // mypy and Ruff cache
+        "**/__pycache__": true
     },
     "files.insertFinalNewline": true,
     "files.trimFinalNewlines": true,
@@ -48,6 +48,7 @@
         "editor.formatOnSave": true,
         "editor.codeActionsOnSave": {
             "source.fixAll": true,
+            // Allow isort or Ruff to organize imports
             "source.organizeImports": true
         }
     },
@@ -110,6 +111,10 @@
     "isort.check": true,
     "isort.importStrategy": "fromEnvironment",
     "black-formatter.importStrategy": "fromEnvironment",
+    "ruff.importStrategy": "fromEnvironment",
+    "ruff.fixAll": true,
+    // Conflict between Ruff and isort
+    "ruff.organizeImports": false,
     "evenBetterToml.formatter.alignComments": false,
     "evenBetterToml.formatter.alignEntries": false,
     "evenBetterToml.formatter.allowedBlankLines": 1,


### PR DESCRIPTION
I recently noticed typeshed started using Ruff. This will ensure that Ruff' autofixes are run correctly and automatically by the IDE VSCode. As well as automatically recommending the extension for users.

I've been using these configurations for a few days now without issues. They are also the same configuration I use in my own projects that use Ruff all the way (except for `"ruff.organizeImports": false`, which is specific to typeshed relying on isort for its import sorting)