### PR TITLE
Skip all parts of the daily test on forks of typeshed

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -98,8 +98,10 @@ jobs:
           fi
 
           $PYTHON_EXECUTABLE tests/stubtest_third_party.py --specified-platforms-only --num-shards 4 --shard-index ${{ matrix.shard-index }}
+
   stub-uploader:
     name: Run the stub_uploader tests
+    if: ${{ github.repository == 'python/typeshed' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
We skip 2/3 jobs in the daily test when running on forks:

https://github.com/python/typeshed/blob/b23042e854e79b54c4d2c609cf1e12a2357335a9/.github/workflows/daily.yml#L33

https://github.com/python/typeshed/blob/b23042e854e79b54c4d2c609cf1e12a2357335a9/.github/workflows/daily.yml#L59

But we missed this condition for the stub-uploader job

Fixes #10781