### PR TITLE
Add stubs for requests-oauthlib

### DIFF
--- a/pyrightconfig.stricter.json
+++ b/pyrightconfig.stricter.json
@@ -68,6 +68,7 @@
         "stubs/qrcode",
         "stubs/redis",
         "stubs/requests",
+        "stubs/requests-oauthlib",
         "stubs/setuptools",
         "stubs/stripe",
         "stubs/tqdm",

--- a/stubs/requests-oauthlib/METADATA.toml
+++ b/stubs/requests-oauthlib/METADATA.toml
@@ -1,0 +1,3 @@
+version = "1.3.*"
+upstream_repository = "https://github.com/requests/requests-oauthlib"
+requires = ["types-oauthlib", "types-requests"]

--- a/stubs/requests-oauthlib/requests_oauthlib/__init__.pyi
+++ b/stubs/requests-oauthlib/requests_oauthlib/__init__.pyi
@@ -1,0 +1,6 @@
+from .oauth1_auth import OAuth1 as OAuth1
+from .oauth1_session import OAuth1Session as OAuth1Session
+from .oauth2_auth import OAuth2 as OAuth2
+from .oauth2_session import OAuth2Session as OAuth2Session, TokenUpdated as TokenUpdated
+
+__version__: str

--- a/stubs/requests-oauthlib/requests_oauthlib/compliance_fixes/__init__.pyi
+++ b/stubs/requests-oauthlib/requests_oauthlib/compliance_fixes/__init__.pyi
@@ -1,0 +1,8 @@
+from .ebay import ebay_compliance_fix as ebay_compliance_fix
+from .facebook import facebook_compliance_fix as facebook_compliance_fix
+from .fitbit import fitbit_compliance_fix as fitbit_compliance_fix
+from .instagram import instagram_compliance_fix as instagram_compliance_fix
+from .mailchimp import mailchimp_compliance_fix as mailchimp_compliance_fix
+from .plentymarkets import plentymarkets_compliance_fix as plentymarkets_compliance_fix
+from .slack import slack_compliance_fix as slack_compliance_fix
+from .weibo import weibo_compliance_fix as weibo_compliance_fix

--- a/stubs/requests-oauthlib/requests_oauthlib/compliance_fixes/douban.pyi
+++ b/stubs/requests-oauthlib/requests_oauthlib/compliance_fixes/douban.pyi
@@ -1,0 +1,7 @@
+from typing import TypeVar
+
+from requests_oauthlib import OAuth2Session
+
+_OAuth2SessionT = TypeVar("_OAuth2SessionT", bound=OAuth2Session)
+
+def douban_compliance_fix(session: _OAuth2SessionT) -> _OAuth2SessionT: ...

--- a/stubs/requests-oauthlib/requests_oauthlib/compliance_fixes/ebay.pyi
+++ b/stubs/requests-oauthlib/requests_oauthlib/compliance_fixes/ebay.pyi
@@ -1,0 +1,7 @@
+from typing import TypeVar
+
+from requests_oauthlib import OAuth2Session
+
+_OAuth2SessionT = TypeVar("_OAuth2SessionT", bound=OAuth2Session)
+
+def ebay_compliance_fix(session: _OAuth2SessionT) -> _OAuth2SessionT: ...

--- a/stubs/requests-oauthlib/requests_oauthlib/compliance_fixes/facebook.pyi
+++ b/stubs/requests-oauthlib/requests_oauthlib/compliance_fixes/facebook.pyi
@@ -1,0 +1,7 @@
+from typing import TypeVar
+
+from requests_oauthlib import OAuth2Session
+
+_OAuth2SessionT = TypeVar("_OAuth2SessionT", bound=OAuth2Session)
+
+def facebook_compliance_fix(session: _OAuth2SessionT) -> _OAuth2SessionT: ...

