### PR TITLE
Fixes #11208: import all events in gdb-stubs init file

### DIFF
--- a/stubs/gdb/gdb/__init__.pyi
+++ b/stubs/gdb/gdb/__init__.pyi
@@ -11,7 +11,8 @@ from typing_extensions import TypeAlias
 import gdb.types
 
 # The following submodules are automatically imported
-from . import events as events, printing as printing, prompt as prompt, types as types
+from . import printing as printing, prompt as prompt, types as types
+from .events import *
 
 # Basic
 


### PR DESCRIPTION
This commit/PR fixes #11208. It turned out that there is no `gdb.events` module in `gdb` and instead all events types are available in `gdb.*` namespace.