### PR TITLE
Improve regression test documentation

### DIFF
--- a/test_cases/README.md
+++ b/test_cases/README.md
@@ -32,6 +32,13 @@ stubs where decisions have been taken that might be slightly unusual. These
 test cases serve a different purpose: to check that type checkers do not emit
 false-positive errors for idiomatic usage of these classes.
 
+## Running the tests
+
+To run the tests in this directory, run `python tests/typecheck_typeshed.py stdlib`
+from the root of the typeshed repository. This assumes that the development
+environment has been set up as described in the [CONTRIBUTING.md](../CONTRIBUTING.md)
+document.
+
 ### How the tests work
 
 The code in this directory is not intended to be directly executed. Instead,

--- a/test_cases/README.md
+++ b/test_cases/README.md
@@ -3,7 +3,7 @@
 This directory contains code samples that act as a regression test for
 typeshed's stdlib stubs.
 
-**This directory should _only_ contain test cases for functions and classes which
+**This directory should *only* contain test cases for functions and classes which
 are known to have caused problems in the past, where the stubs are difficult to
 get right.** 100% test coverage for typeshed is neither necessary nor
 desirable, as it would lead to code duplication. Moreover, typeshed has
@@ -27,17 +27,10 @@ the annotations correctly. Examples of tests like these are
 
 Other test cases, such as the samples for `ExitStack` in `stdlib/check_contextlib.py`
 and the samples for `LogRecord` in `stdlib/check_logging.py`, do not relate to
-stubs where the annotations are particularly complex, but they _do_ relate to
+stubs where the annotations are particularly complex, but they *do* relate to
 stubs where decisions have been taken that might be slightly unusual. These
 test cases serve a different purpose: to check that type checkers do not emit
 false-positive errors for idiomatic usage of these classes.
-
-## Running the tests
-
-To run the tests in this directory, run `python tests/typecheck_typeshed.py stdlib`
-from the root of the typeshed repository. This assumes that the development
-environment has been set up as described in the [CONTRIBUTING.md](../CONTRIBUTING.md)
-document.
 
 ### How the tests work
 
@@ -58,7 +51,7 @@ mypy's
 [`--warn-unused-ignores`](https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-warn-unused-ignores)
 setting and pyright's
 [`reportUnnecessaryTypeIgnoreComment`](https://github.com/microsoft/pyright/blob/main/docs/configuration.md#type-check-diagnostics-settings)
-setting) to test instances where a type checker _should_ emit some kind of
+setting) to test instances where a type checker *should* emit some kind of
 error, if the stubs are correct. Both settings are enabled by default for the entire
 subdirectory.
 
