### PR TITLE
Fix type of `concurrent.futures.wait` for Python <= 3.8

### DIFF
--- a/stdlib/concurrent/futures/_base.pyi
+++ b/stdlib/concurrent/futures/_base.pyi
@@ -1,7 +1,7 @@
 import sys
 import threading
 from _typeshed import Unused
-from collections.abc import Callable, Iterable, Iterator
+from collections.abc import Callable, Collection, Iterable, Iterator
 from logging import Logger
 from types import TracebackType
 from typing import Any, Generic, Literal, NamedTuple, Protocol, TypeVar
@@ -91,9 +91,14 @@ class DoneAndNotDoneFutures(NamedTuple, Generic[_T]):
     done: set[Future[_T]]
     not_done: set[Future[_T]]
 
-def wait(
-    fs: Iterable[Future[_T]], timeout: float | None = None, return_when: str = "ALL_COMPLETED"
-) -> DoneAndNotDoneFutures[_T]: ...
+if sys.version_info >= (3, 9):
+    def wait(
+        fs: Iterable[Future[_T]], timeout: float | None = None, return_when: str = "ALL_COMPLETED"
+    ) -> DoneAndNotDoneFutures[_T]: ...
+else:
+    def wait(
+        fs: Collection[Future[_T]], timeout: float | None = None, return_when: str = "ALL_COMPLETED"
+    ) -> DoneAndNotDoneFutures[_T]: ...
 
 class _Waiter:
     event: threading.Event

--- a/stdlib/concurrent/futures/_base.pyi
+++ b/stdlib/concurrent/futures/_base.pyi
@@ -95,6 +95,7 @@ if sys.version_info >= (3, 9):
     def wait(
         fs: Iterable[Future[_T]], timeout: float | None = None, return_when: str = "ALL_COMPLETED"
     ) -> DoneAndNotDoneFutures[_T]: ...
+
 else:
     def wait(
         fs: Collection[Future[_T]], timeout: float | None = None, return_when: str = "ALL_COMPLETED"


### PR DESCRIPTION
Closes #11533.