### PR TITLE
Replace flake8-bugbear with Ruff

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -17,7 +17,6 @@
 #     E701   Multiple statements on one line (colon) -- disallows "..." on the same line
 
 # Some rules are considered irrelevant to stub files:
-#     B      All flake8-bugbear rules are .py-specific
 #     F401   imported but unused -- does not recognize re-exports
 #            https://github.com/PyCQA/pyflakes/issues/474
 
@@ -30,15 +29,15 @@
 extend-ignore = A, D, N8, SIM, RST, TYP, E301, E302, E305, E501, E701
 per-file-ignores =
   *.py: E203
-  *.pyi: B, E741, F401, F403, F405
+  *.pyi: E741, F401, F403, F405
   # Since typing.pyi defines "overload" this is not recognized by Flake8 as typing.overload.
   # Unfortunately, Flake8 does not allow to "noqa" just a specific error inside the file itself.
   # https://github.com/PyCQA/flake8/issues/1079
   #     F811 redefinition of unused '...'
-  stdlib/typing.pyi: B, E741, F401, F403, F405, F811
+  stdlib/typing.pyi: E741, F401, F403, F405, F811
   # Generated protobuf files include docstrings,
   # and import some things from typing_extensions that could be imported from typing
-  *_pb2.pyi: B, E741, F401, F403, F405, Y021, Y023, Y026, Y053, Y054
+  *_pb2.pyi: E741, F401, F403, F405, Y021, Y023, Y026, Y053, Y054
 
 exclude = .venv*,.git
 noqa_require_code = true

--- a/.flake8
+++ b/.flake8
@@ -26,7 +26,7 @@
 #     F405   defined from star imports
 
 [flake8]
-extend-ignore = A, D, N8, SIM, RST, TYP, E301, E302, E305, E501, E701
+extend-ignore = A, B, D, N8, SIM, RST, TYP, E301, E302, E305, E501, E701
 per-file-ignores =
   *.py: E203
   *.pyi: E741, F401, F403, F405

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,6 @@ repos:
     hooks:
       - id: flake8
         additional_dependencies:
