### PR TITLE
Minor improvements to `stubtest_third_party.py`

### DIFF
--- a/tests/parse_metadata.py
+++ b/tests/parse_metadata.py
@@ -169,8 +169,11 @@ def read_metadata(distribution: str) -> StubMetadata:
     Use `read_dependencies` if you need to parse the dependencies
     given in the `requires` field, for example.
     """
-    with Path("stubs", distribution, "METADATA.toml").open("rb") as f:
-        data: dict[str, object] = tomli.load(f)
+    try:
+        with Path("stubs", distribution, "METADATA.toml").open("rb") as f:
+            data: dict[str, object] = tomli.load(f)
+    except FileNotFoundError:
+        raise ValueError(f"Typeshed has no stubs for {distribution!r}!") from None
 
     unknown_metadata_fields = data.keys() - _KNOWN_METADATA_FIELDS
     assert not unknown_metadata_fields, f"Unexpected keys in METADATA.toml for {distribution!r}: {unknown_metadata_fields}"

--- a/tests/parse_metadata.py
+++ b/tests/parse_metadata.py
@@ -20,6 +20,7 @@ from packaging.version import Version
 from utils import cache
 
 __all__ = [
+    "NoSuchStubError",
     "StubMetadata",
     "PackageDependencies",
     "StubtestSettings",
@@ -160,6 +161,10 @@ _KNOWN_METADATA_TOOL_FIELDS: Final = {
 _DIST_NAME_RE: Final = re.compile(r"^[a-z0-9]([a-z0-9._-]*[a-z0-9])?$", re.IGNORECASE)
 
 
+class NoSuchStubError(ValueError):
+    """Raise NoSuchStubError to indicate that a stubs/{distribution} directory doesn't exist"""
+
+
 @cache
 def read_metadata(distribution: str) -> StubMetadata:
     """Return an object describing the metadata of a stub as given in the METADATA.toml file.
@@ -173,7 +178,7 @@ def read_metadata(distribution: str) -> StubMetadata:
         with Path("stubs", distribution, "METADATA.toml").open("rb") as f:
             data: dict[str, object] = tomli.load(f)
     except FileNotFoundError:
-        raise ValueError(f"Typeshed has no stubs for {distribution!r}!") from None
+        raise NoSuchStubError(f"Typeshed has no stubs for {distribution!r}!") from None
 
     unknown_metadata_fields = data.keys() - _KNOWN_METADATA_FIELDS
     assert not unknown_metadata_fields, f"Unexpected keys in METADATA.toml for {distribution!r}: {unknown_metadata_fields}"

--- a/tests/stubtest_third_party.py
+++ b/tests/stubtest_third_party.py
@@ -16,9 +16,14 @@ from parse_metadata import get_recursive_requirements, read_metadata
 from utils import colored, get_mypy_req, make_venv, print_error, print_success_msg
 
 
-def run_stubtest(dist: Path, *, verbose: bool = False, specified_platforms_only: bool = False) -> bool:
+def run_stubtest(
+    dist: Path, *, parser: argparse.ArgumentParser, verbose: bool = False, specified_platforms_only: bool = False
+) -> bool:
     dist_name = dist.name
-    metadata = read_metadata(dist_name)
+    try:
+        metadata = read_metadata(dist_name)
+    except ValueError as e:
+        parser.error(str(e))
     print(f"{dist_name}... ", end="")
 
     stubtest_settings = metadata.stubtest_settings
@@ -109,6 +114,10 @@ def run_stubtest(dist: Path, *, verbose: bool = False, specified_platforms_only:
             print_error("fail")
             print_commands(dist, pip_cmd, stubtest_cmd, mypypath)
             print_command_output(e)
+
+            print("Python version: ", file=sys.stderr)
+            ret = subprocess.run([sys.executable, "-VV"], capture_output=True)
+            print_command_output(ret)
 
             print("Ran with the following environment:", file=sys.stderr)
             ret = subprocess.run([pip_exe, "freeze", "--all"], capture_output=True)
@@ -253,7 +262,7 @@ def main() -> NoReturn:
     for i, dist in enumerate(dists):
         if i % args.num_shards != args.shard_index:
             continue
-        if not run_stubtest(dist, verbose=args.verbose, specified_platforms_only=args.specified_platforms_only):
+        if not run_stubtest(dist, parser=parser, verbose=args.verbose, specified_platforms_only=args.specified_platforms_only):
             result = 1
     sys.exit(result)
 

--- a/tests/stubtest_third_party.py
+++ b/tests/stubtest_third_party.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from textwrap import dedent
 from typing import NoReturn
 
-from parse_metadata import get_recursive_requirements, read_metadata
+from parse_metadata import NoSuchStubError, get_recursive_requirements, read_metadata
 from utils import colored, get_mypy_req, make_venv, print_error, print_success_msg
 
 
@@ -22,7 +22,7 @@ def run_stubtest(
     dist_name = dist.name
     try:
         metadata = read_metadata(dist_name)
-    except ValueError as e:
+    except NoSuchStubError as e:
         parser.error(str(e))
     print(f"{dist_name}... ", end="")
 


### PR DESCRIPTION
**(1) Give a nicer error message if you try to run stubtest on non-existent stubs.**

Before:

```pytb
typeshed>python tests/stubtest_third_party.py fpdf
Traceback (most recent call last):
  File "C:\Users\alexw\coding\typeshed\tests\stubtest_third_party.py", line 263, in <module>
    main()
  File "C:\Users\alexw\coding\typeshed\tests\stubtest_third_party.py", line 256, in main
    if not run_stubtest(dist, verbose=args.verbose, specified_platforms_only=args.specified_platforms_only):
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\alexw\coding\typeshed\tests\stubtest_third_party.py", line 21, in run_stubtest
    metadata = read_metadata(dist_name)
               ^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\alexw\coding\typeshed\tests\parse_metadata.py", line 172, in read_metadata
    with Path("stubs", distribution, "METADATA.toml").open("rb") as f:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\alexw\AppData\Local\Programs\Python\Python311\Lib\pathlib.py", line 1044, in open
    return io.open(self, mode, buffering, encoding, errors, newline)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: 'stubs\\fpdf\\METADATA.toml'
```

With this PR:

```pytb
typeshed>python tests/stubtest_third_party.py fpdf
usage: stubtest_third_party.py [-h] [-v] [--num-shards NUM_SHARDS] [--shard-index SHARD_INDEX] [--specified-platforms-only] [DISTRIBUTION ...]
stubtest_third_party.py: error: Typeshed has no stubs for 'fpdf'!
```

**(2) Print the Python version to the terminal if there's an error, as well as the output of `pip freeze`.**

You can find out pretty easily from looking at the GitHub Actions workflow (or from the output of `actions/setup-python` in CI) which version of Python the job is running on. It's still easy to forget, though, that the CI might be running a different version of Python to the one you're running locally, and this change makes things more convenient by putting all the information you need to debug all together in one place.