### PR TITLE
socket: rework to match docs more closely, improve accuracy on linux

### DIFF
--- a/stdlib/_socket.pyi
+++ b/stdlib/_socket.pyi
@@ -515,8 +515,8 @@ if sys.platform == "linux":
     SO_VM_SOCKETS_BUFFER_MIN_SIZE: int
     VM_SOCKETS_INVALID_VERSION: int  # undocumented
 
-if sys.platform != "win32" or sys.version_info >= (3, 9):
-    AF_LINK: int
+if sys.platform == "darwin":
+    AF_LINK: int  # BSD, macOS
 
 has_ipv6: bool
 

--- a/stdlib/_socket.pyi
+++ b/stdlib/_socket.pyi
@@ -20,18 +20,17 @@ _CMSGArg: TypeAlias = tuple[int, int, ReadableBuffer]
 _Address: TypeAlias = tuple[Any, ...] | str | ReadableBuffer
 _RetAddress: TypeAlias = Any
 
-# ----- Constants -----
-# Some socket families are listed in the "Socket families" section of the docs,
-# but not the "Constants" section. These are listed at the end of the list of
-# constants.
-#
-# Besides those and the first few constants listed, the constants are listed in
-# documentation order.
+# ===== Constants =====
+# This matches the order in the CPython documentation
+# https://docs.python.org/3/library/socket.html#constants
 
-has_ipv6: bool
+if sys.platform != "win32":
+    AF_UNIX: int
 
 AF_INET: int
 AF_INET6: int
+
+AF_UNSPEC: int
 
 SOCK_STREAM: int
 SOCK_DGRAM: int
@@ -43,68 +42,110 @@ if sys.platform == "linux":
     SOCK_CLOEXEC: int
     SOCK_NONBLOCK: int
 
-# Address families not mentioned in the docs
-AF_APPLETALK: int
-AF_DECnet: int
-AF_IPX: int
-AF_SNA: int
-AF_UNSPEC: int
+# --------------------
+# Many constants of these forms, documented in the Unix documentation on
+# sockets and/or the IP protocol, are also defined in the socket module.
+# SO_*
+# socket.SOMAXCONN
+# MSG_*
+# SOL_*
+# SCM_*
+# IPPROTO_*
+# IPPORT_*
+# INADDR_*
+# IP_*
+# IPV6_*
+# EAI_*
+# AI_*
+# NI_*
+# TCP_*
+# --------------------
+
+SO_ACCEPTCONN: int
+SO_BROADCAST: int
+SO_DEBUG: int
+SO_DONTROUTE: int
+SO_ERROR: int
+SO_KEEPALIVE: int
+SO_LINGER: int
+SO_OOBINLINE: int
+SO_RCVBUF: int
+SO_RCVLOWAT: int
+SO_RCVTIMEO: int
+SO_REUSEADDR: int
+SO_SNDBUF: int
+SO_SNDLOWAT: int
+SO_SNDTIMEO: int
+SO_TYPE: int
+SO_USELOOPBACK: int
+if sys.platform != "win32":
+    SO_REUSEPORT: int
+if sys.platform != "win32" and sys.platform != "darwin":
+    SO_BINDTODEVICE: int
+    SO_DOMAIN: int
+    SO_MARK: int
+    SO_PASSCRED: int
+    SO_PASSSEC: int
+    SO_PEERCRED: int
+    SO_PEERSEC: int
+    SO_PRIORITY: int
+    SO_PROTOCOL: int
+    SO_SETFIB: int
+if sys.platform == "win32":
+    SO_EXCLUSIVEADDRUSE: int
+
+SOMAXCONN: int
+
+MSG_CTRUNC: int
+MSG_DONTROUTE: int
+MSG_OOB: int
+MSG_PEEK: int
+MSG_TRUNC: int
+MSG_WAITALL: int
+if sys.platform != "win32" and sys.platform != "darwin":
+    MSG_BTAG: int
+    MSG_CMSG_CLOEXEC: int
+    MSG_CONFIRM: int
+    MSG_ETAG: int
+    MSG_FASTOPEN: int
+    MSG_MORE: int
+    MSG_NOTIFICATION: int
+if sys.platform != "win32":
+    MSG_DONTWAIT: int
+    MSG_EOF: int
+    MSG_EOR: int
+    MSG_NOSIGNAL: int  # Sometimes this exists on darwin, sometimes not
+if sys.platform != "darwin":
+    MSG_BCAST: int
+    MSG_MCAST: int
+    MSG_ERRQUEUE: int
+
+SOL_IP: int
+SOL_SOCKET: int
+SOL_TCP: int
+SOL_UDP: int
+if sys.platform != "win32" and sys.platform != "darwin":
+    SOL_ATALK: int
+    SOL_AX25: int
+    SOL_HCI: int
+    SOL_IPX: int
+    SOL_NETROM: int
+    SOL_ROSE: int
 
 if sys.platform != "win32":
-    AF_ROUTE: int
-    AF_SYSTEM: int
-    AF_UNIX: int
+    SCM_CREDS: int
+    SCM_RIGHTS: int
 
-if sys.platform != "darwin":
-    AF_IRDA: int
+if sys.platform != "win32" and sys.platform != "darwin":
+    SCM_CREDENTIALS: int
 
-if sys.platform != "darwin" and sys.platform != "win32":
-    AF_AAL5: int
-    AF_ASH: int
-    AF_ATMPVC: int
-    AF_ATMSVC: int
-    AF_AX25: int
-    AF_BRIDGE: int
-    AF_ECONET: int
-    AF_KEY: int
-    AF_LLC: int
-    AF_NETBEUI: int
-    AF_NETROM: int
-    AF_PPPOX: int
-    AF_ROSE: int
-    AF_SECURITY: int
-    AF_WANPIPE: int
-    AF_X25: int
+IPPROTO_ICMP: int
+IPPROTO_IP: int
+IPPROTO_RAW: int
+IPPROTO_TCP: int
+IPPROTO_UDP: int
 
-# The "many constants" referenced by the docs
-SOMAXCONN: int
-AI_ADDRCONFIG: int
-AI_ALL: int
-AI_CANONNAME: int
-AI_NUMERICHOST: int
-AI_NUMERICSERV: int
-AI_PASSIVE: int
-AI_V4MAPPED: int
-EAI_AGAIN: int
-EAI_BADFLAGS: int
-EAI_FAIL: int
-EAI_FAMILY: int
-EAI_MEMORY: int
-EAI_NODATA: int
-EAI_NONAME: int
-EAI_SERVICE: int
-EAI_SOCKTYPE: int
-INADDR_ALLHOSTS_GROUP: int
-INADDR_ANY: int
-INADDR_BROADCAST: int
-INADDR_LOOPBACK: int
-INADDR_MAX_LOCAL_GROUP: int
-INADDR_NONE: int
-INADDR_UNSPEC_GROUP: int
-IPPORT_RESERVED: int
-IPPORT_USERRESERVED: int
-
-if sys.platform != "win32" or sys.version_info >= (3, 8):
+if sys.version_info >= (3, 8) or sys.platform != "win32":
     IPPROTO_AH: int
     IPPROTO_DSTOPTS: int
     IPPROTO_EGP: int
