### PR TITLE
Update `typing_extensions` stubs for v4.8.0

### DIFF
--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -21,7 +21,7 @@ stubdefaulter==0.1.0
 termcolor>=2.3
 tomli==2.0.1
 tomlkit==0.12.1
-typing_extensions
+typing_extensions>=4.8.0
 
 # Type stubs used to type check our scripts.
 types-pyyaml>=6.0.12.7

--- a/stdlib/typing_extensions.pyi
+++ b/stdlib/typing_extensions.pyi
@@ -149,6 +149,7 @@ __all__ = [
     "Collection",
     "Container",
     "Dict",
+    "Doc",
     "ForwardRef",
     "FrozenSet",
     "Generator",
@@ -489,3 +490,9 @@ if sys.version_info >= (3, 13):
 else:
     def is_protocol(__tp: type) -> bool: ...
     def get_protocol_members(__tp: type) -> frozenset[str]: ...
+
+class Doc:
+    documentation: str
+    def __init__(self, __documentation: str) -> None: ...
+    def __hash__(self) -> int: ...
+    def __eq__(self, other: object) -> bool: ...

--- a/tests/stubtest_allowlists/py310.txt
+++ b/tests/stubtest_allowlists/py310.txt
@@ -23,7 +23,6 @@ types.GenericAlias.__mro_entries__
 types.GenericAlias.__call__  # Would be complicated to fix properly, Any could silence problems. #6392
 typing._SpecialForm.__mro_entries__
 weakref.ProxyType.__reversed__  # Doesn't really exist
-typing_extensions\.get_original_bases
 
 # Exist at runtime for internal reasons, no need to put them in the stub
 typing_extensions\.TypeAliasType\.__call__
@@ -139,9 +138,6 @@ dataclasses.KW_ONLY
 typing.ParamSpec(Args|Kwargs).__origin__
 
 # https://github.com/python/mypy/issues/15302
-typing_extensions\.assert_never
-typing_extensions\.assert_type
-typing_extensions\.reveal_type
 typing.NewType.__call__
 
 # Super-special typing primitives
@@ -163,6 +159,3 @@ pkgutil.ImpImporter\..*
 pkgutil.ImpLoader\..*
 
 types.CodeType.replace  # stubtest thinks default values are None but None doesn't work at runtime
-
-# https://github.com/python/mypy/issues/15302
-typing_extensions\.override

--- a/tests/stubtest_allowlists/py311.txt
+++ b/tests/stubtest_allowlists/py311.txt
@@ -14,7 +14,6 @@ enum.Enum._generate_next_value_
 enum.StrEnum._generate_next_value_
 importlib.abc.Finder.find_module
 tkinter._VersionInfoType.__doc__
-typing_extensions\.get_original_bases
 typing.NewType.__call__
 typing.NewType.__mro_entries__
 
@@ -124,6 +123,3 @@ asynchat.async_chat.use_encoding
 asynchat.find_prefix_at_end
 pkgutil.ImpImporter\..*
 pkgutil.ImpLoader\..*
-
-# https://github.com/python/mypy/issues/15302
-typing_extensions\.override

--- a/tests/stubtest_allowlists/py38.txt
+++ b/tests/stubtest_allowlists/py38.txt
@@ -41,7 +41,6 @@ typing.NamedTuple._replace
 typing._SpecialForm.__new__
 xml.etree.ElementTree.TreeBuilder.start  # Discrepancy between Python and C modules, fixed in bpo-39495
 xml.etree.cElementTree.TreeBuilder.start  # bpo-39495
-typing_extensions\.get_original_bases
 
 # Exist at runtime for internal reasons, no need to put them in the stub
 typing_extensions\.TypeAliasType\.__call__
@@ -140,12 +139,6 @@ types.GetSetDescriptorType.__get__
 types.MemberDescriptorType.__get__
 types.MethodDescriptorType.__get__
 types.WrapperDescriptorType.__get__
-
-# https://github.com/python/mypy/issues/15302
-typing_extensions\.assert_never
-typing_extensions\.assert_type
-typing_extensions\.reveal_type
-typing_extensions\.override
 
 # We lie about the existence of these methods
 .*.__buffer__

--- a/tests/stubtest_allowlists/py39.txt
+++ b/tests/stubtest_allowlists/py39.txt
@@ -37,7 +37,6 @@ tkinter.Tk.split
 types.GenericAlias.__getattr__
 types.GenericAlias.__call__  # Would be complicated to fix properly, Any could silence problems. #6392
 weakref.ProxyType.__reversed__  # Doesn't really exist
-typing_extensions\.get_original_bases
 
 # Exist at runtime for internal reasons, no need to put them in the stub
 typing_extensions\.TypeAliasType\.__call__
@@ -127,12 +126,6 @@ types.GetSetDescriptorType.__get__
 types.MemberDescriptorType.__get__
 types.MethodDescriptorType.__get__
 types.WrapperDescriptorType.__get__
-
-# https://github.com/python/mypy/issues/15302
-typing_extensions\.assert_never
-typing_extensions\.assert_type
-typing_extensions\.reveal_type
-typing_extensions\.override
 
 # Super-special typing primitives
 typing\.NamedTuple

--- a/tests/stubtest_allowlists/py3_common.txt
+++ b/tests/stubtest_allowlists/py3_common.txt
@@ -458,9 +458,6 @@ typing_extensions.NewType.__mro_entries__  # just exists for an error message
 
 # https://github.com/python/mypy/issues/15302
 typing_extensions.NewType.__call__
-typing_extensions\.deprecated
-typing_extensions\.get_protocol_members
-typing_extensions\.is_protocol
 
 # Typing-related weirdness
 _collections_abc.Callable


### PR DESCRIPTION
This fixes the stdlib stubtest failures seen on the `main` branch, e.g. https://github.com/python/typeshed/actions/runs/6220458928