### PR TITLE
Use `uv` for installing dependencies on all Linux-only CI jobs

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -116,12 +116,12 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.11"
-          cache: pip
-          cache-dependency-path: stub_uploader/requirements.txt
+      - name: Install uv
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
       - name: Run tests
         run: |
           cd stub_uploader
-          pip install -r requirements.txt
+          uv pip install -r requirements.txt --system
           python -m pytest tests
 
   # https://github.community/t/run-github-actions-job-only-if-previous-job-has-failed/174786/2

--- a/.github/workflows/meta_tests.yml
+++ b/.github/workflows/meta_tests.yml
@@ -38,9 +38,8 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.11"
-          cache: pip
-          cache-dependency-path: requirements-tests.txt
-      - run: pip install -r requirements-tests.txt
+      - run: curl -LsSf https://astral.sh/uv/install.sh | sh
+      - run: uv pip install -r requirements-tests.txt --system
       - run: python ./tests/typecheck_typeshed.py --platform=${{ matrix.platform }}
   pyright:
     name: Run pyright against the scripts and tests directories
@@ -54,9 +53,8 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.9"
-          cache: pip
-          cache-dependency-path: requirements-tests.txt
-      - run: pip install -r requirements-tests.txt
+      - run: curl -LsSf https://astral.sh/uv/install.sh | sh
+      - run: uv pip install -r requirements-tests.txt --system
       - name: Get pyright version
         uses: SebRollen/toml-action@v1.0.2
         id: pyright_version
@@ -78,11 +76,10 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.11"
-          cache: pip
-          cache-dependency-path: requirements-tests.txt
+      - run: curl -LsSf https://astral.sh/uv/install.sh | sh
       - name: Git config
         run: |
           git config --global user.name stubsabot
           git config --global user.email '<>'
-      - run: pip install -r requirements-tests.txt
+      - run: uv pip install -r requirements-tests.txt --system
       - run: python scripts/stubsabot.py --action-level local

--- a/.github/workflows/stubsabot.yml
+++ b/.github/workflows/stubsabot.yml
@@ -27,14 +27,13 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.11"
-          cache: pip
-          cache-dependency-path: requirements-tests.txt
+      - run: curl -LsSf https://astral.sh/uv/install.sh | sh
       - name: git config
         run: |
           git config --global user.name stubsabot
           git config --global user.email '<>'
       - name: Install dependencies
-        run: pip install -r requirements-tests.txt
+        run: uv pip install -r requirements-tests.txt --system
       - name: Run stubsabot
         run: GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} python scripts/stubsabot.py --action-level everything
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,9 +30,8 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.11"
-          cache: pip
-          cache-dependency-path: requirements-tests.txt
-      - run: pip install -r requirements-tests.txt
+      - run: curl -LsSf https://astral.sh/uv/install.sh | sh
+      - run: uv pip install -r requirements-tests.txt --system
       - run: python ./tests/check_consistent.py
 
   new-syntax:
@@ -62,9 +61,8 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.11"
-          cache: pip
-          cache-dependency-path: requirements-tests.txt
-      - run: pip install -r requirements-tests.txt
+      - run: curl -LsSf https://astral.sh/uv/install.sh | sh
+      - run: uv pip install -r requirements-tests.txt --system
       - run: flake8 --color always
 
   pytype:
@@ -75,17 +73,17 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.11"
-          cache: pip
-          cache-dependency-path: requirements-tests.txt
-      - run: pip install -r requirements-tests.txt
+      - name: Install uv
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+      - run: uv pip install -r requirements-tests.txt --system
       - name: Install external dependencies for 3rd-party stubs
         run: |
           DEPENDENCIES=$(python tests/get_external_stub_requirements.py)
           if [ -n "$DEPENDENCIES" ]; then
             echo "Installing packages: $DEPENDENCIES"
-            pip install $DEPENDENCIES
+            uv pip install $DEPENDENCIES --system
           fi
-      - run: pip freeze --all
+      - run: uv pip freeze
       - run: ./tests/pytype_test.py --print-stderr
 
   mypy:
@@ -101,9 +99,8 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-          cache: pip
-          cache-dependency-path: requirements-tests.txt
-      - run: pip install -r requirements-tests.txt
+      - run: curl -LsSf https://astral.sh/uv/install.sh | sh
+      - run: uv pip install -r requirements-tests.txt --system
       - run: python ./tests/mypy_test.py --platform=${{ matrix.platform }} --python-version=${{ matrix.python-version }}
 
   regression-tests:
@@ -114,9 +111,8 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.11"
-          cache: pip
-          cache-dependency-path: requirements-tests.txt
-      - run: pip install -r requirements-tests.txt
+      - run: curl -LsSf https://astral.sh/uv/install.sh | sh
+      - run: uv pip install -r requirements-tests.txt --system
       - run: python ./tests/regr_test.py --all --verbosity QUIET
 
   pyright:
@@ -132,25 +128,25 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.11"
-          cache: pip
-          cache-dependency-path: requirements-tests.txt
+      - name: Install uv
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
       - name: Install typeshed test-suite requirements
         # Install these so we can run `get_external_stub_requirements.py`
-        run: pip install -r requirements-tests.txt
+        run: uv pip install -r requirements-tests.txt --system
       - name: Create an isolated venv for testing
-        run: python -m venv .venv
+        run: uv venv .venv
       - name: Install 3rd-party stub dependencies
         run: |
           DEPENDENCIES=$(python tests/get_external_stub_requirements.py)
           if [ -n "$DEPENDENCIES" ]; then
             source .venv/bin/activate
             echo "Installing packages: $DEPENDENCIES"
-            pip install $DEPENDENCIES
+            uv pip install $DEPENDENCIES --system
           fi
       - name: Activate the isolated venv for the rest of the job
         run: echo "$PWD/.venv/bin" >> $GITHUB_PATH
       - name: List 3rd-party stub dependencies installed
-        run: pip freeze --all
+        run: uv pip freeze
       - name: Get pyright version
         uses: SebRollen/toml-action@v1.0.2
         id: pyright_version
@@ -197,10 +193,10 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.11"
-          cache: pip
-          cache-dependency-path: stub_uploader/requirements.txt
+      - name: Install uv
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
       - name: Run tests
         run: |
           cd stub_uploader
-          pip install -r requirements.txt
+          uv pip install -r requirements.txt --system
           python -m pytest tests


### PR DESCRIPTION
Using [`uv`](https://github.com/astral-sh/uv) rather than pip means our requirements are installed almost instantly in CI, compared to around 10s to install our `requirements.txt` file currently on each job.

I've only changed the jobs that are Linux-only in this PR. `uv` works fine on Windows, but it's slightly fiddly to install `uv` in a workflow that runs on both Windows and Linux without using pip (which is slow, defeating the point of the exercise). It's [possible](https://github.com/AlexWaygood/typeshed-stats/blob/f55c5bee175a97a345209df3fdb86bb611956168/.github/workflows/test.yml#L59-L64C14) to install uv in a cross-platform workflow without using pip, but I wasn't sure it was worth the added complexity for us here.