### PR TITLE
Update os.path.isdir on Windows Python3.12+

### DIFF
--- a/stdlib/ntpath.pyi
+++ b/stdlib/ntpath.pyi
@@ -1,5 +1,5 @@
 import sys
-from _typeshed import BytesPath, StrPath
+from _typeshed import BytesPath, FileDescriptorOrPath, StrPath
 from genericpath import (
     commonprefix as commonprefix,
     exists as exists,
@@ -7,7 +7,6 @@ from genericpath import (
     getctime as getctime,
     getmtime as getmtime,
     getsize as getsize,
-    isdir as isdir,
     isfile as isfile,
     samefile as samefile,
     sameopenfile as sameopenfile,
@@ -45,6 +44,13 @@ from posixpath import (
 
 if sys.version_info >= (3, 12):
     from posixpath import isjunction as isjunction, splitroot as splitroot
+
+if sys.version_info >= (3, 12) and sys.platform == "win32":
+    def isdir(path: FileDescriptorOrPath) -> bool: ...
+
+else:
+    def isdir(s: FileDescriptorOrPath) -> bool: ...
+
 from typing import AnyStr, overload
 from typing_extensions import LiteralString
 

--- a/tests/stubtest_allowlists/win32-py312.txt
+++ b/tests/stubtest_allowlists/win32-py312.txt
@@ -4,5 +4,3 @@ asyncio.IocpProactor.recvfrom_into
 asyncio.windows_events.IocpProactor.finish_socket_func
 asyncio.windows_events.IocpProactor.recvfrom_into
 msvcrt.GetErrorMode
-ntpath.isdir
-os.path.isdir


### PR DESCRIPTION
Following https://github.com/python/typeshed/pull/10748#discussion_r1334279493
cc @AlexWaygood 

Ref: https://github.com/python/cpython/blame/b28ffaa193efc66f46ab90d383279174a11a11d7/Modules/clinic/posixmodule.c.h#L1989

Seems like `os.path.isdir` has different signature `os.path.isdir(path)` compared to `os.path.isdir(s)` in netpath.py, not sure if this was intentional in CPython.