### PR TITLE
`POEntry.msgstr_plural` is mistyped in polib

### DIFF
--- a/stubs/polib/polib.pyi
+++ b/stubs/polib/polib.pyi
@@ -70,7 +70,7 @@ class _BaseEntry:
     msgid: str
     msgstr: str
     msgid_plural: str
-    msgstr_plural: dict(int, str)
+    msgstr_plural: dict[int, str]
     msgctxt: str
     obsolete: bool
     encoding: str

--- a/stubs/polib/polib.pyi
+++ b/stubs/polib/polib.pyi
@@ -70,7 +70,7 @@ class _BaseEntry:
     msgid: str
     msgstr: str
     msgid_plural: str
-    msgstr_plural: list[str]
+    msgstr_plural: dict(int, str)
     msgctxt: str
     obsolete: bool
     encoding: str


### PR DESCRIPTION
Closes #11274 