### PR TITLE
Fix `contextlib.asynccontextmanager` to work with coroutine functions

### DIFF
--- a/stdlib/contextlib.pyi
+++ b/stdlib/contextlib.pyi
@@ -2,7 +2,7 @@ import abc
 import sys
 from _typeshed import FileDescriptorOrPath, Unused
 from abc import abstractmethod
-from collections.abc import AsyncGenerator, Awaitable, Callable, Coroutine, Generator, Iterator
+from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable, Coroutine, Generator, Iterator
 from types import TracebackType
 from typing import IO, Any, Generic, Protocol, TypeVar, overload, runtime_checkable
 from typing_extensions import ParamSpec, Self, TypeAlias
@@ -85,7 +85,7 @@ if sys.version_info >= (3, 10):
         # __init__ and these attributes are actually defined in the base class _GeneratorContextManagerBase,
         # which is more trouble than it's worth to include in the stub (see #6676)
         def __init__(
-            self, func: Callable[..., AsyncGenerator[_T_co, Any]], args: tuple[Any, ...], kwds: dict[str, Any]
+            self, func: Callable[..., AsyncIterator[_T_co]], args: tuple[Any, ...], kwds: dict[str, Any]
         ) -> None: ...
         gen: AsyncGenerator[_T_co, Any]
         func: Callable[..., AsyncGenerator[_T_co, Any]]
@@ -98,7 +98,7 @@ if sys.version_info >= (3, 10):
 else:
     class _AsyncGeneratorContextManager(AbstractAsyncContextManager[_T_co], Generic[_T_co]):
         def __init__(
-            self, func: Callable[..., AsyncGenerator[_T_co, Any]], args: tuple[Any, ...], kwds: dict[str, Any]
+            self, func: Callable[..., AsyncIterator[_T_co]], args: tuple[Any, ...], kwds: dict[str, Any]
         ) -> None: ...
         gen: AsyncGenerator[_T_co, Any]
         func: Callable[..., AsyncGenerator[_T_co, Any]]
@@ -110,10 +110,10 @@ else:
 
 @overload
 def asynccontextmanager(
-    func: Callable[_P, Coroutine[Any, Any, AsyncGenerator[_T_co, Any]]]
+    func: Callable[_P, Coroutine[Any, Any, AsyncIterator[_T_co]]]
 ) -> Callable[_P, _AsyncGeneratorContextManager[_T_co]]: ...
 @overload
-def asynccontextmanager(func: Callable[_P, AsyncGenerator[_T_co, Any]]) -> Callable[_P, _AsyncGeneratorContextManager[_T_co]]: ...
+def asynccontextmanager(func: Callable[_P, AsyncIterator[_T_co]]) -> Callable[_P, _AsyncGeneratorContextManager[_T_co]]: ...
 
 class _SupportsClose(Protocol):
     def close(self) -> object: ...

--- a/stdlib/contextlib.pyi
+++ b/stdlib/contextlib.pyi
@@ -2,7 +2,7 @@ import abc
 import sys
 from _typeshed import FileDescriptorOrPath, Unused
 from abc import abstractmethod
-from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable, Generator, Iterator
+from collections.abc import AsyncGenerator, AsyncGenerator, Awaitable, Callable, Coroutine, Generator, Iterator
 from types import TracebackType
 from typing import IO, Any, Generic, Protocol, TypeVar, overload, runtime_checkable
 from typing_extensions import ParamSpec, Self, TypeAlias
@@ -84,7 +84,7 @@ if sys.version_info >= (3, 10):
     class _AsyncGeneratorContextManager(AbstractAsyncContextManager[_T_co], AsyncContextDecorator, Generic[_T_co]):
         # __init__ and these attributes are actually defined in the base class _GeneratorContextManagerBase,
         # which is more trouble than it's worth to include in the stub (see #6676)
-        def __init__(self, func: Callable[..., AsyncIterator[_T_co]], args: tuple[Any, ...], kwds: dict[str, Any]) -> None: ...
+        def __init__(self, func: Callable[..., AsyncGenerator[_T_co, Any]], args: tuple[Any, ...], kwds: dict[str, Any]) -> None: ...
         gen: AsyncGenerator[_T_co, Any]
         func: Callable[..., AsyncGenerator[_T_co, Any]]
         args: tuple[Any, ...]
@@ -95,7 +95,7 @@ if sys.version_info >= (3, 10):
 
 else:
     class _AsyncGeneratorContextManager(AbstractAsyncContextManager[_T_co], Generic[_T_co]):
-        def __init__(self, func: Callable[..., AsyncIterator[_T_co]], args: tuple[Any, ...], kwds: dict[str, Any]) -> None: ...
+        def __init__(self, func: Callable[..., AsyncGenerator[_T_co, Any]], args: tuple[Any, ...], kwds: dict[str, Any]) -> None: ...
         gen: AsyncGenerator[_T_co, Any]
         func: Callable[..., AsyncGenerator[_T_co, Any]]
         args: tuple[Any, ...]