@@ -134,29 +175,37 @@ if sys.platform != "win32" or sys.version_info >= (3, 8):
         IPPROTO_RDP: int
         IPPROTO_ST: int
 
-IPPROTO_ICMP: int
-IPPROTO_IP: int
-IPPROTO_RAW: int
-IPPROTO_TCP: int
-IPPROTO_UDP: int
-IPV6_CHECKSUM: int
-IPV6_JOIN_GROUP: int
-IPV6_LEAVE_GROUP: int
-IPV6_MULTICAST_HOPS: int
-IPV6_MULTICAST_IF: int
-IPV6_MULTICAST_LOOP: int
-IPV6_RECVTCLASS: int
-IPV6_TCLASS: int
-IPV6_UNICAST_HOPS: int
-IPV6_V6ONLY: int
+if sys.platform != "win32":
+    IPPROTO_EON: int
+    IPPROTO_GRE: int
+    IPPROTO_HELLO: int
+    IPPROTO_IPCOMP: int
+    IPPROTO_IPIP: int
+    IPPROTO_RSVP: int
+    IPPROTO_TP: int
+    IPPROTO_XTP: int
 
-if sys.platform != "darwin" or sys.version_info >= (3, 9):
-    IPV6_DONTFRAG: int
-    IPV6_HOPLIMIT: int
-    IPV6_HOPOPTS: int
-    IPV6_PKTINFO: int
-    IPV6_RECVRTHDR: int
-    IPV6_RTHDR: int
+if sys.platform != "win32" and sys.platform != "darwin":
+    IPPROTO_BIP: int
+    IPPROTO_MOBILE: int
+    IPPROTO_VRRP: int
+
+if sys.version_info >= (3, 9) and sys.platform == "linux":
+    IPPROTO_UDPLITE: int
+
+if sys.version_info >= (3, 10) and sys.platform == "linux":
+    IPPROTO_MPTCP: int
+
+IPPORT_RESERVED: int
+IPPORT_USERRESERVED: int
+
+INADDR_ALLHOSTS_GROUP: int
+INADDR_ANY: int
+INADDR_BROADCAST: int
+INADDR_LOOPBACK: int
+INADDR_MAX_LOCAL_GROUP: int
+INADDR_NONE: int
+INADDR_UNSPEC_GROUP: int
 
 IP_ADD_MEMBERSHIP: int
 IP_DROP_MEMBERSHIP: int
@@ -172,106 +221,47 @@ elif sys.platform != "win32" and sys.platform != "darwin":
     IP_RECVTOS: int
 IP_TOS: int
 IP_TTL: int
-MSG_CTRUNC: int
-MSG_DONTROUTE: int
-
-if sys.platform != "darwin":
-    MSG_ERRQUEUE: int
-
-MSG_OOB: int
-MSG_PEEK: int
-MSG_TRUNC: int
-MSG_WAITALL: int
-NI_DGRAM: int
-NI_MAXHOST: int
-NI_MAXSERV: int
-NI_NAMEREQD: int
-NI_NOFQDN: int
-NI_NUMERICHOST: int
-NI_NUMERICSERV: int
-SHUT_RD: int
-SHUT_RDWR: int
-SHUT_WR: int
-SOL_IP: int
-SOL_SOCKET: int
-SOL_TCP: int
-SOL_UDP: int
-SO_ACCEPTCONN: int
-SO_BROADCAST: int
-SO_DEBUG: int
-SO_DONTROUTE: int
-SO_ERROR: int
-SO_KEEPALIVE: int
-SO_LINGER: int
-SO_OOBINLINE: int
-SO_RCVBUF: int
-SO_RCVLOWAT: int
-SO_RCVTIMEO: int
-SO_REUSEADDR: int
-SO_SNDBUF: int
-SO_SNDLOWAT: int
-SO_SNDTIMEO: int
-SO_TYPE: int
-SO_USELOOPBACK: int
-if sys.platform == "linux" and sys.version_info >= (3, 11):
-    SO_INCOMING_CPU: int
-TCP_FASTOPEN: int
-TCP_KEEPCNT: int
-TCP_KEEPINTVL: int
-
-if sys.platform != "darwin":
-    TCP_KEEPIDLE: int
-
-TCP_MAXSEG: int
-TCP_NODELAY: int
-if sys.platform != "win32":
-    TCP_NOTSENT_LOWAT: int
-if sys.version_info >= (3, 10) and sys.platform == "darwin":
-    TCP_KEEPALIVE: int
-if sys.version_info >= (3, 11) and sys.platform == "darwin":
-    TCP_CONNECTION_INFO: int
-
-if sys.platform != "darwin":
-    MSG_BCAST: int
-    MSG_MCAST: int
-    SO_EXCLUSIVEADDRUSE: int
 
 if sys.platform != "win32":
-    AI_DEFAULT: int
-    AI_MASK: int
-    AI_V4MAPPED_CFG: int
-    EAI_ADDRFAMILY: int
-    EAI_BADHINTS: int
-    EAI_MAX: int
-    EAI_OVERFLOW: int
-    EAI_PROTOCOL: int
-    EAI_SYSTEM: int
-    IPPROTO_EON: int
-    IPPROTO_GRE: int
-    IPPROTO_HELLO: int
-    IPPROTO_IPCOMP: int
-    IPPROTO_IPIP: int
-    IPPROTO_RSVP: int
-    IPPROTO_TP: int
-    IPPROTO_XTP: int
-    IPV6_RTHDR_TYPE_0: int
     IP_DEFAULT_MULTICAST_LOOP: int
     IP_DEFAULT_MULTICAST_TTL: int
     IP_MAX_MEMBERSHIPS: int
     IP_RECVOPTS: int
     IP_RECVRETOPTS: int
     IP_RETOPTS: int
-    LOCAL_PEERCRED: int
-    MSG_DONTWAIT: int
-    MSG_EOF: int
-    MSG_EOR: int
-    MSG_NOSIGNAL: int  # Sometimes this exists on darwin, sometimes not
-    SCM_CREDS: int
-    SCM_RIGHTS: int
-    SO_REUSEPORT: int
+
+if sys.platform != "win32" and sys.platform != "darwin":
+    IP_TRANSPARENT: int
+    IP_BIND_ADDRESS_NO_PORT: int
+
+if sys.version_info >= (3, 12) and sys.platform == "win32":
+    IP_PKTINFO: int
+    IP_UNBLOCK_SOURCE: int
+    IP_BLOCK_SOURCE: int
+    IP_ADD_SOURCE_MEMBERSHIP: int
+    IP_DROP_SOURCE_MEMBERSHIP: int
+
+IPV6_CHECKSUM: int
+IPV6_JOIN_GROUP: int
+IPV6_LEAVE_GROUP: int
+IPV6_MULTICAST_HOPS: int
+IPV6_MULTICAST_IF: int
+IPV6_MULTICAST_LOOP: int
+IPV6_RECVTCLASS: int
+IPV6_TCLASS: int
+IPV6_UNICAST_HOPS: int
+IPV6_V6ONLY: int
+
+if sys.version_info >= (3, 9) or sys.platform != "darwin":
+    IPV6_DONTFRAG: int
+    IPV6_HOPLIMIT: int
+    IPV6_HOPOPTS: int
+    IPV6_PKTINFO: int
+    IPV6_RECVRTHDR: int
+    IPV6_RTHDR: int
 
 if sys.platform != "win32":
