### PR TITLE
importlib.metadata: Use the SimplePath protocol

### DIFF
--- a/stdlib/importlib/metadata/__init__.pyi
+++ b/stdlib/importlib/metadata/__init__.pyi
@@ -9,7 +9,7 @@ from importlib.abc import MetaPathFinder
 from os import PathLike
 from pathlib import Path
 from re import Pattern
-from typing import Any, ClassVar, Generic, NamedTuple, TypeVar, overload
+from typing import Any, ClassVar, Generic, NamedTuple, TypeAlias, TypeVar, overload
 from typing_extensions import Self
 
 _T = TypeVar("_T")
@@ -33,8 +33,12 @@ if sys.version_info >= (3, 10):
     __all__ += ["PackageMetadata", "packages_distributions"]
 
 if sys.version_info >= (3, 10):
-    from importlib.metadata._meta import PackageMetadata as PackageMetadata
+    from importlib.metadata._meta import PackageMetadata as PackageMetadata, SimplePath
     def packages_distributions() -> Mapping[str, list[str]]: ...
+
+    _SimplePath: TypeAlias = SimplePath
+else:
+    _SimplePath: TypeAlias = Path
 
 class PackageNotFoundError(ModuleNotFoundError):
     @property
@@ -184,7 +188,7 @@ class Distribution(_distribution_parent):
     @abc.abstractmethod
     def read_text(self, filename: str) -> str | None: ...
     @abc.abstractmethod
-    def locate_file(self, path: StrPath) -> PathLike[str]: ...
+    def locate_file(self, path: StrPath) -> _SimplePath: ...
     @classmethod
     def from_name(cls, name: str) -> Distribution: ...
     @overload
@@ -233,14 +237,14 @@ class MetadataPathFinder(DistributionFinder):
     @classmethod
     def find_distributions(cls, context: DistributionFinder.Context = ...) -> Iterable[PathDistribution]: ...
     if sys.version_info >= (3, 10):
-        # Yes, this is an instance method that has argumend named "cls"
+        # Yes, this is an instance method that has an argument named "cls"
         def invalidate_caches(cls) -> None: ...
 
 class PathDistribution(Distribution):
-    _path: Path
-    def __init__(self, path: Path) -> None: ...
-    def read_text(self, filename: StrPath) -> str: ...
-    def locate_file(self, path: StrPath) -> PathLike[str]: ...
+    _path: _SimplePath
+    def __init__(self, path: _SimplePath) -> None: ...
+    def read_text(self, filename: StrPath) -> str | None: ...
+    def locate_file(self, path: StrPath) -> _SimplePath: ...
 
 def distribution(distribution_name: str) -> Distribution: ...
 @overload


### PR DESCRIPTION
Closes #9217. Followup from #11436.

This mostly makes a simpler set of changes than #9217; in particular
it does not make PathDistribution generic. I think this is in line with
how the protocol is supposed to be used, though not always in line with
the runtime type annotations (which don't all make sense).
