### PR TITLE
Update `restval`/`restkey` types in `csv.DictReader`

### DIFF
--- a/stdlib/csv.pyi
+++ b/stdlib/csv.pyi
@@ -71,8 +71,8 @@ class unix_dialect(Dialect): ...
 
 class DictReader(Iterator[_DictReadMapping[_T | Any, str | Any]], Generic[_T]):
     fieldnames: Sequence[_T] | None
-    restkey: str | None
-    restval: str | None
+    restkey: _T | None
+    restval: str | Any | None
     reader: _reader
     dialect: _DialectLike
     line_num: int
@@ -81,8 +81,8 @@ class DictReader(Iterator[_DictReadMapping[_T | Any, str | Any]], Generic[_T]):
         self,
         f: Iterable[str],
         fieldnames: Sequence[_T],
-        restkey: str | None = None,
-        restval: str | None = None,
+        restkey: _T | None = None,
+        restval: str | Any | None = None,
         dialect: _DialectLike = "excel",
         *,
         delimiter: str = ",",


### PR DESCRIPTION
Fixes https://github.com/python/typeshed/issues/10145

I'm not sure about the `Any` part, but as iterating over the `DictReader` gives a `dict[_T | Any, str | Any]`, figured I would use the same types