### PR TITLE
Make stubtest pass on libsass/passlib/redis/tree-sitter if you're using Python 3.12

### DIFF
--- a/stubs/libsass/METADATA.toml
+++ b/stubs/libsass/METADATA.toml
@@ -1,3 +1,7 @@
 version = "0.23.*"
 requires = ["types-setuptools"]
 upstream_repository = "https://github.com/sass/libsass-python"
+
+[tool.stubtest]
+# The runtime package has an undeclared dependency on setuptools
+stubtest_requirements = ["setuptools"]

--- a/stubs/passlib/METADATA.toml
+++ b/stubs/passlib/METADATA.toml
@@ -1,2 +1,6 @@
 version = "1.7.*"
 upstream_repository = "https://foss.heptapod.net/python-libs/passlib"
+
+[tool.stubtest]
+# The runtime package has an undeclared dependency on setuptools
+stubtest_requirements = ["setuptools"]

--- a/stubs/redis/METADATA.toml
+++ b/stubs/redis/METADATA.toml
@@ -15,4 +15,6 @@ extra_description = """\
 
 [tool.stubtest]
 ignore_missing_stub = true
+# The runtime has an undeclared dependency on setuptools
+stubtest_requirements = ["setuptools"]
 extras = ["ocsp"]

--- a/stubs/tree-sitter/METADATA.toml
+++ b/stubs/tree-sitter/METADATA.toml
@@ -1,3 +1,7 @@
 version = "0.20.1"
 upstream_repository = "https://github.com/tree-sitter/py-tree-sitter"
 obsolete_since = "0.20.3" # Released on 2023-11-13
+
+[tool.stubtest]
+# The runtime has an undeclared dependency on setuptools
+stubtest_requirements = ["setuptools"]


### PR DESCRIPTION
These two packages depend on setuptools at runtime without declaring that dependency properly. Historically, setuptools has been automatically installed into virtual environments by default, but that isn't the case anymore on py312+