### PR TITLE
Add support for the refresh_token grant type (RefreshTokenGrant) (#11…

### DIFF
--- a/stubs/oauthlib/oauthlib/openid/connect/core/grant_types/__init__.pyi
+++ b/stubs/oauthlib/oauthlib/openid/connect/core/grant_types/__init__.pyi
@@ -7,3 +7,4 @@ from .dispatchers import (
 )
 from .hybrid import HybridGrant as HybridGrant
 from .implicit import ImplicitGrant as ImplicitGrant
+from .refresh_token import RefreshTokenGrant as RefreshTokenGrant

--- a/stubs/oauthlib/oauthlib/openid/connect/core/grant_types/refresh_token.pyi
+++ b/stubs/oauthlib/oauthlib/openid/connect/core/grant_types/refresh_token.pyi
@@ -1,0 +1,10 @@
+from _typeshed import Incomplete
+
+from .base import GrantTypeBase
+
+log: Incomplete
+
+class RefreshTokenGrant(GrantTypeBase):
+    proxy_target: Incomplete
+    def __init__(self, request_validator: Incomplete | None = None, **kwargs) -> None: ...
+    def add_id_token(self, token, token_handler, request): ...


### PR DESCRIPTION
This PR adds support for the refresh_token grant type (RefreshTokenGrant). Fixes #11205 

The changes are based on the following oauthlib files:

* https://github.com/oauthlib/oauthlib/blob/master/oauthlib/openid/connect/core/grant_types/__init__.py

* https://github.com/oauthlib/oauthlib/blob/master/oauthlib/openid/connect/core/grant_types/refresh_token.py