### PR TITLE
Improve JSON typing in requests.requests.models

### DIFF
--- a/stubs/requests/requests/models.pyi
+++ b/stubs/requests/requests/models.pyi
@@ -61,7 +61,7 @@ class Request(RequestHooksMixin):
     headers: Any
     files: Any
     data: Any
-    json: Any
+    json: dict[str, Any]
     params: Any
     auth: Any
     cookies: Any
@@ -157,7 +157,7 @@ class Response:
         parse_constant: Callable[[str], Any] | None = ...,
         object_pairs_hook: Callable[[list[tuple[Any, Any]]], Any] | None = ...,
         **kwds: Any,
-    ) -> Any: ...
+    ) -> dict[str, Any]: ...
     @property
     def links(self) -> dict[Any, Any]: ...
     def raise_for_status(self) -> None: ...


### PR DESCRIPTION
Added a dict[str, Any] type to the Response json() method and Request.

The Request class expects a serializable object (https://github.com/psf/requests/blob/main/src/requests/models.py#L510)

The Response.json() method returns a deserialized JSON string (https://github.com/psf/requests/blob/main/src/requests/models.py#L958)

This was causing issues with my type checker (MyPy) so I thought I would add it in.
```python
def test(response: Response) -> dict[str, Any]:
  res = response.json()
  return res
  # MyPy complains because this function returns an Any object rather than a python 
  # JSON object
```