### PR TITLE
Use stricter pyright settings for `pygit2`

### DIFF
--- a/pyrightconfig.stricter.json
+++ b/pyrightconfig.stricter.json
@@ -62,7 +62,6 @@
         "stubs/psycopg2",
         "stubs/pyasn1",
         "stubs/pyflakes",
-        "stubs/pygit2",
         "stubs/Pygments",
         "stubs/PyMySQL",
         "stubs/python-dateutil",


### PR DESCRIPTION
According to `typeshed-stats`, these stubs are fully annotated: https://github.com/AlexWaygood/typeshed-stats/actions/runs/8257791235/job/22588952236