### PR TITLE
Add a number of properties to PIL.ImageStat.Stat

### DIFF
--- a/stubs/Pillow/PIL/ImageStat.pyi
+++ b/stubs/Pillow/PIL/ImageStat.pyi
@@ -3,6 +3,11 @@ from _typeshed import Incomplete
 class Stat:
     h: Incomplete
     bands: Incomplete
+    count: list[int]
+    mean: list[float]
+    rms: list[float]
+    stddev: list[float]
+    var: list[float]
     def __init__(self, image_or_list, mask: Incomplete | None = None) -> None: ...
     def __getattr__(self, id: str): ...
 


### PR DESCRIPTION
These are created in the original source with what looks like an unusual way of creating properties:

```python
def __getattr__(self, id):
        """Calculate missing attribute"""
        if id[:4] == "_get":
            raise AttributeError(id)
        # calculate missing attribute
        v = getattr(self, "_get" + id)()
        setattr(self, id, v)
        return v
```

See https://github.com/python-pillow/Pillow/blob/main/src/PIL/ImageStat.py#L124, for example.