### PR TITLE
[tty] py312: Fix return types of set(raw|cbreak)

### DIFF
--- a/stdlib/termios.pyi
+++ b/stdlib/termios.pyi
@@ -3,10 +3,12 @@ from _typeshed import FileDescriptorLike
 from typing import Any
 from typing_extensions import TypeAlias
 
-if sys.platform != "win32":
-    # Must be a list of length 7, containing 6 ints and a list of NCCS 1-character bytes or ints.
-    _Attr: TypeAlias = list[int | list[bytes | int]]
+# Must be a list of length 7, containing 6 ints and a list of NCCS 1-character bytes or ints.
+_Attr: TypeAlias = list[int | list[bytes | int]]
+# Same as _Attr for return types; we use Any to avoid a union.
+_AttrReturn: TypeAlias = list[Any]
 
+if sys.platform != "win32":
     B0: int
     B1000000: int
     B110: int
@@ -252,7 +254,7 @@ if sys.platform != "win32":
     XCASE: int
     XTABS: int
 
-    def tcgetattr(__fd: FileDescriptorLike) -> list[Any]: ...  # Returns _Attr; we use Any to avoid a union in the return type
+    def tcgetattr(__fd: FileDescriptorLike) -> _AttrReturn: ...
     def tcsetattr(__fd: FileDescriptorLike, __when: int, __attributes: _Attr) -> None: ...
     def tcsendbreak(__fd: FileDescriptorLike, __duration: int) -> None: ...
     def tcdrain(__fd: FileDescriptorLike) -> None: ...

--- a/stdlib/termios.pyi
+++ b/stdlib/termios.pyi
@@ -4,7 +4,7 @@ from typing import Any
 from typing_extensions import TypeAlias
 
 # Must be a list of length 7, containing 6 ints and a list of NCCS 1-character bytes or ints.
-_Attr: TypeAlias = list[int | list[bytes | int]]
+_Attr: TypeAlias = list[int | list[bytes | int]] | list[int | list[bytes]] | list[int | list[int]]
 # Same as _Attr for return types; we use Any to avoid a union.
 _AttrReturn: TypeAlias = list[Any]
 

--- a/stdlib/tty.pyi
+++ b/stdlib/tty.pyi
@@ -7,9 +7,10 @@ if sys.platform != "win32":
     __all__ = ["setraw", "setcbreak"]
     if sys.version_info >= (3, 12):
         __all__ += ["cfmakeraw", "cfmakecbreak"]
-        _SetReturn: TypeAlias = _AttrReturn
+
+        _ModeSetterReturn: TypeAlias = _AttrReturn
     else:
-        _SetReturn: TypeAlias = None
+        _ModeSetterReturn: TypeAlias = None
 
     _FD: TypeAlias = int | IO[str]
 
@@ -21,8 +22,8 @@ if sys.platform != "win32":
     ISPEED: int
     OSPEED: int
     CC: int
-    def setraw(fd: _FD, when: int = 2) -> _SetReturn: ...
-    def setcbreak(fd: _FD, when: int = 2) -> _SetReturn: ...
+    def setraw(fd: _FD, when: int = 2) -> _ModeSetterReturn: ...
+    def setcbreak(fd: _FD, when: int = 2) -> _ModeSetterReturn: ...
 
     if sys.version_info >= (3, 12):
         # It is: `list[int, int, int, int, int, int, list[str]]

--- a/stdlib/tty.pyi
+++ b/stdlib/tty.pyi
@@ -1,5 +1,5 @@
 import sys
-from termios import _Attr, _AttrReturn
+import termios
 from typing import IO
 from typing_extensions import TypeAlias
 
@@ -8,7 +8,7 @@ if sys.platform != "win32":
     if sys.version_info >= (3, 12):
         __all__ += ["cfmakeraw", "cfmakecbreak"]
 
-        _ModeSetterReturn: TypeAlias = _AttrReturn
+        _ModeSetterReturn: TypeAlias = termios._AttrReturn
     else:
         _ModeSetterReturn: TypeAlias = None
 
@@ -26,5 +26,5 @@ if sys.platform != "win32":
     def setcbreak(fd: _FD, when: int = 2) -> _ModeSetterReturn: ...
 
     if sys.version_info >= (3, 12):
-        def cfmakeraw(mode: _Attr) -> None: ...
-        def cfmakecbreak(mode: _Attr) -> None: ...
+        def cfmakeraw(mode: termios._Attr) -> None: ...
+        def cfmakecbreak(mode: termios._Attr) -> None: ...

--- a/stdlib/tty.pyi
+++ b/stdlib/tty.pyi
@@ -1,9 +1,15 @@
 import sys
+from termios import _AttrReturn
 from typing import IO
 from typing_extensions import TypeAlias
 
 if sys.platform != "win32":
     __all__ = ["setraw", "setcbreak"]
+
+    if sys.version_info >= (3, 12):
+        _SetReturn: TypeAlias = _AttrReturn
+    else:
+        _SetReturn: TypeAlias = None
 
     _FD: TypeAlias = int | IO[str]
 
@@ -15,5 +21,5 @@ if sys.platform != "win32":
     ISPEED: int
     OSPEED: int
     CC: int
-    def setraw(fd: _FD, when: int = 2) -> None: ...
-    def setcbreak(fd: _FD, when: int = 2) -> None: ...
+    def setraw(fd: _FD, when: int = 2) -> _SetReturn: ...
+    def setcbreak(fd: _FD, when: int = 2) -> _SetReturn: ...

--- a/stdlib/tty.pyi
+++ b/stdlib/tty.pyi
@@ -1,5 +1,5 @@
 import sys
-from termios import _AttrReturn
+from termios import _Attr, _AttrReturn
 from typing import IO, Any
 from typing_extensions import TypeAlias
 
@@ -26,8 +26,5 @@ if sys.platform != "win32":
     def setcbreak(fd: _FD, when: int = 2) -> _ModeSetterReturn: ...
 
     if sys.version_info >= (3, 12):
-        # It is: `list[int, int, int, int, int, int, list[str]]
-        _Mode: TypeAlias = list[Any]
-
-        def cfmakeraw(mode: _Mode) -> None: ...
-        def cfmakecbreak(mode: _Mode) -> None: ...
+        def cfmakeraw(mode: _Attr) -> None: ...
+        def cfmakecbreak(mode: _Attr) -> None: ...

--- a/stdlib/tty.pyi
+++ b/stdlib/tty.pyi
@@ -1,6 +1,6 @@
 import sys
 from termios import _Attr, _AttrReturn
-from typing import IO, Any
+from typing import IO
 from typing_extensions import TypeAlias
 
 if sys.platform != "win32":


### PR DESCRIPTION
Also add `termios._AttrReturn` type alias to be used in tty