### PR TITLE
Add types for `pygments.lex`.

### DIFF
--- a/stubs/Pygments/pygments/__init__.pyi
+++ b/stubs/Pygments/pygments/__init__.pyi
@@ -1,14 +1,17 @@
 from _typeshed import SupportsWrite
+from collections.abc import Iterator
 from typing import TypeVar, overload
 
 from pygments.formatter import Formatter
+from pygments.lexer import Lexer
+from pygments.token import _TokenType
 
 _T = TypeVar("_T", str, bytes)
 
 __version__: str
 __all__ = ["lex", "format", "highlight"]
 
-def lex(code, lexer): ...
+def lex(code: str, lexer: Lexer) -> Iterator[tuple[_TokenType, str]]: ...
 @overload
 def format(tokens, formatter: Formatter[_T], outfile: SupportsWrite[_T]) -> None: ...
 @overload


### PR DESCRIPTION
This adds type annotations to the `pygments.lex` helper.

The return type is the same as what we use in `pygments.Lexer.get_tokens`.