### PR TITLE
`select.POLLRDHUP` does not exist on macos

### DIFF
--- a/stdlib/select.pyi
+++ b/stdlib/select.pyi
@@ -15,7 +15,8 @@ if sys.platform != "win32":
     POLLOUT: int
     POLLPRI: int
     POLLRDBAND: int
-    POLLRDHUP: int
+    if sys.platform != "darwin":
+        POLLRDHUP: int
     POLLRDNORM: int
     POLLWRBAND: int
     POLLWRNORM: int

--- a/stdlib/select.pyi
+++ b/stdlib/select.pyi
@@ -15,7 +15,7 @@ if sys.platform != "win32":
     POLLOUT: int
     POLLPRI: int
     POLLRDBAND: int
-    if sys.platform != "darwin":
+    if sys.platform == "linux":
         POLLRDHUP: int
     POLLRDNORM: int
     POLLWRBAND: int

--- a/tests/stubtest_allowlists/darwin.txt
+++ b/tests/stubtest_allowlists/darwin.txt
@@ -34,7 +34,6 @@ _ctypes.dlopen
 _ctypes.dlsym
 
 posix.NGROUPS_MAX
-select.POLLRDHUP
 webbrowser.MacOSX.__init__
 
 # ==========


### PR DESCRIPTION
```
» ./python.exe
Python 3.13.0a0 (heads/main:98c0c1de18e, Sep 28 2023, 09:21:43) [Clang 14.0.3 (clang-1403.0.22.14.1)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import select
>>> select.POLLRDHUP
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'select' has no attribute 'POLLRDHUP'. Did you mean: 'POLLHUP'?
```

And stable Python:

```
Python 3.11.5 (main, Aug 24 2023, 15:09:45) [Clang 14.0.3 (clang-1403.0.22.14.1)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import select
>>> select.POLLRDHUP
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'select' has no attribute 'POLLRDHUP'. Did you mean: 'POLLHUP'?
```

See https://manpages.courier-mta.org/htmlman2/poll.2.html