### PR TITLE
`types-requests`, `types-influxdb-client`: add note to the PyPI readme about the `urllib3` pin

### DIFF
--- a/stubs/influxdb-client/METADATA.toml
+++ b/stubs/influxdb-client/METADATA.toml
@@ -3,6 +3,13 @@ upstream_repository = "https://github.com/influxdata/influxdb-client-python"
 # requires a version of urllib3 with a py.typed file
 requires = ["urllib3>=2"]
 
+extra_description = """\
+    Note: `types-influxdb-client` has required `urllib3>=2` since v1.37.0.1. \
+    If you need to install `types-influxdb-client` into an environment \
+    that must also have `urllib3<2` installed into it, \
+    you will have to use `types-influxdb-client<1.37.0.1`.\
+    """
+
 [tool.stubtest]
 extras = ["extra"]
 stubtest_requirements = ["aiohttp"]

--- a/stubs/requests/METADATA.toml
+++ b/stubs/requests/METADATA.toml
@@ -2,6 +2,12 @@ version = "2.31.*"
 upstream_repository = "https://github.com/psf/requests"
 # requires a version of urllib3 with a py.typed file
 requires = ["urllib3>=2"]
+extra_description = """\
+    Note: `types-requests` has required `urllib3>=2` since v2.31.0.7. \
+    If you need to install `types-requests` into an environment \
+    that must also have `urllib3<2` installed into it, \
+    you will have to use `types-requests<2.31.0.7`.\
+    """
 
 [tool.stubtest]
 extras = ["socks"]


### PR DESCRIPTION
As requested in https://github.com/python/typeshed/issues/10825#issuecomment-1748635927