@@ -118,7 +111,7 @@ test cases for `foo` should be put in a file named `test_cases/stdlib/check_foo-
 This means that mypy will only run the test case
 if `--python-version 3.9`, `--python-version 3.10` or `--python-version 3.11`
 is passed on the command line to `tests/regr_test.py`,
-but it _won't_ run the test case if `--python-version 3.7` or `--python-version 3.8`
+but it *won't* run the test case if `--python-version 3.7` or `--python-version 3.8`
 is passed on the command line.
 
 However, `if sys.version_info >= (3, target):` is still required for `pyright`

--- a/test_cases/README.md
+++ b/test_cases/README.md
@@ -3,7 +3,7 @@
 This directory contains code samples that act as a regression test for
 typeshed's stdlib stubs.
 
-**This directory should *only* contain test cases for functions and classes which
+**This directory should _only_ contain test cases for functions and classes which
 are known to have caused problems in the past, where the stubs are difficult to
 get right.** 100% test coverage for typeshed is neither necessary nor
 desirable, as it would lead to code duplication. Moreover, typeshed has
@@ -27,10 +27,17 @@ the annotations correctly. Examples of tests like these are
 
 Other test cases, such as the samples for `ExitStack` in `stdlib/check_contextlib.py`
 and the samples for `LogRecord` in `stdlib/check_logging.py`, do not relate to
-stubs where the annotations are particularly complex, but they *do* relate to
+stubs where the annotations are particularly complex, but they _do_ relate to
 stubs where decisions have been taken that might be slightly unusual. These
 test cases serve a different purpose: to check that type checkers do not emit
 false-positive errors for idiomatic usage of these classes.
+
+## Running the tests
+
+To run the tests in this directory, run `python tests/typecheck_typeshed.py stdlib`
+from the root of the typeshed repository. This assumes that the development
+environment has been set up as described in the [CONTRIBUTING.md](../CONTRIBUTING.md)
+document.
 
 ### How the tests work
 
@@ -51,7 +58,7 @@ mypy's
 [`--warn-unused-ignores`](https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-warn-unused-ignores)
 setting and pyright's
 [`reportUnnecessaryTypeIgnoreComment`](https://github.com/microsoft/pyright/blob/main/docs/configuration.md#type-check-diagnostics-settings)
-setting) to test instances where a type checker *should* emit some kind of
+setting) to test instances where a type checker _should_ emit some kind of
 error, if the stubs are correct. Both settings are enabled by default for the entire
 subdirectory.
 
@@ -111,7 +118,7 @@ test cases for `foo` should be put in a file named `test_cases/stdlib/check_foo-
 This means that mypy will only run the test case
 if `--python-version 3.9`, `--python-version 3.10` or `--python-version 3.11`
 is passed on the command line to `tests/regr_test.py`,
-but it *won't* run the test case if `--python-version 3.7` or `--python-version 3.8`
+but it _won't_ run the test case if `--python-version 3.7` or `--python-version 3.8`
 is passed on the command line.
 
 However, `if sys.version_info >= (3, target):` is still required for `pyright`

--- a/test_cases/README.md
+++ b/test_cases/README.md
@@ -34,7 +34,7 @@ false-positive errors for idiomatic usage of these classes.
 
 ## Running the tests
 
-To run the tests in this directory, run `python tests/regr_test.py stdlib`
+To verify the test cases in this directory pass with mypy, run `python tests/regr_test.py stdlib`
 from the root of the typeshed repository. This assumes that the development
 environment has been set up as described in the [CONTRIBUTING.md](../CONTRIBUTING.md)
 document.

--- a/test_cases/README.md
+++ b/test_cases/README.md
@@ -34,7 +34,7 @@ false-positive errors for idiomatic usage of these classes.
 
 ## Running the tests
 
-To run the tests in this directory, run `python tests/typecheck_typeshed.py stdlib`
+To run the tests in this directory, run `python tests/regr_test.py stdlib`
 from the root of the typeshed repository. This assumes that the development
 environment has been set up as described in the [CONTRIBUTING.md](../CONTRIBUTING.md)
 document.

--- a/tests/README.md
+++ b/tests/README.md
@@ -104,7 +104,8 @@ the stubs in typeshed (including the standard library).
 ## regr\_test.py
 
 This test runs mypy against the test cases for typeshed's stdlib and third-party
-stubs. See the README in the `test_cases` directory for more information about what
+stubs. See [the README in the `test_cases` directory](../test_cases/README.md)
+for more information about what
 these test cases are for and how they work. Run `python tests/regr_test.py --help`
 for information on the various configuration options.
 

--- a/tests/regr_test.py
+++ b/tests/regr_test.py
@@ -69,7 +69,10 @@ parser.add_argument(
     type=package_with_test_cases,
     nargs="*",
     action="extend",
-    help="Test only these packages (defaults to all typeshed stubs that have test cases)",
+    help=(
+        "Test only these packages (defaults to all typeshed stubs that have test cases). "
+        'Use "stdlib" to test the standard library test cases.'
+    ),
 )
 parser.add_argument(
     "--all",


### PR DESCRIPTION
* Add instructions on how to run the tests to the `test-cases` directory.
* Add instruction on how to test stdlib to the `regr_test.py --help` output.
