### PR TITLE
Bump ruff

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: chartboost/ruff-action@v1
         with:
-          version: "0.1.0" # must match .pre-commit-config.yaml and requirements-test.txt
+          version: "0.1.4" # must match .pre-commit-config.yaml and requirements-test.txt
 
   flake8:
     name: Lint with Flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
       - id: black
         language_version: python3.10
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.0 # must match requirements-tests.txt and tests.yml
+    rev: v0.1.4 # must match requirements-tests.txt and tests.yml
     hooks:
       - id: ruff
         args: [--exit-non-zero-on-fix, --fix-only]

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -9,7 +9,7 @@ flake8-pyi==23.10.0      # must match .pre-commit-config.yaml
 mypy==1.6.1
 pre-commit-hooks==4.5.0  # must match .pre-commit-config.yaml
 pytype==2023.10.17; platform_system != "Windows" and python_version < "3.12"
-ruff==0.1.0              # must match .pre-commit-config.yaml and tests.yml
+ruff==0.1.4              # must match .pre-commit-config.yaml and tests.yml
 
 # Libraries used by our various scripts.
 aiohttp==3.8.5; python_version < "3.12"  # aiohttp can't be installed on 3.12 yet


### PR DESCRIPTION
Btw, since `ruff@1.0.2` there's a builtin autoformatter instead of `black`. 

It produces a code that is a bit different to one that `black` produces. I don't think that we need to change anything, just spreading the news.