### PR TITLE
`asyncio.wait()` no longer allows awaitables in 3.11

### DIFF
--- a/stdlib/asyncio/tasks.pyi
+++ b/stdlib/asyncio/tasks.pyi
@@ -243,12 +243,6 @@ if sys.version_info >= (3, 10):
     async def sleep(delay: float) -> None: ...
     @overload
     async def sleep(delay: float, result: _T) -> _T: ...
-    @overload
-    async def wait(fs: Iterable[_FT], *, timeout: float | None = None, return_when: str = "ALL_COMPLETED") -> tuple[set[_FT], set[_FT]]: ...  # type: ignore[misc]
-    @overload
-    async def wait(
-        fs: Iterable[Awaitable[_T]], *, timeout: float | None = None, return_when: str = "ALL_COMPLETED"
-    ) -> tuple[set[Task[_T]], set[Task[_T]]]: ...
     async def wait_for(fut: _FutureLike[_T], timeout: float | None) -> _T: ...
 
 else:
@@ -257,6 +251,23 @@ else:
     async def sleep(delay: float, *, loop: AbstractEventLoop | None = None) -> None: ...
     @overload
     async def sleep(delay: float, result: _T, *, loop: AbstractEventLoop | None = None) -> _T: ...
+    async def wait_for(fut: _FutureLike[_T], timeout: float | None, *, loop: AbstractEventLoop | None = None) -> _T: ...
+
+if sys.version_info >= (3, 11):
+    @overload
+    async def wait(fs: Iterable[_FT], *, timeout: float | None = None, return_when: str = "ALL_COMPLETED") -> tuple[set[_FT], set[_FT]]: ...  # type: ignore[misc]
+    @overload
+    async def wait(
+        fs: Iterable[Task[_T]], *, timeout: float | None = None, return_when: str = "ALL_COMPLETED"
+    ) -> tuple[set[Task[_T]], set[Task[_T]]]: ...
+elif sys.version_info >= (3, 10):
+    @overload
+    async def wait(fs: Iterable[_FT], *, timeout: float | None = None, return_when: str = "ALL_COMPLETED") -> tuple[set[_FT], set[_FT]]: ...  # type: ignore[misc]
+    @overload
+    async def wait(
+        fs: Iterable[Awaitable[_T]], *, timeout: float | None = None, return_when: str = "ALL_COMPLETED"
+    ) -> tuple[set[Task[_T]], set[Task[_T]]]: ...
+else:
     @overload
     async def wait(  # type: ignore[misc]
         fs: Iterable[_FT],
@@ -273,7 +284,6 @@ else:
         timeout: float | None = None,
         return_when: str = "ALL_COMPLETED",
     ) -> tuple[set[Task[_T]], set[Task[_T]]]: ...
-    async def wait_for(fut: _FutureLike[_T], timeout: float | None, *, loop: AbstractEventLoop | None = None) -> _T: ...
 
 if sys.version_info >= (3, 12):
     _TaskCompatibleCoro: TypeAlias = Coroutine[Any, Any, _T_co]

--- a/stdlib/asyncio/tasks.pyi
+++ b/stdlib/asyncio/tasks.pyi
@@ -260,6 +260,7 @@ if sys.version_info >= (3, 11):
     async def wait(
         fs: Iterable[Task[_T]], *, timeout: float | None = None, return_when: str = "ALL_COMPLETED"
     ) -> tuple[set[Task[_T]], set[Task[_T]]]: ...
+
 elif sys.version_info >= (3, 10):
     @overload
     async def wait(fs: Iterable[_FT], *, timeout: float | None = None, return_when: str = "ALL_COMPLETED") -> tuple[set[_FT], set[_FT]]: ...  # type: ignore[misc]
@@ -267,6 +268,7 @@ elif sys.version_info >= (3, 10):
     async def wait(
         fs: Iterable[Awaitable[_T]], *, timeout: float | None = None, return_when: str = "ALL_COMPLETED"
     ) -> tuple[set[Task[_T]], set[Task[_T]]]: ...
+
 else:
     @overload
     async def wait(  # type: ignore[misc]


### PR DESCRIPTION
https://docs.python.org/3.10/library/asyncio-task.html#asyncio.wait
> Run awaitable objects in the aws iterable concurrently and block until the condition specified by `return_when`.

https://docs.python.org/3.11/library/asyncio-task.html#asyncio.wait
> Run Future and Task instances in the aws iterable concurrently and block until the condition specified by `return_when`.

https://github.com/python/cpython/blob/v3.11.0/Lib/asyncio/tasks.py#L414-L415
```python
    if any(coroutines.iscoroutine(f) for f in fs):
        raise TypeError("Passing coroutines is forbidden, use tasks explicitly.")
```