### PR TITLE
Re-export `SYSPROTO_CONTROL` and `PF_SYSTEM` in `socket` on macos

### DIFF
--- a/stdlib/socket.pyi
+++ b/stdlib/socket.pyi
@@ -129,10 +129,10 @@ if sys.platform != "darwin" or sys.version_info >= (3, 9):
         IPV6_RTHDR as IPV6_RTHDR,
     )
 
-if sys.platform != "darwin":
-    from _socket import SO_EXCLUSIVEADDRUSE as SO_EXCLUSIVEADDRUSE
-else:
+if sys.platform == "darwin":
     from _socket import PF_SYSTEM as PF_SYSTEM, SYSPROTO_CONTROL as SYSPROTO_CONTROL
+else:
+    from _socket import SO_EXCLUSIVEADDRUSE as SO_EXCLUSIVEADDRUSE
 
 if sys.version_info >= (3, 10):
     from _socket import IP_RECVTOS as IP_RECVTOS

--- a/stdlib/socket.pyi
+++ b/stdlib/socket.pyi
@@ -131,6 +131,8 @@ if sys.platform != "darwin" or sys.version_info >= (3, 9):
 
 if sys.platform != "darwin":
     from _socket import SO_EXCLUSIVEADDRUSE as SO_EXCLUSIVEADDRUSE
+else:
+    from _socket import PF_SYSTEM as PF_SYSTEM, SYSPROTO_CONTROL as SYSPROTO_CONTROL
 
 if sys.version_info >= (3, 10):
     from _socket import IP_RECVTOS as IP_RECVTOS

--- a/tests/stubtest_allowlists/darwin.txt
+++ b/tests/stubtest_allowlists/darwin.txt
@@ -31,8 +31,6 @@ select.POLLMSG   # system dependent
 # Exists at runtime, but missing from stubs
 mimetypes.MimeTypes.read_windows_registry
 selectors.DefaultSelector.fileno
-socket.PF_SYSTEM
-socket.SYSPROTO_CONTROL
 
 _ctypes.dlclose
 _ctypes.dlopen


### PR DESCRIPTION
Local demo:

```python
Python 3.13.0a0 (heads/main:98c0c1de18e, Sep 28 2023, 09:21:43) [Clang 14.0.3 (clang-1403.0.22.14.1)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import socket
>>> socket.SYSPROTO_CONTROL
2
>>> socket.PF_SYSTEM
32
```