--- a/stubs/requests-oauthlib/requests_oauthlib/compliance_fixes/fitbit.pyi
+++ b/stubs/requests-oauthlib/requests_oauthlib/compliance_fixes/fitbit.pyi
@@ -1,0 +1,3 @@
+from requests_oauthlib import OAuth2Session
+
+def fitbit_compliance_fix(session: OAuth2Session) -> OAuth2Session: ...

--- a/stubs/requests-oauthlib/requests_oauthlib/compliance_fixes/instagram.pyi
+++ b/stubs/requests-oauthlib/requests_oauthlib/compliance_fixes/instagram.pyi
@@ -1,0 +1,7 @@
+from typing import TypeVar
+
+from requests_oauthlib import OAuth2Session
+
+_OAuth2SessionT = TypeVar("_OAuth2SessionT", bound=OAuth2Session)
+
+def instagram_compliance_fix(session: _OAuth2SessionT) -> _OAuth2SessionT: ...

--- a/stubs/requests-oauthlib/requests_oauthlib/compliance_fixes/mailchimp.pyi
+++ b/stubs/requests-oauthlib/requests_oauthlib/compliance_fixes/mailchimp.pyi
@@ -1,0 +1,7 @@
+from typing import TypeVar
+
+from requests_oauthlib import OAuth2Session
+
+_OAuth2SessionT = TypeVar("_OAuth2SessionT", bound=OAuth2Session)
+
+def mailchimp_compliance_fix(session: _OAuth2SessionT) -> _OAuth2SessionT: ...

--- a/stubs/requests-oauthlib/requests_oauthlib/compliance_fixes/plentymarkets.pyi
+++ b/stubs/requests-oauthlib/requests_oauthlib/compliance_fixes/plentymarkets.pyi
@@ -1,0 +1,7 @@
+from typing import TypeVar
+
+from requests_oauthlib import OAuth2Session
+
+_OAuth2SessionT = TypeVar("_OAuth2SessionT", bound=OAuth2Session)
+
+def plentymarkets_compliance_fix(session: _OAuth2SessionT) -> _OAuth2SessionT: ...

--- a/stubs/requests-oauthlib/requests_oauthlib/compliance_fixes/slack.pyi
+++ b/stubs/requests-oauthlib/requests_oauthlib/compliance_fixes/slack.pyi
@@ -1,0 +1,7 @@
+from typing import TypeVar
+
+from requests_oauthlib import OAuth2Session
+
+_OAuth2SessionT = TypeVar("_OAuth2SessionT", bound=OAuth2Session)
+
+def slack_compliance_fix(session: _OAuth2SessionT) -> _OAuth2SessionT: ...

--- a/stubs/requests-oauthlib/requests_oauthlib/compliance_fixes/weibo.pyi
+++ b/stubs/requests-oauthlib/requests_oauthlib/compliance_fixes/weibo.pyi
@@ -1,0 +1,7 @@
+from typing import TypeVar
+
+from requests_oauthlib import OAuth2Session
+
+_OAuth2SessionT = TypeVar("_OAuth2SessionT", bound=OAuth2Session)
+
+def weibo_compliance_fix(session: _OAuth2SessionT) -> _OAuth2SessionT: ...

--- a/stubs/requests-oauthlib/requests_oauthlib/oauth1_auth.pyi
+++ b/stubs/requests-oauthlib/requests_oauthlib/oauth1_auth.pyi
@@ -1,0 +1,33 @@
+from _typeshed import Incomplete
+from logging import Logger
+
+from oauthlib.oauth1 import Client
+from requests.auth import AuthBase
+
+CONTENT_TYPE_FORM_URLENCODED: str
+CONTENT_TYPE_MULTI_PART: str
+log: Logger
+
+class OAuth1(AuthBase):
+    client_class: type[Client]
+    client: Client
+    force_include_body: bool
+    def __init__(
+        self,
+        client_key,
+        client_secret: Incomplete | None = None,
+        resource_owner_key: Incomplete | None = None,
+        resource_owner_secret: Incomplete | None = None,
+        callback_uri: Incomplete | None = None,
+        signature_method="HMAC-SHA1",
+        signature_type="AUTH_HEADER",
+        rsa_key: Incomplete | None = None,
+        verifier: Incomplete | None = None,
+        decoding: str = "utf-8",
+        client_class: type[Client] | None = None,
+        force_include_body: bool = False,
+        *,
+        encoding: str = "utf-8",
+        nonce: Incomplete | None = None,
+        timestamp: Incomplete | None = None,
+    ) -> None: ...

