### PR TITLE
protobuf: Prevent namespace package google from having a py.typed file at root

### DIFF
--- a/stubs/protobuf/METADATA.toml
+++ b/stubs/protobuf/METADATA.toml
@@ -1,7 +1,9 @@
 version = "4.24.*"
 upstream_repository = "https://github.com/protocolbuffers/protobuf"
 extra_description = "Generated using [mypy-protobuf==3.5.0](https://github.com/nipunn1313/mypy-protobuf/tree/v3.5.0) on protobuf==4.21.8"
-partial_stub = true
+# Namespace packages shouldn't have py.typed files at the root. See #11254
+# This could be better reolved in stub_uploader, but in the mean time, this stays false.
+partial_stub = false
 
 [tool.stubtest]
 ignore_missing_stub = true


### PR DESCRIPTION
Short-term fix for #11254 (see discussion in the issue)

Long story short, assuming I got everything right: Spec says that namespace stubs-only packages should either not have a `py.typed` marker (which is already do for complete stubs) or that it should be in the submodules, not at root (we add a `py.typed` file at root for partial stubs).

mypy gets tripped up by the presence of the file. And it is not mypy's fault as it's within spec. This could be improved in stub_uploader. But the short term fix is simply to not generate a partial `py.typed` marker file for this stub at all.