### PR TITLE
Changed return type of Awaitable.__await__() to match PEP 492

### DIFF
--- a/stdlib/typing.pyi
+++ b/stdlib/typing.pyi
@@ -435,7 +435,7 @@ class Generator(Iterator[_YieldT_co], Generic[_YieldT_co, _SendT_contra, _Return
 @runtime_checkable
 class Awaitable(Protocol[_T_co]):
     @abstractmethod
-    def __await__(self) -> Generator[Any, None, _T_co]: ...
+    def __await__(self) -> Iterator[_T_co]: ...
 
 class Coroutine(Awaitable[_ReturnT_co], Generic[_YieldT_co, _SendT_contra, _ReturnT_co]):
     __name__: str


### PR DESCRIPTION
The language of PEP 492 (and the stdlib documentation) plainly states that `__await__()` must return an **iterator**. Not a `Generator`, like how the return type is now specified in Typeshed.