### PR TITLE
Revert "pin pyright-action to 2.0.2"

### DIFF
--- a/.github/workflows/meta_tests.yml
+++ b/.github/workflows/meta_tests.yml
@@ -64,7 +64,7 @@ jobs:
           file: "pyproject.toml"
           field: "tool.typeshed.pyright_version"
       - name: Run pyright on typeshed
-        uses: jakebailey/pyright-action@v2.0.2
+        uses: jakebailey/pyright-action@v2
         with:
           version: ${{ steps.pyright_version.outputs.value }}
           python-platform: ${{ matrix.python-platform }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -158,14 +158,14 @@ jobs:
           file: "pyproject.toml"
           field: "tool.typeshed.pyright_version"
       - name: Run pyright with basic settings on all the stubs
-        uses: jakebailey/pyright-action@v2.0.2
+        uses: jakebailey/pyright-action@v2
         with:
           version: ${{ steps.pyright_version.outputs.value }}
           python-platform: ${{ matrix.python-platform }}
           python-version: ${{ matrix.python-version }}
           no-comments: ${{ matrix.python-version != '3.11' || matrix.python-platform != 'Linux' }} # Having each job create the same comment is too noisy.
       - name: Run pyright with stricter settings on some of the stubs
-        uses: jakebailey/pyright-action@v2.0.2
+        uses: jakebailey/pyright-action@v2
         with:
           version: ${{ steps.pyright_version.outputs.value }}
           python-platform: ${{ matrix.python-platform }}
@@ -173,7 +173,7 @@ jobs:
           no-comments: ${{ matrix.python-version != '3.11' || matrix.python-platform != 'Linux' }} # Having each job create the same comment is too noisy.
           project: ./pyrightconfig.stricter.json
       - name: Run pyright on the test cases
-        uses: jakebailey/pyright-action@v2.0.2
+        uses: jakebailey/pyright-action@v2
         with:
           version: ${{ steps.pyright_version.outputs.value }}
           python-platform: ${{ matrix.python-platform }}


### PR DESCRIPTION
Reverts python/typeshed#11475
Closes #11474

The CI failures should be fixed now that pyright-action 2.1.1 has been released
