### PR TITLE
Mark types-paho-mqtt as obsolete since v2.0.0

### DIFF
--- a/stubs/paho-mqtt/METADATA.toml
+++ b/stubs/paho-mqtt/METADATA.toml
@@ -1,2 +1,3 @@
 version = "1.6.*"
 upstream_repository = "https://github.com/eclipse/paho.mqtt.python"
+obsolete_since = "2.0.0" # Released on 2024-02-10


### PR DESCRIPTION
Cf. #11633