### PR TITLE
Redis: add Lock in __init__

### DIFF
--- a/stubs/redis/redis/__init__.pyi
+++ b/stubs/redis/redis/__init__.pyi
@@ -1,4 +1,4 @@
-from . import backoff, client, connection, credentials, exceptions, sentinel, utils
+from . import backoff, client, connection, credentials, exceptions, lock, sentinel, utils
 from .cluster import RedisCluster as RedisCluster
 
 __all__ = [
@@ -15,6 +15,7 @@ __all__ = [
     "from_url",
     "default_backoff",
     "InvalidResponse",
+    "Lock",
     "PubSubError",
     "ReadOnlyError",
     "Redis",
@@ -67,6 +68,8 @@ WatchError = exceptions.WatchError
 
 CredentialProvider = credentials.CredentialProvider
 UsernamePasswordCredentialProvider = credentials.UsernamePasswordCredentialProvider
+
+Lock = lock.Lock
 
 __version__: str
 VERSION: tuple[int | str, ...]


### PR DESCRIPTION
I know it seems to be a bit of a discussion regarding redis-py, but I ran into the issue today of figuring out the types to pass a Lock-type. This fix worked out if I made the same changes in the types-redis locally.