### PR TITLE
Add taskName to LogRecord

### DIFF
--- a/stdlib/logging/__init__.pyi
+++ b/stdlib/logging/__init__.pyi
@@ -343,6 +343,7 @@ class LogRecord:
     threadName: str | None
     if sys.version_info >= (3, 12):
         taskName: str | None
+
     def __init__(
         self,
         name: str,

--- a/stdlib/logging/__init__.pyi
+++ b/stdlib/logging/__init__.pyi
@@ -341,6 +341,8 @@ class LogRecord:
     stack_info: str | None
     thread: int | None
     threadName: str | None
+    if sys.version_info >= (3, 12):
+        taskName: str | None
     def __init__(
         self,
         name: str,


### PR DESCRIPTION
Add `taskName` to `LogRecord` (it got added in Python 3.12.0).

related cpython issue: https://github.com/python/cpython/issues/91513