-    if sys.platform != "darwin" or sys.version_info >= (3, 9):
+    if sys.version_info >= (3, 9) or sys.platform != "darwin":
         IPV6_DSTOPTS: int
         IPV6_NEXTHOP: int
         IPV6_PATHMTU: int
@@ -283,41 +273,77 @@ if sys.platform != "win32":
         IPV6_RTHDRDSTOPTS: int
         IPV6_USE_MIN_MTU: int
 
+if sys.platform != "win32":
+    IPV6_RTHDR_TYPE_0: int
+
+EAI_AGAIN: int
+EAI_BADFLAGS: int
+EAI_FAIL: int
+EAI_FAMILY: int
+EAI_MEMORY: int
+EAI_NODATA: int
+EAI_NONAME: int
+EAI_SERVICE: int
+EAI_SOCKTYPE: int
+
+if sys.platform != "win32":
+    EAI_ADDRFAMILY: int
+    EAI_BADHINTS: int
+    EAI_MAX: int
+    EAI_OVERFLOW: int
+    EAI_PROTOCOL: int
+    EAI_SYSTEM: int
+
+AI_ADDRCONFIG: int
+AI_ALL: int
+AI_CANONNAME: int
+AI_NUMERICHOST: int
+AI_NUMERICSERV: int
+AI_PASSIVE: int
+AI_V4MAPPED: int
+
+if sys.platform != "win32":
+    AI_DEFAULT: int
+    AI_MASK: int
+    AI_V4MAPPED_CFG: int
+
+NI_DGRAM: int
+NI_MAXHOST: int
+NI_MAXSERV: int
+NI_NAMEREQD: int
+NI_NOFQDN: int
+NI_NUMERICHOST: int
+NI_NUMERICSERV: int
+
+TCP_FASTOPEN: int
+TCP_KEEPCNT: int
+TCP_KEEPINTVL: int
+TCP_MAXSEG: int
+TCP_NODELAY: int
+
+if sys.platform != "darwin":
+    TCP_KEEPIDLE: int
+if sys.platform != "win32":
+    TCP_NOTSENT_LOWAT: int
+if sys.version_info >= (3, 10) and sys.platform == "darwin":
+    TCP_KEEPALIVE: int
+if sys.version_info >= (3, 11) and sys.platform == "darwin":
+    TCP_CONNECTION_INFO: int
+
 if sys.platform != "win32" and sys.platform != "darwin":
-    IPPROTO_BIP: int
-    IPPROTO_MOBILE: int
-    IPPROTO_VRRP: int
-    IPX_TYPE: int
-    IP_TRANSPARENT: int
-    MSG_BTAG: int
-    MSG_CMSG_CLOEXEC: int
-    MSG_CONFIRM: int
-    MSG_ETAG: int
-    MSG_FASTOPEN: int
-    MSG_MORE: int
-    MSG_NOTIFICATION: int
-    SCM_CREDENTIALS: int
-    SOL_ATALK: int
-    SOL_AX25: int
-    SOL_HCI: int
-    SOL_IPX: int
-    SOL_NETROM: int
-    SOL_ROSE: int
-    SO_BINDTODEVICE: int
-    SO_MARK: int
-    SO_PASSCRED: int
-    SO_PEERCRED: int
-    SO_PRIORITY: int
-    SO_SETFIB: int
+    TCP_CONGESTION: int
     TCP_CORK: int
     TCP_DEFER_ACCEPT: int
     TCP_INFO: int
     TCP_LINGER2: int
     TCP_QUICKACK: int
     TCP_SYNCNT: int
+    TCP_USER_TIMEOUT: int
     TCP_WINDOW_CLAMP: int
 
-# Specifically-documented constants
+# --------------------
+# Specifically documented constants
+# --------------------
 
 if sys.platform == "linux":
     AF_CAN: int
@@ -336,6 +362,7 @@ if sys.platform == "linux":
     CAN_RTR_FLAG: int
     CAN_SFF_MASK: int
 
+if sys.platform == "linux":
     CAN_BCM: int
     CAN_BCM_TX_SETUP: int
     CAN_BCM_TX_DELETE: int
@@ -350,28 +377,31 @@ if sys.platform == "linux":
     CAN_BCM_RX_TIMEOUT: int
     CAN_BCM_RX_CHANGED: int
 
+    if sys.version_info >= (3, 8):
+        CAN_BCM_SETTIMER: int
+        CAN_BCM_STARTTIMER: int
+        CAN_BCM_TX_COUNTEVT: int
+        CAN_BCM_TX_ANNOUNCE: int
+        CAN_BCM_TX_CP_CAN_ID: int
+        CAN_BCM_RX_FILTER_ID: int
+        CAN_BCM_RX_CHECK_DLC: int
+        CAN_BCM_RX_NO_AUTOTIMER: int
+        CAN_BCM_RX_ANNOUNCE_RESUME: int
+        CAN_BCM_TX_RESET_MULTI_IDX: int
+        CAN_BCM_RX_RTR_FRAME: int
+        CAN_BCM_CAN_FD_FRAME: int
+
+if sys.platform == "linux":
     CAN_RAW_FD_FRAMES: int
 
-if sys.platform == "linux" and sys.version_info >= (3, 8):
-    CAN_BCM_SETTIMER: int
-    CAN_BCM_STARTTIMER: int
-    CAN_BCM_TX_COUNTEVT: int
-    CAN_BCM_TX_ANNOUNCE: int
-    CAN_BCM_TX_CP_CAN_ID: int
-    CAN_BCM_RX_FILTER_ID: int
-    CAN_BCM_RX_CHECK_DLC: int
-    CAN_BCM_RX_NO_AUTOTIMER: int
-    CAN_BCM_RX_ANNOUNCE_RESUME: int
-    CAN_BCM_TX_RESET_MULTI_IDX: int
-    CAN_BCM_RX_RTR_FRAME: int
-    CAN_BCM_CAN_FD_FRAME: int
+if sys.platform == "linux" and sys.version_info >= (3, 9):
+    CAN_RAW_JOIN_FILTERS: int
 
 if sys.platform == "linux":
     CAN_ISOTP: int
 
 if sys.platform == "linux" and sys.version_info >= (3, 9):
     CAN_J1939: int
-    CAN_RAW_JOIN_FILTERS: int
 
     J1939_MAX_UNICAST_ADDR: int
     J1939_IDLE_ADDR: int
@@ -396,14 +426,13 @@ if sys.platform == "linux" and sys.version_info >= (3, 9):
 
     J1939_NLA_PAD: int
     J1939_NLA_BYTES_ACKED: int