--- a/stubs/requests-oauthlib/requests_oauthlib/oauth1_session.pyi
+++ b/stubs/requests-oauthlib/requests_oauthlib/oauth1_session.pyi
@@ -1,0 +1,64 @@
+from _typeshed import Incomplete
+from logging import Logger
+from typing_extensions import TypeAlias, TypedDict
+
+import requests
+from oauthlib.oauth1 import Client
+
+from . import OAuth1
+
+# should be dict[str, str] but could look different
+_ParsedToken: TypeAlias = dict[str, Incomplete]
+
+class _TokenDict(TypedDict, total=False):
+    oauth_token: Incomplete  # oauthlib.oauth1.Client.resource_owner_key
+    oauth_token_secret: Incomplete  # oauthlib.oauth1.Client.resource_token_secret
+    oauth_verifier: Incomplete  # oauthlib.oauth1.Client.oauth_verifier
+
+log: Logger
+
+def urldecode(body): ...
+
+class TokenRequestDenied(ValueError):
+    response: requests.Response
+    def __init__(self, message: str, response: requests.Response) -> None: ...
+    @property
+    def status_code(self) -> int: ...
+
+class TokenMissing(ValueError):
+    response: requests.Response
+    def __init__(self, message: str, response: requests.Response) -> None: ...
+
+class VerifierMissing(ValueError): ...
+
+class OAuth1Session(requests.Session):
+    auth: OAuth1
+    def __init__(
+        self,
+        client_key,
+        client_secret: Incomplete | None = None,
+        resource_owner_key: Incomplete | None = None,
+        resource_owner_secret: Incomplete | None = None,
+        callback_uri: Incomplete | None = None,
+        signature_method="HMAC-SHA1",
+        signature_type="AUTH_HEADER",
+        rsa_key: Incomplete | None = None,
+        verifier: Incomplete | None = None,
+        client_class: type[Client] | None = None,
+        force_include_body: bool = False,
+        *,
+        encoding: str = "utf-8",
+        nonce: Incomplete | None = None,
+        timestamp: Incomplete | None = None,
+    ) -> None: ...
+    @property
+    def token(self) -> _TokenDict: ...
+    @token.setter
+    def token(self, value: _TokenDict) -> None: ...
+    @property
+    def authorized(self) -> bool: ...
+    def authorization_url(self, url: str, request_token: Incomplete | None = None, **kwargs) -> str: ...
+    def fetch_request_token(self, url: str, realm: Incomplete | None = None, **request_kwargs) -> _ParsedToken: ...
+    def fetch_access_token(self, url: str, verifier: Incomplete | None = None, **request_kwargs) -> _ParsedToken: ...
+    def parse_authorization_response(self, url: str) -> _ParsedToken: ...
+    def rebuild_auth(self, prepared_request: requests.PreparedRequest, response: requests.Response) -> None: ...

--- a/stubs/requests-oauthlib/requests_oauthlib/oauth2_auth.pyi
+++ b/stubs/requests-oauthlib/requests_oauthlib/oauth2_auth.pyi
@@ -1,0 +1,9 @@
+from _typeshed import Incomplete
+
+from oauthlib.oauth2 import Client
+from requests.auth import AuthBase
+
+class OAuth2(AuthBase):
+    def __init__(
+        self, client_id: Incomplete | None = None, client: Client | None = None, token: Incomplete | None = None
+    ) -> None: ...

