### PR TITLE
Missing `importlib` re-exported top-level modules

### DIFF
--- a/stdlib/importlib/__init__.pyi
+++ b/stdlib/importlib/__init__.pyi
@@ -1,5 +1,6 @@
 import sys
 from collections.abc import Mapping, Sequence
+from importlib import abc as abc, machinery as machinery, util as util
 from importlib.abc import Loader
 from types import ModuleType
 


### PR DESCRIPTION
```py
>>> import importlib
>>> dir(importlib)
['_RELOADING', '__all__', '__builtins__', '__cached__', '__doc__', '__file__', '__import__', '__loader__', '__name__', '__package__', '__path__', '__spec__', '_bootstrap', '_bootstrap_external', '_imp', '_pack_uint32', '_unpack_uint32', 'abc', 'find_loader', 'import_module', 'invalidate_caches', 'machinery', 'reload', 'sys', 'types', 'util', 'warnings']
>>> importlib.abc
<module 'importlib.abc' from 'C:\\Program Files\\Python39\\lib\\importlib\\abc.py'>
>>> importlib.machinery
<module 'importlib.machinery' from 'C:\\Program Files\\Python39\\lib\\importlib\\machinery.py'>
>>> importlib.util
<module 'importlib.util' from 'C:\\Program Files\\Python39\\lib\\importlib\\util.py'>
```