### PR TITLE
Remove duplicated items from ruff's exclude list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,6 @@ exclude = [
     ".git",
     ".mypy_cache",
     ".pytype",
-    ".venv",
-    "env",
 ]
 select = [
     "FA", # flake8-future-annotations


### PR DESCRIPTION
Hello,

There are a few duplicated items in the `exclude` list of `ruff` at the `pyproject.toml`.
I suppose they might be removed safely.

Best regards!