### PR TITLE
Improve a few dataclass reprs in stubsabot

### DIFF
--- a/scripts/stubsabot.py
+++ b/scripts/stubsabot.py
@@ -329,9 +329,6 @@ class DiffAnalysis:
     py_files: list[FileInfo]
     py_files_stubbed_in_typeshed: list[FileInfo]
 
-    def __repr__(self) -> str:
-        return f"<DiffAnalysis object at {id(self)}>"
-
     @property
     def runtime_definitely_has_consistent_directory_structure_with_typeshed(self) -> bool:
         """

--- a/scripts/stubsabot.py
+++ b/scripts/stubsabot.py
@@ -143,7 +143,7 @@ class Update:
     old_version_spec: str
     new_version_spec: str
     links: dict[str, str]
-    diff_analysis: DiffAnalysis | None = field(repr=False)
+    diff_analysis: DiffAnalysis | None
 
     def __str__(self) -> str:
         return f"Updating {self.distribution} from {self.old_version_spec!r} to {self.new_version_spec!r}"

--- a/scripts/stubsabot.py
+++ b/scripts/stubsabot.py
@@ -17,7 +17,7 @@ import textwrap
 import urllib.parse
 import zipfile
 from collections.abc import Iterator, Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from http import HTTPStatus
 from pathlib import Path
 from typing import Annotated, Any, ClassVar, NamedTuple
@@ -105,8 +105,8 @@ def _best_effort_version(version: VersionString) -> packaging.version.Version:
 class PypiInfo:
     distribution: str
     pypi_root: str
-    releases: dict[VersionString, list[ReleaseDownload]]
-    info: dict[str, Any]
+    releases: dict[VersionString, list[ReleaseDownload]] = field(repr=False)
+    info: dict[str, Any] = field(repr=False)
 
     def get_release(self, *, version: VersionString) -> PypiReleaseDownload:
         # prefer wheels, since it's what most users will get / it's pretty easy to mess up MANIFEST
@@ -143,7 +143,7 @@ class Update:
     old_version_spec: str
     new_version_spec: str
     links: dict[str, str]
-    diff_analysis: DiffAnalysis | None
+    diff_analysis: DiffAnalysis | None = field(repr=False)
 
     def __str__(self) -> str:
         return f"Updating {self.distribution} from {self.old_version_spec!r} to {self.new_version_spec!r}"
@@ -244,7 +244,7 @@ def get_github_api_headers() -> Mapping[str, str]:
 @dataclass
 class GithubInfo:
     repo_path: str
-    tags: list[dict[str, Any]]
+    tags: list[dict[str, Any]] = field(repr=False)
 
 
 async def get_github_repo_info(session: aiohttp.ClientSession, stub_info: StubInfo) -> GithubInfo | None:
@@ -323,11 +323,14 @@ def _plural_s(num: int, /) -> str:
     return "s" if num != 1 else ""
 
 
-@dataclass
+@dataclass(repr=False)
 class DiffAnalysis:
     MAXIMUM_NUMBER_OF_FILES_TO_LIST: ClassVar[int] = 7
     py_files: list[FileInfo]
     py_files_stubbed_in_typeshed: list[FileInfo]
+
+    def __repr__(self) -> str:
+        return f"<DiffAnalysis object at {id(self)}>"
 
     @property
     def runtime_definitely_has_consistent_directory_structure_with_typeshed(self) -> bool:


### PR DESCRIPTION
This would have made interactively debugging #11049 a bit easier -- some of these dataclass fields have huge reprs