### PR TITLE
asyncio: create_subprocess_exec is the same as create_subprocess_shell, except where it isnt

### DIFF
--- a/stdlib/asyncio/subprocess.pyi
+++ b/stdlib/asyncio/subprocess.pyi
@@ -80,14 +80,14 @@ if sys.version_info >= (3, 11):
         stdout: int | IO[Any] | None = None,
         stderr: int | IO[Any] | None = None,
         limit: int = 65536,
-        # These parameters are forced to these values by BaseEventLoop.subprocess_shell
+        # These parameters are forced to these values by BaseEventLoop.subprocess_exec
         universal_newlines: Literal[False] = False,
-        shell: Literal[True] = True,
+        shell: Literal[False] = False,
         bufsize: Literal[0] = 0,
         encoding: None = None,
         errors: None = None,
+        text: Literal[False] | None = None,
         # These parameters are taken by subprocess.Popen, which this ultimately delegates to
-        text: bool | None = None,
         executable: StrOrBytesPath | None = None,
         preexec_fn: Callable[[], Any] | None = None,
         close_fds: bool = True,
@@ -145,14 +145,14 @@ elif sys.version_info >= (3, 10):
         stdout: int | IO[Any] | None = None,
         stderr: int | IO[Any] | None = None,
         limit: int = 65536,
-        # These parameters are forced to these values by BaseEventLoop.subprocess_shell
+        # These parameters are forced to these values by BaseEventLoop.subprocess_exec
         universal_newlines: Literal[False] = False,
-        shell: Literal[True] = True,
+        shell: Literal[False] = False,
         bufsize: Literal[0] = 0,
         encoding: None = None,
         errors: None = None,
+        text: Literal[False] | None = None,
         # These parameters are taken by subprocess.Popen, which this ultimately delegates to
-        text: bool | None = None,
         executable: StrOrBytesPath | None = None,
         preexec_fn: Callable[[], Any] | None = None,
         close_fds: bool = True,
@@ -210,14 +210,14 @@ else:  # >= 3.9
         stderr: int | IO[Any] | None = None,
         loop: events.AbstractEventLoop | None = None,
         limit: int = 65536,
-        # These parameters are forced to these values by BaseEventLoop.subprocess_shell
+        # These parameters are forced to these values by BaseEventLoop.subprocess_exec
         universal_newlines: Literal[False] = False,
-        shell: Literal[True] = True,
+        shell: Literal[False] = False,
         bufsize: Literal[0] = 0,
         encoding: None = None,
         errors: None = None,
+        text: Literal[False] | None = None,
         # These parameters are taken by subprocess.Popen, which this ultimately delegates to
-        text: bool | None = None,
         executable: StrOrBytesPath | None = None,
         preexec_fn: Callable[[], Any] | None = None,
         close_fds: bool = True,


### PR DESCRIPTION
Duplicate for the _exec case what has already been duplicated for the _shell case in 38dfb57adf7404fdf7419c472c08e3f0670b72f3 and follow-ups.
Except for the `shell: bool` argument: that one is the whole point of having two; that one needs to be flipped.