### PR TITLE
Declare that `types-jsonschema` requires Python 3.8+

### DIFF
--- a/stubs/jsonschema/METADATA.toml
+++ b/stubs/jsonschema/METADATA.toml
@@ -2,6 +2,7 @@ version = "4.19.*"
 upstream_repository = "https://github.com/python-jsonschema/jsonschema"
 requires = ["referencing"]
 partial_stub = true
+requires_python = ">=3.8"
 
 [tool.stubtest]
 ignore_missing_stub = true


### PR DESCRIPTION
See #10772