### PR TITLE
regr_test.py: Run mypy with `--no-incremental`

### DIFF
--- a/tests/regr_test.py
+++ b/tests/regr_test.py
@@ -177,6 +177,9 @@ def run_testcases(
         platform,
         "--strict",
         "--pretty",
+        # Avoid race conditions when reading the cache
+        # (https://github.com/python/typeshed/issues/11220)
+        "--no-incremental",
     ]
 
     if package.is_stdlib:


### PR DESCRIPTION
Fixes #11220. I'm currently stress-testing this locally to see if it fixes the crash. Creating a PR as well so that we can see if this significantly slows things down at all for us in CI. If it does, we'll be better off going with something like #11344, regardless of whether this fixes the crash.