### PR TITLE
`defusedxml`: Add xml.dom.minidom.Document return type annotation

### DIFF
--- a/stubs/defusedxml/defusedxml/minidom.pyi
+++ b/stubs/defusedxml/defusedxml/minidom.pyi
@@ -1,4 +1,5 @@
 from _typeshed import Incomplete
+from xml.dom.minidom import Document
 
 __origin__: str
 
@@ -9,11 +10,11 @@ def parse(
     forbid_dtd: bool = False,
     forbid_entities: bool = True,
     forbid_external: bool = True,
-): ...
+) -> Document: ...
 def parseString(
     string: str,
     parser: Incomplete | None = None,
     forbid_dtd: bool = False,
     forbid_entities: bool = True,
     forbid_external: bool = True,
-): ...
+) -> Document: ...


### PR DESCRIPTION
This is a follow-up to #11179 (thanks again @solkaz)

This PR just adds the return types to the minidom methods [as discussed](https://github.com/python/typeshed/pull/11179#issuecomment-1893201330).