### PR TITLE
stubtest: List ignored `building` sub-modules explicitly

### DIFF
--- a/stubs/pyinstaller/@tests/stubtest_allowlist.txt
+++ b/stubs/pyinstaller/@tests/stubtest_allowlist.txt
@@ -9,20 +9,20 @@ PyInstaller.__main__.run_makespec
 PyInstaller.utils.hooks.conda.lib_dir
 
 # A mix of modules meant to be private, and shallow incomplete type references for other modules
-PyInstaller.building.build_main.*
+PyInstaller\.building\.build_main\..*
 PyInstaller.building.datastruct.unique_name
-PyInstaller.building.icon.*
-PyInstaller.building.makespec.*
-PyInstaller.building.osx.*
-PyInstaller.building.splash_templates.*
-PyInstaller.building.templates.*
-PyInstaller.building.utils.*
-PyInstaller.depend.analysis.*
-PyInstaller.isolated._parent.*
+PyInstaller\.depend\.analysis\..*
+PyInstaller\.isolated\._parent\..*
 PyInstaller\.lib\.modulegraph\.modulegraph\.\w+?
 
 # Most modules are not meant to be used, yet are not marked as private
-PyInstaller.archive.*
+PyInstaller\.archive(\.\w+)*
+PyInstaller.building.icon
+PyInstaller.building.makespec
+PyInstaller.building.osx
+PyInstaller.building.splash_templates
+PyInstaller.building.templates
+PyInstaller.building.utils
 PyInstaller.config
 PyInstaller.configure
 PyInstaller.depend.bindepend
@@ -31,11 +31,14 @@ PyInstaller.depend.dylib
 PyInstaller.depend.imphook
 PyInstaller.depend.utils
 PyInstaller.exceptions
-PyInstaller.hooks.*
-PyInstaller\.lib\.modulegraph\.\w+?
-PyInstaller.loader.*
+PyInstaller\.hooks(\.[\w-]+)*  # weird hyphens in runtime module names
+PyInstaller.lib.modulegraph.__main__
+PyInstaller.lib.modulegraph.find_modules
+PyInstaller.lib.modulegraph.util
+PyInstaller.lib.modulegraph.zipio
+PyInstaller\.loader(\.\w+)*
 PyInstaller.log
-PyInstaller.utils.cliutils.*
+PyInstaller\.utils\.cliutils(\.\w+)*
 PyInstaller.utils.conftest
 PyInstaller.utils.git
 PyInstaller.utils.hooks.django
@@ -46,4 +49,10 @@ PyInstaller.utils.misc
 PyInstaller.utils.osx
 PyInstaller.utils.run_tests
 PyInstaller.utils.tests
-PyInstaller\.utils\.win32\.\w+?
+PyInstaller.utils.win32.icon
+PyInstaller.utils.win32.winmanifest
+PyInstaller.utils.win32.winresource
+PyInstaller.utils.win32.winutils
+
+# Module can't be imported at runtime on non-win32 platforms
+PyInstaller.utils.win32.versioninfo

--- a/stubs/pyinstaller/@tests/stubtest_allowlist.txt
+++ b/stubs/pyinstaller/@tests/stubtest_allowlist.txt
@@ -9,9 +9,14 @@ PyInstaller.__main__.run_makespec
 PyInstaller.utils.hooks.conda.lib_dir
 
 # A mix of modules meant to be private, and shallow incomplete type references for other modules
-PyInstaller\.building\.\w+?
 PyInstaller.building.build_main.*
 PyInstaller.building.datastruct.unique_name
+PyInstaller.building.icon.*
+PyInstaller.building.makespec.*
+PyInstaller.building.osx.*
+PyInstaller.building.splash_templates.*
+PyInstaller.building.templates.*
+PyInstaller.building.utils.*
 PyInstaller.depend.analysis.*
 PyInstaller.isolated._parent.*
 PyInstaller\.lib\.modulegraph\.modulegraph\.\w+?


### PR DESCRIPTION
This prevents stubtest from ignoring errors in modules that are stubbed.