### PR TITLE
update two classes to use StrEnum as their base class, when available.

### DIFF
--- a/stdlib/_typeshed/__init__.pyi
+++ b/stdlib/_typeshed/__init__.pyi
@@ -320,3 +320,12 @@ class DataclassInstance(Protocol):
 # Anything that can be passed to the int/float constructors
 ConvertibleToInt: TypeAlias = str | ReadableBuffer | SupportsInt | SupportsIndex | SupportsTrunc
 ConvertibleToFloat: TypeAlias = str | ReadableBuffer | SupportsFloat | SupportsIndex
+
+# A few classes updated from Foo(str, Enum) to Foo(StrEnum). This is a convenience so these
+# can be accurate on all python versions without getting too wordy
+if sys.version_info >= (3, 11):
+    from enum import StrEnum as StrEnum
+else:
+    from enum import Enum
+
+    class StrEnum(str, Enum): ...

--- a/stdlib/pstats.pyi
+++ b/stdlib/pstats.pyi
@@ -1,8 +1,7 @@
 import sys
-from _typeshed import StrOrBytesPath
+from _typeshed import StrEnum, StrOrBytesPath
 from collections.abc import Iterable
 from cProfile import Profile as _cProfile
-from enum import Enum
 from profile import Profile
 from typing import IO, Any, overload
 from typing_extensions import Literal, Self, TypeAlias
@@ -14,7 +13,7 @@ else:
 
 _Selector: TypeAlias = str | float | int
 
-class SortKey(str, Enum):
+class SortKey(StrEnum):
     CALLS: str
     CUMULATIVE: str
     FILENAME: str

--- a/stdlib/tkinter/__init__.pyi
+++ b/stdlib/tkinter/__init__.pyi
@@ -1,8 +1,7 @@
 import _tkinter
 import sys
-from _typeshed import Incomplete, StrOrBytesPath
+from _typeshed import Incomplete, StrEnum, StrOrBytesPath
 from collections.abc import Callable, Mapping, Sequence
-from enum import Enum
 from tkinter.constants import *
 from tkinter.font import _FontDescription
 from types import TracebackType
@@ -195,7 +194,7 @@ if sys.version_info >= (3, 11):
         releaselevel: str
         serial: int
 
-class EventType(str, Enum):
+class EventType(StrEnum):
     Activate: str
     ButtonPress: str
     Button = ButtonPress

--- a/tests/stubtest_allowlists/py310.txt
+++ b/tests/stubtest_allowlists/py310.txt
@@ -172,3 +172,7 @@ pkgutil.ImpImporter\..*
 pkgutil.ImpLoader\..*
 
 types.CodeType.replace  # stubtest thinks default values are None but None doesn't work at runtime
+
+# These enums derive from (int, IntEnum) or (str, Enum)
+pstats.SortKey.__new__
+tkinter.EventType.__new__

--- a/tests/stubtest_allowlists/py310.txt
+++ b/tests/stubtest_allowlists/py310.txt
@@ -173,6 +173,6 @@ pkgutil.ImpLoader\..*
 
 types.CodeType.replace  # stubtest thinks default values are None but None doesn't work at runtime
 
-# These enums derive from (int, IntEnum) or (str, Enum)
+# These enums derive from (str, Enum)
 pstats.SortKey.__new__
 tkinter.EventType.__new__

--- a/tests/stubtest_allowlists/py38.txt
+++ b/tests/stubtest_allowlists/py38.txt
@@ -182,6 +182,6 @@ tkinter\.test\..+
 unittest.test
 unittest\.test\..+
 
-# These enums derive from (int, IntEnum) or (str, Enum)
+# These enums derive from (str, Enum)
 pstats.SortKey.__new__
 tkinter.EventType.__new__

--- a/tests/stubtest_allowlists/py38.txt
+++ b/tests/stubtest_allowlists/py38.txt
@@ -181,3 +181,7 @@ tkinter.test
 tkinter\.test\..+
 unittest.test
 unittest\.test\..+
+
+# These enums derive from (int, IntEnum) or (str, Enum)
+pstats.SortKey.__new__
+tkinter.EventType.__new__

--- a/tests/stubtest_allowlists/py39.txt
+++ b/tests/stubtest_allowlists/py39.txt
@@ -164,6 +164,6 @@ pkgutil.ImpLoader\..*
 
 types.CodeType.replace  # stubtest thinks default values are None but None doesn't work at runtime
 
-# These enums derive from (int, IntEnum) or (str, Enum)
+# These enums derive from (str, Enum)
 pstats.SortKey.__new__
 tkinter.EventType.__new__

--- a/tests/stubtest_allowlists/py39.txt
+++ b/tests/stubtest_allowlists/py39.txt
@@ -163,3 +163,7 @@ pkgutil.ImpImporter\..*
 pkgutil.ImpLoader\..*
 
 types.CodeType.replace  # stubtest thinks default values are None but None doesn't work at runtime
+
+# These enums derive from (int, IntEnum) or (str, Enum)
+pstats.SortKey.__new__
+tkinter.EventType.__new__

--- a/tests/stubtest_allowlists/py3_common.txt
+++ b/tests/stubtest_allowlists/py3_common.txt
@@ -433,10 +433,6 @@ inspect.Signature.__init__
 inspect.Parameter.empty  # set as private marker _empty
 inspect.Signature.empty  # set as private marker _empty
 
-# These enums derive from (int, IntEnum) or (str, Enum)
-pstats.SortKey.__new__
-tkinter.EventType.__new__
-
 # These multiprocessing proxy methods have *args, **kwargs signatures at runtime,
 # But have more precise (accurate) signatures in the stub
 multiprocessing.managers.BaseListProxy.__imul__


### PR DESCRIPTION
related to https://github.com/python/typeshed/issues/3968

Creating StrEnum in _typeshed avoids needing to repeat the enum, nearly unchanged, in both branches of the version check. I hope I haven't missed something. 