-          - "flake8-bugbear==24.1.17" # must match requirements-tests.txt
           - "flake8-noqa==1.4.0" # must match requirements-tests.txt
           - "flake8-pyi==24.1.0" # must match requirements-tests.txt
         types: [file]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,7 +108,6 @@ you're free to do so. Either run the following manually...
 
 Our code is also linted using [`Flake8`](https://github.com/pycqa/flake8),
 with plugins [`flake8-pyi`](https://github.com/pycqa/flake8-pyi),
-[`flake8-bugbear`](https://github.com/PyCQA/flake8-bugbear),
 and [`flake8-noqa`](https://github.com/plinss/flake8-noqa).
 As with our other checks, running
 Flake8 before filing a PR is not required. However, if you wish to run Flake8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ exclude = [
 
 [tool.ruff.lint]
 select = [
+    "B", # flake8-bugbear
     "FA", # flake8-future-annotations
     "I", # isort
     # Only enable rules that have safe autofixes:
@@ -47,6 +48,12 @@ select = [
     "UP019", # Use str over typing.Text
     "UP035", # import from typing, not typing_extensions, wherever possible
     "UP039", # don't use parens after a class definition with no bases
+]
+
+[tool.ruff.lint.extend-per-file-ignores]
+"*.pyi" = [
+    # Rules that are out of the control of stub authors:
+    "B006", # Do not use mutable data structures for argument defaults
 ]
 
 [tool.ruff.lint.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,10 +50,11 @@ select = [
     "UP039", # don't use parens after a class definition with no bases
 ]
 
-[tool.ruff.lint.extend-per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "*.pyi" = [
-    # Rules that are out of the control of stub authors:
-    "B006", # Do not use mutable data structures for argument defaults
+    # Most flake8-bugbear rules don't apply for third-party stubs like typeshed,
+    # B033 could be slightly useful but Ruff doesn't have per-file select
+    "B", # flake8-bugbear
 ]
 
 [tool.ruff.lint.isort]

--- a/pyrightconfig.testcases.json
+++ b/pyrightconfig.testcases.json
@@ -15,7 +15,7 @@
     // See https://github.com/python/typeshed/pull/8083
     "enableTypeIgnoreComments": true,
     // If a test case uses this anti-pattern, there's likely a reason and annoying to `type: ignore`.
-    // Let flake8-bugbear flag it (B006)
+    // Let Ruff flag it (B006)
     "reportCallInDefaultInitializer": "none",
     // Too strict and not needed for type testing
     "reportMissingSuperCall": "none",

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -3,7 +3,6 @@
 # "tool.typeshed" section in pyproject.toml for additional type checkers.
 black==24.1.1            # must match .pre-commit-config.yaml
 flake8==7.0.0            # must match .pre-commit-config.yaml
-flake8-bugbear==24.1.17  # must match .pre-commit-config.yaml
 flake8-noqa==1.4.0       # must match .pre-commit-config.yaml
 flake8-pyi==24.1.0       # must match .pre-commit-config.yaml
 mypy==1.8.0

--- a/scripts/stubsabot.py
+++ b/scripts/stubsabot.py
@@ -48,7 +48,7 @@ class ActionLevel(enum.IntEnum):
         try:
             return cls[cmd_arg]
         except KeyError:
-            raise argparse.ArgumentTypeError(f'Argument must be one of "{list(cls.__members__)}"')
+            raise argparse.ArgumentTypeError(f'Argument must be one of "{list(cls.__members__)}"') from None
 
     nothing = 0, "make no changes"
     local = 1, "make changes that affect local repo"

--- a/stubs/s2clientprotocol/s2clientprotocol/query_pb2.pyi
+++ b/stubs/s2clientprotocol/s2clientprotocol/query_pb2.pyi
@@ -4,18 +4,13 @@ isort:skip_file
 """
 import builtins
 import collections.abc
-import sys
+import typing as typing_extensions
 
 import google.protobuf.descriptor
 import google.protobuf.internal.containers
 import google.protobuf.message
 import s2clientprotocol.common_pb2
 import s2clientprotocol.error_pb2
-
-if sys.version_info >= (3, 8):
-    import typing as typing_extensions
-else:
-    import typing_extensions
 
 DESCRIPTOR: google.protobuf.descriptor.FileDescriptor
 

--- a/stubs/s2clientprotocol/s2clientprotocol/query_pb2.pyi
+++ b/stubs/s2clientprotocol/s2clientprotocol/query_pb2.pyi
@@ -4,13 +4,18 @@ isort:skip_file
 """
 import builtins
 import collections.abc
-import typing as typing_extensions
+import sys
 
 import google.protobuf.descriptor
 import google.protobuf.internal.containers
 import google.protobuf.message
 import s2clientprotocol.common_pb2
 import s2clientprotocol.error_pb2
+
+if sys.version_info >= (3, 8):
+    import typing as typing_extensions
+else:
+    import typing_extensions
 
 DESCRIPTOR: google.protobuf.descriptor.FileDescriptor
 

--- a/tests/check_consistent.py
+++ b/tests/check_consistent.py
@@ -23,7 +23,7 @@ extension_descriptions = {".pyi": "stub", ".py": ".py"}
 
 # These type checkers and linters must have exact versions in the requirements file to ensure
 # consistent CI runs.
-linters = {"black", "flake8", "flake8-bugbear", "flake8-noqa", "flake8-pyi", "ruff", "mypy", "pytype"}
+linters = {"black", "flake8", "flake8-noqa", "flake8-pyi", "ruff", "mypy", "pytype"}
 
 
 def assert_consistent_filetypes(


### PR DESCRIPTION
Replaces flake8-bugbear with https://docs.astral.sh/ruff/rules/#flake8-bugbear-b
Extracted from #11496