### PR TITLE
sys: add `last_exc` on Python>=3.12

### DIFF
--- a/stdlib/sys/__init__.pyi
+++ b/stdlib/sys/__init__.pyi
@@ -42,6 +42,8 @@ hexversion: int
 last_type: type[BaseException] | None
 last_value: BaseException | None
 last_traceback: TracebackType | None
+if sys.version_info >= (3, 12):
+    last_exc: BaseException  # or undefined.
 maxsize: int
 maxunicode: int
 meta_path: list[_MetaPathFinder]

--- a/tests/stubtest_allowlists/py312.txt
+++ b/tests/stubtest_allowlists/py312.txt
@@ -76,6 +76,9 @@ types.GenericAlias.__mro_entries__
 sys._monitoring  # Doesn't really exist. See comments in the stub.
 weakref.ProxyType.__reversed__  # Doesn't really exist
 
+# sys attributes that are not always defined
+sys.last_exc
+
 # C signature is broader than what is actually accepted
 ast.ExtSlice.__new__
 ast.Index.__new__


### PR DESCRIPTION
https://docs.python.org/3/library/sys.html#sys.last_exc