### PR TITLE
Fix types for `setuptools._distutils.ccompiler.CCompiler.compile`

### DIFF
--- a/stdlib/distutils/ccompiler.pyi
+++ b/stdlib/distutils/ccompiler.pyi
@@ -56,7 +56,7 @@ class CCompiler:
         self,
         sources: list[str],
         output_dir: str | None = None,
-        macros: _Macro | None = None,
+        macros: list[_Macro] | None = None,
         include_dirs: list[str] | None = None,
         debug: bool = ...,
         extra_preargs: list[str] | None = None,

--- a/stubs/setuptools/setuptools/_distutils/ccompiler.pyi
+++ b/stubs/setuptools/setuptools/_distutils/ccompiler.pyi
@@ -65,7 +65,7 @@ class CCompiler:
         self,
         sources: list[str],
         output_dir: str | None = ...,
-        macros: _Macro | None = ...,
+        macros: list[_Macro] | None = ...,
         include_dirs: list[str] | None = ...,
         debug: bool = ...,
         extra_preargs: list[str] | None = ...,


### PR DESCRIPTION
Fixed types for `setuptools._distutils.CCompiler.compile`, fixes #11271.


Also fixed the types in the `distutils` in `stdlib`, let me know if I should undo changing the one in `stdlib` (see the comment in the `__init__.pyi`):
https://github.com/python/typeshed/blob/8e8204b83f68d807c2a8bb9df3298fe92f5684df/stdlib/distutils/__init__.pyi#L1-L5