### PR TITLE
pygit2: Workaround python/mypy#16972

### DIFF
--- a/stubs/pygit2/@tests/stubtest_allowlist.txt
+++ b/stubs/pygit2/@tests/stubtest_allowlist.txt
@@ -1,7 +1,3 @@
-# stubtest wrongly checks the Python implementation with the cffi type's
-# stubs, likely due to name shadowing that happens at import-time
-pygit2.Repository.__init__
-pygit2.Repository._from_c
 # @cached_property that fail to get recognized as such by stubtest
 pygit2.config.ConfigEntry.level
 pygit2.config.ConfigEntry.raw_name

--- a/stubs/pygit2/pygit2/__init__.pyi
+++ b/stubs/pygit2/pygit2/__init__.pyi
@@ -1,9 +1,15 @@
 from _typeshed import StrOrBytesPath, SupportsAllComparisons
 from collections.abc import Callable
 
+# This is intentionally duplicated and placed above the _pygit2
+# star-import to workaround mypy issue #16972, so that consumers
+# of the stubs see the correct, wrapped type for the name
+# "Repository".
+from .repository import Repository as Repository  # isort: skip
+
 from . import enums
 from ._build import __version__ as __version__
-from ._pygit2 import *
+from ._pygit2 import *  # type: ignore[assignment]
 from .blame import Blame as Blame, BlameHunk as BlameHunk
 from .blob import BlobIO as BlobIO
 from .callbacks import (
@@ -21,7 +27,7 @@ from .index import Index as Index, IndexEntry as IndexEntry
 from .legacyenums import *
 from .packbuilder import PackBuilder as PackBuilder
 from .remotes import Remote as Remote
-from .repository import Repository  # type: ignore[assignment]
+from .repository import Repository as Repository  # noqa: F811 # intentional workaround
 from .settings import Settings
 from .submodules import Submodule as Submodule
 


### PR DESCRIPTION
To fix the signatures of `clone_repository` and `init_repository` as seen by type checkers.