### PR TITLE
Fix allowlists on linux and macos for `posix` module

### DIFF
--- a/stdlib/os/__init__.pyi
+++ b/stdlib/os/__init__.pyi
@@ -282,6 +282,8 @@ if sys.platform != "win32":
     EX_PROTOCOL: int
     EX_NOPERM: int
     EX_CONFIG: int
+
+if sys.platform != "win32" and sys.platform != "darwin":
     EX_NOTFOUND: int
 
 P_NOWAIT: int

--- a/stdlib/posix.pyi
+++ b/stdlib/posix.pyi
@@ -14,7 +14,6 @@ if sys.platform != "win32":
         EX_NOHOST as EX_NOHOST,
         EX_NOINPUT as EX_NOINPUT,
         EX_NOPERM as EX_NOPERM,
-        EX_NOTFOUND as EX_NOTFOUND,
         EX_NOUSER as EX_NOUSER,
         EX_OK as EX_OK,
         EX_OSERR as EX_OSERR,

--- a/stdlib/posix.pyi
+++ b/stdlib/posix.pyi
@@ -29,6 +29,7 @@ if sys.platform != "win32":
         F_TEST as F_TEST,
         F_TLOCK as F_TLOCK,
         F_ULOCK as F_ULOCK,
+        NGROUPS_MAX as NGROUPS_MAX,
         O_APPEND as O_APPEND,
         O_ASYNC as O_ASYNC,
         O_CREAT as O_CREAT,
@@ -224,6 +225,7 @@ if sys.platform != "win32":
 
     if sys.platform == "linux":
         from os import (
+            EX_NOTFOUND as EX_NOTFOUND,
             GRND_NONBLOCK as GRND_NONBLOCK,
             GRND_RANDOM as GRND_RANDOM,
             RTLD_DEEPBIND as RTLD_DEEPBIND,

--- a/stdlib/posix.pyi
+++ b/stdlib/posix.pyi
@@ -222,9 +222,11 @@ if sys.platform != "win32":
         writev as writev,
     )
 
+    if sys.platform != "darwin":
+        from os import EX_NOTFOUND as EX_NOTFOUND
+
     if sys.platform == "linux":
         from os import (
-            EX_NOTFOUND as EX_NOTFOUND,
             GRND_NONBLOCK as GRND_NONBLOCK,
             GRND_RANDOM as GRND_RANDOM,
             RTLD_DEEPBIND as RTLD_DEEPBIND,

--- a/tests/stubtest_allowlists/darwin.txt
+++ b/tests/stubtest_allowlists/darwin.txt
@@ -33,7 +33,6 @@ _ctypes.dlclose
 _ctypes.dlopen
 _ctypes.dlsym
 
-posix.NGROUPS_MAX
 webbrowser.MacOSX.__init__
 
 # ==========

--- a/tests/stubtest_allowlists/darwin.txt
+++ b/tests/stubtest_allowlists/darwin.txt
@@ -1,12 +1,10 @@
 _?curses.A_ITALIC
 
 _posixsubprocess.cloexec_pipe
-os.EX_NOTFOUND
 os.SF_MNOWAIT
 os.SF_NODISKIO
 os.SF_SYNC
 (os|posix).sched_param  # system dependent. Unclear if macos has it.
-posix.EX_NOTFOUND
 select.KQ_FILTER_NETDEV  # system dependent
 select.kqueue.__init__  # default C signature is wrong
 select.POLLMSG   # system dependent

--- a/tests/stubtest_allowlists/linux.txt
+++ b/tests/stubtest_allowlists/linux.txt
@@ -5,8 +5,6 @@ os.SF_MNOWAIT
 os.SF_NODISKIO
 os.SF_SYNC
 os.plock
-posix.EX_NOTFOUND
-posix.NGROUPS_MAX
 select.EPOLL_RDHUP
 selectors.KqueueSelector
 signal.SIGEMT

--- a/tests/stubtest_allowlists/linux.txt
+++ b/tests/stubtest_allowlists/linux.txt
@@ -1,6 +1,5 @@
 _socket.*
 _posixsubprocess.cloexec_pipe
-os.EX_NOTFOUND
 os.SF_MNOWAIT
 os.SF_NODISKIO
 os.SF_SYNC
@@ -45,6 +44,10 @@ multiprocessing.popen_spawn_win32
 fcntl.I_[A-Z0-9_]+
 os.SCHED_[A-Z_]+
 posix.SCHED_[A-Z_]+
+
+# Exists on some Unix platforms, but not in CI:
+os.EX_NOTFOUND
+posix.EX_NOTFOUND
 
 # Some of these exist on non-windows, but they are useless and this is not intended
 stat.FILE_ATTRIBUTE_[A-Z_]+


### PR DESCRIPTION
Mac demo:

```
>>> import posix
>>> posix.NGROUPS_MAX
16
>>> posix.EX_NOTFOUND
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'posix' has no attribute 'EX_NOTFOUND'
>>> 
```