### PR TITLE
psycopg2: fix RangeCaster.__init__ annotation

### DIFF
--- a/stubs/psycopg2/psycopg2/_range.pyi
+++ b/stubs/psycopg2/psycopg2/_range.pyi
@@ -51,7 +51,7 @@ class RangeCaster:
     typecaster: Any
     array_typecaster: Any
     def __init__(
-        self, pgrange: str | RangeAdapter, pyrange: str | Range, oid: int, subtype_oid: int, array_oid: int | None = None
+        self, pgrange: str | type[RangeAdapter], pyrange: str | type[Range], oid: int, subtype_oid: int, array_oid: int | None = None
     ) -> None: ...
     @overload
     def parse(self, s: None, cur: cursor | None = None) -> None: ...

--- a/stubs/psycopg2/psycopg2/_range.pyi
+++ b/stubs/psycopg2/psycopg2/_range.pyi
@@ -33,7 +33,7 @@ class Range:
     def __ge__(self, other: Range) -> bool: ...
 
 def register_range(
-    pgrange: str, pyrange: str | Range, conn_or_curs: connection | cursor, globally: bool = False
+    pgrange: str, pyrange: str | type[Range], conn_or_curs: connection | cursor, globally: bool = False
 ) -> RangeCaster: ...
 
 class RangeAdapter:

--- a/stubs/psycopg2/psycopg2/_range.pyi
+++ b/stubs/psycopg2/psycopg2/_range.pyi
@@ -51,7 +51,12 @@ class RangeCaster:
     typecaster: Any
     array_typecaster: Any
     def __init__(
-        self, pgrange: str | type[RangeAdapter], pyrange: str | type[Range], oid: int, subtype_oid: int, array_oid: int | None = None
+        self,
+        pgrange: str | type[RangeAdapter],
+        pyrange: str | type[Range],
+        oid: int,
+        subtype_oid: int,
+        array_oid: int | None = None,
     ) -> None: ...
     @overload
     def parse(self, s: None, cur: cursor | None = None) -> None: ...


### PR DESCRIPTION
The pgrange and pyrange arguments should be a string or a class object derived from RangeAdapter and Range, respectively. See

https://github.com/psycopg/psycopg2/blob/2.9.9/lib/_range.py#L313 https://github.com/psycopg/psycopg2/blob/2.9.9/lib/_range.py#L330