### PR TITLE
runtests.py: note that stdlib stubtest might fail

### DIFF
--- a/scripts/runtests.py
+++ b/scripts/runtests.py
@@ -55,7 +55,8 @@ def main() -> None:
         action="store_true",
         help=(
             "Run stubtest for the selected package(s). Running stubtest may download and execute arbitrary code from PyPI: "
-            "only use this option if you trust the package you are testing."
+            "only use this option if you trust the package you are testing. Running stubtest on the stdlib may fail "
+            "unless you're using exactly the same version of Python that we use in CI for stubtest."
         ),
     )
     parser.add_argument("path", help="Path of the stub to test in format <folder>/<stub>, from the root of the project.")

--- a/scripts/runtests.py
+++ b/scripts/runtests.py
@@ -55,8 +55,7 @@ def main() -> None:
         action="store_true",
         help=(
             "Run stubtest for the selected package(s). Running stubtest may download and execute arbitrary code from PyPI: "
-            "only use this option if you trust the package you are testing. Running stubtest on the stdlib may fail "
-            "unless you're using exactly the same version of Python that we use in CI for stubtest."
+            "only use this option if you trust the package you are testing."
         ),
     )
     parser.add_argument("path", help="Path of the stub to test in format <folder>/<stub>, from the root of the project.")

--- a/tests/README.md
+++ b/tests/README.md
@@ -49,7 +49,10 @@ You must provide a single argument which is a path to the stubs to test, like
 so: `stdlib/os` or `stubs/requests`.
 
 Run `python scripts/runtests.py --help` for information on the various configuration options
-for this script.
+for this script. Note that if you use the `--run-stubtest` flag with the stdlib stubs,
+whether or not the test passes will depend on the exact version of Python
+you're using, as well as various other details regarding your local environment.
+For more information, see the docs on [`stubtest_stdlib.py`](#stubtest_stdlibpy) below.
 
 ## mypy\_test.py
 


### PR DESCRIPTION
This is an attempt to clear up some of the confusion in https://github.com/python/typeshed/pull/10612#discussion_r1306440772 (cc. @josephcourtney). `tests/README.md` already has a note to this effect in the section on `stubtest_stdlib.py`, so this just adds a note to the `scripts/runtests.py` docs