### PR TITLE
Bump pyinstaller to 6.2.*

### DIFF
--- a/stubs/pyinstaller/@tests/stubtest_allowlist.txt
+++ b/stubs/pyinstaller/@tests/stubtest_allowlist.txt
@@ -2,6 +2,7 @@
 pyi_splash
 
 # Undocumented and clearly not meant to be exposed
+PyInstaller\..+?\.autocomplete
 PyInstaller\..+?\.logger
 PyInstaller.__main__.generate_parser
 PyInstaller.__main__.run_build

--- a/stubs/pyinstaller/@tests/stubtest_allowlist.txt
+++ b/stubs/pyinstaller/@tests/stubtest_allowlist.txt
@@ -2,7 +2,6 @@
 pyi_splash
 
 # Undocumented and clearly not meant to be exposed
-PyInstaller\..+?\.autocomplete
 PyInstaller\..+?\.logger
 PyInstaller.__main__.generate_parser
 PyInstaller.__main__.run_build

--- a/stubs/pyinstaller/METADATA.toml
+++ b/stubs/pyinstaller/METADATA.toml
@@ -4,5 +4,4 @@ requires = ["types-setuptools"]
 requires_python = ">=3.8"
 
 [tool.stubtest]
-# Avoids stubtest-false-positives, doesn't affect type-hints since autocomplete is for internal use for the CLI app
 extras = ["completion"]

--- a/stubs/pyinstaller/METADATA.toml
+++ b/stubs/pyinstaller/METADATA.toml
@@ -1,4 +1,4 @@
-version = "6.1.*"
+version = "6.2.*"
 upstream_repository = "https://github.com/pyinstaller/pyinstaller"
 requires = ["types-setuptools"]
 requires_python = ">=3.8"

--- a/stubs/pyinstaller/METADATA.toml
+++ b/stubs/pyinstaller/METADATA.toml
@@ -2,3 +2,7 @@ version = "6.2.*"
 upstream_repository = "https://github.com/pyinstaller/pyinstaller"
 requires = ["types-setuptools"]
 requires_python = ">=3.8"
+
+[tool.stubtest]
+# Avoids stubtest-false-positives, doesn't affect type-hints since autocomplete is for internal use for the CLI app
+extras = ["completion"]


### PR DESCRIPTION
Closes #11021 .
Just a false-positive from stubtest. `autocomplete` is for internal use for the CLI app. About as useful as exposing "logger"