-
     J1939_EE_INFO_NONE: int
     J1939_EE_INFO_TX_ABORT: int
-
     J1939_FILTER_MAX: int
 
-if sys.platform == "linux" and sys.version_info >= (3, 10):
-    IPPROTO_MPTCP: int
+if sys.version_info >= (3, 12) and sys.platform != "linux" and sys.platform != "win32" and sys.platform != "darwin":
+    AF_DIVERT: int
+    PF_DIVERT: int
 
 if sys.platform == "linux":
     AF_PACKET: int
@@ -415,6 +444,9 @@ if sys.platform == "linux":
     PACKET_MULTICAST: int
     PACKET_OTHERHOST: int
     PACKET_OUTGOING: int
+
+if sys.version_info >= (3, 12) and sys.platform == "linux":
+    ETH_P_ALL: int
 
 if sys.platform == "linux":
     AF_RDS: int
@@ -498,26 +530,61 @@ if sys.platform == "linux":
     SO_VM_SOCKETS_BUFFER_MAX_SIZE: int
     SO_VM_SOCKETS_BUFFER_SIZE: int
     SO_VM_SOCKETS_BUFFER_MIN_SIZE: int
-    VM_SOCKETS_INVALID_VERSION: int
+    VM_SOCKETS_INVALID_VERSION: int  # undocumented
 
 if sys.platform != "win32" or sys.version_info >= (3, 9):
     AF_LINK: int
 
-# BDADDR_* and HCI_* listed with other bluetooth constants below
+has_ipv6: bool
+
+if sys.platform != "darwin":
+    if sys.platform != "win32" or sys.version_info >= (3, 9):
+        BDADDR_ANY: str
+        BDADDR_LOCAL: str
 
 if sys.platform != "win32" and sys.platform != "darwin":
-    SO_DOMAIN: int
-    SO_PASSSEC: int
-    SO_PEERSEC: int
-    SO_PROTOCOL: int
-    TCP_CONGESTION: int
-    TCP_USER_TIMEOUT: int
+    HCI_FILTER: int  # not in NetBSD or DragonFlyBSD
+    HCI_TIME_STAMP: int  # not in FreeBSD, NetBSD, or DragonFlyBSD
+    HCI_DATA_DIR: int  # not in FreeBSD, NetBSD, or DragonFlyBSD
 
 if sys.platform == "linux" and sys.version_info >= (3, 8):
     AF_QIPCRTR: int
 
+if sys.version_info >= (3, 11) and sys.platform != "linux" and sys.platform != "win32" and sys.platform != "darwin":
+    # FreeBSD
+    SCM_CREDS2: int
+    LOCAL_CREDS: int
+    LOCAL_CREDS_PERSISTENT: int
+
+if sys.version_info >= (3, 11) and sys.platform == "linux":
+    SO_INCOMING_CPU: int
+
+if sys.version_info >= (3, 12) and sys.platform == "win32":
+    AF_HYPERV: int
+    HV_PROTOCOL_RAW: int
+    HVSOCKET_CONNECT_TIMEOUT: int
+    HVSOCKET_CONNECT_TIMEOUT_MAX: int
+    HVSOCKET_CONNECTED_SUSPEND: int
+    HVSOCKET_ADDRESS_FLAG_PASSTHRU: int
+    HV_GUID_ZERO: str
+    HV_GUID_WILDCARD: str
+    HV_GUID_BROADCAST: str
+    HV_GUID_CHILDREN: str
+    HV_GUID_LOOPBACK: str
+    HV_GUID_PARENT: str
+
+if sys.version_info >= (3, 12):
+    if sys.platform != "win32":
+        ETHERTYPE_ARP: int
+        ETHERTYPE_IP: int
+        ETHERTYPE_IPV6: int
+        ETHERTYPE_VLAN: int
+
+# --------------------
 # Semi-documented constants
-# (Listed under "Socket families" in the docs, but not "Constants")
+# These are alluded to under the "Socket families" section in the docs
+# https://docs.python.org/3/library/socket.html#socket-families
+# --------------------
 
 if sys.platform == "linux":
     # Netlink is defined by Linux
@@ -537,12 +604,13 @@ if sys.platform == "linux":
     NETLINK_W1: int
     NETLINK_XFRM: int
 
+if sys.platform == "darwin":
+    PF_SYSTEM: int
+    SYSPROTO_CONTROL: int
+
 if sys.platform != "darwin":
-    if sys.platform != "win32" or sys.version_info >= (3, 9):
+    if sys.version_info >= (3, 9) or sys.platform != "win32":
         AF_BLUETOOTH: int
-        BDADDR_ANY: str
-        BDADDR_LOCAL: str
-        BTPROTO_RFCOMM: int
 
 if sys.platform != "win32" and sys.platform != "darwin":
     # Linux and some BSD support is explicit in the docs
@@ -550,17 +618,66 @@ if sys.platform != "win32" and sys.platform != "darwin":
     BTPROTO_HCI: int
     BTPROTO_L2CAP: int
     BTPROTO_SCO: int  # not in FreeBSD
-    HCI_FILTER: int  # not in NetBSD or DragonFlyBSD
-    # not in FreeBSD, NetBSD, or DragonFlyBSD
-    HCI_TIME_STAMP: int
-    HCI_DATA_DIR: int
 
-if sys.platform == "darwin":
-    # PF_SYSTEM is defined by macOS
-    PF_SYSTEM: int
-    SYSPROTO_CONTROL: int
+if sys.platform != "darwin":
+    if sys.version_info >= (3, 9) or sys.platform != "win32":
+        BTPROTO_RFCOMM: int
 
-# ----- Exceptions -----
+if sys.version_info >= (3, 9) and sys.platform == "linux":
+    UDPLITE_RECV_CSCOV: int
+    UDPLITE_SEND_CSCOV: int
+
+# --------------------
+# Documented under socket.shutdown
+# --------------------
+SHUT_RD: int
+SHUT_RDWR: int
+SHUT_WR: int
+
+# --------------------
+# Undocumented constants
+# --------------------
+
+# Undocumented address families
+AF_APPLETALK: int
+AF_DECnet: int
+AF_IPX: int
+AF_SNA: int
+
+if sys.platform != "win32":
+    AF_ROUTE: int
+    AF_SYSTEM: int
+
+if sys.platform != "darwin":
+    AF_IRDA: int
+
+if sys.platform != "darwin" and sys.platform != "win32":
+    AF_AAL5: int
+    AF_ASH: int
+    AF_ATMPVC: int
+    AF_ATMSVC: int
+    AF_AX25: int
+    AF_BRIDGE: int
+    AF_ECONET: int
+    AF_KEY: int
+    AF_LLC: int
+    AF_NETBEUI: int
+    AF_NETROM: int
+    AF_PPPOX: int
+    AF_ROSE: int
+    AF_SECURITY: int
+    AF_WANPIPE: int
+    AF_X25: int
+
+# Miscellaneous undocumented
+
+if sys.platform != "win32":
+    LOCAL_PEERCRED: int
+
+if sys.platform != "win32" and sys.platform != "darwin":
+    IPX_TYPE: int
+
+# ===== Exceptions =====
 
 error = OSError
 
