### PR TITLE
Add deprecation classes in importlib.metadata

### DIFF
--- a/stdlib/importlib/metadata/__init__.pyi
+++ b/stdlib/importlib/metadata/__init__.pyi
@@ -174,9 +174,7 @@ class FileHash:
     def __init__(self, spec: str) -> None: ...
 
 if sys.version_info >= (3, 12):
-    class DeprecatedNonAbstract:
-        def __new__(cls, *args: object, **kwargs: object) -> Self: ...
-
+    class DeprecatedNonAbstract: ...
     _distribution_parent = DeprecatedNonAbstract
 else:
     _distribution_parent = object

--- a/tests/stubtest_allowlists/py310.txt
+++ b/tests/stubtest_allowlists/py310.txt
@@ -153,6 +153,10 @@ typing.ParamSpec(Args|Kwargs).__origin__
 importlib.abc.Traversable.joinpath
 importlib.abc.Traversable.open
 
+# Deprecation wrapper classes; their methods are just pass-through, so we can ignore them.
+importlib.metadata.DeprecatedList.reverse
+importlib.metadata.DeprecatedList.sort
+
 # Super-special typing primitives
 typing\.NamedTuple
 typing\.Annotated

--- a/tests/stubtest_allowlists/py311.txt
+++ b/tests/stubtest_allowlists/py311.txt
@@ -106,6 +106,10 @@ unittest.case.TestCase.__init_subclass__
 importlib.abc.Traversable.open
 importlib.resources.abc.Traversable.open
 
+# Deprecation wrapper classes; their methods are just pass-through, so we can ignore them.
+importlib.metadata.DeprecatedList.reverse
+importlib.metadata.DeprecatedList.sort
+
 # Super-special typing primitives
 typing\._SpecialForm.*
 typing\.NamedTuple

--- a/tests/stubtest_allowlists/py312.txt
+++ b/tests/stubtest_allowlists/py312.txt
@@ -101,6 +101,9 @@ unittest.case.TestCase.__init_subclass__
 importlib.abc.Traversable.open
 importlib.resources.abc.Traversable.open
 
+# Deprecation wrapper classes; their methods are just pass-through, so we can ignore them.
+importlib.metadata.DeprecatedNonAbstract.__new__
+
 # Super-special typing primitives
 typing\._SpecialForm.*
 typing\.NamedTuple


### PR DESCRIPTION
related to https://github.com/python/typeshed/issues/3968

Generally speaking these classes print warnings and then call super().method() without changing anything's type signature, so they don't need much to be filled out here.