### PR TITLE
Experiment with zip typing

### DIFF
--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -1848,17 +1848,7 @@ class zip(Iterator[_T_co], Generic[_T_co]):
             strict: bool = ...,
         ) -> zip[tuple[_T1, _T2, _T3, _T4, _T5]]: ...
         @overload
-        def __new__(
-            cls,
-            __iter1: Iterable[Any],
-            __iter2: Iterable[Any],
-            __iter3: Iterable[Any],
-            __iter4: Iterable[Any],
-            __iter5: Iterable[Any],
-            __iter6: Iterable[Any],
-            *iterables: Iterable[Any],
-            strict: bool = ...,
-        ) -> zip[tuple[Any, ...]]: ...
+        def __new__(cls, *iterables: Iterable[_T], strict: bool = ...) -> zip[tuple[_T, ...]]: ...
     else:
         @overload
         def __new__(cls, __iter1: Iterable[_T1]) -> zip[tuple[_T1]]: ...
@@ -1880,16 +1870,7 @@ class zip(Iterator[_T_co], Generic[_T_co]):
             __iter5: Iterable[_T5],
         ) -> zip[tuple[_T1, _T2, _T3, _T4, _T5]]: ...
         @overload
-        def __new__(
-            cls,
-            __iter1: Iterable[Any],
-            __iter2: Iterable[Any],
-            __iter3: Iterable[Any],
-            __iter4: Iterable[Any],
-            __iter5: Iterable[Any],
-            __iter6: Iterable[Any],
-            *iterables: Iterable[Any],
-        ) -> zip[tuple[Any, ...]]: ...
+        def __new__(cls, *iterables: Iterable[_T]) -> zip[tuple[_T, ...]]: ...
 
     def __iter__(self) -> Self: ...
     def __next__(self) -> _T_co: ...

--- a/test_cases/stdlib/builtins/check_zip.py
+++ b/test_cases/stdlib/builtins/check_zip.py
@@ -1,0 +1,25 @@
+from typing import Any
+from typing_extensions import assert_type
+
+
+def lists(li: list[int], ls: list[str]) -> None:
+    assert_type(zip(li), zip[tuple[int]])
+    assert_type(zip(li, li), zip[tuple[int, int]])
+    assert_type(zip(ls, li), zip[tuple[str, int]])
+    assert_type(zip(li, ls), zip[tuple[int, str]])
+    assert_type(zip(ls, li, li), zip[tuple[str, int, int]])
+
+    assert_type(zip(ls, li, li, li, li, li, li, li, li, ls, li, ls), zip[tuple[object, ...]])
+
+
+def lists_any(la: list[Any], li: list[int]) -> None:
+    assert_type(zip(la), zip[tuple[Any]])
+    assert_type(zip(la, li), zip[tuple[Any, int]])
+    assert_type(zip(li, la), zip[tuple[int, Any]])
+
+    assert_type(zip(la, li, li, li, li, li, li, li, li, la, li, la), zip[tuple[Any, ...]])
+
+
+def star_lists(ltii: list[tuple[int, int]], ltis: list[tuple[int, str]]) -> None:
+    assert_type(zip(*ltii), zip[tuple[int, ...]])
+    assert_type(zip(*ltis), zip[tuple[object, ...]])


### PR DESCRIPTION
It's been a couple years, maybe I can change zip without it being disastrous. This change makes zip type safe, which is probably undesirable. Would also fix #10651. Note this isn't a join vs union thing, both unions and joins are often undesirable for `zip(*x)` use cases.