### PR TITLE
Update `os` and `posix` to python 3.12 on darwin

### DIFF
--- a/stdlib/os/__init__.pyi
+++ b/stdlib/os/__init__.pyi
@@ -122,6 +122,12 @@ if sys.platform == "linux":
     GRND_NONBLOCK: int
     GRND_RANDOM: int
 
+if sys.platform == "darwin" and sys.version_info >= (3, 12):
+    PRIO_DARWIN_BG: int
+    PRIO_DARWIN_NONUI: int
+    PRIO_DARWIN_PROCESS: int
+    PRIO_DARWIN_THREAD: int
+
 SEEK_SET: int
 SEEK_CUR: int
 SEEK_END: int

--- a/stdlib/posix.pyi
+++ b/stdlib/posix.pyi
@@ -347,6 +347,14 @@ if sys.platform != "win32":
             unshare as unshare,
         )
 
+    if sys.version_info >= (3, 12) and sys.platform == "darwin":
+        from os import (
+            PRIO_DARWIN_BG as PRIO_DARWIN_BG,
+            PRIO_DARWIN_NONUI as PRIO_DARWIN_NONUI,
+            PRIO_DARWIN_PROCESS as PRIO_DARWIN_PROCESS,
+            PRIO_DARWIN_THREAD as PRIO_DARWIN_THREAD,
+        )
+
     # Not same as os.environ or os.environb
     # Because of this variable, we can't do "from posix import *" in os/__init__.pyi
     environ: dict[bytes, bytes]

--- a/tests/stubtest_allowlists/darwin-py312.txt
+++ b/tests/stubtest_allowlists/darwin-py312.txt
@@ -4,14 +4,6 @@ _curses.window.get_wch
 _posixsubprocess.fork_exec
 curses.unget_wch
 curses.window.get_wch
-os.PRIO_DARWIN_BG
-os.PRIO_DARWIN_NONUI
-os.PRIO_DARWIN_PROCESS
-os.PRIO_DARWIN_THREAD
-posix.PRIO_DARWIN_BG
-posix.PRIO_DARWIN_NONUI
-posix.PRIO_DARWIN_PROCESS
-posix.PRIO_DARWIN_THREAD
 tty.__all__
 tty.cfmakecbreak
 tty.cfmakeraw


### PR DESCRIPTION
Docs:

```
.. data:: PRIO_DARWIN_THREAD
          PRIO_DARWIN_PROCESS
          PRIO_DARWIN_BG
          PRIO_DARWIN_NONUI

   Parameters for the :func:`getpriority` and :func:`setpriority` functions.

   .. availability:: macOS

   .. versionadded:: 3.12
```