@@ -572,7 +689,7 @@ if sys.version_info >= (3, 10):
 else:
     class timeout(error): ...
 
-# ----- Classes -----
+# ===== Classes =====
 
 class socket:
     @property
@@ -648,7 +765,7 @@ class socket:
 
 SocketType = socket
 
-# ----- Functions -----
+# ===== Functions =====
 
 def close(__fd: _FD) -> None: ...
 def dup(__fd: _FD) -> int: ...
@@ -693,27 +810,4 @@ if sys.platform != "win32" or sys.version_info >= (3, 8):
     def if_nametoindex(__name: str) -> int: ...
     def if_indextoname(__index: int) -> str: ...
 
-if sys.version_info >= (3, 12):
-    IP_PKTINFO: int
-    IP_UNBLOCK_SOURCE: int
-    IP_BLOCK_SOURCE: int
-    IP_ADD_SOURCE_MEMBERSHIP: int
-    IP_DROP_SOURCE_MEMBERSHIP: int
-    if sys.platform == "win32":
-        AF_HYPERV: int
-        HV_PROTOCOL_RAW: int
-        HVSOCKET_CONNECT_TIMEOUT: int
-        HVSOCKET_CONNECT_TIMEOUT_MAX: int
-        HVSOCKET_CONNECTED_SUSPEND: int
-        HVSOCKET_ADDRESS_FLAG_PASSTHRU: int
-        HV_GUID_ZERO: str
-        HV_GUID_WILDCARD: str
-        HV_GUID_BROADCAST: str
-        HV_GUID_CHILDREN: str
-        HV_GUID_LOOPBACK: str
-        HV_GUID_PARENT: str
-    else:
-        ETHERTYPE_ARP: int
-        ETHERTYPE_IP: int
-        ETHERTYPE_IPV6: int
-        ETHERTYPE_VLAN: int
+CAPI: object

--- a/stdlib/_socket.pyi
+++ b/stdlib/_socket.pyi
@@ -618,7 +618,9 @@ if sys.platform != "win32" and sys.platform != "darwin":
     BTPROTO_HCI: int
     BTPROTO_L2CAP: int
     BTPROTO_SCO: int  # not in FreeBSD
-    BTPROTO_RFCOMM: int
+if sys.platform != "darwin":
+    if sys.version_info >= (3, 9) or sys.platform != "win32":
+        BTPROTO_RFCOMM: int
 
 if sys.version_info >= (3, 9) and sys.platform == "linux":
     UDPLITE_RECV_CSCOV: int

--- a/stdlib/_socket.pyi
+++ b/stdlib/_socket.pyi
@@ -78,6 +78,8 @@ SO_SNDLOWAT: int
 SO_SNDTIMEO: int
 SO_TYPE: int
 SO_USELOOPBACK: int
+if sys.platform == "win32":
+    SO_EXCLUSIVEADDRUSE: int
 if sys.platform != "win32":
     SO_REUSEPORT: int
 if sys.platform != "win32" and sys.platform != "darwin":
@@ -91,8 +93,6 @@ if sys.platform != "win32" and sys.platform != "darwin":
     SO_PRIORITY: int
     SO_PROTOCOL: int
     SO_SETFIB: int
-if sys.platform == "win32":
-    SO_EXCLUSIVEADDRUSE: int
 
 SOMAXCONN: int
 
@@ -102,6 +102,15 @@ MSG_OOB: int
 MSG_PEEK: int
 MSG_TRUNC: int
 MSG_WAITALL: int
+if sys.platform != "win32":
+    MSG_DONTWAIT: int
+    MSG_EOF: int
+    MSG_EOR: int
+    MSG_NOSIGNAL: int  # Sometimes this exists on darwin, sometimes not
+if sys.platform != "darwin":
+    MSG_BCAST: int
+    MSG_ERRQUEUE: int
+    MSG_MCAST: int
 if sys.platform != "win32" and sys.platform != "darwin":
     MSG_BTAG: int
     MSG_CMSG_CLOEXEC: int
@@ -110,15 +119,6 @@ if sys.platform != "win32" and sys.platform != "darwin":
     MSG_FASTOPEN: int
     MSG_MORE: int
     MSG_NOTIFICATION: int
-if sys.platform != "win32":
-    MSG_DONTWAIT: int
-    MSG_EOF: int
-    MSG_EOR: int
-    MSG_NOSIGNAL: int  # Sometimes this exists on darwin, sometimes not
-if sys.platform != "darwin":
-    MSG_BCAST: int
-    MSG_MCAST: int
-    MSG_ERRQUEUE: int
 
 SOL_IP: int
 SOL_SOCKET: int
@@ -135,7 +135,6 @@ if sys.platform != "win32" and sys.platform != "darwin":
 if sys.platform != "win32":
     SCM_CREDS: int
     SCM_RIGHTS: int
-
 if sys.platform != "win32" and sys.platform != "darwin":
     SCM_CREDENTIALS: int
 
@@ -144,7 +143,6 @@ IPPROTO_IP: int
 IPPROTO_RAW: int
 IPPROTO_TCP: int
 IPPROTO_UDP: int
-
 if sys.version_info >= (3, 8) or sys.platform != "win32":
     IPPROTO_AH: int
     IPPROTO_DSTOPTS: int
@@ -165,7 +163,6 @@ if sys.version_info >= (3, 8) or sys.platform != "win32":
     IPPROTO_PUP: int
     IPPROTO_ROUTING: int
     IPPROTO_SCTP: int
-
     if sys.platform != "darwin":
         IPPROTO_CBT: int
         IPPROTO_ICLFXBM: int
@@ -174,7 +171,6 @@ if sys.version_info >= (3, 8) or sys.platform != "win32":
         IPPROTO_PGM: int
         IPPROTO_RDP: int
         IPPROTO_ST: int
-
 if sys.platform != "win32":
     IPPROTO_EON: int
     IPPROTO_GRE: int
@@ -184,15 +180,12 @@ if sys.platform != "win32":
     IPPROTO_RSVP: int
     IPPROTO_TP: int
     IPPROTO_XTP: int
-
 if sys.platform != "win32" and sys.platform != "darwin":
     IPPROTO_BIP: int
     IPPROTO_MOBILE: int
     IPPROTO_VRRP: int
-
 if sys.version_info >= (3, 9) and sys.platform == "linux":
     IPPROTO_UDPLITE: int
-
 if sys.version_info >= (3, 10) and sys.platform == "linux":
     IPPROTO_MPTCP: int
 
@@ -221,7 +214,6 @@ elif sys.platform != "win32" and sys.platform != "darwin":
     IP_RECVTOS: int
 IP_TOS: int
 IP_TTL: int
-
 if sys.platform != "win32":
     IP_DEFAULT_MULTICAST_LOOP: int
     IP_DEFAULT_MULTICAST_TTL: int
