### PR TITLE
Configure editors to explicitly use `LF` / `\n` line endings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,12 +1,14 @@
 root = true
 
-[*.{py,pyi,rst,md,yml,yaml,toml,json,txt}]
+[*]
 trim_trailing_whitespace = true
 insert_final_newline = true
 indent_style = space
+end_of_line = lf
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
 
 [*.{py,pyi,toml,json}]
 indent_size = 4
-
-[*.{yml,yaml}]
-indent_size = 2

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,6 @@
+# Normalize EOF
+* autocrlf=false
+* eol=lf
 # Set linguist-language to support comments syntax highlight
 **/stubtest_allowlist*.txt linguist-language=ini
 tests/stubtest_allowlists/*.txt linguist-language=ini

--- a/.vscode/settings.default.json
+++ b/.vscode/settings.default.json
@@ -24,6 +24,7 @@
         "**/.*_cache": true, // mypy and Ruff cache
         "**/__pycache__": true
     },
+    "files.eol": "\n",
     "files.insertFinalNewline": true,
     "files.trimFinalNewlines": true,
     "files.trimTrailingWhitespace": true,
@@ -31,7 +32,7 @@
     "editor.insertSpaces": true,
     "editor.detectIndentation": false,
     "editor.tabSize": 2,
-    "[json][jsonc][python]": {
+    "[json][jsonc][python][toml]": {
         "editor.tabSize": 4
     },
     "editor.rulers": [


### PR DESCRIPTION
This solves a couple Windows-Linux consistency issues. Namely:
- Running bash scripts using WSL on Windows
- git thinking the entire repository changed EOF when opening VSCode in WSL context.
- git changing EOF to CRLF on checkout on Windows

Fixed VSCode defaults not using 4-spaces for tom while I'm at it (since I have the `editorconfig.editorconfig` extension installed, it was correctly using the value in `.editorconfig` for me)