### PR TITLE
Bump pyright to 1.1.342

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,5 +94,5 @@ extra-standard-library = [
 known-first-party = ["parse_metadata", "utils"]
 
 [tool.typeshed]
-pyright_version = "1.1.339"
+pyright_version = "1.1.342"
 oldest_supported_python = "3.7"


### PR DESCRIPTION
We've missed 3 new versions: https://github.com/microsoft/pyright/releases/tag/1.1.342