### PR TITLE
Update for typing_extensions 4.10

### DIFF
--- a/stdlib/typing_extensions.pyi
+++ b/stdlib/typing_extensions.pyi
@@ -220,10 +220,14 @@ def IntVar(name: str) -> Any: ...  # returns a new TypeVar
 class _TypedDict(Mapping[str, object], metaclass=abc.ABCMeta):
     __required_keys__: ClassVar[frozenset[str]]
     __optional_keys__: ClassVar[frozenset[str]]
-    __readonly_keys__: ClassVar[frozenset[str]]
-    __mutable_keys__: ClassVar[frozenset[str]]
     __total__: ClassVar[bool]
     __orig_bases__: ClassVar[tuple[Any, ...]]
+    # PEP 705
+    __readonly_keys__: ClassVar[frozenset[str]]
+    __mutable_keys__: ClassVar[frozenset[str]]
+    # PEP 728
+    __closed__: ClassVar[bool]
+    __extra_items__: ClassVar[Any]
     def copy(self) -> Self: ...
     # Using Never so that only calls using mypy plugin hook that specialize the signature
     # can go through.
@@ -501,3 +505,4 @@ class Doc:
     def __eq__(self, other: object) -> bool: ...
 
 ReadOnly: _SpecialForm
+TypeIs: _SpecialForm

--- a/stdlib/typing_extensions.pyi
+++ b/stdlib/typing_extensions.pyi
@@ -182,6 +182,7 @@ __all__ = [
     "no_type_check",
     "no_type_check_decorator",
     "ReadOnly",
+    "TypeIs",
 ]
 
 _T = typing.TypeVar("_T")

--- a/tests/stubtest_allowlists/py3_common.txt
+++ b/tests/stubtest_allowlists/py3_common.txt
@@ -519,6 +519,9 @@ _typeshed.*  # Utility types for typeshed, doesn't exist at runtime
 typing._SpecialForm.__call__
 typing._SpecialForm.__init__
 
+# Should go away with a future version of stubtest
+typing_extensions\..*\.__non_callable_proto_members__
+
 # Pretend typing.ByteString is a Union, to better match its documented semantics.
 # As a side effect, this changes the definition of collections.abc.ByteString, which is okay,
 # because it's not an ABC that makes any sense and was deprecated in 3.12


### PR DESCRIPTION
I just released 4.10.0rc1. Getting this into typeshed now is helpful for fixing python/typing_extensions#339.