### PR TITLE
define slots on abc.ABC

### DIFF
--- a/stdlib/abc.pyi
+++ b/stdlib/abc.pyi
@@ -40,7 +40,8 @@ class abstractstaticmethod(staticmethod[_P, _R_co]):
 class abstractproperty(property):
     __isabstractmethod__: Literal[True]
 
-class ABC(metaclass=ABCMeta): ...
+class ABC(metaclass=ABCMeta):
+    __slots__ = ()
 
 def get_cache_token() -> object: ...
 


### PR DESCRIPTION
Add `__slots__` to the declaration of `abc.ABC` to properly reflect its implementation.

This allows Pyright to properly check ABCs, see https://github.com/microsoft/pyright/issues/5976 for more details