### PR TITLE
Add `io.text_encoding` on py310+

### DIFF
--- a/stdlib/io.pyi
+++ b/stdlib/io.pyi
@@ -6,7 +6,7 @@ from _typeshed import FileDescriptorOrPath, ReadableBuffer, WriteableBuffer
 from collections.abc import Callable, Iterable, Iterator
 from os import _Opener
 from types import TracebackType
-from typing import IO, Any, BinaryIO, TextIO
+from typing import IO, Any, BinaryIO, TextIO, TypeVar, overload
 from typing_extensions import Literal, Self
 
 __all__ = [
@@ -32,6 +32,8 @@ __all__ = [
 
 if sys.version_info >= (3, 8):
     __all__ += ["open_code"]
+
+_T = TypeVar("_T")
 
 DEFAULT_BUFFER_SIZE: Literal[8192]
 
@@ -194,3 +196,9 @@ class IncrementalNewlineDecoder(codecs.IncrementalDecoder):
     @property
     def newlines(self) -> str | tuple[str, ...] | None: ...
     def setstate(self, __state: tuple[bytes, int]) -> None: ...
+
+if sys.version_info >= (3, 10):
+    @overload
+    def text_encoding(__encoding: None, __stacklevel: int = 2) -> Literal["locale", "utf-8"]: ...
+    @overload
+    def text_encoding(__encoding: _T, __stacklevel: int = 2) -> _T: ...


### PR DESCRIPTION
See https://discuss.python.org/t/type-checkers-complain-about-io-text-encoding/37187/1 for discussion. The function is documented, even though it's not included in `io.__all__` (which is why stubtest hasn't been complaining about it being missing): https://docs.python.org/3/library/io.html#io.text_encoding