### PR TITLE
Bump `ruff` to `0.1.0`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
       - id: isort
         name: isort (python)
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.0.292  # must match requirements-tests.txt
+    rev: v0.1.0 # must match requirements-tests.txt
     hooks:
       - id: ruff
         args: [--exit-non-zero-on-fix]

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -10,7 +10,7 @@ isort==5.12.0            # must match .pre-commit-config.yaml
 mypy==1.5.1
 pre-commit-hooks==4.5.0  # must match .pre-commit-config.yaml
 pytype==2023.10.5; platform_system != "Windows" and python_version < "3.11"
-ruff==0.0.292            # must match .pre-commit-config.yaml
+ruff==0.1.0              # must match .pre-commit-config.yaml
 
 # Libraries used by our various scripts.
 aiohttp==3.8.5; python_version < "3.12"  # aiohttp can't be installed on 3.12 yet


### PR DESCRIPTION
Release post: https://astral.sh/blog/ruff-v0.1.0