### PR TITLE
Go back to default for `useLibraryCodeForTypes` & delete removed vscode-python configs.

### DIFF
--- a/.vscode/settings.default.json
+++ b/.vscode/settings.default.json
@@ -71,23 +71,11 @@
         ],
         "editor.defaultFormatter": "ms-python.black-formatter"
     },
-    // Use the new dedicated extensions instead
-    "python.formatting.provider": "none",
-    "python.linting.enabled": false,
-    "python.linting.mypyEnabled": false,
-    "python.linting.flake8Enabled": false,
-    "python.linting.pycodestyleEnabled": false,
-    "python.linting.prospectorEnabled": false,
-    "python.linting.pylamaEnabled": false,
-    "python.linting.pylintEnabled": false,
-    "python.linting.banditEnabled": false,
     // python.analysis is Pylance (pyright) configurations
     "python.analysis.fixAll": [
         "source.unusedImports"
         // Explicitly omiting "source.convertImportFormat", some stubs use relative imports
     ],
-    // Important to use `types-*` and flag untyped dependencies.
-    "python.analysis.useLibraryCodeForTypes": false,
     "python.analysis.typeshedPaths": [
         "${workspaceFolder}"
     ],

--- a/pyrightconfig.scripts_and_tests.json
+++ b/pyrightconfig.scripts_and_tests.json
@@ -6,8 +6,6 @@
         "tests",
     ],
     "typeCheckingMode": "strict",
-    // Runtime libraries used by typeshed are not all py.typed
-    "useLibraryCodeForTypes": true,
     // More of a lint. Unwanted for typeshed's own code.
     "reportImplicitStringConcatenation": "none",
     // Extra strict settings


### PR DESCRIPTION
Since `pyright@1.1.303` the default value of `useLibraryCodeForTypes` has been updated to `true` to be the same as Pylance. So it doesn't need to be configured in Pylance anymore to have the same default as Pyright.

Having the value to `false` atm differs from our pyright configs and can lead to wild desyncs with partial `Unknowns` (see https://github.com/microsoft/pylance-release/issues/5202#issuecomment-1839272649)

The rest of the python settings removed are settings that *were* deprecated, but now no longer even exists since https://github.com/microsoft/vscode-python/pull/22266. (also see for more info: https://github.com/microsoft/vscode-python/wiki/Migration-to-Python-Tools-Extensions )