### PR TITLE
Bump various test dependency pins

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -40,7 +40,7 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
         uses: actions/setup-python@v4
         with:
@@ -64,7 +64,7 @@ jobs:
         shard-index: [0, 1, 2, 3]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: "3.10"
@@ -104,13 +104,12 @@ jobs:
     if: ${{ github.repository == 'python/typeshed' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
       - name: Checkout typeshed
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: typeshed
       - name: Checkout stub_uploader
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: typeshed-internal/stub_uploader
           path: stub_uploader

--- a/.github/workflows/meta_tests.yml
+++ b/.github/workflows/meta_tests.yml
@@ -34,7 +34,7 @@ jobs:
         platform: ["linux", "win32"]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: "3.11"
@@ -50,7 +50,7 @@ jobs:
         python-platform: ["Linux", "Windows"]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: "3.9"
@@ -74,7 +74,7 @@ jobs:
     name: Stubsabot dry run
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: "3.11"

--- a/.github/workflows/mypy_primer.yml
+++ b/.github/workflows/mypy_primer.yml
@@ -25,7 +25,7 @@ jobs:
         shard-index: [0, 1, 2, 3]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           path: typeshed_to_test
           fetch-depth: 0

--- a/.github/workflows/stubsabot.yml
+++ b/.github/workflows/stubsabot.yml
@@ -19,7 +19,7 @@ jobs:
     if: github.repository == 'python/typeshed'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           # use an ssh key so that checks automatically run on stubsabot PRs
           ssh-key: ${{ secrets.STUBSABOT_SSH_PRIVATE_KEY }}

--- a/.github/workflows/stubtest_stdlib.yml
+++ b/.github/workflows/stubtest_stdlib.yml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/stubtest_third_party.yml
+++ b/.github/workflows/stubtest_third_party.yml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: actions/setup-python@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
     name: Check file consistency
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: "3.11"
@@ -39,7 +39,7 @@ jobs:
     name: Ensure new syntax usage
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: "3.11"
@@ -49,7 +49,7 @@ jobs:
     name: Lint with flake8
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: "3.11"
@@ -62,7 +62,7 @@ jobs:
     name: Run pytype against the stubs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: "3.10"
@@ -88,7 +88,7 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
@@ -107,7 +107,7 @@ jobs:
         platform: ["linux", "win32", "darwin"]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: "3.11"
@@ -120,7 +120,7 @@ jobs:
     name: Run mypy on the test cases
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: "3.11"
@@ -138,7 +138,7 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: "3.11"
@@ -195,13 +195,12 @@ jobs:
     name: Run the stub_uploader tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
       - name: Checkout typeshed
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: typeshed
       - name: Checkout stub_uploader
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: typeshed-internal/stub_uploader
           path: stub_uploader

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0 # must match requirements-tests.txt
+    rev: v4.5.0 # must match requirements-tests.txt
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -29,9 +29,9 @@ repos:
     hooks:
       - id: flake8
         additional_dependencies:
-          - "flake8-bugbear==23.7.10" # must match requirements-tests.txt
+          - "flake8-bugbear==23.9.16" # must match requirements-tests.txt
           - "flake8-noqa==1.3.2" # must match requirements-tests.txt
-          - "flake8-pyi==23.6.0" # must match requirements-tests.txt
+          - "flake8-pyi==23.10.0" # must match requirements-tests.txt
         types: [file]
         types_or: [python, pyi]
 

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -3,18 +3,18 @@
 # "tool.typeshed" section in pyproject.toml for additional type checkers.
 black==23.9.1            # must match .pre-commit-config.yaml
 flake8==6.1.0            # must match .pre-commit-config.yaml
-flake8-bugbear==23.7.10  # must match .pre-commit-config.yaml
+flake8-bugbear==23.9.16  # must match .pre-commit-config.yaml
 flake8-noqa==1.3.2       # must match .pre-commit-config.yaml
-flake8-pyi==23.6.0       # must match .pre-commit-config.yaml
+flake8-pyi==23.10.0      # must match .pre-commit-config.yaml
 isort==5.12.0            # must match .pre-commit-config.yaml
 mypy==1.5.1
-pre-commit-hooks==4.4.0  # must match .pre-commit-config.yaml
-pytype==2023.8.31; platform_system != "Windows" and python_version < "3.11"
+pre-commit-hooks==4.5.0  # must match .pre-commit-config.yaml
+pytype==2023.10.5; platform_system != "Windows" and python_version < "3.11"
 ruff==0.0.292            # must match .pre-commit-config.yaml
 
 # Libraries used by our various scripts.
 aiohttp==3.8.5; python_version < "3.12"  # aiohttp can't be installed on 3.12 yet
-packaging==23.1
+packaging==23.2
 pathspec>=0.11.1
 pyyaml==6.0.1
 stubdefaulter==0.1.0

--- a/stdlib/argparse.pyi
+++ b/stdlib/argparse.pyi
@@ -342,11 +342,11 @@ if sys.version_info >= (3, 12):
             option_strings: Sequence[str],
             dest: str,
             default: _T | str | None = None,
-            type: Callable[[str], _T] | FileType | None = sentinel,  # noqa: Y011
-            choices: Iterable[_T] | None = sentinel,  # noqa: Y011
+            type: Callable[[str], _T] | FileType | None = sentinel,
+            choices: Iterable[_T] | None = sentinel,
             required: bool = False,
             help: str | None = None,
-            metavar: str | tuple[str, ...] | None = sentinel,  # noqa: Y011
+            metavar: str | tuple[str, ...] | None = sentinel,
         ) -> None: ...
 
 elif sys.version_info >= (3, 9):


### PR DESCRIPTION
We could possibly also upgrade our `aiohttp` pin to 3.9.0b0, which supports Python 3.12. Looks like there are one or two regressions in the beta, though (https://github.com/aio-libs/aiohttp/issues/7675), so I'm inclined to say we should hold off on that for now.