### PR TITLE
Remove old type-ignore explanation comments not removed in #8280

### DIFF
--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -98,7 +98,6 @@ class object:
     __annotations__: dict[str, Any]
     @property
     def __class__(self) -> type[Self]: ...
-    # Ignore errors about type mismatch between property getter and setter
     @__class__.setter
     def __class__(self, __type: type[object]) -> None: ...  # noqa: F811
     def __init__(self) -> None: ...

--- a/stdlib/importlib/metadata/__init__.pyi
+++ b/stdlib/importlib/metadata/__init__.pyi
@@ -241,6 +241,7 @@ class MetadataPathFinder(DistributionFinder):
     @classmethod
     def find_distributions(cls, context: DistributionFinder.Context = ...) -> Iterable[PathDistribution]: ...
     if sys.version_info >= (3, 10):
+        # Yes, this is an instance method that has a parameter named "cls"
         def invalidate_caches(cls) -> None: ...
 
 class PathDistribution(Distribution):

--- a/stdlib/importlib/metadata/__init__.pyi
+++ b/stdlib/importlib/metadata/__init__.pyi
@@ -241,7 +241,6 @@ class MetadataPathFinder(DistributionFinder):
     @classmethod
     def find_distributions(cls, context: DistributionFinder.Context = ...) -> Iterable[PathDistribution]: ...
     if sys.version_info >= (3, 10):
-        # Yes, this is an instance method that has a parameter named "cls"
         def invalidate_caches(cls) -> None: ...
 
 class PathDistribution(Distribution):

--- a/stdlib/weakref.pyi
+++ b/stdlib/weakref.pyi
@@ -93,7 +93,6 @@ class WeakValueDictionary(MutableMapping[_KT, _VT]):
 
 class KeyedRef(ref[_T], Generic[_KT, _T]):
     key: _KT
-    # This __new__ method uses a non-standard name for the "cls" parameter
     def __new__(type, ob: _T, callback: Callable[[_T], Any], key: _KT) -> Self: ...
     def __init__(self, ob: _T, callback: Callable[[_T], Any], key: _KT) -> None: ...
 


### PR DESCRIPTION
https://github.com/python/typeshed/issues/8280 removed some redundant `#type: ignore`, but not the associated comments.