### PR TITLE
Use Python 3.11 for the stub_uploader tests in the daily test

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -116,7 +116,7 @@ jobs:
           path: stub_uploader
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
           cache: pip
           cache-dependency-path: stub_uploader/requirements.txt
       - name: Run tests


### PR DESCRIPTION
Hopefully fixes #10853