--- a/stubs/requests-oauthlib/requests_oauthlib/oauth2_session.pyi
+++ b/stubs/requests-oauthlib/requests_oauthlib/oauth2_session.pyi
@@ -54,17 +54,17 @@ class OAuth2Session(requests.Session):
     ) -> None: ...
     def new_state(self): ...
     @property
-    def client_id(self) -> Incomplete | None: ...  # oauthlib.ouath2.Client.client_id
+    def client_id(self) -> Incomplete | None: ...  # oauthlib.oauth2.Client.client_id
     @client_id.setter
     def client_id(self, value: Incomplete | None) -> None: ...
     @client_id.deleter
     def client_id(self) -> None: ...
     @property
-    def token(self): ...  # oauthlib.ouath2.Client.token
+    def token(self): ...  # oauthlib.oauth2.Client.token
     @token.setter
     def token(self, value) -> None: ...
     @property
-    def access_token(self): ...  # oauthlib.ouath2.Client.access_token
+    def access_token(self): ...  # oauthlib.oauth2.Client.access_token
     @access_token.setter
     def access_token(self, value) -> None: ...
     @access_token.deleter

--- a/stubs/requests-oauthlib/requests_oauthlib/oauth2_session.pyi
+++ b/stubs/requests-oauthlib/requests_oauthlib/oauth2_session.pyi
@@ -1,0 +1,136 @@
+from _typeshed import Incomplete
+from logging import Logger
+from typing import Any, Protocol, TypedDict, overload
+from typing_extensions import Literal, TypeAlias
+
+import requests
+from oauthlib.oauth2 import Client
+from requests.cookies import RequestsCookieJar
+
+_Token: TypeAlias = dict[str, Incomplete]  # oauthlib.oauth2.Client.token
+
+class _AccessTokenResponseHook(Protocol):
+    def __call__(self, __response: requests.Response) -> requests.Response: ...
+
+class _RefreshTokenResponseHook(Protocol):
+    def __call__(self, __response: requests.Response) -> requests.Response: ...
+
+class _ProtectedRequestHook(Protocol):
+    def __call__(
+        self, __url: Incomplete, __headers: Incomplete, __data: Incomplete
+    ) -> tuple[Incomplete, Incomplete, Incomplete]: ...
+
+class _ComplianceHooks(TypedDict):
+    access_token_response: set[_AccessTokenResponseHook]
+    refresh_token_response: set[_RefreshTokenResponseHook]
+    protected_request: set[_ProtectedRequestHook]
+
+log: Logger
+
+class TokenUpdated(Warning):
+    token: Incomplete
+    def __init__(self, token) -> None: ...
+
+class OAuth2Session(requests.Session):
+    redirect_uri: Incomplete
+    state: Incomplete
+    auto_refresh_url: str | None
+    auto_refresh_kwargs: dict[str, Any]
+    token_updater: Incomplete
+    compliance_hook: _ComplianceHooks
+    scope: Incomplete | None
+    def __init__(
+        self,
+        client_id: Incomplete | None = None,
+        client: Client | None = None,
+        auto_refresh_url: str | None = None,
+        auto_refresh_kwargs: dict[str, Any] | None = None,
+        scope: Incomplete | None = None,
+        redirect_uri: Incomplete | None = None,
+        token: Incomplete | None = None,
+        state: Incomplete | None = None,
+        token_updater: Incomplete | None = None,
+        **kwargs,
+    ) -> None: ...
+    def new_state(self): ...
+    @property
+    def client_id(self) -> Incomplete | None: ...  # oauthlib.ouath2.Client.client_id
+    @client_id.setter
+    def client_id(self, value: Incomplete | None) -> None: ...
+    @client_id.deleter
+    def client_id(self) -> None: ...
+    @property
+    def token(self): ...  # oauthlib.ouath2.Client.token
+    @token.setter
+    def token(self, value) -> None: ...
+    @property
+    def access_token(self): ...  # oauthlib.ouath2.Client.access_token
+    @access_token.setter
+    def access_token(self, value) -> None: ...
+    @access_token.deleter
+    def access_token(self) -> None: ...
+    @property
+    def authorized(self) -> bool: ...
+    def authorization_url(self, url: str, state: Incomplete | None = None, **kwargs) -> str: ...
+    def fetch_token(
+        self,
+        token_url: str,
+        code: Incomplete | None = None,
+        authorization_response: Incomplete | None = None,
+        body: str = "",
+        auth: Incomplete | None = None,
+        username: Incomplete | None = None,
+        password: Incomplete | None = None,
+        method: str = "POST",
+        force_querystring: bool = False,
+        timeout: Incomplete | None = None,
+        headers: Incomplete | None = None,
+        verify: bool = True,
+        proxies: Incomplete | None = None,
+        include_client_id: Incomplete | None = None,
+        client_secret: Incomplete | None = None,
+        cert: Incomplete | None = None,
+        **kwargs,
+    ) -> _Token: ...
+    def token_from_fragment(self, authorization_response: str) -> _Token: ...
+    def refresh_token(
+        self,
+        token_url: str,
+        refresh_token: Incomplete | None = None,
+        body: str = "",
+        auth: Incomplete | None = None,
+        timeout: Incomplete | None = None,
+        headers: Incomplete | None = None,
+        verify: bool = True,
+        proxies: Incomplete | None = None,
+        **kwargs,
+    ) -> _Token: ...
+    def request(  # type: ignore[override]
+        self,
+        method: str | bytes,
+        url: str | bytes,
+        data: requests.sessions._Data | None = None,
+        headers: requests.sessions._HeadersUpdateMapping | None = None,
+        withhold_token: bool = False,
+        client_id: Incomplete | None = None,
+        client_secret: Incomplete | None = None,
+        *,
+        params: requests.sessions._Params | None = None,
+        cookies: None | RequestsCookieJar | requests.sessions._TextMapping = None,
+        files: requests.sessions._Files | None = None,
+        auth: requests.sessions._Auth | None = None,
+        timeout: requests.sessions._Timeout | None = None,
+        allow_redirects: bool = True,
+        proxies: requests.sessions._TextMapping | None = None,
+        hooks: requests.sessions._HooksInput | None = None,
+        stream: bool | None = None,
+        verify: requests.sessions._Verify | None = None,
+        cert: requests.sessions._Cert | None = None,
+        json: Incomplete | None = None,
+    ) -> requests.Response: ...
+    @overload
+    def register_compliance_hook(self, hook_type: Literal["access_token_response"], hook: _AccessTokenResponseHook) -> None: ...
+    @overload
+    def register_compliance_hook(self, hook_type: Literal["refresh_token_response"], hook: _RefreshTokenResponseHook) -> None: ...
+    @overload
+    def register_compliance_hook(self, hook_type: Literal["protected_request"], hook: _ProtectedRequestHook) -> None: ...

--- a/stubs/requests-oauthlib/requests_oauthlib/oauth2_session.pyi
+++ b/stubs/requests-oauthlib/requests_oauthlib/oauth2_session.pyi
@@ -1,7 +1,7 @@
 from _typeshed import Incomplete
 from logging import Logger
-from typing import Any, Protocol, TypedDict, overload
-from typing_extensions import Literal, TypeAlias
+from typing import Any, Protocol, overload
+from typing_extensions import Literal, TypeAlias, TypedDict
 
 import requests
 from oauthlib.oauth2 import Client


### PR DESCRIPTION
These are mostly still baseline stubs since the same is true for `types-oauthlib`, however some simple things have been filled in/copied over from `types-requests`.

Source can be found at: https://github.com/requests/requests-oauthlib/blob/v1.3.1/requests_oauthlib/__init__.py
Docs here: https://requests-oauthlib.readthedocs.io/en/v1.3.1/