### PR TITLE
Revert "Do a dry run of stubsabot on PRs touching `scripts/` or `tests/`"

### DIFF
--- a/.github/workflows/typecheck_typeshed_code.yml
+++ b/.github/workflows/typecheck_typeshed_code.yml
@@ -1,5 +1,4 @@
-# This workflow is for testing typeshed's scripts and tests themselves
-name: Meta-tests
+name: Typecheck-typeshed-code
 
 on:
   workflow_dispatch:
@@ -10,9 +9,8 @@ on:
     paths:
       - "scripts/**"
       - "tests/**"
-      - ".github/workflows/meta_tests.yml"
+      - ".github/workflows/typecheck_typeshed_code.yml"
       - "requirements-tests.txt"
-      - "pyproject.toml"
 
 permissions:
   contents: read
@@ -70,19 +68,3 @@ jobs:
           python-platform: ${{ matrix.python-platform }}
           python-version: "3.9"
           project: ./pyrightconfig.scripts_and_tests.json
-  stubsabot-dry-run:
-    name: Stubsabot dry run
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: "3.11"
-          cache: pip
-          cache-dependency-path: requirements-tests.txt
-      - name: Git config
-        run: |
-          git config --global user.name stubsabot
-          git config --global user.email '<>'
-      - run: pip install -r requirements-tests.txt
-      - run: python scripts/stubsabot.py --action-level local

--- a/scripts/stubsabot.py
+++ b/scripts/stubsabot.py
@@ -744,7 +744,7 @@ async def main() -> None:
         ["git", "branch", "--show-current"], text=True, capture_output=True, check=True
     ).stdout.strip()
 
-    if args.action_level >= ActionLevel.local:
+    if args.action_level >= ActionLevel.fork:
         subprocess.check_call(["git", "fetch", "--prune", "--all"])
 
     try:
@@ -784,7 +784,7 @@ async def main() -> None:
     finally:
         # if you need to cleanup, try:
         # git branch -D $(git branch --list 'stubsabot/*')
-        if args.action_level >= ActionLevel.local and original_branch:
+        if args.action_level >= ActionLevel.local:
             subprocess.check_call(["git", "checkout", original_branch])
 
 


### PR DESCRIPTION
Reverts python/typeshed#10508. It looks like doing a dry run of stubsabot on every PR touching `tests/` or `scripts/` is causing us to exceed our rate limit for GitHub's API: https://github.com/python/typeshed/actions/runs/6285081126/job/17067070901?pr=10724