### PR TITLE
`tensorflow` fix `tensorflow.data.Dataset`'s zip

### DIFF
--- a/stubs/tensorflow/tensorflow/data/__init__.pyi
+++ b/stubs/tensorflow/tensorflow/data/__init__.pyi
@@ -226,7 +226,7 @@ class Dataset(ABC, Generic[_T1]):
     @overload
     @staticmethod
     def zip(
-        *args: Collection[Dataset[Any]] | ContainerGeneric[Dataset[Any]], name: str | None = None
+        *args: Dataset[Any] | Collection[Dataset[Any]] | ContainerGeneric[Dataset[Any]], name: str | None = None
     ) -> Dataset[tuple[Any, ...]]: ...
     @overload
     @staticmethod


### PR DESCRIPTION
Sorry open this just after [the PR to bump the tensorflow version](https://github.com/python/typeshed/pull/11352) got merged, but I just realized that if `Dataset[Any]` is not present in the function's signature, then only nested structures of datasets can be passed to the zip method.

Related comments in the previous PR [here](https://github.com/python/typeshed/pull/11352#discussion_r1477044838) and [here](https://github.com/python/typeshed/pull/11352#discussion_r1477044359).