### PR TITLE
Complete psycopg2

### DIFF
--- a/stubs/psycopg2/METADATA.toml
+++ b/stubs/psycopg2/METADATA.toml
@@ -1,6 +1,3 @@
 version = "2.9.*"
 upstream_repository = "https://github.com/psycopg/psycopg2"
-partial_stub = true
-
-[tool.stubtest]
-ignore_missing_stub = false
+partial_stub = false

--- a/stubs/psycopg2/psycopg2/__init__.pyi
+++ b/stubs/psycopg2/psycopg2/__init__.pyi
@@ -1,7 +1,7 @@
 from collections.abc import Callable
 from typing import Any, TypeVar, overload
 
-# connection and cursor not available at runtime
+from psycopg2 import errors as errors, extensions as extensions
 from psycopg2._psycopg import (
     BINARY as BINARY,
     DATETIME as DATETIME,


### PR DESCRIPTION
```python
>>> import psycopg2
>>> psycopg2.extensions
<module 'psycopg2.extensions' from '/tmp/.venv/lib/python3.10/site-packages/psycopg2/extensions.py'>
>>> psycopg2.errors
<module 'psycopg2.errors' from '/tmp/.venv/lib/python3.10/site-packages/psycopg2/errors.py'>
```