### PR TITLE
Add `MAP_STACK` to `mmap` module

### DIFF
--- a/stdlib/mmap.pyi
+++ b/stdlib/mmap.pyi
@@ -16,8 +16,8 @@ if sys.platform == "linux":
     MAP_EXECUTABLE: int
     if sys.version_info >= (3, 10):
         MAP_POPULATE: int
-    if sys.version_info >= (3, 11):
-        MAP_STACK: int
+if sys.version_info >= (3, 11) and sys.platform != "win32" and sys.platform != "darwin":
+    MAP_STACK: int
 
 if sys.platform != "win32":
     MAP_ANON: int

--- a/stdlib/mmap.pyi
+++ b/stdlib/mmap.pyi
@@ -16,6 +16,8 @@ if sys.platform == "linux":
     MAP_EXECUTABLE: int
     if sys.version_info >= (3, 10):
         MAP_POPULATE: int
+    if sys.version_info >= (3, 11):
+        MAP_STACK: int
 
 if sys.platform != "win32":
     MAP_ANON: int

--- a/tests/stubtest_allowlists/linux-py311.txt
+++ b/tests/stubtest_allowlists/linux-py311.txt
@@ -1,5 +1,4 @@
 _?curses.color_pair
-mmap.MAP_STACK
 (os|posix).sendfile
 signal.sigtimedwait
 signal.sigwaitinfo

--- a/tests/stubtest_allowlists/linux-py312.txt
+++ b/tests/stubtest_allowlists/linux-py312.txt
@@ -2,7 +2,6 @@ _?curses.color_pair
 _posixsubprocess.fork_exec
 (os|posix).sendfile
 (os|posix).setns
-mmap.MAP_STACK
 resource.prlimit
 signal.sigtimedwait
 signal.sigwaitinfo


### PR DESCRIPTION
Source:

```c
#ifdef MAP_STACK
    // Mostly a no-op on Linux and NetBSD, but useful on OpenBSD
    // for stack usage (even on x86 arch)
    ADD_INT_MACRO(module, MAP_STACK);
#endif
```

Docs:

```rst
    .. versionadded:: 3.11
       Added :data:`MAP_STACK` constant.
```