### PR TITLE
ldap3: Connection: auto_bind also supports booleans

### DIFF
--- a/stubs/ldap3/ldap3/core/connection.pyi
+++ b/stubs/ldap3/ldap3/core/connection.pyi
@@ -70,7 +70,7 @@ class Connection:
         server: Server | str | _ServerSequence | ServerPool,
         user: str | None = None,
         password: str | None = None,
-        auto_bind: Literal["DEFAULT", "NONE", "NO_TLS", "TLS_BEFORE_BIND", "TLS_AFTER_BIND"] = "DEFAULT",
+        auto_bind: Literal["DEFAULT", "NONE", "NO_TLS", "TLS_BEFORE_BIND", "TLS_AFTER_BIND"] | bool = "DEFAULT",
         version: int = 3,
         authentication: Literal["ANONYMOUS", "SIMPLE", "SASL", "NTLM"] | None = None,
         client_strategy: Literal[


### PR DESCRIPTION
Earlier ldap3 versions only accepted booleans as auto_bind values, and
they are still supported and used in various places in upstream
documentation (e.g. at [0]).

[0]: https://ldap3.readthedocs.io/en/latest/bind.html?highlight=auto_bind
