### PR TITLE
fix superclass for UnixDatagramServer and UnixStreamServer

### DIFF
--- a/stdlib/socketserver.pyi
+++ b/stdlib/socketserver.pyi
@@ -86,7 +86,7 @@ class UDPServer(TCPServer):
     def get_request(self) -> tuple[tuple[bytes, _socket], _RetAddress]: ...  # type: ignore[override]
 
 if sys.platform != "win32":
-    class UnixStreamServer(BaseServer):
+    class UnixStreamServer(TCPServer):
         server_address: _AfUnixAddress  # type: ignore[assignment]
         def __init__(
             self,
@@ -95,7 +95,7 @@ if sys.platform != "win32":
             bind_and_activate: bool = True,
         ) -> None: ...
 
-    class UnixDatagramServer(BaseServer):
+    class UnixDatagramServer(UDPServer):
         server_address: _AfUnixAddress  # type: ignore[assignment]
         def __init__(
             self,


### PR DESCRIPTION
related to https://github.com/python/typeshed/issues/3968

This should be pretty minor as far as I can see; TCPServer and UDPServer are both subclasses of BaseServer. I couldn't find any prior discussion or clear reason why they weren't used in the first place here, so it's quite possible I missed something.