### PR TITLE
stubsabot: Skip over empty `__init__.py` files when determining if all Python files are covered by `py.typed` markers

### DIFF
--- a/scripts/stubsabot.py
+++ b/scripts/stubsabot.py
@@ -194,7 +194,7 @@ def all_py_files_in_source_are_in_py_typed_dirs(source: zipfile.ZipFile | tarfil
         path_iter = (
             Path(zip_info.filename)
             for zip_info in source.infolist()
-            if not (zip_info.is_dir() or (Path(zip_info.filename).name == "__init__.py" and zip_info.file_size == 0))
+            if (not zip_info.is_dir()) and not (Path(zip_info.filename).name == "__init__.py" and zip_info.file_size == 0))
         )
     else:
         path_iter = (

--- a/scripts/stubsabot.py
+++ b/scripts/stubsabot.py
@@ -194,7 +194,7 @@ def all_py_files_in_source_are_in_py_typed_dirs(source: zipfile.ZipFile | tarfil
         path_iter = (
             Path(zip_info.filename)
             for zip_info in source.infolist()
-            if (not zip_info.is_dir()) and not (Path(zip_info.filename).name == "__init__.py" and zip_info.file_size == 0))
+            if ((not zip_info.is_dir()) and not (Path(zip_info.filename).name == "__init__.py" and zip_info.file_size == 0))
         )
     else:
         path_iter = (


### PR DESCRIPTION
An attempt to address the false negatives seen in https://github.com/python/typeshed/issues/11633#issuecomment-2008975395