### PR TITLE
issue-11282: psycopg2 ReplicationConnection.cursor() return type

### DIFF
--- a/stubs/psycopg2/psycopg2/_psycopg.pyi
+++ b/stubs/psycopg2/psycopg2/_psycopg.pyi
@@ -6,6 +6,7 @@ from typing import Any, Literal, NoReturn, Protocol, TypeVar, overload, type_che
 from typing_extensions import Self, TypeAlias
 
 from psycopg2.sql import Composable
+from psycopg2.extras import ReplicationCursor as extras_ReplicationCursor
 
 _Vars: TypeAlias = Sequence[Any] | Mapping[str, Any] | None
 
@@ -516,6 +517,30 @@ class ReplicationConnection(connection):
     set_isolation_level: Any
     set_session: Any
     def __init__(self, *args, **kwargs) -> None: ...
+    @overload
+    def cursor(
+        self, name: str | bytes | None = None, cursor_factory: None = None, withhold: bool = False, scrollable: bool | None = None
+    ) -> extras_ReplicationCursor: ...
+    # https://github.com/python/typeshed/issues/11282
+    # There should be exactly extras.ReplicationCursor (not _psycopg.ReplicationCursor)
+    # See the C code: replicationConnection_init(), psyco_conn_cursor()
+    @overload
+    def cursor(
+        self,
+        name: str | bytes | None = None,
+        *,
+        cursor_factory: Callable[[connection, str | bytes | None], _T_cur],
+        withhold: bool = False,
+        scrollable: bool | None = None,
+    ) -> _T_cur: ...
+    @overload
+    def cursor(
+        self,
+        name: str | bytes | None,
+        cursor_factory: Callable[[connection, str | bytes | None], _T_cur],
+        withhold: bool = False,
+        scrollable: bool | None = None,
+    ) -> _T_cur: ...
 
 class lobject:
     closed: Any

--- a/stubs/psycopg2/psycopg2/_psycopg.pyi
+++ b/stubs/psycopg2/psycopg2/_psycopg.pyi
@@ -517,13 +517,13 @@ class ReplicationConnection(connection):
     set_isolation_level: Any
     set_session: Any
     def __init__(self, *args, **kwargs) -> None: ...
+    # https://github.com/python/typeshed/issues/11282
+    # The return type should be exactly extras.ReplicationCursor (not _psycopg.ReplicationCursor)
+    # See the C code: replicationConnection_init(), psyco_conn_cursor()
     @overload
     def cursor(
         self, name: str | bytes | None = None, cursor_factory: None = None, withhold: bool = False, scrollable: bool | None = None
     ) -> extras_ReplicationCursor: ...
-    # https://github.com/python/typeshed/issues/11282
-    # There should be exactly extras.ReplicationCursor (not _psycopg.ReplicationCursor)
-    # See the C code: replicationConnection_init(), psyco_conn_cursor()
     @overload
     def cursor(
         self,

--- a/stubs/psycopg2/psycopg2/_psycopg.pyi
+++ b/stubs/psycopg2/psycopg2/_psycopg.pyi
@@ -5,8 +5,8 @@ from types import TracebackType
 from typing import Any, Literal, NoReturn, Protocol, TypeVar, overload, type_check_only
 from typing_extensions import Self, TypeAlias
 
-from psycopg2.sql import Composable
 from psycopg2.extras import ReplicationCursor as extras_ReplicationCursor
+from psycopg2.sql import Composable
 
 _Vars: TypeAlias = Sequence[Any] | Mapping[str, Any] | None
 


### PR DESCRIPTION
Fix https://github.com/python/typeshed/issues/11282