### PR TITLE
influx-db: fix flake8

### DIFF
--- a/stubs/influxdb-client/influxdb_client/service/tasks_service.pyi
+++ b/stubs/influxdb-client/influxdb_client/service/tasks_service.pyi
@@ -1,7 +1,6 @@
 from _typeshed import Incomplete
 from multiprocessing.pool import ApplyResult
-from typing import overload
-from typing_extensions import Literal
+from typing import Literal, overload
 
 from influxdb_client.domain.tasks import Tasks
 from influxdb_client.service._base_service import _BaseService


### PR DESCRIPTION
flake8 is failing on `main`, due to a merge race between  #11116 and #11249