### PR TITLE
psycopg2: improve `cursor_factory` params

### DIFF
--- a/stubs/psycopg2/psycopg2/__init__.pyi
+++ b/stubs/psycopg2/psycopg2/__init__.pyi
@@ -39,7 +39,7 @@ _T_conn = TypeVar("_T_conn", bound=connection)
 def connect(
     dsn: str | None,
     connection_factory: Callable[..., _T_conn],
-    cursor_factory: Callable[..., cursor] | None = None,
+    cursor_factory: Callable[[connection, str | bytes | None], cursor] | None = None,
     **kwargs: Any,
 ) -> _T_conn: ...
 @overload
@@ -47,13 +47,13 @@ def connect(
     dsn: str | None = None,
     *,
     connection_factory: Callable[..., _T_conn],
-    cursor_factory: Callable[..., cursor] | None = None,
+    cursor_factory: Callable[[connection, str | bytes | None], cursor] | None = None,
     **kwargs: Any,
 ) -> _T_conn: ...
 @overload
 def connect(
     dsn: str | None = None,
     connection_factory: Callable[..., connection] | None = None,
-    cursor_factory: Callable[..., cursor] | None = None,
+    cursor_factory: Callable[[connection, str | bytes | None], cursor] | None = None,
     **kwargs: Any,
 ) -> connection: ...

--- a/stubs/psycopg2/psycopg2/_psycopg.pyi
+++ b/stubs/psycopg2/psycopg2/_psycopg.pyi
@@ -89,7 +89,7 @@ class _SupportsReadAndReadlineAndWrite(_SupportsReadAndReadline, SupportsWrite[s
 class cursor:
     arraysize: int
     binary_types: Incomplete | None
-    connection: _Connection
+    connection: connection
     itersize: int
     row_factory: Incomplete | None
     scrollable: bool | None
@@ -149,8 +149,6 @@ class cursor:
     ) -> None: ...
     def __iter__(self) -> Self: ...
     def __next__(self) -> tuple[Any, ...]: ...
-
-_Cursor: TypeAlias = cursor
 
 class AsIs:
     def __init__(self, __obj: object, **kwargs: Unused) -> None: ...
@@ -258,7 +256,7 @@ class ConnectionInfo:
     def ssl_attribute(self, name: str) -> str | None: ...
 
 class Error(Exception):
-    cursor: _Cursor | None
+    cursor: cursor | None
     diag: Diagnostics
     pgcode: str | None
     pgerror: str | None
@@ -412,7 +410,7 @@ class connection:
     def binary_types(self) -> dict[Incomplete, Incomplete]: ...
     @property
     def closed(self) -> int: ...
-    cursor_factory: Callable[..., _Cursor]
+    cursor_factory: Callable[[connection, str | bytes | None], cursor]
     @property
     def dsn(self) -> str: ...
     @property
@@ -452,13 +450,13 @@ class connection:
     @overload
     def cursor(
         self, name: str | bytes | None = None, cursor_factory: None = None, withhold: bool = False, scrollable: bool | None = None
-    ) -> _Cursor: ...
+    ) -> cursor: ...
     @overload
     def cursor(
         self,
         name: str | bytes | None = None,
         *,
-        cursor_factory: Callable[..., _T_cur],
+        cursor_factory: Callable[[connection, str | bytes | None], _T_cur],
         withhold: bool = False,
         scrollable: bool | None = None,
     ) -> _T_cur: ...
@@ -466,7 +464,7 @@ class connection:
     def cursor(
         self,
         name: str | bytes | None,
-        cursor_factory: Callable[..., _T_cur],
+        cursor_factory: Callable[[connection, str | bytes | None], _T_cur],
         withhold: bool = False,
         scrollable: bool | None = None,
     ) -> _T_cur: ...

