### PR TITLE
Introduce _typeshed.SupportsFlush

### DIFF
--- a/stdlib/_typeshed/__init__.pyi
+++ b/stdlib/_typeshed/__init__.pyi
@@ -236,6 +236,10 @@ class SupportsNoArgReadline(Protocol[_T_co]):
 class SupportsWrite(Protocol[_T_contra]):
     def write(self, __s: _T_contra) -> object: ...
 
+# stable
+class SupportsFlush(Protocol):
+    def flush(self) -> object: ...
+
 # Unfortunately PEP 688 does not allow us to distinguish read-only
 # from writable buffers. We use these aliases for readability for now.
 # Perhaps a future extension of the buffer protocol will allow us to

--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -18,6 +18,7 @@ from _typeshed import (
     SupportsAiter,
     SupportsAnext,
     SupportsDivMod,
+    SupportsFlush,
     SupportsIter,
     SupportsKeysAndGetItem,
     SupportsLenAndGetItem,
@@ -1637,8 +1638,7 @@ def open(
 ) -> IO[Any]: ...
 def ord(__c: str | bytes | bytearray) -> int: ...
 
-class _SupportsWriteAndFlush(SupportsWrite[_T_contra], Protocol[_T_contra]):
-    def flush(self) -> None: ...
+class _SupportsWriteAndFlush(SupportsWrite[_T_contra], SupportsFlush, Protocol[_T_contra]): ...
 
 @overload
 def print(


### PR DESCRIPTION
`flush()` is a standard I/O method. This allows us to construct I/O protocols using composition. (I.e. using base classes at the moment and hopefully using the `&` operator at some point in the future.)