### PR TITLE
Make stubtest work on pyscreeze if you're using py312

### DIFF
--- a/stubs/PyScreeze/METADATA.toml
+++ b/stubs/PyScreeze/METADATA.toml
@@ -5,3 +5,7 @@ requires = ["types-Pillow"]
 [tool.stubtest]
 # Linux has extra constants, win32 has different definitions
 platforms = ["linux", "win32"]
+# PyScreeze has an odd setup.py file
+# that doesn't list Pillow as a dependency for py312+ yet:
+# https://github.com/asweigart/pyscreeze/blob/eeca245a135cf171c163b3691300138518efa64e/setup.py#L38-L46
+stubtest_requirements = ["Pillow"]


### PR DESCRIPTION
Same principle as with https://github.com/python/typeshed/pull/11561, though this one's a little strange...