### PR TITLE
Set the maximum line length in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,7 +8,9 @@ end_of_line = lf
 indent_size = 2
 
 [*.md]
+max_line_length = 79
 trim_trailing_whitespace = false
 
 [*.{py,pyi,toml,json}]
+max_line_length = 130
 indent_size = 4


### PR DESCRIPTION
* 130 matches what the linter and formatter are told for Python files.
* 79 appears to be the limit for README.md.