### PR TITLE
Add annotations for `tkinter.ttk.LabeledScale`

### DIFF
--- a/stdlib/tkinter/ttk.pyi
+++ b/stdlib/tkinter/ttk.pyi
@@ -334,6 +334,8 @@ class Combobox(Entry):
     def set(self, value: Any) -> None: ...
 
 class Frame(Widget):
+    # This should be kept in sync with tkinter.ttk.LabeledScale.__init__()
+    # (all of these keyword-only arguments are also present there)
     def __init__(
         self,
         master: tkinter.Misc | None = None,
@@ -1160,6 +1162,8 @@ class Treeview(Widget, tkinter.XView, tkinter.YView):
 class LabeledScale(Frame):
     label: Label
     scale: Scale
+    # This should be kept in sync with tkinter.ttk.Frame.__init__()
+    # (all the keyword-only args except compound are from there)
     def __init__(
         self,
         master: tkinter.Misc | None = None,
@@ -1170,7 +1174,7 @@ class LabeledScale(Frame):
         border: tkinter._ScreenUnits = ...,
         borderwidth: tkinter._ScreenUnits = ...,
         class_: str = ...,
-        compound: Literal["top", "bottom"] = ...,
+        compound: Literal["top", "bottom"] = "top",
         cursor: tkinter._Cursor = ...,
         height: tkinter._ScreenUnits = ...,
         name: str = ...,

--- a/stdlib/tkinter/ttk.pyi
+++ b/stdlib/tkinter/ttk.pyi
@@ -1158,9 +1158,8 @@ class Treeview(Widget, tkinter.XView, tkinter.YView):
     def tag_has(self, tagname: str, item: str | int) -> bool: ...
 
 class LabeledScale(Frame):
-    label: Incomplete
-    scale: Incomplete
-    # TODO: don't any-type **kw. That goes to Frame.__init__.
+    label: Label
+    scale: Scale
     def __init__(
         self,
         master: tkinter.Misc | None = None,
@@ -1168,8 +1167,18 @@ class LabeledScale(Frame):
         from_: float = 0,
         to: float = 10,
         *,
+        border: tkinter._ScreenUnits = ...,
+        borderwidth: tkinter._ScreenUnits = ...,
+        class_: str = ...,
         compound: Literal["top", "bottom"] = ...,
-        **kw,
+        cursor: tkinter._Cursor = ...,
+        height: tkinter._ScreenUnits = ...,
+        name: str = ...,
+        padding: _Padding = ...,
+        relief: tkinter._Relief = ...,
+        style: str = ...,
+        takefocus: tkinter._TakeFocusValue = ...,
+        width: tkinter._ScreenUnits = ...,
     ) -> None: ...
     # destroy is overridden, signature does not change
     value: Any


### PR DESCRIPTION
Add annotations for `tkinter.ttk.LabeledScale`. This [doesn't seem the be documented](https://docs.python.org/3/search.html?q=labeledscale) in the official Python documentation so I just took the types from [the source code](https://github.com/python/cpython/blob/b1043607884d774acabd255ecdcebb159f76a2fb/Lib/tkinter/ttk.py#L1492-L1527).