### PR TITLE
Bump mypy to 1.7.0

### DIFF
--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -6,7 +6,7 @@ flake8==6.1.0            # must match .pre-commit-config.yaml
 flake8-bugbear==23.9.16  # must match .pre-commit-config.yaml
 flake8-noqa==1.3.2       # must match .pre-commit-config.yaml
 flake8-pyi==23.11.0      # must match .pre-commit-config.yaml
-mypy==1.6.1
+mypy==1.7.0
 pre-commit-hooks==4.5.0  # must match .pre-commit-config.yaml
 pytype==2023.10.17; platform_system != "Windows" and python_version < "3.12"
 ruff==0.1.4              # must match .pre-commit-config.yaml and tests.yml

--- a/test_cases/stdlib/check_dataclasses.py
+++ b/test_cases/stdlib/check_dataclasses.py
@@ -87,9 +87,4 @@ def check_other_isdataclass_overloads(x: type, y: object) -> None:
         assert_type(dc.fields(y), Tuple[dc.Field[Any], ...])
         assert_type(dc.asdict(y), Dict[str, Any])
         assert_type(dc.astuple(y), Tuple[Any, ...])
-
-        # No longer passes with mypy 1.5.0
-        # now that mypy gives a tailored signature for dataclasses.replace()
-        # (https://github.com/python/mypy/issues/15843):
-        #
-        # dc.replace(y)
+        dc.replace(y)


### PR DESCRIPTION
This mypy release means that mypy now supports PEP-646 and PEP-692 (`TypeVarTuple` and `Unpack`) by default 🥳

X-ref:
- #8708
- #9710