### PR TITLE
tkinter: font size must be integer

### DIFF
--- a/stdlib/tkinter/font.pyi
+++ b/stdlib/tkinter/font.pyi
@@ -15,8 +15,11 @@ ITALIC: Literal["italic"]
 _FontDescription: TypeAlias = (
     str  # "Helvetica 12"
     | Font  # A font object constructed in Python
-    | list[Any]  # ("Helvetica", 12, BOLD)
-    | tuple[Any, ...]
+    | list[Any]  # ["Helvetica", 12, BOLD]
+    | tuple[str]  # ("Liberation Sans",) needs wrapping in tuple/list to handle spaces
+    | tuple[str, int]  # ("Liberation Sans", 12)
+    | tuple[str, int, str]  # ("Liberation Sans", 12, "bold")
+    | tuple[str, int, list[str] | tuple[str, ...]]  # e.g. bold and italic
     | _tkinter.Tcl_Obj  # A font object constructed in Tcl
 )
 

--- a/test_cases/stdlib/check_tkinter.py
+++ b/test_cases/stdlib/check_tkinter.py
@@ -20,3 +20,11 @@ def foo(x: int, y: str) -> None:
 
 root.after(1000, foo, 10, "lol")
 root.after(1000, foo, 10, 10)  # type: ignore
+
+
+# Font size must be integer
+label = tkinter.Label()
+label.config(font=("", 12))
+label.config(font=("", 12.34))  # type: ignore
+label.config(font=("", 12, "bold"))
+label.config(font=("", 12.34, "bold"))  # type: ignore


### PR DESCRIPTION
Fixes #11270 