### PR TITLE
Fix typing of FreeTypeFont.getlength

### DIFF
--- a/stubs/Pillow/PIL/ImageFont.pyi
+++ b/stubs/Pillow/PIL/ImageFont.pyi
@@ -44,7 +44,7 @@ class FreeTypeFont:
         direction: Literal["ltr", "rtl", "ttb"] | None = None,
         features: Incomplete | None = None,
         language: str | None = None,
-    ) -> int: ...
+    ) -> float: ...
     def getbbox(
         self,
         text: str | bytes,


### PR DESCRIPTION
`FreeTypeFont.getlength` in Pillow is returned as float

Reference: https://github.com/python-pillow/Pillow/blob/main/src/PIL/ImageFont.py#L263