### PR TITLE
Code improvements from new Ruff checks

### DIFF
--- a/scripts/runtests.py
+++ b/scripts/runtests.py
@@ -101,7 +101,7 @@ def main() -> None:
     strict_params = _get_strict_params(path)
     print(f"\nRunning Pyright ({'stricter' if strict_params else 'base' } configs) for Python {python_version}...")
     pyright_result = subprocess.run(
-        [sys.executable, "tests/pyright_test.py", path, "--pythonversion", python_version] + strict_params,
+        [sys.executable, "tests/pyright_test.py", path, "--pythonversion", python_version, *strict_params],
         stderr=subprocess.PIPE,
         text=True,
     )

--- a/scripts/stubsabot.py
+++ b/scripts/stubsabot.py
@@ -48,7 +48,7 @@ class ActionLevel(enum.IntEnum):
         try:
             return cls[cmd_arg]
         except KeyError:
-            raise argparse.ArgumentTypeError(f'Argument must be one of "{list(cls.__members__)}"')
+            raise argparse.ArgumentTypeError(f'Argument must be one of "{list(cls.__members__)}"') from None
 
     nothing = 0, "make no changes"
     local = 1, "make changes that affect local repo"
@@ -516,7 +516,7 @@ async def determine_action(stub_path: Path, session: aiohttp.ClientSession) -> U
     )
 
 
-@functools.lru_cache()
+@functools.lru_cache
 def get_origin_owner() -> str:
     output = subprocess.check_output(["git", "remote", "get-url", "origin"], text=True).strip()
     match = re.match(r"(git@github.com:|https://github.com/)(?P<owner>[^/]+)/(?P<repo>[^/\s]+)", output)

--- a/test_cases/stdlib/typing/check_all.py
+++ b/test_cases/stdlib/typing/check_all.py
@@ -1,10 +1,8 @@
-from __future__ import annotations
-
 # pyright: reportWildcardImportFromLibrary=false
-
 """
 This tests that star imports work when using "all += " syntax.
 """
+from __future__ import annotations
 
 import sys
 from typing import *  # noqa: F403

--- a/tests/mypy_test.py
+++ b/tests/mypy_test.py
@@ -279,7 +279,7 @@ def run_mypy(
             flags.append("--no-site-packages")
 
         mypy_args = [*flags, *map(str, files)]
-        mypy_command = [venv_info.python_exe, "-m", "mypy"] + mypy_args
+        mypy_command = [venv_info.python_exe, "-m", "mypy", *mypy_args]
         if args.verbose:
             print(colored(f"running {' '.join(mypy_command)}", "blue"))
         result = subprocess.run(mypy_command, capture_output=True, text=True, env=env_vars)

--- a/tests/pytype_test.py
+++ b/tests/pytype_test.py
@@ -210,7 +210,7 @@ def run_all_tests(*, files_to_test: Sequence[str], print_stderr: bool, dry_run: 
     missing_modules = get_missing_modules(files_to_test)
     print("Testing files with pytype...")
     for i, f in enumerate(files_to_test):
-        python_version = "{0.major}.{0.minor}".format(sys.version_info)
+        python_version = f"{sys.version_info.major}.{sys.version_info.minor}"
         if dry_run:
             stderr = None
         else:

--- a/tests/regr_test.py
+++ b/tests/regr_test.py
@@ -211,7 +211,7 @@ def run_testcases(
                 continue
         flags.append(str(path))
 
-    mypy_command = [python_exe, "-m", "mypy"] + flags
+    mypy_command = [python_exe, "-m", "mypy", *flags]
     if verbosity is Verbosity.VERBOSE:
         description = f"{package.name}/{version}/{platform}"
         msg = f"{description}: {mypy_command=}\n"

--- a/tests/stubtest_third_party.py
+++ b/tests/stubtest_third_party.py
@@ -53,7 +53,7 @@ def run_stubtest(
 
         # If tool.stubtest.stubtest_requirements exists, run "pip install" on it.
         if stubtest_settings.stubtest_requirements:
-            pip_cmd = [pip_exe, "install"] + stubtest_settings.stubtest_requirements
+            pip_cmd = [pip_exe, "install", *stubtest_settings.stubtest_requirements]
             try:
                 subprocess.run(pip_cmd, check=True, capture_output=True)
             except subprocess.CalledProcessError as e:
@@ -67,7 +67,7 @@ def run_stubtest(
         # TODO: Maybe find a way to cache these in CI
         dists_to_install = [dist_req, get_mypy_req()]
         dists_to_install.extend(requirements.external_pkgs)  # Internal requirements are added to MYPYPATH
-        pip_cmd = [pip_exe, "install"] + dists_to_install
+        pip_cmd = [pip_exe, "install", *dists_to_install]
         try:
             subprocess.run(pip_cmd, check=True, capture_output=True)
         except subprocess.CalledProcessError as e:
@@ -134,7 +134,7 @@ def run_stubtest(
                 print(file=sys.stderr)
             else:
                 print(f"Re-running stubtest with --generate-allowlist.\nAdd the following to {allowlist_path}:", file=sys.stderr)
-                ret = subprocess.run(stubtest_cmd + ["--generate-allowlist"], env=stubtest_env, capture_output=True)
+                ret = subprocess.run([*stubtest_cmd, "--generate-allowlist"], env=stubtest_env, capture_output=True)
                 print_command_output(ret)
 
             return False

--- a/tests/typecheck_typeshed.py
+++ b/tests/typecheck_typeshed.py
@@ -21,7 +21,7 @@ EMPTY: list[str] = []
 parser = argparse.ArgumentParser(description="Run mypy on typeshed's own code in the `scripts` and `tests` directories.")
 parser.add_argument(
     "dir",
-    choices=DIRECTORIES_TO_TEST + (EMPTY,),
+    choices=(*DIRECTORIES_TO_TEST, EMPTY),
     nargs="*",
     action="extend",
     help=f"Test only these top-level typeshed directories (defaults to {DIRECTORIES_TO_TEST!r})",

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -119,7 +119,7 @@ def get_all_testcase_directories() -> list[PackageInfo]:
         potential_testcase_dir = testcase_dir_from_package_name(package_name)
         if potential_testcase_dir.is_dir():
             testcase_directories.append(PackageInfo(package_name, potential_testcase_dir))
-    return [PackageInfo("stdlib", Path("test_cases"))] + sorted(testcase_directories)
+    return [PackageInfo("stdlib", Path("test_cases")), *sorted(testcase_directories)]
 
 
 # ====================================================================


### PR DESCRIPTION
Unless you find potential issues with these changes, they seemed valid on their own, even if not correctly checked for. Extracted from https://github.com/python/typeshed/pull/11496 . Overlaps with #11499

https://docs.astral.sh/ruff/rules/collection-literal-concatenation/
https://docs.astral.sh/ruff/rules/raise-without-from-inside-except/
https://docs.astral.sh/ruff/rules/lru-cache-without-parameters/
https://docs.astral.sh/ruff/rules/module-import-not-at-top-of-file/
https://docs.astral.sh/ruff/rules/f-string/