### PR TITLE
Use Python 3.8 in runtests.py

### DIFF
--- a/scripts/runtests.py
+++ b/scripts/runtests.py
@@ -26,7 +26,7 @@ _NPX_ERROR_MESSAGE = colored("\nSkipping Pyright tests: npx is not installed or 
 _SUCCESS = colored("Success", "green")
 _SKIPPED = colored("Skipped", "yellow")
 _FAILED = colored("Failed", "red")
-# We're using the oldest supported version because it's the most likely to produce errors
+# We're using the oldest fully supported version because it's the most likely to produce errors
 # due to unsupported syntax, feature, or bug in a tool.
 _PYTHON_VERSION = "3.8"
 

--- a/scripts/runtests.py
+++ b/scripts/runtests.py
@@ -28,7 +28,7 @@ _SKIPPED = colored("Skipped", "yellow")
 _FAILED = colored("Failed", "red")
 # We're using the oldest supported version because it's the most likely to produce errors
 # due to unsupported syntax, feature, or bug in a tool.
-_PYTHON_VERSION = "3.7"
+_PYTHON_VERSION = "3.8"
 
 
 def _parse_jsonc(json_text: str) -> str:


### PR DESCRIPTION
We only support running mypy using 3.8+ up, since mypy 1.5 dropped support for running with Python 3.7.

Closes: #10599