### PR TITLE
Pillow: Allow float(s) for cutoff param of autocontrast

### DIFF
--- a/stubs/Pillow/PIL/ImageOps.pyi
+++ b/stubs/Pillow/PIL/ImageOps.pyi
@@ -13,7 +13,7 @@ class _Deformer(Protocol):
 
 def autocontrast(
     image: Image,
-    cutoff: int | tuple[int, int] = 0,
+    cutoff: float | tuple[float, float] = 0,
     ignore: int | None = None,
     mask: Image | None = None,
     preserve_tone: bool = False,


### PR DESCRIPTION
This is an extension of https://github.com/python/typeshed/pull/11376 to permit float values (and 2-tuple values containing 1 or 2 floats) as the value of `cutoff` for the `autocontrast` function in the `ImageOps` module.

The previous pull request only permits `int`s, but the documentation doesn't stipulate `int`s (only "number"), and passing `float`s could be desirable if a more specific cutoff is required. Using a `float` type also permits `int` (see [&ldquo;The numeric tower&rdquo; in PEP 484](https://peps.python.org/pep-0484/#the-numeric-tower)).