### PR TITLE
seaborn: mark simple deprecations with typing_extensions.deprecated

### DIFF
--- a/stubs/seaborn/seaborn/algorithms.pyi
+++ b/stubs/seaborn/seaborn/algorithms.pyi
@@ -5,7 +5,7 @@ from numpy.typing import ArrayLike, NDArray
 
 from .utils import _Seed
 
-# TODO: Uncomment when stubtest crash is fixed
+# TODO: This crashes stubtest. Uncomment when mypy 1.8 is released with the fix https://github.com/python/mypy/pull/16457
 # @overload
 # def bootstrap(
 #     *args: ArrayLike,

--- a/stubs/seaborn/seaborn/algorithms.pyi
+++ b/stubs/seaborn/seaborn/algorithms.pyi
@@ -1,22 +1,22 @@
 from collections.abc import Callable
-from typing import Any, overload
-from typing_extensions import deprecated
+from typing import Any
 
 from numpy.typing import ArrayLike, NDArray
 
 from .utils import _Seed
 
-@overload
-def bootstrap(
-    *args: ArrayLike,
-    n_boot: int = 10000,
-    func: str | Callable[..., Any] = "mean",
-    axis: int | None = None,
-    units: ArrayLike | None = None,
-    seed: _Seed | None = None,
-) -> NDArray[Any]: ...
-@overload
-@deprecated("Parameter `random_seed` is deprecated in favor of `seed`")
+# TODO: Uncomment when stubtest crash is fixed
+# @overload
+# def bootstrap(
+#     *args: ArrayLike,
+#     n_boot: int = 10000,
+#     func: str | Callable[..., Any] = "mean",
+#     axis: int | None = None,
+#     units: ArrayLike | None = None,
+#     seed: _Seed | None = None,
+# ) -> NDArray[Any]: ...
+# @overload
+# @deprecated("Parameter `random_seed` is deprecated in favor of `seed`")
 def bootstrap(
     *args: ArrayLike,
     n_boot: int = 10000,

--- a/stubs/seaborn/seaborn/algorithms.pyi
+++ b/stubs/seaborn/seaborn/algorithms.pyi
@@ -1,10 +1,12 @@
 from collections.abc import Callable
-from typing import Any
+from typing import Any, overload
+from typing_extensions import deprecated
 
 from numpy.typing import ArrayLike, NDArray
 
 from .utils import _Seed
 
+@overload
 def bootstrap(
     *args: ArrayLike,
     n_boot: int = 10000,
@@ -12,5 +14,15 @@ def bootstrap(
     axis: int | None = None,
     units: ArrayLike | None = None,
     seed: _Seed | None = None,
-    random_seed: _Seed | None = None,  # deprecated
+) -> NDArray[Any]: ...
+@overload
+@deprecated("Parameter `random_seed` is deprecated in favor of `seed`")
+def bootstrap(
+    *args: ArrayLike,
+    n_boot: int = 10000,
+    func: str | Callable[..., Any] = "mean",
+    axis: int | None = None,
+    units: ArrayLike | None = None,
+    seed: _Seed | None = None,
+    random_seed: _Seed | None = None,
 ) -> NDArray[Any]: ...

--- a/stubs/seaborn/seaborn/axisgrid.pyi
+++ b/stubs/seaborn/seaborn/axisgrid.pyi
@@ -2,7 +2,7 @@ import os
 from _typeshed import Incomplete
 from collections.abc import Callable, Generator, Iterable, Mapping
 from typing import IO, Any, TypeVar
-from typing_extensions import Concatenate, Literal, ParamSpec, Self, TypeAlias
+from typing_extensions import Concatenate, Literal, ParamSpec, Self, TypeAlias, deprecated
 
 import numpy as np
 from matplotlib.artist import Artist
@@ -92,6 +92,7 @@ class _BaseGrid:
         **kwargs: Any,
     ) -> Self: ...
     @property
+    @deprecated("Attribute `fig` is deprecated in favor of `figure`")
     def fig(self) -> Figure: ...
     @property
     def figure(self) -> Figure: ...

--- a/stubs/seaborn/seaborn/distributions.pyi
+++ b/stubs/seaborn/seaborn/distributions.pyi
@@ -1,7 +1,7 @@
 from _typeshed import Incomplete
 from collections.abc import Iterable
 from typing import Any
-from typing_extensions import Literal
+from typing_extensions import Literal, deprecated
 
 from matplotlib.axes import Axes
 from matplotlib.colors import Colormap
@@ -139,7 +139,8 @@ def displot(
     facet_kws: dict[str, Any] | None = None,
     **kwargs: Any,
 ) -> FacetGrid: ...
-def distplot(  # deprecated
+@deprecated("Function `distplot` is deprecated and will be removed in seaborn v0.14.0")
+def distplot(
     a: Incomplete | None = None,
     bins: Incomplete | None = None,
     hist: bool = True,

--- a/stubs/seaborn/seaborn/rcmod.pyi
+++ b/stubs/seaborn/seaborn/rcmod.pyi
@@ -1,7 +1,7 @@
 from _typeshed import Unused
 from collections.abc import Callable, Sequence
 from typing import Any, TypeVar
-from typing_extensions import Literal
+from typing_extensions import Literal, deprecated
 
 from matplotlib.typing import ColorType
 
@@ -30,10 +30,16 @@ def set_theme(
     color_codes: bool = True,
     rc: dict[str, Any] | None = None,
 ) -> None: ...
-
-# def set(*args, **kwargs) -> None: ...  # deprecated alias for set_theme
-set = set_theme
-
+@deprecated("Function `set` is deprecated in favor of `set_theme`")
+def set(
+    context: Literal["paper", "notebook", "talk", "poster"] | dict[str, Any] = "notebook",
+    style: Literal["white", "dark", "whitegrid", "darkgrid", "ticks"] | dict[str, Any] = "darkgrid",
+    palette: str | Sequence[ColorType] | None = "deep",
+    font: str = "sans-serif",
+    font_scale: float = 1,
+    color_codes: bool = True,
+    rc: dict[str, Any] | None = None,
+) -> None: ...
 def reset_defaults() -> None: ...
 def reset_orig() -> None: ...
 def axes_style(

--- a/stubs/seaborn/seaborn/utils.pyi
+++ b/stubs/seaborn/seaborn/utils.pyi
@@ -2,7 +2,7 @@ import datetime as dt
 from _typeshed import Incomplete, SupportsGetItem
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from typing import Any, TypeVar, overload
-from typing_extensions import Literal, SupportsIndex, TypeAlias
+from typing_extensions import Literal, SupportsIndex, TypeAlias, deprecated
 
 import numpy as np
 import pandas as pd
@@ -75,7 +75,8 @@ def saturate(color: ColorType) -> tuple[float, float, float]: ...
 def set_hls_values(
     color: ColorType, h: float | None = None, l: float | None = None, s: float | None = None
 ) -> tuple[float, float, float]: ...
-def axlabel(xlabel: str, ylabel: str, **kwargs: Any) -> None: ...  # deprecated
+@deprecated("Function `axlabel` is deprecated and will be removed in a future version")
+def axlabel(xlabel: str, ylabel: str, **kwargs: Any) -> None: ...
 def remove_na(vector: _VectorT) -> _VectorT: ...
 def get_color_cycle() -> list[str]: ...
 


### PR DESCRIPTION
Note that I intentionally left out deprecated parameters of the big API functions as they would require overloads with very long signatures.