### PR TITLE
Bump various test dependencies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: chartboost/ruff-action@v1
         with:
-          version: "0.1.4" # must match .pre-commit-config.yaml and requirements-test.txt
+          version: "0.1.5" # must match .pre-commit-config.yaml and requirements-test.txt
 
   flake8:
     name: Lint with Flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,12 +10,12 @@ repos:
       - id: mixed-line-ending
       - id: check-case-conflict
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 23.9.1 # must match requirements-tests.txt
+    rev: 23.11.0 # must match requirements-tests.txt
     hooks:
       - id: black
         language_version: python3.10
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.4 # must match requirements-tests.txt and tests.yml
+    rev: v0.1.5 # must match requirements-tests.txt and tests.yml
     hooks:
       - id: ruff
         args: [--exit-non-zero-on-fix, --fix-only]

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,25 +1,25 @@
 # Type checkers and other linters that we test our stubs against. These should always
 # be pinned to a specific version to make failure reproducible. See also the
 # "tool.typeshed" section in pyproject.toml for additional type checkers.
-black==23.9.1            # must match .pre-commit-config.yaml
+black==23.11.0           # must match .pre-commit-config.yaml
 flake8==6.1.0            # must match .pre-commit-config.yaml
 flake8-bugbear==23.9.16  # must match .pre-commit-config.yaml
 flake8-noqa==1.3.2       # must match .pre-commit-config.yaml
 flake8-pyi==23.11.0      # must match .pre-commit-config.yaml
 mypy==1.7.0
 pre-commit-hooks==4.5.0  # must match .pre-commit-config.yaml
-pytype==2023.10.17; platform_system != "Windows" and python_version < "3.12"
-ruff==0.1.4              # must match .pre-commit-config.yaml and tests.yml
+pytype==2023.10.31; platform_system != "Windows" and python_version < "3.12"
+ruff==0.1.5              # must match .pre-commit-config.yaml and tests.yml
 
 # Libraries used by our various scripts.
-aiohttp==3.8.5; python_version < "3.12"  # aiohttp can't be installed on 3.12 yet
+aiohttp==3.8.6; python_version < "3.12"  # aiohttp can't be installed on 3.12 yet
 packaging==23.2
 pathspec>=0.11.1
 pyyaml==6.0.1
 stubdefaulter==0.1.0
 termcolor>=2.3
 tomli==2.0.1
-tomlkit==0.12.1
+tomlkit==0.12.3
 typing_extensions>=4.8.0
 
 # Type stubs used to type check our scripts.


### PR DESCRIPTION
The aiohttp bump resolves an open dependabot security alert for this repo: https://github.com/python/typeshed/security/dependabot