@@ -104,7 +104,10 @@ else:
             self, typ: type[BaseException] | None, value: BaseException | None, traceback: TracebackType | None
         ) -> bool | None: ...
 
-def asynccontextmanager(func: Callable[_P, AsyncIterator[_T_co]]) -> Callable[_P, _AsyncGeneratorContextManager[_T_co]]: ...
+@overload
+def asynccontextmanager(func: Callable[_P, Coroutine[Any, Any, AsyncGenerator[_T_co, Any]]]) -> Callable[_P, _AsyncGeneratorContextManager[_T_co]]: ...
+@overload
+def asynccontextmanager(func: Callable[_P, AsyncGenerator[_T_co, Any]]) -> Callable[_P, _AsyncGeneratorContextManager[_T_co]]: ...
 
 class _SupportsClose(Protocol):
     def close(self) -> object: ...

--- a/stdlib/contextlib.pyi
+++ b/stdlib/contextlib.pyi
@@ -84,9 +84,7 @@ if sys.version_info >= (3, 10):
     class _AsyncGeneratorContextManager(AbstractAsyncContextManager[_T_co], AsyncContextDecorator, Generic[_T_co]):
         # __init__ and these attributes are actually defined in the base class _GeneratorContextManagerBase,
         # which is more trouble than it's worth to include in the stub (see #6676)
-        def __init__(
-            self, func: Callable[..., AsyncIterator[_T_co]], args: tuple[Any, ...], kwds: dict[str, Any]
-        ) -> None: ...
+        def __init__(self, func: Callable[..., AsyncIterator[_T_co]], args: tuple[Any, ...], kwds: dict[str, Any]) -> None: ...
         gen: AsyncGenerator[_T_co, Any]
         func: Callable[..., AsyncGenerator[_T_co, Any]]
         args: tuple[Any, ...]
@@ -97,9 +95,7 @@ if sys.version_info >= (3, 10):
 
 else:
     class _AsyncGeneratorContextManager(AbstractAsyncContextManager[_T_co], Generic[_T_co]):
-        def __init__(
-            self, func: Callable[..., AsyncIterator[_T_co]], args: tuple[Any, ...], kwds: dict[str, Any]
-        ) -> None: ...
+        def __init__(self, func: Callable[..., AsyncIterator[_T_co]], args: tuple[Any, ...], kwds: dict[str, Any]) -> None: ...
         gen: AsyncGenerator[_T_co, Any]
         func: Callable[..., AsyncGenerator[_T_co, Any]]
         args: tuple[Any, ...]

--- a/test_cases/stdlib/check_contextlib.py
+++ b/test_cases/stdlib/check_contextlib.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from contextlib import ExitStack
+from contextlib import ExitStack, asynccontextmanager
+from typing import AsyncIterator, Awaitable
 from typing_extensions import assert_type
 
 
@@ -18,3 +19,17 @@ with stack as cm:
     assert_type(cm, ExitStack)
 with thing as cm2:
     assert_type(cm2, Thing)
+
+
+@asynccontextmanager
+async def async_context() -> AsyncGenerator[str, None]:
+    yield 'example'
+
+
+async def async_gen() -> AsyncGenerator[str, None]:
+    yield 'async gen'
+
+
+@asynccontextmanager
+def async_cm_func() -> AsyncGenerator[str, None]:
+    return async_gen()

--- a/test_cases/stdlib/check_contextlib.py
+++ b/test_cases/stdlib/check_contextlib.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from contextlib import ExitStack, asynccontextmanager
-from typing import AsyncIterator, Awaitable
+from typing import AsyncGenerator
 from typing_extensions import assert_type
 
 


### PR DESCRIPTION
Right now a code from the docs: https://docs.python.org/3/library/contextlib.html#contextlib.asynccontextmanager does not type-check.

Example: https://mypy-play.net/?mypy=latest&python=3.11&gist=f20e230fa7b1af15064b2828dfd7dfd7

We are also required to have `AsyncGenerator` annotation here, because `.athrow()` method is used in this function: https://github.com/python/cpython/blob/e8be0c9c5a7c2327b3dd64009f45ee0682322dcb/Lib/contextlib.py#L226 (since 3.8: https://github.com/python/cpython/blob/3.8/Lib/contextlib.py#L189)

Runtime:

```python
>>> from typing import AsyncGenerator
>>> from contextlib import asynccontextmanager
>>> import asyncio
>>> @asynccontextmanager
... async def async_context() -> AsyncGenerator[str, None]:
...     yield 'example'
... 
>>> async def main():
...     async with async_context() as ac:
...         print(ac)
... 
>>> asyncio.run(main())
example
```

So, I went with the fix that also has some tests.