### PR TITLE
feat: Add _thread attribute for logging.handlers.QueueListener

### DIFF
--- a/stdlib/logging/handlers.pyi
+++ b/stdlib/logging/handlers.pyi
@@ -2,14 +2,13 @@ import datetime
 import http.client
 import ssl
 import sys
+from _typeshed import ReadableBuffer, StrPath
 from collections.abc import Callable
 from logging import FileHandler, Handler, LogRecord
 from re import Pattern
 from socket import SocketKind, socket
 from threading import Thread
 from typing import Any, ClassVar, Protocol, TypeVar
-
-from _typeshed import ReadableBuffer, StrPath
 
 _T = TypeVar("_T")
 

--- a/stdlib/logging/handlers.pyi
+++ b/stdlib/logging/handlers.pyi
@@ -2,12 +2,14 @@ import datetime
 import http.client
 import ssl
 import sys
-from _typeshed import ReadableBuffer, StrPath
 from collections.abc import Callable
 from logging import FileHandler, Handler, LogRecord
 from re import Pattern
 from socket import SocketKind, socket
+from threading import Thread
 from typing import Any, ClassVar, Protocol, TypeVar
+
+from _typeshed import ReadableBuffer, StrPath
 
 _T = TypeVar("_T")
 
@@ -264,6 +266,7 @@ class QueueListener:
     handlers: tuple[Handler, ...]  # undocumented
     respect_handler_level: bool  # undocumented
     queue: _QueueLike[Any]  # undocumented
+    _thread: Thread | None  # undocumented
     def __init__(self, queue: _QueueLike[Any], *handlers: Handler, respect_handler_level: bool = False) -> None: ...
     def dequeue(self, block: bool) -> LogRecord: ...
     def prepare(self, record: LogRecord) -> Any: ...


### PR DESCRIPTION
This seems like a small change so I've skipped opening an issue.

The only way of knowing whether a `logging.handlers.QueueListener` has already been started is by checking that the `_thread` attribute has been set to a non-`None` value. This attribute is not included in type stubs, so running `mypy` on a code like this will raise a `"QueueListener" has no attribute "_thread"` error, even though it's perfectly valid:

```python
import logging.handlers
import queue

LOG_QUEUE: queue.Queue = queue.Queue(-1)

QUEUE_LISTENER: logging.handlers.QueueListener = logging.handlers.QueueListener(LOG_QUEUE, logging.StreamHandler())


def check():
    assert hasattr(QUEUE_LISTENER, "_thread")
    
    if QUEUE_LISTENER._thread is None:  # error: "QueueListener" has no attribute "_thread"
        QUEUE_LISTENER.start()
```

Delaying the start of a `logging.handlers.QueueListener` can be a useful pattern if sharing a logger in multiple modules.

I've read the contributing docs and it seems that adding private attributes is discouraged. 

However, [this comment](https://github.com/python/typeshed/issues/10611#issuecomment-1691722625) from last month indicates that the policy is to accept changes if requested. So, this PR requests the addition of `_thread` to the type stub of `logging.handlers.QueueListener` as it's the only way of knowing we have started to listen on a queue (or at least the most direct way).

Hope this can be accepted and thank you for your work in maintaining typeshed!


