### PR TITLE
`ssl.OP_ENABLE_KTLS` should exist on linux

### DIFF
--- a/stdlib/ssl.pyi
+++ b/stdlib/ssl.pyi
@@ -226,7 +226,6 @@ if sys.version_info >= (3, 8):
     OP_ENABLE_MIDDLEBOX_COMPAT: Options
 if sys.version_info >= (3, 12):
     OP_LEGACY_SERVER_CONNECT: Options
-if sys.version_info >= (3, 12):
     OP_ENABLE_KTLS: Options
 if sys.version_info >= (3, 11):
     OP_IGNORE_UNEXPECTED_EOF: Options

--- a/stdlib/ssl.pyi
+++ b/stdlib/ssl.pyi
@@ -203,7 +203,6 @@ class Options(enum.IntFlag):
         OP_ENABLE_MIDDLEBOX_COMPAT: int
     if sys.version_info >= (3, 12):
         OP_LEGACY_SERVER_CONNECT: int
-    if sys.version_info >= (3, 12) and sys.platform != "linux":
         OP_ENABLE_KTLS: int
     if sys.version_info >= (3, 11):
         OP_IGNORE_UNEXPECTED_EOF: int
@@ -227,7 +226,7 @@ if sys.version_info >= (3, 8):
     OP_ENABLE_MIDDLEBOX_COMPAT: Options
 if sys.version_info >= (3, 12):
     OP_LEGACY_SERVER_CONNECT: Options
-if sys.version_info >= (3, 12) and sys.platform != "linux":
+if sys.version_info >= (3, 12):
     OP_ENABLE_KTLS: Options
 if sys.version_info >= (3, 11):
     OP_IGNORE_UNEXPECTED_EOF: Options

--- a/tests/stubtest_allowlists/linux-py312.txt
+++ b/tests/stubtest_allowlists/linux-py312.txt
@@ -8,8 +8,6 @@ mmap.MAP_STACK
 resource.prlimit
 signal.sigtimedwait
 signal.sigwaitinfo
-ssl.OP_ENABLE_KTLS
-ssl.Options.OP_ENABLE_KTLS
 tty.__all__
 tty.cfmakecbreak
 tty.cfmakeraw


### PR DESCRIPTION
Docs say:

```
.. data:: OP_ENABLE_KTLS

   Enable the use of the kernel TLS. To benefit from the feature, OpenSSL must
   have been compiled with support for it, and the negotiated cipher suites and
   extensions must be supported by it (a list of supported ones may vary by
   platform and kernel version).

   Note that with enabled kernel TLS some cryptographic operations are
   performed by the kernel directly and not via any available OpenSSL
   Providers. This might be undesirable if, for example, the application
   requires all cryptographic operations to be performed by the FIPS provider.

   This option is only available with OpenSSL 3.0.0 and later.
```
