### PR TITLE
[bleach] Add html5lib_shim.Filter__init__/__iter__

### DIFF
--- a/stubs/bleach/bleach/html5lib_shim.pyi
+++ b/stubs/bleach/bleach/html5lib_shim.pyi
@@ -1,11 +1,14 @@
 from _typeshed import Incomplete
-from collections.abc import Generator, Iterable
+from collections.abc import Generator, Iterable, Iterator
 
 class HTMLParser:  # actually html5lib.HTMLParser
     def __getattr__(self, __name: str) -> Incomplete: ...
 
 class Filter:  # actually html5lib.filters.base.Filter
-    def __getattr__(self, __name: str) -> Incomplete: ...
+    source: Incomplete
+    def __init__(self, source) -> None: ...
+    def __iter__(self) -> Iterator[Incomplete]: ...
+    def __getattr__(self, name: str) -> Incomplete: ...  # copy attributes from source
 
 class SanitizerFilter:  # actually html5lib.filters.sanitizer.Filter
     def __getattr__(self, __name: str) -> Incomplete: ...


### PR DESCRIPTION
The missing __init__ method caused `Filter` to be incompatible with the `_Filter` protocol, preventing valid initialization of `Cleaner` instances.

Closes: #10834