### PR TITLE
pytype_test.py: Handle non-typeshed requirements that are stub-only packages

### DIFF
--- a/tests/pytype_test.py
+++ b/tests/pytype_test.py
@@ -152,12 +152,15 @@ def find_stubs_in_paths(paths: Sequence[str]) -> list[str]:
 def _get_pkgs_associated_with_requirement(req_name: str) -> list[str]:
     dist = importlib.metadata.distribution(req_name)
     toplevel_txt_contents = dist.read_text("top_level.txt")
-    if toplevel_txt_contents is not None:
-        return toplevel_txt_contents.split()
-    if dist.files is None:
-        raise RuntimeError("Can't read find the packages associated with requirement {req_name!r}")
-    maybe_modules = [f.parts[0] if len(f.parts) > 1 else inspect.getmodulename(f) for f in dist.files]
-    return [name for name in maybe_modules if name is not None and "." not in name]
+    if toplevel_txt_contents is None:
+        if dist.files is None:
+            raise RuntimeError("Can't read find the packages associated with requirement {req_name!r}")
+        maybe_modules = [f.parts[0] if len(f.parts) > 1 else inspect.getmodulename(f) for f in dist.files]
+        packages = [name for name in maybe_modules if name is not None and "." not in name]
+    else:
+        packages = toplevel_txt_contents.split()
+    # https://peps.python.org/pep-0561/#stub-only-packages
+    return sorted({package.removesuffix("-stubs") for package in packages})
 
 
 def get_missing_modules(files_to_test: Sequence[str]) -> Iterable[str]:


### PR DESCRIPTION
From my reading of https://peps.python.org/pep-0561/#stub-only-packages, I _think_ this is all the normalisation we need to do here in order to get `pytype_test.py` passing when a typeshed stubs package has `pandas-stubs` as a dependency. It's a somewhat more principled solution than the special-casing @hamdanal currently has in https://github.com/python/typeshed/pull/10721/files#diff-b08f977b5767c8fef257d9641aa0e00aa67abbc5fac2ad25824880c7a50995c4R153-R154 :D