### PR TITLE
Update description of `_typeshed.Self`

### DIFF
--- a/stdlib/_typeshed/__init__.pyi
+++ b/stdlib/_typeshed/__init__.pyi
@@ -19,6 +19,10 @@ _T = TypeVar("_T")
 _T_co = TypeVar("_T_co", covariant=True)
 _T_contra = TypeVar("_T_contra", contravariant=True)
 
+# Alternative to `typing_extensions.Self`, for use with `__new__`:
+#     def __new__(cls: type[Self], ...) -> Self: ...
+Self = TypeVar("Self")  # noqa: Y001
+
 # covariant version of typing.AnyStr, useful for protocols
 AnyStr_co = TypeVar("AnyStr_co", str, bytes, covariant=True)  # noqa: Y001
 

--- a/stdlib/_typeshed/__init__.pyi
+++ b/stdlib/_typeshed/__init__.pyi
@@ -21,6 +21,7 @@ _T_contra = TypeVar("_T_contra", contravariant=True)
 
 # Alternative to `typing_extensions.Self`, for use with `__new__`:
 #     def __new__(cls: type[Self], ...) -> Self: ...
+# In other cases, use `typing_extensions.Self`.
 Self = TypeVar("Self")  # noqa: Y001
 
 # covariant version of typing.AnyStr, useful for protocols

--- a/stdlib/_typeshed/__init__.pyi
+++ b/stdlib/_typeshed/__init__.pyi
@@ -19,10 +19,6 @@ _T = TypeVar("_T")
 _T_co = TypeVar("_T_co", covariant=True)
 _T_contra = TypeVar("_T_contra", contravariant=True)
 
-# Use for "self" annotations:
-#   def __enter__(self: Self) -> Self: ...
-Self = TypeVar("Self")  # noqa: Y001
-
 # covariant version of typing.AnyStr, useful for protocols
 AnyStr_co = TypeVar("AnyStr_co", str, bytes, covariant=True)  # noqa: Y001
 

--- a/stdlib/_typeshed/__init__.pyi
+++ b/stdlib/_typeshed/__init__.pyi
@@ -19,7 +19,8 @@ _T = TypeVar("_T")
 _T_co = TypeVar("_T_co", covariant=True)
 _T_contra = TypeVar("_T_contra", contravariant=True)
 
-# Alternative to `typing_extensions.Self`, for use with `__new__`:
+# Alternative to `typing_extensions.Self`, exclusively for use with `__new__`
+# in metaclasses:
 #     def __new__(cls: type[Self], ...) -> Self: ...
 # In other cases, use `typing_extensions.Self`.
 Self = TypeVar("Self")  # noqa: Y001


### PR DESCRIPTION
~~This was never marked as "stable" and all uses have been replaced with `typing_extensions.Self`.~~
