### PR TITLE
stubsabot: avoid validating diff info url

### DIFF
--- a/scripts/stubsabot.py
+++ b/scripts/stubsabot.py
@@ -313,9 +313,6 @@ async def get_diff_info(
         old_tag = versions_to_tags[old_version]
 
     diff_url = f"https://github.com/{github_info.repo_path}/compare/{old_tag}...{new_tag}"
-    async with session.get(diff_url, headers=get_github_api_headers()) as response:
-        # Double-check we're returning a valid URL here
-        response.raise_for_status()
     return GithubDiffInfo(repo_path=github_info.repo_path, old_tag=old_tag, new_tag=new_tag, diff_url=diff_url)
 
 


### PR DESCRIPTION
It looks like all the timeouts are happening in the get_diff_info code. I don't think we really need to validate the URL exists. In any case, we probably end up hitting a very similar endpoint later in analyze_diff.