@@ -229,11 +221,9 @@ if sys.platform != "win32":
     IP_RECVOPTS: int
     IP_RECVRETOPTS: int
     IP_RETOPTS: int
-
 if sys.platform != "win32" and sys.platform != "darwin":
     IP_TRANSPARENT: int
     IP_BIND_ADDRESS_NO_PORT: int
-
 if sys.version_info >= (3, 12):
     IP_ADD_SOURCE_MEMBERSHIP: int
     IP_BLOCK_SOURCE: int
@@ -251,7 +241,6 @@ IPV6_RECVTCLASS: int
 IPV6_TCLASS: int
 IPV6_UNICAST_HOPS: int
 IPV6_V6ONLY: int
-
 if sys.version_info >= (3, 9) or sys.platform != "darwin":
     IPV6_DONTFRAG: int
     IPV6_HOPLIMIT: int
@@ -259,8 +248,8 @@ if sys.version_info >= (3, 9) or sys.platform != "darwin":
     IPV6_PKTINFO: int
     IPV6_RECVRTHDR: int
     IPV6_RTHDR: int
-
 if sys.platform != "win32":
+    IPV6_RTHDR_TYPE_0: int
     if sys.version_info >= (3, 9) or sys.platform != "darwin":
         IPV6_DSTOPTS: int
         IPV6_NEXTHOP: int
@@ -273,9 +262,6 @@ if sys.platform != "win32":
         IPV6_RTHDRDSTOPTS: int
         IPV6_USE_MIN_MTU: int
 
-if sys.platform != "win32":
-    IPV6_RTHDR_TYPE_0: int
-
 EAI_AGAIN: int
 EAI_BADFLAGS: int
 EAI_FAIL: int
@@ -285,7 +271,6 @@ EAI_NODATA: int
 EAI_NONAME: int
 EAI_SERVICE: int
 EAI_SOCKTYPE: int
-
 if sys.platform != "win32":
     EAI_ADDRFAMILY: int
     EAI_BADHINTS: int
@@ -301,7 +286,6 @@ AI_NUMERICHOST: int
 AI_NUMERICSERV: int
 AI_PASSIVE: int
 AI_V4MAPPED: int
-
 if sys.platform != "win32":
     AI_DEFAULT: int
     AI_MASK: int
@@ -320,11 +304,10 @@ TCP_KEEPCNT: int
 TCP_KEEPINTVL: int
 TCP_MAXSEG: int
 TCP_NODELAY: int
-
-if sys.platform != "darwin":
-    TCP_KEEPIDLE: int
 if sys.platform != "win32":
     TCP_NOTSENT_LOWAT: int
+if sys.platform != "darwin":
+    TCP_KEEPIDLE: int
 if sys.version_info >= (3, 10) and sys.platform == "darwin":
     TCP_KEEPALIVE: int
 if sys.version_info >= (3, 11) and sys.platform == "darwin":
@@ -651,7 +634,7 @@ if sys.platform != "win32":
 if sys.platform != "darwin":
     AF_IRDA: int
 
-if sys.platform != "darwin" and sys.platform != "win32":
+if sys.platform != "win32" and sys.platform != "darwin":
     AF_AAL5: int
     AF_ASH: int
     AF_ATMPVC: int

--- a/stdlib/_socket.pyi
+++ b/stdlib/_socket.pyi
@@ -39,6 +39,7 @@ SOCK_RDM: int
 SOCK_SEQPACKET: int
 
 if sys.platform == "linux":
+    # Availability: Linux >= 2.6.27
     SOCK_CLOEXEC: int
     SOCK_NONBLOCK: int
 
@@ -185,6 +186,7 @@ if sys.platform != "win32" and sys.platform != "darwin":
     IPPROTO_MOBILE: int
     IPPROTO_VRRP: int
 if sys.version_info >= (3, 9) and sys.platform == "linux":
+    # Availability: Linux >= 2.6.20, FreeBSD >= 10.1
     IPPROTO_UDPLITE: int
 if sys.version_info >= (3, 10) and sys.platform == "linux":
     IPPROTO_MPTCP: int
@@ -329,6 +331,7 @@ if sys.platform != "win32" and sys.platform != "darwin":
 # --------------------
 
 if sys.platform == "linux":
+    # Availability: Linux >= 2.6.25, NetBSD >= 8
     AF_CAN: int
     PF_CAN: int
     SOL_CAN_BASE: int
@@ -346,6 +349,7 @@ if sys.platform == "linux":
     CAN_SFF_MASK: int
 
 if sys.platform == "linux":
+    # Availability: Linux >= 2.6.25
     CAN_BCM: int
     CAN_BCM_TX_SETUP: int
     CAN_BCM_TX_DELETE: int
@@ -375,15 +379,19 @@ if sys.platform == "linux":
         CAN_BCM_CAN_FD_FRAME: int
 
 if sys.platform == "linux":
+    # Availability: Linux >= 3.6
     CAN_RAW_FD_FRAMES: int
 
 if sys.platform == "linux" and sys.version_info >= (3, 9):
+    # Availability: Linux >= 4.1
     CAN_RAW_JOIN_FILTERS: int
 
 if sys.platform == "linux":
+    # Availability: Linux >= 2.6.25
     CAN_ISOTP: int
 
 if sys.platform == "linux" and sys.version_info >= (3, 9):
+    # Availability: Linux >= 5.4
     CAN_J1939: int
 
     J1939_MAX_UNICAST_ADDR: int
@@ -414,10 +422,12 @@ if sys.platform == "linux" and sys.version_info >= (3, 9):
     J1939_FILTER_MAX: int
 
 if sys.version_info >= (3, 12) and sys.platform != "linux" and sys.platform != "win32" and sys.platform != "darwin":
+    # Availability: FreeBSD >= 14.0
     AF_DIVERT: int
     PF_DIVERT: int
 
 if sys.platform == "linux":
+    # Availability: Linux >= 2.2
     AF_PACKET: int
     PF_PACKET: int
     PACKET_BROADCAST: int
@@ -432,6 +442,7 @@ if sys.version_info >= (3, 12) and sys.platform == "linux":
     ETH_P_ALL: int
 
 if sys.platform == "linux":
+    # Availability: Linux >= 2.6.30
     AF_RDS: int
     PF_RDS: int
     SOL_RDS: int
@@ -491,6 +502,7 @@ if sys.platform == "linux":
     TIPC_ZONE_SCOPE: int
 
 if sys.platform == "linux":
+    # Availability: Linux >= 2.6.38
     AF_ALG: int
     SOL_ALG: int
     ALG_OP_DECRYPT: int
@@ -505,6 +517,7 @@ if sys.platform == "linux":
     ALG_SET_PUBKEY: int
 
 if sys.platform == "linux":
+    # Availability: Linux >= 4.8 (or maybe 3.9, CPython docs are confusing)
     AF_VSOCK: int
     IOCTL_VM_SOCKETS_GET_LOCAL_CID: int
     VMADDR_CID_ANY: int
