### PR TITLE
uWSGI: Use a `TypeVarTuple` in `uwsgidecorators.thread`

### DIFF
--- a/stubs/uWSGI/@tests/stubtest_allowlist.txt
+++ b/stubs/uWSGI/@tests/stubtest_allowlist.txt
@@ -5,10 +5,3 @@
 uwsgidecorators.erlang
 # This should really only be internal API, so we don't export it
 uwsgidecorators.harakiri.real_call
-
-# Error: is inconsistent
-# ======================
-# This is a limitation of ParamSpec, we can't specify that the
-# the ParamSpec does have no keyword arguments, but we need the
-# ParamSpec to properly annotate this decorator
-uwsgidecorators.thread.__call__

--- a/stubs/uWSGI/uwsgidecorators.pyi
+++ b/stubs/uWSGI/uwsgidecorators.pyi
@@ -1,11 +1,12 @@
 from collections.abc import Callable
 from typing import Any, Generic, TypeVar, overload
-from typing_extensions import Literal, ParamSpec
+from typing_extensions import Literal, ParamSpec, TypeVarTuple, Unpack
 
 from uwsgi import _RPCCallable
 
 _T = TypeVar("_T")
 _T2 = TypeVar("_T2")
+_Ts = TypeVarTuple("_Ts")
 _SR = TypeVar("_SR", bound=Literal[0, -1, -2] | None)
 _SignalCallbackT = TypeVar("_SignalCallbackT", bound=Callable[[int], Any])
 _RPCCallableT = TypeVar("_RPCCallableT", bound=_RPCCallable)
@@ -166,13 +167,10 @@ class lock(Generic[_P, _T]):
     def __init__(self, f: Callable[_P, _T]) -> None: ...
     def __call__(self, *args: _P.args, **kwargs: _P.kwargs) -> _T: ...
 
-# FIXME: Technically this only allows positional arguments, but there is not really
-#        an adequate way yet to express this, once bound on ParamSpec does something
-#        we could probably enforce this
-class thread(Generic[_P, _T]):
-    f: Callable[_P, _T]
-    def __init__(self, f: Callable[_P, _T]) -> None: ...
-    def __call__(self, *args: _P.args, **kwargs: _P.kwargs) -> Callable[_P, _T]: ...
+class thread(Generic[Unpack[_Ts], _T]):
+    f: Callable[[Unpack[_Ts]], _T]
+    def __init__(self, f: Callable[[Unpack[_Ts]], _T]) -> None: ...
+    def __call__(self, *args: Unpack[_Ts]) -> Callable[[Unpack[_Ts]], _T]: ...
 
 class harakiri:
     s: int


### PR DESCRIPTION
This addresses one of the FIXME comments (and a stubtest_allowlist entry) in types-uWSGI