### PR TITLE
Go back to using py311 for `regr-test.py` for now

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -90,7 +90,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          # Use py311 for now, as py312 seems to be around 30s slower in CI
+          # TODO: figure out why that is (#11590)
+          python-version: "3.11"
       - run: curl -LsSf https://astral.sh/uv/install.sh | sh
       - run: uv pip install -r requirements-tests.txt --system
       - run: python ./tests/regr_test.py --all --verbosity QUIET


### PR DESCRIPTION
See #11590. (But let's keep that issue open, as I still haven't had a chance to properly investigate yet.)