### PR TITLE
Allow reduce_prod's input to be a TensorShape.

### DIFF
--- a/stubs/tensorflow/tensorflow/math.pyi
+++ b/stubs/tensorflow/tensorflow/math.pyi
@@ -3,7 +3,7 @@ from collections.abc import Iterable
 from typing import TypeVar, overload
 from typing_extensions import TypeAlias
 
-from tensorflow import IndexedSlices, RaggedTensor, Tensor
+from tensorflow import IndexedSlices, RaggedTensor, Tensor, TensorShape
 from tensorflow._aliases import DTypeLike, ShapeLike, TensorCompatible
 from tensorflow.sparse import SparseTensor
 
@@ -242,7 +242,7 @@ def reduce_min(
     name: str | None = None,
 ) -> Tensor: ...
 def reduce_prod(
-    input_tensor: TensorCompatible | RaggedTensor,
+    input_tensor: TensorCompatible | RaggedTensor | TensorShape,
     axis: TensorCompatible | None = None,
     keepdims: bool = False,
     name: str | None = None,


### PR DESCRIPTION
[The documentation](https://www.tensorflow.org/api_docs/python/tf/math/reduce_prod) says that the input should be a Tensor, however the following runs without issue:

```python
import tensorflow as tf
c = tf.constant([[1.0, 2.0], [3.0, 4.0]])
tf.reduce_prod(c.shape)
```