### PR TITLE
openpyxl: Type usages of `PIL` and `zipfile`

### DIFF
--- a/stubs/openpyxl/openpyxl/drawing/image.pyi
+++ b/stubs/openpyxl/openpyxl/drawing/image.pyi
@@ -1,9 +1,20 @@
-from _typeshed import Incomplete
+from _typeshed import SupportsRead
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+from typing_extensions import Literal, TypeAlias
+
+# Is actually PIL.Image.Image
+_PILImageImage: TypeAlias = Any
+# same as first parameter of PIL.Image.open
+_PILImageFilePath: TypeAlias = str | bytes | Path | SupportsRead[bytes]
+
+PILImage: ModuleType | Literal[False]
 
 class Image:
     anchor: str
-    ref: Incomplete
-    format: Incomplete
-    def __init__(self, img) -> None: ...
+    ref: _PILImageImage | _PILImageFilePath
+    format: str
+    def __init__(self, img: _PILImageImage | _PILImageFilePath) -> None: ...
     @property
-    def path(self): ...
+    def path(self) -> str: ...

--- a/stubs/openpyxl/openpyxl/packaging/relationship.pyi
+++ b/stubs/openpyxl/openpyxl/packaging/relationship.pyi
@@ -1,10 +1,13 @@
 from _typeshed import Incomplete, Unused
 from collections.abc import Generator
-from typing import ClassVar, overload
+from typing import ClassVar, TypeVar, overload
 from typing_extensions import Literal
+from zipfile import ZipFile
 
 from openpyxl.descriptors.base import Alias, String
 from openpyxl.descriptors.serialisable import Serialisable
+
+_SerialisableT = TypeVar("_SerialisableT", bound=Serialisable)
 
 class Relationship(Serialisable):
     tagname: ClassVar[str]
@@ -37,5 +40,12 @@ class RelationshipList(Serialisable):
     def to_tree(self): ...
 
 def get_rels_path(path): ...
-def get_dependents(archive, filename): ...
-def get_rel(archive, deps, id: Incomplete | None = None, cls: Incomplete | None = None): ...
+def get_dependents(archive: ZipFile, filename: str) -> RelationshipList: ...
+@overload
+def get_rel(
+    archive: ZipFile, deps: RelationshipList, id: str, cls: type[_SerialisableT]
+) -> _SerialisableT: ...  # incomplete: this could be restricted further from "Serialisable"
+@overload
+def get_rel(
+    archive: ZipFile, deps: RelationshipList, id: str | None = None, *, cls: type[_SerialisableT]
+) -> _SerialisableT: ...  # incomplete: this could be restricted further from "Serialisable"

--- a/stubs/openpyxl/openpyxl/reader/drawings.pyi
+++ b/stubs/openpyxl/openpyxl/reader/drawings.pyi
@@ -1,1 +1,6 @@
-def find_images(archive, path): ...
+from zipfile import ZipFile
+
+from openpyxl.chart._chart import ChartBase
+from openpyxl.drawing.image import Image
+
+def find_images(archive: ZipFile, path: str) -> tuple[list[ChartBase], list[Image]]: ...

--- a/stubs/openpyxl/openpyxl/reader/excel.pyi
+++ b/stubs/openpyxl/openpyxl/reader/excel.pyi
@@ -1,4 +1,5 @@
-from _typeshed import Incomplete, StrPath, SupportsRead
+from _typeshed import Incomplete, StrPath
+from typing import IO
 from typing_extensions import Final, Literal, TypeAlias
 from zipfile import ZipFile
 
