### PR TITLE
set `root` for logging dict config to be non-None

### DIFF
--- a/stdlib/logging/config.pyi
+++ b/stdlib/logging/config.pyi
@@ -55,7 +55,7 @@ class _OptionalDictConfigArgs(TypedDict, total=False):
     filters: dict[str, _FilterConfiguration]
     handlers: dict[str, _HandlerConfiguration]
     loggers: dict[str, _LoggerConfiguration]
-    root: _RootLoggerConfiguration | None
+    root: _RootLoggerConfiguration
     incremental: bool
     disable_existing_loggers: bool
 


### PR DESCRIPTION
it is already NotRequired due to total=False

see #6193