@@ -515,8 +528,10 @@ if sys.platform == "linux":
     SO_VM_SOCKETS_BUFFER_MIN_SIZE: int
     VM_SOCKETS_INVALID_VERSION: int  # undocumented
 
-if sys.platform == "darwin":
-    AF_LINK: int  # BSD, macOS
+if sys.platform != "win32" or sys.version_info >= (3, 9):
+    # Documented as only available on BSD, macOS, but empirically sometimes
+    # available on Windows
+    AF_LINK: int
 
 has_ipv6: bool
 
@@ -531,7 +546,7 @@ if sys.platform != "win32" and sys.platform != "darwin":
     HCI_DATA_DIR: int  # not in FreeBSD, NetBSD, or DragonFlyBSD
 
 if sys.platform == "linux" and sys.version_info >= (3, 8):
-    AF_QIPCRTR: int
+    AF_QIPCRTR: int  # Availability: Linux >= 4.7
 
 if sys.version_info >= (3, 11) and sys.platform != "linux" and sys.platform != "win32" and sys.platform != "darwin":
     # FreeBSD
@@ -540,9 +555,10 @@ if sys.version_info >= (3, 11) and sys.platform != "linux" and sys.platform != "
     LOCAL_CREDS_PERSISTENT: int
 
 if sys.version_info >= (3, 11) and sys.platform == "linux":
-    SO_INCOMING_CPU: int
+    SO_INCOMING_CPU: int  # Availability: Linux >= 3.9
 
 if sys.version_info >= (3, 12) and sys.platform == "win32":
+    # Availability: Windows
     AF_HYPERV: int
     HV_PROTOCOL_RAW: int
     HVSOCKET_CONNECT_TIMEOUT: int
@@ -558,6 +574,7 @@ if sys.version_info >= (3, 12) and sys.platform == "win32":
 
 if sys.version_info >= (3, 12):
     if sys.platform != "win32":
+        # Availability: Linux, FreeBSD, macOS
         ETHERTYPE_ARP: int
         ETHERTYPE_IP: int
         ETHERTYPE_IPV6: int
@@ -601,10 +618,7 @@ if sys.platform != "win32" and sys.platform != "darwin":
     BTPROTO_HCI: int
     BTPROTO_L2CAP: int
     BTPROTO_SCO: int  # not in FreeBSD
-
-if sys.platform != "darwin":
-    if sys.version_info >= (3, 9) or sys.platform != "win32":
-        BTPROTO_RFCOMM: int
+    BTPROTO_RFCOMM: int
 
 if sys.version_info >= (3, 9) and sys.platform == "linux":
     UDPLITE_RECV_CSCOV: int

--- a/stdlib/_socket.pyi
+++ b/stdlib/_socket.pyi
@@ -234,12 +234,12 @@ if sys.platform != "win32" and sys.platform != "darwin":
     IP_TRANSPARENT: int
     IP_BIND_ADDRESS_NO_PORT: int
 
-if sys.version_info >= (3, 12) and sys.platform == "win32":
+if sys.version_info >= (3, 12):
+    IP_ADD_SOURCE_MEMBERSHIP: int
+    IP_BLOCK_SOURCE: int
+    IP_DROP_SOURCE_MEMBERSHIP: int
     IP_PKTINFO: int
     IP_UNBLOCK_SOURCE: int
-    IP_BLOCK_SOURCE: int
-    IP_ADD_SOURCE_MEMBERSHIP: int
-    IP_DROP_SOURCE_MEMBERSHIP: int
 
 IPV6_CHECKSUM: int
 IPV6_JOIN_GROUP: int

