### PR TITLE
Bump various test dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,8 +9,8 @@ repos:
       - id: check-merge-conflict
       - id: mixed-line-ending
       - id: check-case-conflict
-  - repo: https://github.com/psf/black
-    rev: 23.7.0 # must match requirements-tests.txt
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 23.9.1 # must match requirements-tests.txt
     hooks:
       - id: black
         language_version: python3.10
@@ -20,12 +20,12 @@ repos:
       - id: isort
         name: isort (python)
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.0.280  # must match requirements-tests.txt
+    rev: v0.0.287  # must match requirements-tests.txt
     hooks:
       - id: ruff
         args: [--exit-non-zero-on-fix]
   - repo: https://github.com/pycqa/flake8
-    rev: 6.0.0 # must match requirements-tests.txt
+    rev: 6.1.0 # must match requirements-tests.txt
     hooks:
       - id: flake8
         additional_dependencies:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,4 +97,4 @@ select = [
 ]
 
 [tool.typeshed]
-pyright_version = "1.1.325"
+pyright_version = "1.1.326"

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,26 +1,26 @@
 # Type checkers and other linters that we test our stubs against. These should always
 # be pinned to a specific version to make failure reproducible. See also the
 # "tool.typeshed" section in pyproject.toml for additional type checkers.
-black==23.7.0; python_version >= "3.8"            # must match .pre-commit-config.yaml
-flake8==6.0.0; python_version >= "3.8"            # must match .pre-commit-config.yaml
-flake8-bugbear==23.7.10; python_version >= "3.8"  # must match .pre-commit-config.yaml
-flake8-noqa==1.3.2; python_version >= "3.8"       # must match .pre-commit-config.yaml
-flake8-pyi==23.6.0; python_version >= "3.8"       # must match .pre-commit-config.yaml
-isort==5.12.0; python_version >= "3.8"            # must match .pre-commit-config.yaml
+black==23.9.1            # must match .pre-commit-config.yaml
+flake8==6.1.0            # must match .pre-commit-config.yaml
+flake8-bugbear==23.7.10  # must match .pre-commit-config.yaml
+flake8-noqa==1.3.2       # must match .pre-commit-config.yaml
+flake8-pyi==23.6.0       # must match .pre-commit-config.yaml
+isort==5.12.0            # must match .pre-commit-config.yaml
 mypy==1.5.1
-pre-commit-hooks==4.4.0                           # must match .pre-commit-config.yaml
-pytype==2023.8.14; platform_system != "Windows" and python_version >= "3.8" and python_version < "3.11"
-ruff==0.0.280                                     # must match .pre-commit-config.yaml
+pre-commit-hooks==4.4.0  # must match .pre-commit-config.yaml
+pytype==2023.8.31; platform_system != "Windows" and python_version < "3.11"
+ruff==0.0.287            # must match .pre-commit-config.yaml
 
 # Libraries used by our various scripts.
-aiohttp==3.8.5; python_version < "3.12"           # aiohttp can't be installed on 3.12 yet
+aiohttp==3.8.5; python_version < "3.12"  # aiohttp can't be installed on 3.12 yet
 packaging==23.1
 pathspec>=0.11.1
 pyyaml==6.0.1
 stubdefaulter==0.1.0
 termcolor>=2.3
 tomli==2.0.1
-tomlkit==0.11.8
+tomlkit==0.12.1
 typing_extensions
 
 # Type stubs used to type check our scripts.

--- a/tests/check_consistent.py
+++ b/tests/check_consistent.py
@@ -191,9 +191,9 @@ def check_precommit_requirements() -> None:
     precommit_requirements = get_precommit_requirements()
     no_txt_entry_msg = "All pre-commit requirements must also be listed in `requirements-tests.txt` (missing {requirement!r})"
     for requirement, specifier in precommit_requirements.items():
-        # annoying: the ruff repo for pre-commit is different to the name in requirements-tests.txt
-        if requirement == "ruff-pre-commit":
-            requirement = "ruff"
+        # annoying: the ruff and black repos for pre-commit are different to the names in requirements-tests.txt
+        if requirement in {"ruff-pre-commit", "black-pre-commit-mirror"}:
+            requirement = requirement.split("-")[0]
         assert requirement in requirements_txt_requirements, no_txt_entry_msg.format(requirement=requirement)
         specifier_mismatch = (
             f'Specifier "{specifier}" for {requirement!r} in `.pre-commit-config.yaml` '


### PR DESCRIPTION
- Bump various test dependencies
- Simplify `requirements-tests.txt`: we no longer have any jobs in CI that need to run on Python 3.7, and in `tests/README.md` we only promise the entire test suite can be run if you're using py39+. That means we don't need any of the `python_version >= '3.8'` markers anymore.
- Use the official pre-commit mirror for black. This is much faster, as it means we get a version of black that's compiled with mypyc