### PR TITLE
pywin32: Annotate `win32com.client.constants`

### DIFF
--- a/stubs/pywin32/win32com/client/__init__.pyi
+++ b/stubs/pywin32/win32com/client/__init__.pyi
@@ -1,5 +1,5 @@
 from _typeshed import Incomplete
-from typing_extensions import TypeAlias
+from typing_extensions import Final, TypeAlias
 
 import _win32typing
 from win32com.client import dynamic as dynamic, gencache as gencache
@@ -36,7 +36,7 @@ class Constants:
     __dicts__: Incomplete
     def __getattr__(self, a: str): ...
 
-constants: Incomplete
+constants: Final[Constants]
 
 class EventsProxy:
     def __init__(self, ob) -> None: ...


### PR DESCRIPTION
Resolve type of `constants` to allow type-checkers to trace this back to the `Constants` class. Under normal circumstances, no extra type errors should be introduced, because `Constants` has a dynamic `__getattr__`.

**Motivation**: This type annotation can be used to infer a more precise type for attribute accesses by third-party static analysis plugins, e.g. mypy's [`get_attribute_hook`](https://mypy.readthedocs.io/en/stable/extending_mypy.html#current-list-of-plugin-hooks).

See implementation at https://github.com/mhammond/pywin32/blob/main/com/win32com/client/__init__.py:

```python

class Constants:
    """A container for generated COM constants."""
    ...

# And create an instance.
constants = Constants()
```