### PR TITLE
Add `@deprecated` to `abstractclass/staticmethod/property`

### DIFF
--- a/stdlib/abc.pyi
+++ b/stdlib/abc.pyi
@@ -3,7 +3,7 @@ import sys
 from _typeshed import SupportsWrite
 from collections.abc import Callable
 from typing import Any, Literal, TypeVar
-from typing_extensions import Concatenate, ParamSpec
+from typing_extensions import Concatenate, ParamSpec, deprecated
 
 _T = TypeVar("_T")
 _R_co = TypeVar("_R_co", covariant=True)
@@ -29,14 +29,17 @@ class ABCMeta(type):
 
 def abstractmethod(funcobj: _FuncT) -> _FuncT: ...
 
+@deprecated("Deprecated, use 'classmethod' with 'abstractmethod' instead")
 class abstractclassmethod(classmethod[_T, _P, _R_co]):
     __isabstractmethod__: Literal[True]
     def __init__(self, callable: Callable[Concatenate[type[_T], _P], _R_co]) -> None: ...
 
+@deprecated("Deprecated, use 'staticmethod' with 'abstractmethod' instead")
 class abstractstaticmethod(staticmethod[_P, _R_co]):
     __isabstractmethod__: Literal[True]
     def __init__(self, callable: Callable[_P, _R_co]) -> None: ...
 
+@deprecated("Deprecated, use 'property' with 'abstractmethod' instead")
 class abstractproperty(property):
     __isabstractmethod__: Literal[True]
 


### PR DESCRIPTION
There might be a reason it wasn't added yet, but couldn't find anything when searching.