### PR TITLE
stdlib: HTTPSConnection(port=) is int|None

### DIFF
--- a/stdlib/http/client.pyi
+++ b/stdlib/http/client.pyi
@@ -187,7 +187,7 @@ class HTTPSConnection(HTTPConnection):
         def __init__(
             self,
             host: str,
-            port: str | None = None,
+            port: int | None = None,
             *,
             timeout: float | None = ...,
             source_address: tuple[str, int] | None = None,


### PR DESCRIPTION
Fix an apparent typo in the type of this field.

Closes #11057