### PR TITLE
Skip ruff's isort rules on files generated with mypy-protobuf

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,48 @@ skip_magic_trailing_comma = true
 # for just these files, but doesn't seem possible yet.
 force-exclude = ".*_pb2.pyi"
 
+[tool.ruff]
+line-length = 130
+# Oldest supported Python version
+target-version = "py37"
+fix = true
+exclude = [
+    # virtual environment
+    ".env",
+    ".venv",
+    "env",
+    # cache directories, etc.:
+    ".git",
+    ".mypy_cache",
+    ".pytype",
+    ".venv",
+    "env",
+]
+select = [
+    "FA", # flake8-future-annotations
+    "I", # isort
+    # Only enable rules that have safe autofixes:
+    "F401", # Remove unused imports
+    "PYI009", # use `...`, not `pass`, in empty class bodies
+    "PYI010", # function bodies must be empty
+    "PYI012", # class bodies must not contain `pass`
+    "PYI013", # non-empty class bodies must not contain `...`
+    "PYI020", # quoted annotations are always unnecessary in stubs
+    "PYI025", # always alias `collections.abc.Set` as `AbstractSet` when importing it
+    "PYI032", # use `object`, not `Any`, as the second parameter to `__eq__`
+    "UP004", # Remove explicit `object` inheritance
+    "UP006", # PEP-585 autofixes
+    "UP007", # PEP-604 autofixes
+    "UP013", # Class-based syntax for TypedDicts
+    "UP014", # Class-based syntax for NamedTuples
+    "UP019", # Use str over typing.Text
+    "UP035", # import from typing, not typing_extensions, wherever possible
+    "UP039", # don't use parens after a class definition with no bases
+]
+
+[tool.ruff.per-file-ignores]
+"*_pb2.pyi" = ["I"]  # Skip isort rules for files generated with mypy-protobuf
+
 [tool.ruff.isort]
 split-on-trailing-comma = false
 combine-as-imports = true
@@ -55,45 +97,6 @@ extra-standard-library = [
     "pyexpat",
 ]
 known-first-party = ["parse_metadata", "utils"]
-
-[tool.ruff]
-line-length = 130
-# Oldest supported Python version
-target-version = "py37"
-fix = true
-exclude = [
-    # virtual environment
-    ".env",
-    ".venv",
-    "env",
-    # cache directories, etc.:
-    ".git",
-    ".mypy_cache",
-    ".pytype",
-    ".venv",
-    "env",
-]
-select = [
-    "FA", # flake8-future-annotations
-    "I", # isort
-    # Only enable rules that have safe autofixes:
-    "F401", # Remove unused imports
-    "PYI009", # use `...`, not `pass`, in empty class bodies
-    "PYI010", # function bodies must be empty
-    "PYI012", # class bodies must not contain `pass`
-    "PYI013", # non-empty class bodies must not contain `...`
-    "PYI020", # quoted annotations are always unnecessary in stubs
-    "PYI025", # always alias `collections.abc.Set` as `AbstractSet` when importing it
-    "PYI032", # use `object`, not `Any`, as the second parameter to `__eq__`
-    "UP004", # Remove explicit `object` inheritance
-    "UP006", # PEP-585 autofixes
-    "UP007", # PEP-604 autofixes
-    "UP013", # Class-based syntax for TypedDicts
-    "UP014", # Class-based syntax for NamedTuples
-    "UP019", # Use str over typing.Text
-    "UP035", # import from typing, not typing_extensions, wherever possible
-    "UP039", # don't use parens after a class definition with no bases
-]
 
 [tool.typeshed]
 pyright_version = "1.1.332"


### PR DESCRIPTION
This takes us back to how things worked prior to https://github.com/python/typeshed/commit/49ba409da8906d7950dfedc7b34c3dea67bb0db9. See https://github.com/python/typeshed/pull/10939#pullrequestreview-1702764114 for an explanation of what's going on here.