### PR TITLE
Teach stubsabot to be smarter about the required locations of `py.typed` files

### DIFF
--- a/scripts/stubsabot.py
+++ b/scripts/stubsabot.py
@@ -180,7 +180,7 @@ def all_py_files_in_source_are_in_py_typed_dirs(source: zipfile.ZipFile | tarfil
     if isinstance(source, zipfile.ZipFile):
         all_whl_paths = {Path(info.filename): info for info in source.infolist()}
         for path, zip_info in all_whl_paths.items():
-            if not zip_info.is_dir()
+            if not zip_info.is_dir():
                 if path.suffix in py_file_suffixes:
                     all_python_files.append(path)
                 elif path.name == "py.typed":

--- a/scripts/stubsabot.py
+++ b/scripts/stubsabot.py
@@ -179,18 +179,20 @@ def all_py_files_in_source_are_in_py_typed_dirs(source: zipfile.ZipFile | tarfil
 
     if isinstance(source, zipfile.ZipFile):
         all_whl_paths = {Path(info.filename): info for info in source.infolist()}
-        for path, tar_info in all_whl_paths.items():
-            if path.suffix in py_file_suffixes:
-                all_python_files.append(path)
-            elif path.name == "py.typed" and not tar_info.is_dir():
-                py_typed_dirs.append(path.parent)
+        for path, zip_info in all_whl_paths.items():
+            if not zip_info.is_dir()
+                if path.suffix in py_file_suffixes:
+                    all_python_files.append(path)
+                elif path.name == "py.typed":
+                    py_typed_dirs.append(path.parent)
     else:
         all_sdist_paths = {Path(info.path): info for info in source}
-        for path, zip_info in all_sdist_paths.items():
-            if path.suffix in py_file_suffixes:
-                all_python_files.append(path)
-            elif path.name == "py.typed" and zip_info.isfile():
-                py_typed_dirs.append(path.parent)
+        for path, tar_info in all_sdist_paths.items():
+            if tar_info.isfile():
+                if path.suffix in py_file_suffixes:
+                    all_python_files.append(path)
+                elif path.name == "py.typed":
+                    py_typed_dirs.append(path.parent)
 
     if not py_typed_dirs:
         return False

--- a/scripts/stubsabot.py
+++ b/scripts/stubsabot.py
@@ -178,11 +178,9 @@ def all_py_files_in_source_are_in_py_typed_dirs(source: zipfile.ZipFile | tarfil
     py_file_suffixes = {".py", ".pyi"}
 
     if isinstance(source, zipfile.ZipFile):
-        all_whl_paths = {Path(info.filename): info for info in source.infolist()}
-        path_iter = (path for path, zip_info in all_whl_paths.items() if not zip_info.is_dir())
+        path_iter = (Path(zip_info.filename) for zip_info in source.infolist() if not zip_info.is_dir())
     else:
-        all_sdist_paths = {Path(info.path): info for info in source}
-        path_iter = (path for path, tar_info in all_sdist_paths.items() if tar_info.isfile())
+        path_iter = (Path(tar_info.path) for tar_info in source if tar_info.isfile())
 
     for path in path_iter:
         if path.suffix in py_file_suffixes:

--- a/scripts/stubsabot.py
+++ b/scripts/stubsabot.py
@@ -15,6 +15,7 @@ import sys
 import tarfile
 import textwrap
 import urllib.parse
+import warnings
 import zipfile
 from collections.abc import Iterator, Mapping, Sequence
 from dataclasses import dataclass, field
@@ -34,6 +35,10 @@ TYPESHED_OWNER = "python"
 TYPESHED_API_URL = f"https://api.github.com/repos/{TYPESHED_OWNER}/typeshed"
 
 STUBSABOT_LABEL = "stubsabot"
+
+
+class EmptyRuntimeDistributionWarning(Warning):
+    pass
 
 
 class ActionLevel(enum.IntEnum):
@@ -79,6 +84,7 @@ def read_typeshed_stub_metadata(stub_path: Path) -> StubInfo:
 
 @dataclass
 class PypiReleaseDownload:
+    distribution: str
     url: str
     packagetype: Annotated[str, "Should hopefully be either 'bdist_wheel' or 'sdist'"]
     filename: str
@@ -112,6 +118,7 @@ class PypiInfo:
         # prefer wheels, since it's what most users will get / it's pretty easy to mess up MANIFEST
         release_info = sorted(self.releases[version], key=lambda x: bool(x["packagetype"] == "bdist_wheel"))[-1]
         return PypiReleaseDownload(
+            distribution=self.distribution,
             url=release_info["url"],
             packagetype=release_info["packagetype"],
             filename=release_info["filename"],
@@ -170,21 +177,72 @@ class NoUpdate:
         return f"Skipping {self.distribution}: {self.reason}"
 
 
+def wheel_dir_is_py_typed(directory: zipfile.Path, *, dist_name: str) -> bool:
+    top_level = list(directory.iterdir())
+    if any(path.is_dir() and path.name.endswith(".dist-info") for path in top_level):
+        raise RuntimeError(f"Unexpectedly found a `.dist-info` subdirectory in the wheel for {dist_name}!")
+    if all(path.is_dir() for path in top_level):
+        # The directory only contains other directories: we're probably looking at a namespace package
+        # Recurse into the lower-down directories to see if they all have py.typed files.
+        return all(wheel_dir_is_py_typed(path, dist_name=dist_name) for path in top_level)
+    return any(path.is_file() and path.name == "py.typed" for path in top_level)
+
+
+def all_pkgs_in_wheel_are_py_typed(wheel_file: zipfile.ZipFile, *, dist_name: str) -> bool:
+    wheel = zipfile.Path(wheel_file)
+    top_level_contents = [path for path in wheel.iterdir() if not (path.is_dir() and path.name.endswith(".dist-info"))]
+    if not top_level_contents:
+        warnings.warn(f"Unexpectedly found an empty wheel for {dist_name}", EmptyRuntimeDistributionWarning, stacklevel=1)
+    top_level_dirs = [path for path in top_level_contents if path.is_dir()]
+    if not top_level_dirs:
+        # single-module package, e.g. mypy-extensions, flake8-pyi
+        return False
+    return all(wheel_dir_is_py_typed(dirpath, dist_name=dist_name) for dirpath in top_level_dirs)
+
+
+def tarfile_dir_is_py_typed(directory: Path, tarfile_map: dict[Path, tarfile.TarInfo], *, dist_name: str) -> bool:
+    toplevel = {path: info for path, info in tarfile_map.items() if path.parent == directory}
+    if any(info.isdir() and path.suffix == ".dist-info" for path, info in toplevel.items()):
+        raise RuntimeError(f"Unexpectedly found a `.dist-info` subdirectory in the sdist for {dist_name}!")
+    if all(info.isdir() for info in toplevel.values()):
+        # The directory only contains other directories: we're probably looking at a namespace package
+        # Recurse into the lower-down directories to see if they all have py.typed files.
+        return all(tarfile_dir_is_py_typed(path, tarfile_map, dist_name=dist_name) for path in toplevel)
+    return any(info.isfile() and path.name == "py.typed" for path, info in toplevel.items())
+
+
+def all_pkgs_in_tarfile_are_py_typed(sdist: tarfile.TarFile, *, dist_name: str) -> bool:
+    tar_paths = {Path(info.path): info for info in sdist}
+    top_level_contents = {
+        path: info
+        for path, info in tar_paths.items()
+        if len(path.parts) == 2 and not (path.suffix == ".dist-info" and info.isdir())
+    }
+    if not top_level_contents:
+        warnings.warn(f"Unexpectedly found an empty wheel for {dist_name}", EmptyRuntimeDistributionWarning, stacklevel=1)
+    top_level_dirs = [path for path, info in top_level_contents.items() if info.isdir()]
+    if not top_level_dirs:
+        # single-module package, e.g. mypy-extensions, flake8-pyi
+        return False
+    return all(tarfile_dir_is_py_typed(dirpath, tar_paths, dist_name=dist_name) for dirpath in top_level_dirs)
+
+
 async def release_contains_py_typed(release_to_download: PypiReleaseDownload, *, session: aiohttp.ClientSession) -> bool:
     async with session.get(release_to_download.url) as response:
         body = io.BytesIO(await response.read())
 
     packagetype = release_to_download.packagetype
+    dist_name = release_to_download.distribution
     if packagetype == "bdist_wheel":
         assert release_to_download.filename.endswith(".whl")
         with zipfile.ZipFile(body) as zf:
-            return any(Path(f).name == "py.typed" for f in zf.namelist())
+            return all_pkgs_in_wheel_are_py_typed(zf, dist_name=dist_name)
     elif packagetype == "sdist":
         assert release_to_download.filename.endswith(".tar.gz")
         with tarfile.open(fileobj=body, mode="r:gz") as zf:
-            return any(Path(f).name == "py.typed" for f in zf.getnames())
+            return all_pkgs_in_tarfile_are_py_typed(zf, dist_name=dist_name)
     else:
-        raise AssertionError(f"Unknown package type: {packagetype!r}")
+        raise AssertionError(f"Unknown package type for {dist_name}: {packagetype!r}")
 
 
 async def find_first_release_with_py_typed(pypi_info: PypiInfo, *, session: aiohttp.ClientSession) -> PypiReleaseDownload | None:

--- a/scripts/stubsabot.py
+++ b/scripts/stubsabot.py
@@ -179,20 +179,16 @@ def all_py_files_in_source_are_in_py_typed_dirs(source: zipfile.ZipFile | tarfil
 
     if isinstance(source, zipfile.ZipFile):
         all_whl_paths = {Path(info.filename): info for info in source.infolist()}
-        for path, zip_info in all_whl_paths.items():
-            if not zip_info.is_dir():
-                if path.suffix in py_file_suffixes:
-                    all_python_files.append(path)
-                elif path.name == "py.typed":
-                    py_typed_dirs.append(path.parent)
+        path_iter = (path for path, zip_info in all_whl_paths.items() if not zip_info.is_dir())
     else:
         all_sdist_paths = {Path(info.path): info for info in source}
-        for path, tar_info in all_sdist_paths.items():
-            if tar_info.isfile():
-                if path.suffix in py_file_suffixes:
-                    all_python_files.append(path)
-                elif path.name == "py.typed":
-                    py_typed_dirs.append(path.parent)
+        path_iter = (path for path, tar_info in all_sdist_paths.items() if tar_info.isfile())
+
+    for path in path_iter:
+        if path.suffix in py_file_suffixes:
+            all_python_files.append(path)
+        elif path.name == "py.typed":
+            py_typed_dirs.append(path.parent)
 
     if not py_typed_dirs:
         return False

--- a/scripts/stubsabot.py
+++ b/scripts/stubsabot.py
@@ -196,8 +196,7 @@ def all_py_files_in_source_are_in_py_typed_dirs(source: zipfile.ZipFile | tarfil
     for path in all_python_files:
         if not any(py_typed_dir in path.parents for py_typed_dir in py_typed_dirs):
             return False
-    else:
-        return True
+    return True
 
 
 async def release_contains_py_typed(release_to_download: PypiReleaseDownload, *, session: aiohttp.ClientSession) -> bool:


### PR DESCRIPTION
An attempt to fix the bug that resulted in #11049.

~~The approach is this:~~
- ~~If there are no directories at the top level of a wheel or sdist (except for the `.dist-info` directory), none of the packages for this distribution can be `py.typed`~~
- ~~Else, return True if all top-level directories (except for `.dist-info`) are marked as `py.typed`:~~
  - ~~for each directory, if it contains at least one file, consider it marked as `py.typed` if it has a `py.typed` file at the top-level~~
  - ~~Else, if it only contains subdirectories, consider it marked as `py.typed` if all subdirectories are marked as `py.typed` (applying the same logic recursively).~~

Edit: all the above is out of date. The PR now uses the better approach suggested by Akuli in https://github.com/python/typeshed/pull/11053#issuecomment-1821660482.

I've tested this a fair bit locally, and I think it does the right thing, but would appreciate careful eyes on this and additional testing