### PR TITLE
Add a lint forbidding PEP-570 syntax

### DIFF
--- a/tests/check_new_syntax.py
+++ b/tests/check_new_syntax.py
@@ -27,6 +27,9 @@ def check_new_syntax(tree: ast.AST, path: Path, stub: str) -> list[str]:
             self.generic_visit(node)
 
     class PEP570Finder(ast.NodeVisitor):
+        def __init__(self) -> None:
+            self.lineno: int | None = None
+        
         def _visit_function(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
             self.lineno = node.lineno
             self.generic_visit(node)
@@ -35,6 +38,7 @@ def check_new_syntax(tree: ast.AST, path: Path, stub: str) -> list[str]:
 
         def visit_arguments(self, node: ast.arguments) -> None:
             if node.posonlyargs:
+                assert isinstance(self.lineno, int)
                 errors.append(
                     f"{path}:{self.lineno}: PEP-570 syntax cannot be used in typeshed yet. "
                     f"Prefix parameter names with `__` to indicate positional-only parameters"

--- a/tests/check_new_syntax.py
+++ b/tests/check_new_syntax.py
@@ -29,7 +29,7 @@ def check_new_syntax(tree: ast.AST, path: Path, stub: str) -> list[str]:
     class PEP570Finder(ast.NodeVisitor):
         def __init__(self) -> None:
             self.lineno: int | None = None
-        
+
         def _visit_function(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
             self.lineno = node.lineno
             self.generic_visit(node)

--- a/tests/check_new_syntax.py
+++ b/tests/check_new_syntax.py
@@ -31,8 +31,10 @@ def check_new_syntax(tree: ast.AST, path: Path, stub: str) -> list[str]:
             self.lineno: int | None = None
 
         def _visit_function(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+            old_lineno = self.lineno
             self.lineno = node.lineno
             self.generic_visit(node)
+            self.lineno = old_lineno
 
         visit_FunctionDef = visit_AsyncFunctionDef = _visit_function
 


### PR DESCRIPTION
We don't want to start using PEP-570 syntax in typeshed yet, because we don't want to unnecessarily break compatibility with Python 3.7 (#10113) -- mypy users will not be able to check their code using `--python-version 3.7` after we start using PEP-570 syntax in typeshed. However, now that we no longer run mypy or stubtest in CI using Python 3.7, none of our CI fails if somebody proposes using PEP-570 syntax in a PR (e.g. https://github.com/python/typeshed/pull/10646#discussion_r1312919259 wouldn't have been caught if it hadn't been for @srittau's sharp eye!).

This PR proposes adding a simple lint to `check_new_syntax.py` so that we don't accidentally start using PEP-570 syntax in typeshed before we formally drop support for Python 3.7.