### PR TITLE
Use `Literal` values for `sys.version_info.release_level`

### DIFF
--- a/stdlib/sys.pyi
+++ b/stdlib/sys.pyi
@@ -225,7 +225,7 @@ class _thread_info(_UninstantiableStructseq, tuple[_ThreadInfoName, _ThreadInfoL
     def version(self) -> str | None: ...
 
 thread_info: _thread_info
-_ReleaseLevel: TypeAlias = Literal['alpha', 'beta', 'candidate', 'final']
+_ReleaseLevel: TypeAlias = Literal["alpha", "beta", "candidate", "final"]
 
 @final
 class _version_info(_UninstantiableStructseq, tuple[int, int, int, _ReleaseLevel, int]):

--- a/stdlib/sys.pyi
+++ b/stdlib/sys.pyi
@@ -225,9 +225,10 @@ class _thread_info(_UninstantiableStructseq, tuple[_ThreadInfoName, _ThreadInfoL
     def version(self) -> str | None: ...
 
 thread_info: _thread_info
+_ReleaseLevel: TypeAlias = Literal['alpha', 'beta', 'candidate', 'final']
 
 @final
-class _version_info(_UninstantiableStructseq, tuple[int, int, int, str, int]):
+class _version_info(_UninstantiableStructseq, tuple[int, int, int, _ReleaseLevel, int]):
     @property
     def major(self) -> int: ...
     @property
@@ -235,7 +236,7 @@ class _version_info(_UninstantiableStructseq, tuple[int, int, int, str, int]):
     @property
     def micro(self) -> int: ...
     @property
-    def releaselevel(self) -> str: ...
+    def releaselevel(self) -> _ReleaseLevel: ...
     @property
     def serial(self) -> int: ...
 


### PR DESCRIPTION
It is documented as `Literal`: https://docs.python.org/3/library/sys.html#sys.version_info