--- a/stubs/psycopg2/psycopg2/_psycopg.pyi
+++ b/stubs/psycopg2/psycopg2/_psycopg.pyi
@@ -89,7 +89,7 @@ class _SupportsReadAndReadlineAndWrite(_SupportsReadAndReadline, SupportsWrite[s
 class cursor:
     arraysize: int
     binary_types: Incomplete | None
-    connection: connection
+    connection: _Connection
     itersize: int
     row_factory: Incomplete | None
     scrollable: bool | None
@@ -149,6 +149,8 @@ class cursor:
     ) -> None: ...
     def __iter__(self) -> Self: ...
     def __next__(self) -> tuple[Any, ...]: ...
+
+_Cursor: TypeAlias = cursor
 
 class AsIs:
     def __init__(self, __obj: object, **kwargs: Unused) -> None: ...
@@ -256,7 +258,7 @@ class ConnectionInfo:
     def ssl_attribute(self, name: str) -> str | None: ...
 
 class Error(Exception):
-    cursor: cursor | None
+    cursor: _Cursor | None
     diag: Diagnostics
     pgcode: str | None
     pgerror: str | None

--- a/stubs/psycopg2/psycopg2/extras.pyi
+++ b/stubs/psycopg2/psycopg2/extras.pyi
@@ -46,7 +46,7 @@ class DictConnection(_connection):
         self,
         name: str | bytes | None = None,
         *,
-        cursor_factory: Callable[..., _T_cur],
+        cursor_factory: Callable[[_connection, str | bytes | None], _T_cur],
         withhold: bool = False,
         scrollable: bool | None = None,
     ) -> _T_cur: ...
@@ -54,7 +54,7 @@ class DictConnection(_connection):
     def cursor(
         self,
         name: str | bytes | None,
-        cursor_factory: Callable[..., _T_cur],
+        cursor_factory: Callable[[_connection, str | bytes | None], _T_cur],
         withhold: bool = False,
         scrollable: bool | None = None,
     ) -> _T_cur: ...
@@ -91,7 +91,7 @@ class RealDictConnection(_connection):
         self,
         name: str | bytes | None = None,
         *,
-        cursor_factory: Callable[..., _T_cur],
+        cursor_factory: Callable[[_connection, str | bytes | None], _T_cur],
         withhold: bool = False,
         scrollable: bool | None = None,
     ) -> _T_cur: ...
@@ -99,7 +99,7 @@ class RealDictConnection(_connection):
     def cursor(
         self,
         name: str | bytes | None,
-        cursor_factory: Callable[..., _T_cur],
+        cursor_factory: Callable[[_connection, str | bytes | None], _T_cur],
         withhold: bool = False,
         scrollable: bool | None = None,
     ) -> _T_cur: ...
@@ -128,7 +128,7 @@ class NamedTupleConnection(_connection):
         self,
         name: str | bytes | None = None,
         *,
-        cursor_factory: Callable[..., _T_cur],
+        cursor_factory: Callable[[_connection, str | bytes | None], _T_cur],
         withhold: bool = False,
         scrollable: bool | None = None,
     ) -> _T_cur: ...
@@ -136,7 +136,7 @@ class NamedTupleConnection(_connection):
     def cursor(
         self,
         name: str | bytes | None,
-        cursor_factory: Callable[..., _T_cur],
+        cursor_factory: Callable[[_connection, str | bytes | None], _T_cur],
         withhold: bool = False,
         scrollable: bool | None = None,
     ) -> _T_cur: ...


### PR DESCRIPTION
Change originating from: https://github.com/python/typeshed/pull/11084#issuecomment-1831274491

idk if specifying the possible kwarg is necessary here. If not, then the tests in `stubs/psycopg2/@tests/test_cases/check_extensions.py` are still accurate. @JelleZijlstra I believe you last looked at this in https://github.com/python/typeshed/pull/7964/files#diff-0f425c352331e97f72634f6e626545d46059d6744c3b7e6a439119482869c8eeR91