### PR TITLE
Run pytype_test in Python 3.11.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,7 +65,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
           cache: pip
           cache-dependency-path: requirements-tests.txt
       - run: pip install -r requirements-tests.txt

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -9,7 +9,7 @@ flake8-pyi==23.10.0      # must match .pre-commit-config.yaml
 isort==5.12.0            # must match .pre-commit-config.yaml
 mypy==1.5.1
 pre-commit-hooks==4.5.0  # must match .pre-commit-config.yaml
-pytype==2023.10.5; platform_system != "Windows" and python_version < "3.11"
+pytype==2023.10.17; platform_system != "Windows" and python_version < "3.12"
 ruff==0.1.0              # must match .pre-commit-config.yaml
 
 # Libraries used by our various scripts.

--- a/tests/pytype_test.py
+++ b/tests/pytype_test.py
@@ -29,8 +29,8 @@ from parse_metadata import read_dependencies
 if sys.platform == "win32":
     print("pytype does not support Windows.", file=sys.stderr)
     sys.exit(1)
-if sys.version_info >= (3, 11):
-    print("pytype does not support Python 3.11+ yet.", file=sys.stderr)
+if sys.version_info >= (3, 12):
+    print("pytype does not support Python 3.12+ yet.", file=sys.stderr)
     sys.exit(1)
 
 # pytype is not py.typed https://github.com/google/pytype/issues/1325


### PR DESCRIPTION
As of version 2023.10.17, pytype now supports 3.11.