--- a/stdlib/socket.pyi
+++ b/stdlib/socket.pyi
@@ -190,6 +190,7 @@ if sys.platform != "win32" or sys.version_info >= (3, 8):
         )
 if sys.platform != "win32" and sys.platform != "darwin":
     from _socket import (
+        IP_BIND_ADDRESS_NO_PORT as IP_BIND_ADDRESS_NO_PORT,
         IP_TRANSPARENT as IP_TRANSPARENT,
         IPPROTO_BIP as IPPROTO_BIP,
         IPPROTO_MOBILE as IPPROTO_MOBILE,
@@ -221,8 +222,6 @@ if sys.platform != "win32" and sys.platform != "darwin":
         TCP_SYNCNT as TCP_SYNCNT,
         TCP_USER_TIMEOUT as TCP_USER_TIMEOUT,
         TCP_WINDOW_CLAMP as TCP_WINDOW_CLAMP,
-        IP_TRANSPARENT as IP_TRANSPARENT,
-        IP_BIND_ADDRESS_NO_PORT as IP_BIND_ADDRESS_NO_PORT,
     )
 if sys.platform != "win32":
     from _socket import (

--- a/stdlib/socket.pyi
+++ b/stdlib/socket.pyi
@@ -152,7 +152,7 @@ if sys.platform != "darwin":
 
 if sys.version_info >= (3, 10):
     from _socket import IP_RECVTOS as IP_RECVTOS
-elif sys.platform != "darwin" and sys.platform != "win32":
+elif sys.platform != "win32" and sys.platform != "darwin":
     from _socket import IP_RECVTOS as IP_RECVTOS
 
 if sys.platform != "win32" or sys.version_info >= (3, 8):
@@ -504,7 +504,7 @@ class AddressFamily(IntEnum):
         AF_ROUTE: int
         AF_SYSTEM: int
         AF_UNIX: int
-    if sys.platform != "darwin" and sys.platform != "win32":
+    if sys.platform != "win32" and sys.platform != "darwin":
         AF_AAL5: int
         AF_ASH: int
         AF_ATMPVC: int

--- a/stdlib/socket.pyi
+++ b/stdlib/socket.pyi
@@ -5,6 +5,7 @@ import _socket
 import sys
 from _socket import (
     _FD,
+    CAPI as CAPI,
     EAI_AGAIN as EAI_AGAIN,
     EAI_BADFLAGS as EAI_BADFLAGS,
     EAI_FAIL as EAI_FAIL,
@@ -82,11 +83,13 @@ from _socket import (
     SOMAXCONN as SOMAXCONN,
     TCP_FASTOPEN as TCP_FASTOPEN,
     TCP_KEEPCNT as TCP_KEEPCNT,
+    TCP_KEEPINTVL as TCP_KEEPINTVL,
     TCP_MAXSEG as TCP_MAXSEG,
     TCP_NODELAY as TCP_NODELAY,
     SocketType as SocketType,
     _Address as _Address,
     _RetAddress as _RetAddress,
+    close as close,
     dup as dup,
     error as error,
     gaierror as gaierror,
@@ -119,6 +122,18 @@ from io import BufferedReader, BufferedRWPair, BufferedWriter, IOBase, RawIOBase
 from typing import Any, Protocol, overload
 from typing_extensions import Literal, Self
 
+if sys.platform == "win32":
+    from _socket import (
+        RCVALL_MAX as RCVALL_MAX,
+        RCVALL_OFF as RCVALL_OFF,
+        RCVALL_ON as RCVALL_ON,
+        RCVALL_SOCKETLEVELONLY as RCVALL_SOCKETLEVELONLY,
+        SIO_KEEPALIVE_VALS as SIO_KEEPALIVE_VALS,
+        SIO_LOOPBACK_FAST_PATH as SIO_LOOPBACK_FAST_PATH,
+        SIO_RCVALL as SIO_RCVALL,
+        SO_EXCLUSIVEADDRUSE as SO_EXCLUSIVEADDRUSE,
+    )
+
 if sys.platform != "darwin" or sys.version_info >= (3, 9):
     from _socket import (
         IPV6_DONTFRAG as IPV6_DONTFRAG,
@@ -131,18 +146,14 @@ if sys.platform != "darwin" or sys.version_info >= (3, 9):
 
 if sys.platform == "darwin":
     from _socket import PF_SYSTEM as PF_SYSTEM, SYSPROTO_CONTROL as SYSPROTO_CONTROL
-else:
-    from _socket import SO_EXCLUSIVEADDRUSE as SO_EXCLUSIVEADDRUSE
+
+if sys.platform != "darwin":
+    from _socket import TCP_KEEPIDLE as TCP_KEEPIDLE
 
 if sys.version_info >= (3, 10):
     from _socket import IP_RECVTOS as IP_RECVTOS
 elif sys.platform != "darwin" and sys.platform != "win32":
     from _socket import IP_RECVTOS as IP_RECVTOS
-
-from _socket import TCP_KEEPINTVL as TCP_KEEPINTVL, close as close
-
-if sys.platform != "darwin":
-    from _socket import TCP_KEEPIDLE as TCP_KEEPIDLE
 
 if sys.platform != "win32" or sys.version_info >= (3, 8):
     from _socket import (
@@ -186,10 +197,14 @@ if sys.platform != "win32" and sys.platform != "darwin":
         IPX_TYPE as IPX_TYPE,
         SCM_CREDENTIALS as SCM_CREDENTIALS,
         SO_BINDTODEVICE as SO_BINDTODEVICE,
+        SO_DOMAIN as SO_DOMAIN,
         SO_MARK as SO_MARK,
         SO_PASSCRED as SO_PASSCRED,
+        SO_PASSSEC as SO_PASSSEC,
         SO_PEERCRED as SO_PEERCRED,
+        SO_PEERSEC as SO_PEERSEC,
         SO_PRIORITY as SO_PRIORITY,
+        SO_PROTOCOL as SO_PROTOCOL,
         SO_SETFIB as SO_SETFIB,
         SOL_ATALK as SOL_ATALK,
         SOL_AX25 as SOL_AX25,
@@ -197,6 +212,7 @@ if sys.platform != "win32" and sys.platform != "darwin":
         SOL_IPX as SOL_IPX,
         SOL_NETROM as SOL_NETROM,
         SOL_ROSE as SOL_ROSE,
+        TCP_CONGESTION as TCP_CONGESTION,
         TCP_CORK as TCP_CORK,
         TCP_DEFER_ACCEPT as TCP_DEFER_ACCEPT,
         TCP_INFO as TCP_INFO,
@@ -205,6 +221,8 @@ if sys.platform != "win32" and sys.platform != "darwin":
         TCP_SYNCNT as TCP_SYNCNT,
         TCP_USER_TIMEOUT as TCP_USER_TIMEOUT,
         TCP_WINDOW_CLAMP as TCP_WINDOW_CLAMP,
+        IP_TRANSPARENT as IP_TRANSPARENT,
+        IP_BIND_ADDRESS_NO_PORT as IP_BIND_ADDRESS_NO_PORT,
     )
 if sys.platform != "win32":
     from _socket import (
@@ -261,6 +279,9 @@ if sys.platform != "darwin":
 
 if sys.platform == "darwin" and sys.version_info >= (3, 10):
     from _socket import TCP_KEEPALIVE as TCP_KEEPALIVE
+
+if sys.platform == "darwin" and sys.version_info >= (3, 11):
+    from _socket import TCP_CONNECTION_INFO as TCP_CONNECTION_INFO
 
 if sys.platform == "linux":
     from _socket import (
@@ -426,21 +447,14 @@ if sys.platform == "linux" and sys.version_info >= (3, 9):
         SO_J1939_FILTER as SO_J1939_FILTER,
         SO_J1939_PROMISC as SO_J1939_PROMISC,
         SO_J1939_SEND_PRIO as SO_J1939_SEND_PRIO,
+        UDPLITE_RECV_CSCOV as UDPLITE_RECV_CSCOV,
+        UDPLITE_SEND_CSCOV as UDPLITE_SEND_CSCOV,
     )
 if sys.platform == "linux" and sys.version_info >= (3, 10):
     from _socket import IPPROTO_MPTCP as IPPROTO_MPTCP
 if sys.platform == "linux" and sys.version_info >= (3, 11):
     from _socket import SO_INCOMING_CPU as SO_INCOMING_CPU
-if sys.platform == "win32":
-    from _socket import (
-        RCVALL_MAX as RCVALL_MAX,
-        RCVALL_OFF as RCVALL_OFF,
-        RCVALL_ON as RCVALL_ON,
-        RCVALL_SOCKETLEVELONLY as RCVALL_SOCKETLEVELONLY,
-        SIO_KEEPALIVE_VALS as SIO_KEEPALIVE_VALS,
-        SIO_LOOPBACK_FAST_PATH as SIO_LOOPBACK_FAST_PATH,
-        SIO_RCVALL as SIO_RCVALL,
-    )
+
 if sys.version_info >= (3, 12):
     from _socket import (
         IP_ADD_SOURCE_MEMBERSHIP as IP_ADD_SOURCE_MEMBERSHIP,
@@ -471,8 +485,6 @@ if sys.version_info >= (3, 12):
             ETHERTYPE_IPV6 as ETHERTYPE_IPV6,
             ETHERTYPE_VLAN as ETHERTYPE_VLAN,
         )
-if sys.version_info >= (3, 11) and sys.platform == "darwin":
-    from _socket import TCP_CONNECTION_INFO as TCP_CONNECTION_INFO
 
 # Re-exported from errno
 EBADF: int

--- a/tests/stubtest_allowlists/py3_common.txt
+++ b/tests/stubtest_allowlists/py3_common.txt
@@ -198,7 +198,6 @@ xml.sax.expatreader
 # Module members that exist at runtime, but are missing from stubs
 # ==========
 _json.encode_basestring
-_socket.CAPI
 _thread.LockType.acquire_lock
 _thread.LockType.locked_lock
 _thread.LockType.release_lock
@@ -249,7 +248,6 @@ multiprocessing.managers.SyncManager.Pool
 multiprocessing.pool.Pool.Process
 multiprocessing.pool.ThreadPool.Process
 multiprocessing.synchronize.Semaphore.get_value
-socket.CAPI
 tkinter.Misc.config
 tkinter.font.Font.counter
 tkinter.tix.CObjView


### PR DESCRIPTION
Match the documentation more closely

Fixes some of #8101 , in particular I no longer see any missing constants on the Linux machines I have access to