@@ -26,7 +27,7 @@ class ExcelReader:
 
     def __init__(
         self,
-        fn: SupportsRead[bytes] | str,
+        fn: StrPath | IO[bytes],
         read_only: bool = False,
         keep_vba: bool = False,
         data_only: bool = False,
@@ -44,7 +45,7 @@ class ExcelReader:
     def read(self) -> None: ...
 
 def load_workbook(
-    filename: SupportsRead[bytes] | StrPath,
+    filename: StrPath | IO[bytes],
     read_only: bool = False,
     keep_vba: bool = False,
     data_only: bool = False,

--- a/stubs/openpyxl/openpyxl/reader/workbook.pyi
+++ b/stubs/openpyxl/openpyxl/reader/workbook.pyi
@@ -1,15 +1,16 @@
 from _typeshed import Incomplete
 from collections.abc import Generator
+from zipfile import ZipFile
 
 from openpyxl.workbook import Workbook
 
 class WorkbookParser:
-    archive: Incomplete
+    archive: ZipFile
     workbook_part_name: Incomplete
     wb: Workbook
     keep_links: Incomplete
     sheets: Incomplete
-    def __init__(self, archive, workbook_part_name, keep_links: bool = True) -> None: ...
+    def __init__(self, archive: ZipFile, workbook_part_name, keep_links: bool = True) -> None: ...
     @property
     def rels(self): ...
     caches: Incomplete

--- a/stubs/openpyxl/openpyxl/styles/stylesheet.pyi
+++ b/stubs/openpyxl/openpyxl/styles/stylesheet.pyi
@@ -1,6 +1,7 @@
 from _typeshed import Incomplete, Unused
-from typing import ClassVar
+from typing import ClassVar, TypeVar
 from typing_extensions import Literal, Self
+from zipfile import ZipFile
 
 from openpyxl.descriptors.base import Typed
 from openpyxl.descriptors.excel import ExtensionList
@@ -10,6 +11,9 @@ from openpyxl.styles.colors import ColorList
 from openpyxl.styles.named_styles import _NamedCellStyleList
 from openpyxl.styles.numbers import NumberFormatList
 from openpyxl.styles.table import TableStyleList
+from openpyxl.workbook.workbook import Workbook
+
+_WorkbookT = TypeVar("_WorkbookT", bound=Workbook)
 
 class Stylesheet(Serialisable):
     tagname: ClassVar[str]
@@ -50,5 +54,5 @@ class Stylesheet(Serialisable):
     def custom_formats(self): ...
     def to_tree(self, tagname: str | None = None, idx: Incomplete | None = None, namespace: str | None = None): ...
 
-def apply_stylesheet(archive, wb): ...
+def apply_stylesheet(archive: ZipFile, wb: _WorkbookT) -> _WorkbookT | None: ...
 def write_stylesheet(wb): ...

--- a/stubs/openpyxl/openpyxl/workbook/external_link/external.pyi
+++ b/stubs/openpyxl/openpyxl/workbook/external_link/external.pyi
@@ -1,6 +1,7 @@
 from _typeshed import Incomplete, Unused
 from typing import ClassVar
 from typing_extensions import Literal, TypeAlias
+from zipfile import ZipFile
 
 from openpyxl.descriptors.base import Bool, Integer, NoneSet, String, Typed, _ConvertibleToBool, _ConvertibleToInt
 from openpyxl.descriptors.nested import NestedText
@@ -76,4 +77,4 @@ class ExternalLink(Serialisable):
     @property
     def path(self): ...
 
-def read_external_link(archive, book_path): ...
+def read_external_link(archive: ZipFile, book_path: str) -> ExternalLink: ...

--- a/stubs/openpyxl/openpyxl/workbook/workbook.pyi
+++ b/stubs/openpyxl/openpyxl/workbook/workbook.pyi
@@ -3,6 +3,7 @@ from collections.abc import Iterator
 from datetime import datetime
 from typing import IO
 from typing_extensions import Final
+from zipfile import ZipFile
 
 from openpyxl import _Decodable
 from openpyxl.chartsheet.chartsheet import Chartsheet
@@ -21,7 +22,7 @@ class Workbook:
     security: Incomplete
     shared_strings: Incomplete
     loaded_theme: Incomplete
-    vba_archive: Incomplete
+    vba_archive: ZipFile | None
     is_template: bool
     code_name: Incomplete
     encoding: str

--- a/stubs/openpyxl/openpyxl/writer/excel.pyi
+++ b/stubs/openpyxl/openpyxl/writer/excel.pyi
@@ -1,10 +1,13 @@
-from _typeshed import Incomplete
+from zipfile import ZipFile
+
+from openpyxl.packaging.manifest import Manifest
+from openpyxl.workbook.workbook import Workbook
 
 class ExcelWriter:
-    workbook: Incomplete
-    manifest: Incomplete
-    vba_modified: Incomplete
-    def __init__(self, workbook, archive) -> None: ...
+    workbook: Workbook
+    manifest: Manifest
+    vba_modified: set[str | None]
+    def __init__(self, workbook: Workbook, archive: ZipFile) -> None: ...
     def write_data(self) -> None: ...
     def write_worksheet(self, ws) -> None: ...
     def save(self) -> None: ...


### PR DESCRIPTION
Overlaps with #9511 to reduce changes there.

Typed all usages of non-type, non excel, libraries external to openpyxl: `PIL` and `zipfile`.
Completed annotations of affected methods and classes. (unless they got complicated or uncertain)