### PR TITLE
Renovate config: give the dependency groups better names

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -20,14 +20,14 @@
   ],
   "packageRules": [
     {
-      "groupName": "GitHub Actions update",
+      "groupName": "GitHub Actions",
       "matchManagers": ["github-actions"],
       "description": "Quarterly update of GitHub Action dependencies",
       "separateMajorMinor": "false",
       "schedule": ["every 3 months on the first day of the month"]
     },
     {
-      "groupName": "Quarterly dependency update",
+      "groupName": "most test/lint dependencies",
       "matchManagers": ["pip_requirements", "pre-commit"],
       "excludePackageNames": ["pytype", "pyright"],
       "description": "Quarterly update of most test dependencies",
@@ -35,7 +35,7 @@
       "schedule": ["every 3 months on the first day of the month"]
     },
     {
-      "groupName": "Daily dependency update",
+      "groupName": "pytype and pyright",
       "matchManagers": ["pip_requirements", "regex"],
       "matchPackageNames": ["pytype", "pyright"],
       "description": "Daily update of pyright and pytype",


### PR DESCRIPTION
This should make the sentences in https://github.com/python/typeshed/issues/11588#issue-2183664294 make more sense...