### PR TITLE
Fix the hint for XMLGenerator.__init__().

### DIFF
--- a/stdlib/xml/sax/saxutils.pyi
+++ b/stdlib/xml/sax/saxutils.pyi
@@ -11,7 +11,7 @@ def quoteattr(data: str, entities: Mapping[str, str] = {}) -> str: ...
 class XMLGenerator(handler.ContentHandler):
     def __init__(
         self,
-        out: TextIOBase | RawIOBase | StreamWriter | StreamReaderWriter | SupportsWrite[str] | None = None,
+        out: TextIOBase | RawIOBase | StreamWriter | StreamReaderWriter | SupportsWrite[bytes] | None = None,
         encoding: str = "iso-8859-1",
         short_empty_elements: bool = False,
     ) -> None: ...


### PR DESCRIPTION
Fixes #10550.

I've checked that `TextIOWrapper` (in addition to docs saying it wraps a binary stream) indeed doesn't work with a str-based stream so keeping `SupportsWrite[str]` indeed is wrong.