### PR TITLE
email.message: Allow any header value

### DIFF
--- a/stdlib/email/message.pyi
+++ b/stdlib/email/message.pyi
@@ -15,9 +15,10 @@ _PayloadType: TypeAlias = Message | str
 _EncodedPayloadType: TypeAlias = Message | bytes
 _MultipartPayloadType: TypeAlias = list[_PayloadType]
 _CharsetType: TypeAlias = Charset | str | None
-# Type returned by Policy.header_fetch_parse, AnyOf[str | Header]
+# Type returned by Policy.header_fetch_parse, often str or Header.
 _HeaderType: TypeAlias = Any
-_HeaderTypeParam: TypeAlias = str | Header
+# Type accepted by Policy.header_store_parse.
+_HeaderTypeParam: TypeAlias = str | Header | Any
 
 class _SupportsEncodeToPayload(Protocol):
     def encode(self, encoding: str, /) -> _PayloadType | _MultipartPayloadType | _SupportsDecodeToPayload: ...
@@ -25,6 +26,9 @@ class _SupportsEncodeToPayload(Protocol):
 class _SupportsDecodeToPayload(Protocol):
     def decode(self, encoding: str, errors: str, /) -> _PayloadType | _MultipartPayloadType: ...
 
+# TODO: This class should be generic over the header policy and/or the header
+# value types allowed by the policy. This depends on PEP 696 support
+# (https://github.com/python/typeshed/issues/11422).
 class Message:
     policy: Policy  # undocumented
     preamble: str | None

--- a/test_cases/stdlib/email/check_message.py
+++ b/test_cases/stdlib/email/check_message.py
@@ -1,0 +1,6 @@
+from email.headerregistry import Address
+from email.message import EmailMessage
+
+msg = EmailMessage()
+msg["To"] = "receiver@example.com"
+msg["From"] = Address("Sender Name", "sender", "example.com")


### PR DESCRIPTION
The allowed value depends on the used policy. For example,
`EmailPolicy` allows objects with a `name` attribute, which the
compat policy does not allow.

This can be improved in the future, especially when TypeVar defaults become available.