### PR TITLE
Use `bool | Literal[0, 1]` instead of `int` in some tkinter bool parameters

### DIFF
--- a/stdlib/tkinter/__init__.pyi
+++ b/stdlib/tkinter/__init__.pyi
@@ -185,7 +185,7 @@ _ScreenUnits: TypeAlias = str | float  # Often the right type instead of int. Ma
 # -xscrollcommand and -yscrollcommand in 'options' manual page
 _XYScrollCommand: TypeAlias = str | Callable[[float, float], object]
 _TakeFocusValue: TypeAlias = (
-    bool | Literal[0, 1] | Literal[""] | Callable[[str], bool | None]
+    bool | Literal[0, 1, ""] | Callable[[str], bool | None]
 )  # -takefocus in manual page named 'options'
 
 if sys.version_info >= (3, 11):

--- a/stdlib/tkinter/__init__.pyi
+++ b/stdlib/tkinter/__init__.pyi
@@ -829,7 +829,7 @@ class Pack:
         after: Misc = ...,
         anchor: _Anchor = ...,
         before: Misc = ...,
-        expand: bool | Literal[0, 1] = ...,
+        expand: bool | Literal[0, 1] = 0,
         fill: Literal["none", "x", "y", "both"] = ...,
         side: Literal["left", "right", "top", "bottom"] = ...,
         ipadx: _ScreenUnits = ...,

--- a/stdlib/tkinter/__init__.pyi
+++ b/stdlib/tkinter/__init__.pyi
@@ -184,9 +184,7 @@ _Relief: TypeAlias = Literal["raised", "sunken", "flat", "ridge", "solid", "groo
 _ScreenUnits: TypeAlias = str | float  # Often the right type instead of int. Manual page: Tk_GetPixels
 # -xscrollcommand and -yscrollcommand in 'options' manual page
 _XYScrollCommand: TypeAlias = str | Callable[[float, float], object]
-_TakeFocusValue: TypeAlias = (
-    bool | Literal[0, 1, ""] | Callable[[str], bool | None]
-)  # -takefocus in manual page named 'options'
+_TakeFocusValue: TypeAlias = bool | Literal[0, 1, ""] | Callable[[str], bool | None]  # -takefocus in manual page named 'options'
 
 if sys.version_info >= (3, 11):
     class _VersionInfoType(NamedTuple):

--- a/stdlib/tkinter/__init__.pyi
+++ b/stdlib/tkinter/__init__.pyi
@@ -184,7 +184,7 @@ _Relief: TypeAlias = Literal["raised", "sunken", "flat", "ridge", "solid", "groo
 _ScreenUnits: TypeAlias = str | float  # Often the right type instead of int. Manual page: Tk_GetPixels
 # -xscrollcommand and -yscrollcommand in 'options' manual page
 _XYScrollCommand: TypeAlias = str | Callable[[float, float], object]
-_TakeFocusValue: TypeAlias = int | Literal[""] | Callable[[str], bool | None]  # -takefocus in manual page named 'options'
+_TakeFocusValue: TypeAlias = bool | Literal[0, 1] | Literal[""] | Callable[[str], bool | None]  # -takefocus in manual page named 'options'
 
 if sys.version_info >= (3, 11):
     class _VersionInfoType(NamedTuple):
@@ -829,7 +829,7 @@ class Pack:
         after: Misc = ...,
         anchor: _Anchor = ...,
         before: Misc = ...,
-        expand: int = ...,
+        expand: bool | Literal[0, 1] = ...,
         fill: Literal["none", "x", "y", "both"] = ...,
         side: Literal["left", "right", "top", "bottom"] = ...,
         ipadx: _ScreenUnits = ...,
@@ -2110,7 +2110,7 @@ class Listbox(Widget, XView, YView):
         borderwidth: _ScreenUnits = 1,
         cursor: _Cursor = "",
         disabledforeground: str = ...,
-        exportselection: int = 1,
+        exportselection: bool | Literal[0, 1] = 1,
         fg: str = ...,
         font: _FontDescription = ...,
         foreground: str = ...,
@@ -2233,7 +2233,7 @@ class Menu(Widget):
         relief: _Relief = ...,
         selectcolor: str = ...,
         takefocus: _TakeFocusValue = 0,
-        tearoff: int = ...,
+        tearoff: bool | Literal[0, 1] = 1,
         # I guess tearoffcommand arguments are supposed to be widget objects,
         # but they are widget name strings. Use nametowidget() to handle the
         # arguments of tearoffcommand.


### PR DESCRIPTION
This is a less disruptive version of #11394.

In general, passing 0 or 1 is less readable and just not the right thing to do in new code. Users should just use the new and readable thing instead of the confusing legacy thing. Tkinter (and much of its documentation) was created before `bool` was added to Python.

That said, there's still plenty of example code around (e.g. stackoverflow answers, tkinter docstrings) that use 0 and 1. IMO we should apply `Literal[0, 1]` to tkinter booleans **only** when someone needs it in a specific place, not blindly to all boolean parameters.

This is also why I don't want yet another type alias, e.g. `_TkBool = bool | Literal[0, 1]`. In most cases, it's not the right thing to use, so I don't want a convenience thing for it.