### PR TITLE
Remove redundant `NoReturn` union in openpyxl

### DIFF
--- a/stubs/openpyxl/openpyxl/descriptors/serialisable.pyi
+++ b/stubs/openpyxl/openpyxl/descriptors/serialisable.pyi
@@ -1,5 +1,5 @@
 from _typeshed import Incomplete, SupportsIter
-from typing import Any, ClassVar, NoReturn, Protocol
+from typing import Any, ClassVar, Protocol
 from typing_extensions import Final, Self
 
 from openpyxl.descriptors import MetaSerialisable
@@ -21,8 +21,10 @@ class Serialisable(metaclass=MetaSerialisable):
     __namespaced__: ClassVar[tuple[tuple[str, str], ...]]
     idx_base: int
     # Needs overrides in many sub-classes. But a lot of subclasses are instanciated without overriding it, so can't be abstract
+    # Subclasses "overrides" this property with a ClassVar, and Serialisable is too widely used,
+    # so it can't be typed as NoReturn either without introducing many false-positives.
     @property
-    def tagname(self) -> str | NoReturn: ...
+    def tagname(self) -> str: ...
     namespace: ClassVar[str | None]
     # Note: To respect the Liskov substitution principle, the protocol for node includes all child class requirements.
     # Same with the return type to avoid override issues.


### PR DESCRIPTION
From https://github.com/python/typeshed/issues/8217#issuecomment-1742239764

Unless you think there's documentation/semantic value in keeping the union. kindof like how sometimes we have redundant unions with `None` or `Any`. In which case I'll update the comment to make that obvious. Although pyright/Pylance seem to completely strip it out.
![image](https://github.com/python/typeshed/assets/1350584/38dce909-2115-4e91-8d81-c33bce9f2f3c)

Not going with `def tagname(self) -> NoReturn: ...` for the reason listed in the comment.