### PR TITLE
Allow specifying python version in runtests script

### DIFF
--- a/scripts/runtests.py
+++ b/scripts/runtests.py
@@ -58,10 +58,17 @@ def main() -> None:
             "only use this option if you trust the package you are testing."
         ),
     )
+    parser.add_argument(
+        "--python-version",
+        default=_PYTHON_VERSION,
+        choices=("3.8", "3.9", "3.10", "3.11", "3.12"),
+        help="Target Python version for the test (default: %(default)s).",
+    )
     parser.add_argument("path", help="Path of the stub to test in format <folder>/<stub>, from the root of the project.")
     args = parser.parse_args()
     path: str = args.path
     run_stubtest: bool = args.run_stubtest
+    python_version: str = args.python_version
 
     path_tokens = Path(path).parts
     if len(path_tokens) != 2:
@@ -94,9 +101,9 @@ def main() -> None:
     check_new_syntax_result = subprocess.run([sys.executable, "tests/check_new_syntax.py"])
 
     strict_params = _get_strict_params(path)
-    print(f"\nRunning Pyright ({'stricter' if strict_params else 'base' } configs) for Python {_PYTHON_VERSION}...")
+    print(f"\nRunning Pyright ({'stricter' if strict_params else 'base' } configs) for Python {python_version}...")
     pyright_result = subprocess.run(
-        [sys.executable, "tests/pyright_test.py", path, "--pythonversion", _PYTHON_VERSION] + strict_params,
+        [sys.executable, "tests/pyright_test.py", path, "--pythonversion", python_version] + strict_params,
         stderr=subprocess.PIPE,
         text=True,
     )
@@ -109,8 +116,8 @@ def main() -> None:
         pyright_returncode = pyright_result.returncode
         pyright_skipped = False
 
-    print(f"\nRunning mypy for Python {_PYTHON_VERSION}...")
-    mypy_result = subprocess.run([sys.executable, "tests/mypy_test.py", path, "--python-version", _PYTHON_VERSION])
+    print(f"\nRunning mypy for Python {python_version}...")
+    mypy_result = subprocess.run([sys.executable, "tests/mypy_test.py", path, "--python-version", python_version])
     # If mypy failed, stubtest will fail without any helpful error
     if mypy_result.returncode == 0:
         if folder == "stdlib":
@@ -146,13 +153,13 @@ def main() -> None:
         pyright_testcases_skipped = False
         regr_test_returncode = 0
     else:
-        print(f"\nRunning Pyright regression tests for Python {_PYTHON_VERSION}...")
+        print(f"\nRunning Pyright regression tests for Python {python_version}...")
         command = [
             sys.executable,
             "tests/pyright_test.py",
             str(test_cases_path),
             "--pythonversion",
-            _PYTHON_VERSION,
+            python_version,
             "-p",
             _TESTCASES_CONFIG_FILE,
         ]
@@ -166,9 +173,9 @@ def main() -> None:
             pyright_testcases_returncode = pyright_testcases_result.returncode
             pyright_testcases_skipped = False
 
-        print(f"\nRunning mypy regression tests for Python {_PYTHON_VERSION}...")
+        print(f"\nRunning mypy regression tests for Python {python_version}...")
         regr_test_result = subprocess.run(
-            [sys.executable, "tests/regr_test.py", "stdlib" if folder == "stdlib" else stub, "--python-version", _PYTHON_VERSION],
+            [sys.executable, "tests/regr_test.py", "stdlib" if folder == "stdlib" else stub, "--python-version", python_version],
             stderr=subprocess.PIPE,
             text=True,
         )


### PR DESCRIPTION
This makes the script usable for packages that do not support the minimum python version hardcoded in the script.

Another part of #10722