### PR TITLE
`dbm.gnu` does exist on macos

### DIFF
--- a/.github/workflows/stubtest_stdlib.yml
+++ b/.github/workflows/stubtest_stdlib.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         # tkinter doesn't import on macOS 12
-        os: ["ubuntu-latest", "windows-latest", "macos-11"]
+        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
       fail-fast: false
 

--- a/.github/workflows/stubtest_stdlib.yml
+++ b/.github/workflows/stubtest_stdlib.yml
@@ -46,7 +46,7 @@ jobs:
           allow-prereleases: true
           check-latest: true
       - name: Temp
-        if: matrix.os == 'macos-11'
+        if: matrix.os == 'macos-latest'
         run: |
           gdbmtool --version || true
           brew --version || true

--- a/.github/workflows/stubtest_stdlib.yml
+++ b/.github/workflows/stubtest_stdlib.yml
@@ -45,6 +45,13 @@ jobs:
           cache-dependency-path: requirements-tests.txt
           allow-prereleases: true
           check-latest: true
+      - name: Temp
+        if: matrix.os == 'macos-11'
+        run: |
+          gdbmtool --version || true
+          brew --version || true
+          brew list || true
+          gettext --version || true
       - name: Install dependencies
         run: pip install -r requirements-tests.txt
       - name: Run stubtest

--- a/tests/stubtest_allowlists/darwin-py311.txt
+++ b/tests/stubtest_allowlists/darwin-py311.txt
@@ -1,6 +1,5 @@
 _?curses.color_pair
 
-(dbm.gnu)?
 (locale.bind_textdomain_codeset)?
 (locale.bindtextdomain)?
 (locale.dcgettext)?

--- a/tests/stubtest_allowlists/darwin-py312.txt
+++ b/tests/stubtest_allowlists/darwin-py312.txt
@@ -5,7 +5,6 @@ _posixsubprocess.fork_exec
 curses.unget_wch
 curses.window.get_wch
 
-(dbm.gnu)?
 (locale.bind_textdomain_codeset)?
 (locale.bindtextdomain)?
 (locale.dcgettext)?


### PR DESCRIPTION
At least locally:

```
~/Desktop/cpython  main ✔                                                                 
» ~/.pyenv/versions/3.9.17/bin/python
Python 3.9.17 (main, Jul 12 2023, 22:57:20) 
[Clang 14.0.3 (clang-1403.0.22.14.1)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import dbm.gnu
>>> 
KeyboardInterrupt
>>> 
                                                                                           
~/Desktop/cpython  main ✔                                                                 
» python                             
Python 3.11.5 (main, Sep  5 2023, 10:34:31) [Clang 14.0.3 (clang-1403.0.22.14.1)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import dbm.gnu
>>> 
```

Let's try it in CI.