### PR TITLE
Update `os. EX_NOTFOUND` not available in Linux

### DIFF
--- a/stdlib/os/__init__.pyi
+++ b/stdlib/os/__init__.pyi
@@ -308,7 +308,7 @@ if sys.platform != "win32":
     EX_NOPERM: int
     EX_CONFIG: int
 
-if sys.platform != "win32" and sys.platform != "darwin":
+if sys.platform != "win32" and sys.platform != "darwin" and sys.platform != "linux":
     EX_NOTFOUND: int
 
 P_NOWAIT: int

--- a/stdlib/os/__init__.pyi
+++ b/stdlib/os/__init__.pyi
@@ -308,6 +308,7 @@ if sys.platform != "win32":
     EX_NOPERM: int
     EX_CONFIG: int
 
+# Exists on some Unix platforms, e.g. Solaris.
 if sys.platform != "win32" and sys.platform != "darwin" and sys.platform != "linux":
     EX_NOTFOUND: int
 

--- a/stdlib/posix.pyi
+++ b/stdlib/posix.pyi
@@ -239,9 +239,11 @@ if sys.platform != "win32":
     if sys.platform != "linux":
         from os import chflags as chflags, lchflags as lchflags, lchmod as lchmod
 
+    if sys.platform != "linux" and sys.platform != "darwin":
+        from os import EX_NOTFOUND as EX_NOTFOUND
+
     if sys.platform != "darwin":
         from os import (
-            EX_NOTFOUND as EX_NOTFOUND,
             POSIX_FADV_DONTNEED as POSIX_FADV_DONTNEED,
             POSIX_FADV_NOREUSE as POSIX_FADV_NOREUSE,
             POSIX_FADV_NORMAL as POSIX_FADV_NORMAL,

--- a/tests/stubtest_allowlists/linux.txt
+++ b/tests/stubtest_allowlists/linux.txt
@@ -41,10 +41,6 @@ fcntl.I_[A-Z0-9_]+
 os.SCHED_[A-Z_]+
 posix.SCHED_[A-Z_]+
 
-# Exists on some Unix platforms, but not in CI:
-os.EX_NOTFOUND
-posix.EX_NOTFOUND
-
 # Some of these exist on non-windows, but they are useless and this is not intended
 stat.FILE_ATTRIBUTE_[A-Z_]+
 


### PR DESCRIPTION
Closes https://github.com/python/typeshed/issues/11259