### PR TITLE
Ignore Y023 in generated `*_pb2.pyi` files

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -36,8 +36,9 @@ per-file-ignores =
   # https://github.com/PyCQA/flake8/issues/1079
   #     F811 redefinition of unused '...'
   stdlib/typing.pyi: B, E701, E741, F401, F403, F405, F811
-  # Generated protobuf files include docstrings
-  *_pb2.pyi: B, E701, E741, F401, F403, F405, Y021, Y026, Y053, Y054
+  # Generated protobuf files include docstrings,
+  # and import some things from typing_extensions that could be imported from typing
+  *_pb2.pyi: B, E701, E741, F401, F403, F405, Y021, Y023, Y026, Y053, Y054
 
 exclude = .venv*,.git
 noqa_require_code = true


### PR DESCRIPTION
Temporary workaround to unblock https://github.com/PyCQA/flake8-pyi/pull/459. Longer term, we can create issues/PRs over at mypy-protobuf so that the generated stubs import these things from typing rather than typing_extensions.