### PR TITLE
Bump various test dependencies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: chartboost/ruff-action@v1
         with:
-          version: "0.1.5" # must match .pre-commit-config.yaml and requirements-test.txt
+          version: "0.1.6" # must match .pre-commit-config.yaml and requirements-test.txt
 
   flake8:
     name: Lint with Flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
       - id: black
         language_version: python3.10
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.5 # must match requirements-tests.txt and tests.yml
+    rev: v0.1.6 # must match requirements-tests.txt and tests.yml
     hooks:
       - id: ruff
         args: [--exit-non-zero-on-fix, --fix-only]

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -9,10 +9,10 @@ flake8-pyi==23.11.0      # must match .pre-commit-config.yaml
 mypy==1.7.0
 pre-commit-hooks==4.5.0  # must match .pre-commit-config.yaml
 pytype==2023.10.31; platform_system != "Windows" and python_version < "3.12"
-ruff==0.1.5              # must match .pre-commit-config.yaml and tests.yml
+ruff==0.1.6              # must match .pre-commit-config.yaml and tests.yml
 
 # Libraries used by our various scripts.
-aiohttp==3.8.6; python_version < "3.12"  # aiohttp can't be installed on 3.12 yet
+aiohttp==3.9.0
 packaging==23.2
 pathspec>=0.11.1
 pyyaml==6.0.1


### PR DESCRIPTION
The aiohttp bump means that stubsabot can be run locally on Python 3.12