### PR TITLE
Revert "Change some tkinter function parameter types from bool to int (#4765)"

### DIFF
--- a/stdlib/tkinter/__init__.pyi
+++ b/stdlib/tkinter/__init__.pyi
@@ -184,7 +184,7 @@ _Relief: TypeAlias = Literal["raised", "sunken", "flat", "ridge", "solid", "groo
 _ScreenUnits: TypeAlias = str | float  # Often the right type instead of int. Manual page: Tk_GetPixels
 # -xscrollcommand and -yscrollcommand in 'options' manual page
 _XYScrollCommand: TypeAlias = str | Callable[[float, float], object]
-_TakeFocusValue: TypeAlias = int | Literal[""] | Callable[[str], bool | None]  # -takefocus in manual page named 'options'
+_TakeFocusValue: TypeAlias = bool | Literal[""] | Callable[[str], bool | None]  # -takefocus in manual page named 'options'
 
 if sys.version_info >= (3, 11):
     class _VersionInfoType(NamedTuple):
@@ -829,7 +829,7 @@ class Pack:
         after: Misc = ...,
         anchor: _Anchor = ...,
         before: Misc = ...,
-        expand: int = ...,
+        expand: bool = ...,
         fill: Literal["none", "x", "y", "both"] = ...,
         side: Literal["left", "right", "top", "bottom"] = ...,
         ipadx: _ScreenUnits = ...,
@@ -2110,7 +2110,7 @@ class Listbox(Widget, XView, YView):
         borderwidth: _ScreenUnits = 1,
         cursor: _Cursor = "",
         disabledforeground: str = ...,
-        exportselection: int = 1,
+        exportselection: bool = True,
         fg: str = ...,
         font: _FontDescription = ...,
         foreground: str = ...,
@@ -2233,7 +2233,7 @@ class Menu(Widget):
         relief: _Relief = ...,
         selectcolor: str = ...,
         takefocus: _TakeFocusValue = 0,
-        tearoff: int = ...,
+        tearoff: bool = ...,
         # I guess tearoffcommand arguments are supposed to be widget objects,
         # but they are widget name strings. Use nametowidget() to handle the
         # arguments of tearoffcommand.

--- a/stdlib/tkinter/__init__.pyi
+++ b/stdlib/tkinter/__init__.pyi
@@ -967,7 +967,7 @@ class Toplevel(BaseWidget, Wm):
         pady: _ScreenUnits = 0,
         relief: _Relief = "flat",
         screen: str = "",  # can't be changed after creating widget
-        takefocus: _TakeFocusValue = 0,
+        takefocus: _TakeFocusValue = False,
         use: int = ...,
         visual: str | tuple[str, int] = "",
         width: _ScreenUnits = 0,
@@ -1987,7 +1987,7 @@ class Frame(Widget):
         padx: _ScreenUnits = 0,
         pady: _ScreenUnits = 0,
         relief: _Relief = "flat",
-        takefocus: _TakeFocusValue = 0,
+        takefocus: _TakeFocusValue = False,
         visual: str | tuple[str, int] = "",  # can't be changed with configure()
         width: _ScreenUnits = 0,
     ) -> None: ...
@@ -2048,7 +2048,7 @@ class Label(Widget):
         pady: _ScreenUnits = 1,
         relief: _Relief = "flat",
         state: Literal["normal", "active", "disabled"] = "normal",
-        takefocus: _TakeFocusValue = 0,
+        takefocus: _TakeFocusValue = False,
         text: float | str = "",
         textvariable: Variable = ...,
         underline: int = -1,
@@ -2232,7 +2232,7 @@ class Menu(Widget):
         postcommand: Callable[[], object] | str = "",
         relief: _Relief = ...,
         selectcolor: str = ...,
-        takefocus: _TakeFocusValue = 0,
+        takefocus: _TakeFocusValue = False,
         tearoff: bool = ...,
         # I guess tearoffcommand arguments are supposed to be widget objects,
         # but they are widget name strings. Use nametowidget() to handle the
@@ -2514,7 +2514,7 @@ class Menubutton(Widget):
         pady: _ScreenUnits = ...,
         relief: _Relief = "flat",
         state: Literal["normal", "active", "disabled"] = "normal",
-        takefocus: _TakeFocusValue = 0,
+        takefocus: _TakeFocusValue = False,
         text: float | str = "",
         textvariable: Variable = ...,
         underline: int = -1,
@@ -2590,7 +2590,7 @@ class Message(Widget):
         padx: _ScreenUnits = ...,
         pady: _ScreenUnits = ...,
         relief: _Relief = "flat",
-        takefocus: _TakeFocusValue = 0,
+        takefocus: _TakeFocusValue = False,
         text: float | str = "",
         textvariable: Variable = ...,
         # there's width but no height
@@ -3526,7 +3526,7 @@ class LabelFrame(Widget):
         padx: _ScreenUnits = 0,
         pady: _ScreenUnits = 0,
         relief: _Relief = "groove",
-        takefocus: _TakeFocusValue = 0,
+        takefocus: _TakeFocusValue = False,
         text: float | str = "",
         visual: str | tuple[str, int] = "",  # can't be changed with configure()
         width: _ScreenUnits = 0,


### PR DESCRIPTION
Reverts #4765, fixes #11389. Typings of `tkinter/constants.pyi` were later changed in #4669.