### PR TITLE
fix `__match_args__` attribute name

### DIFF
--- a/stdlib/_ast.pyi
+++ b/stdlib/_ast.pyi
@@ -602,7 +602,7 @@ if sys.version_info >= (3, 12):
         name: _Identifier
 
     class TypeAlias(stmt):
-        __match_args__ = ("name", "typeparams", "value")
+        __match_args__ = ("name", "type_params", "value")
         name: Name
         type_params: list[type_param]
         value: expr


### PR DESCRIPTION
```pycon
>>> import ast
>>> m = ast.parse("type ListOrSet[T] = list[T] | set[T]")
>>> print(m.body[0].__match_args__)
('name', 'type_params', 'value')
```