### PR TITLE
Always install `six` when stubtesting `types-google-cloud-ndb`

### DIFF
--- a/stubs/google-cloud-ndb/METADATA.toml
+++ b/stubs/google-cloud-ndb/METADATA.toml
@@ -3,5 +3,5 @@ upstream_repository = "https://github.com/googleapis/python-ndb"
 partial_stub = true
 
 [tool.stubtest]
-stubtest_requirements = ["protobuf==3.20.2"]
+stubtest_requirements = ["protobuf==3.20.2", "six"]
 ignore_missing_stub = true


### PR DESCRIPTION
Hopefully fixes #10703