### PR TITLE
Add `convert_to_tensor` to `tensorflow`

### DIFF
--- a/stubs/tensorflow/tensorflow/__init__.pyi
+++ b/stubs/tensorflow/tensorflow/__init__.pyi
@@ -407,5 +407,8 @@ class RaggedTensorSpec(TypeSpec[struct_pb2.TypeSpecProto]):
 
 def __getattr__(name: str) -> Incomplete: ...
 def convert_to_tensor(
-    value: _TensorCompatible | IndexedSlices, dtype: _DTypeLike | None = None, dtype_hint: _DTypeLike | None = None, name: str | None = None
+    value: _TensorCompatible | IndexedSlices,
+    dtype: _DTypeLike | None = None,
+    dtype_hint: _DTypeLike | None = None,
+    name: str | None = None,
 ) -> Tensor: ...

--- a/stubs/tensorflow/tensorflow/__init__.pyi
+++ b/stubs/tensorflow/tensorflow/__init__.pyi
@@ -406,10 +406,6 @@ class RaggedTensorSpec(TypeSpec[struct_pb2.TypeSpecProto]):
     def from_value(cls, value: RaggedTensor) -> Self: ...
 
 def __getattr__(name: str) -> Incomplete: ...
-
 def convert_to_tensor(
-    value: _TensorCompatible,
-    dtype: DType | None = None,
-    dtype_hint: DType | None = None,
-    name: str | None = None
+    value: _TensorCompatible, dtype: DType | None = None, dtype_hint: DType | None = None, name: str | None = None
 ) -> Tensor: ...

--- a/stubs/tensorflow/tensorflow/__init__.pyi
+++ b/stubs/tensorflow/tensorflow/__init__.pyi
@@ -406,3 +406,10 @@ class RaggedTensorSpec(TypeSpec[struct_pb2.TypeSpecProto]):
     def from_value(cls, value: RaggedTensor) -> Self: ...
 
 def __getattr__(name: str) -> Incomplete: ...
+
+def convert_to_tensor(
+    value: _TensorCompatible,
+    dtype: DType | None = None,
+    dtype_hint: DType | None = None,
+    name: str | None = None
+) -> Tensor: ...

--- a/stubs/tensorflow/tensorflow/__init__.pyi
+++ b/stubs/tensorflow/tensorflow/__init__.pyi
@@ -407,5 +407,5 @@ class RaggedTensorSpec(TypeSpec[struct_pb2.TypeSpecProto]):
 
 def __getattr__(name: str) -> Incomplete: ...
 def convert_to_tensor(
-    value: _TensorCompatible, dtype: DType | None = None, dtype_hint: DType | None = None, name: str | None = None
+    value: _TensorCompatible | IndexedSlices, dtype: _DTypeLike | None = None, dtype_hint: _DTypeLike | None = None, name: str | None = None
 ) -> Tensor: ...


### PR DESCRIPTION
Add the [convert_to_tensor](https://www.tensorflow.org/api_docs/python/tf/convert_to_tensor) TensorFlow function.

The actual return type of the function is `Union[EagerTensor, SymbolicTensor]` (cf [the tensorflow function](https://github.com/tensorflow/tensorflow/blob/ac478d8173f9c0c63b1d215e6f6aa85b10d5cb7e/tensorflow/python/framework/ops.py#L685)), however those are not present in the stub yet, should they be added ?

I would like to help complete the TensorFlow stubs, so I would be thankful if you could tell me anything I would need to know in order to contribute.