### PR TITLE
Fix `ttk`'s `compound` argument

### DIFF
--- a/stdlib/tkinter/ttk.pyi
+++ b/stdlib/tkinter/ttk.pyi
@@ -46,7 +46,7 @@ _Padding: TypeAlias = (
 )
 
 # from ttk_widget (aka ttk::widget) manual page, differs from tkinter._Compound
-_TtkCompound: TypeAlias = Literal["text", "image", tkinter._Compound]
+_TtkCompound: TypeAlias = Literal["", "text", "image", tkinter._Compound]
 
 class Style:
     master: Incomplete


### PR DESCRIPTION
Fix `ttk`'s `compound` argument, fixes #11392 