### PR TITLE
Pin PyScreeze more tightly

### DIFF
--- a/stubs/PyScreeze/METADATA.toml
+++ b/stubs/PyScreeze/METADATA.toml
@@ -1,3 +1,3 @@
-version = "0.1.*"
+version = "0.1.29"
 upstream_repository = "https://github.com/asweigart/pyscreeze"
 requires = ["types-Pillow"]


### PR DESCRIPTION
To stop the "stubtest failed" bot opening a new issue every night until we have a chance to look at the stubtest failures (stubsabot will just open a PR instead)

Closes #11016