### PR TITLE
Pillow: ImageOps.autocontrast can set low and high cutoffs separately

### DIFF
--- a/stubs/Pillow/PIL/ImageOps.pyi
+++ b/stubs/Pillow/PIL/ImageOps.pyi
@@ -12,7 +12,11 @@ class _Deformer(Protocol):
     def getmesh(self, __image: Image): ...
 
 def autocontrast(
-    image: Image, cutoff: int = 0, ignore: int | None = None, mask: Image | None = None, preserve_tone: bool = False
+    image: Image,
+    cutoff: int | tuple[int, int] = 0,
+    ignore: int | None = None,
+    mask: Image | None = None,
+    preserve_tone: bool = False,
 ) -> Image: ...
 def colorize(
     image: Image,


### PR DESCRIPTION
Updates the type hint for the `cutoff` argument of `ImageOps.autocontrast()` to allow for functionality added in Pillow 8.0.0.

https://pillow.readthedocs.io/en/stable/releasenotes/8.0.0.html#imageops-autocontrast-cutoffs
> Previously, the cutoff parameter of [ImageOps.autocontrast()](https://pillow.readthedocs.io/en/stable/reference/ImageOps.html#PIL.ImageOps.autocontrast) could only be a single number, used as the percent to cut off from the histogram on the low and high ends.
>
> Now, it can also be a tuple (low, high).

This is a recreation of https://github.com/python/typeshed/pull/11376