### PR TITLE
Use consistent mypy output spacing

### DIFF
--- a/tests/mypy_test.py
+++ b/tests/mypy_test.py
@@ -374,7 +374,7 @@ def test_stdlib(args: TestConfig) -> TestResult:
     if not files:
         return TestResult(MypyResult.SUCCESS, 0)
 
-    print(f"Testing stdlib ({len(files)} files)...", end="", flush=True)
+    print(f"Testing stdlib ({len(files)} files)... ", end="", flush=True)
     # We don't actually need pip for the stdlib testing
     venv_info = VenvInfo(pip_exe="", python_exe=sys.executable)
     result = run_mypy(args, [], files, venv_info=venv_info, testing_stdlib=True, non_types_dependencies=False)


### PR DESCRIPTION
Before:

```
*** Testing Python 3.9 on darwin
Testing stdlib (557 files)...success

Testing third-party packages...
testing Deprecated (3 files)... success
testing ExifRead (17 files)... success
testing Flask-Cors (5 files)... success
```

After:

```
*** Testing Python 3.9 on darwin
Testing stdlib (557 files)... success

Testing third-party packages...
testing Deprecated (3 files)... success
testing ExifRead (17 files)... success
testing Flask-Cors (5 files)... success
```