### PR TITLE
Support for pexpect.spawn(..., logfile=sys.stdout)

### DIFF
--- a/stubs/pexpect/pexpect/fdpexpect.pyi
+++ b/stubs/pexpect/pexpect/fdpexpect.pyi
@@ -1,6 +1,6 @@
 from _typeshed import Incomplete
 
-from .spawnbase import SpawnBase
+from .spawnbase import SpawnBase, _Logfile
 
 class fdspawn(SpawnBase):
     args: Incomplete
@@ -17,7 +17,7 @@ class fdspawn(SpawnBase):
         timeout: int = 30,
         maxread: int = 2000,
         searchwindowsize: Incomplete | None = None,
-        logfile: Incomplete | None = None,
+        logfile: _Logfile | None = None,
         encoding: Incomplete | None = None,
         codec_errors: str = "strict",
         use_poll: bool = False,

--- a/stubs/pexpect/pexpect/popen_spawn.pyi
+++ b/stubs/pexpect/pexpect/popen_spawn.pyi
@@ -1,6 +1,6 @@
 from _typeshed import Incomplete
 
-from .spawnbase import SpawnBase
+from .spawnbase import SpawnBase, _Logfile
 
 class PopenSpawn(SpawnBase):
     crlf: Incomplete
@@ -13,7 +13,7 @@ class PopenSpawn(SpawnBase):
         timeout: int = 30,
         maxread: int = 2000,
         searchwindowsize: Incomplete | None = None,
-        logfile: Incomplete | None = None,
+        logfile: _Logfile | None = None,
         cwd: Incomplete | None = None,
         env: Incomplete | None = None,
         encoding: Incomplete | None = None,

--- a/stubs/pexpect/pexpect/pty_spawn.pyi
+++ b/stubs/pexpect/pexpect/pty_spawn.pyi
@@ -2,6 +2,7 @@ from _typeshed import Incomplete
 from collections.abc import Callable
 from io import TextIOWrapper
 from os import _Environ
+from typing import TextIO
 
 from .spawnbase import SpawnBase
 
@@ -22,7 +23,7 @@ class spawn(SpawnBase):
         timeout: int = 30,
         maxread: int = 2000,
         searchwindowsize: int | None = None,
-        logfile: TextIOWrapper | None = None,
+        logfile: TextIOWrapper | TextIO | None = None,
         cwd: str | bytes | None = None,
         env: _Environ[Incomplete] | None = None,
         ignore_sighup: bool = False,

--- a/stubs/pexpect/pexpect/pty_spawn.pyi
+++ b/stubs/pexpect/pexpect/pty_spawn.pyi
@@ -1,10 +1,8 @@
 from _typeshed import Incomplete
 from collections.abc import Callable
-from io import TextIOWrapper
 from os import _Environ
-from typing import TextIO
 
-from .spawnbase import SpawnBase
+from .spawnbase import SpawnBase, _Logfile
 
 PY3: Incomplete
 
@@ -23,7 +21,7 @@ class spawn(SpawnBase):
         timeout: int = 30,
         maxread: int = 2000,
         searchwindowsize: int | None = None,
-        logfile: TextIOWrapper | TextIO | None = None,
+        logfile: _Logfile | None = None,
         cwd: str | bytes | None = None,
         env: _Environ[Incomplete] | None = None,
         ignore_sighup: bool = False,

--- a/stubs/pexpect/pexpect/pxssh.pyi
+++ b/stubs/pexpect/pexpect/pxssh.pyi
@@ -2,6 +2,8 @@ from _typeshed import Incomplete
 
 from pexpect import ExceptionPexpect, spawn
 
+from .spawnbase import _Logfile
+
 class ExceptionPxssh(ExceptionPexpect): ...
 
 class pxssh(spawn):
@@ -19,7 +21,7 @@ class pxssh(spawn):
         timeout: int = 30,
         maxread: int = 2000,
         searchwindowsize: Incomplete | None = None,
-        logfile: Incomplete | None = None,
+        logfile: _Logfile | None = None,
         cwd: Incomplete | None = None,
         env: Incomplete | None = None,
         ignore_sighup: bool = True,

--- a/stubs/pexpect/pexpect/run.pyi
+++ b/stubs/pexpect/pexpect/run.pyi
@@ -1,12 +1,14 @@
 from _typeshed import Incomplete
 
+from pexpect.spawnbase import _Logfile
+
 def run(
     command,
     timeout: int = 30,
     withexitstatus: bool = False,
     events: Incomplete | None = None,
     extra_args: Incomplete | None = None,
-    logfile: Incomplete | None = None,
+    logfile: _Logfile | None = None,
     cwd: Incomplete | None = None,
     env: Incomplete | None = None,
     **kwargs,
@@ -17,7 +19,7 @@ def runu(
     withexitstatus: bool = False,
     events: Incomplete | None = None,
     extra_args: Incomplete | None = None,
-    logfile: Incomplete | None = None,
+    logfile: _Logfile | None = None,
     cwd: Incomplete | None = None,
     env: Incomplete | None = None,
     **kwargs,

--- a/stubs/pexpect/pexpect/spawnbase.pyi
+++ b/stubs/pexpect/pexpect/spawnbase.pyi
@@ -1,7 +1,7 @@
 from _typeshed import Incomplete
 from collections.abc import Callable
 from re import Pattern
-from typing import AnyStr
+from typing import AnyStr, Protocol
 
 PY3: bool
 text_type: Callable[[Incomplete], Incomplete]
@@ -11,6 +11,10 @@ class _NullCoder:
     def encode(b: str, final: bool = False): ...
     @staticmethod
     def decode(b: str, final: bool = False): ...
+
+class _Logfile(Protocol):
+    def write(self, __s) -> object: ...
+    def flush(self) -> object: ...
 
 class SpawnBase:
     encoding: Incomplete
@@ -32,9 +36,9 @@ class SpawnBase:
     child_fd: int
     timeout: Incomplete
     delimiter: Incomplete
-    logfile: Incomplete
-    logfile_read: Incomplete
-    logfile_send: Incomplete
+    logfile: _Logfile
+    logfile_read: _Logfile
+    logfile_send: _Logfile
     maxread: Incomplete
     searchwindowsize: Incomplete
     delaybeforesend: float
@@ -57,7 +61,7 @@ class SpawnBase:
         timeout: int = 30,
         maxread: int = 2000,
         searchwindowsize: Incomplete | None = None,
-        logfile: Incomplete | None = None,
+        logfile: _Logfile | None = None,
         encoding: Incomplete | None = None,
         codec_errors: str = "strict",
     ) -> None: ...


### PR DESCRIPTION
We can set the logfile for pexpect's spawn using sys.stdout, but the type hint shows an error.