### PR TITLE
polib: Fix POEntry.occurrences

### DIFF
--- a/stubs/polib/polib.pyi
+++ b/stubs/polib/polib.pyi
@@ -83,7 +83,7 @@ class _BaseEntry:
 class POEntry(_BaseEntry):
     comment: str
     tcomment: str
-    occurrences: list[tuple[str, int]]
+    occurrences: list[tuple[str, str]]
     flags: list[str]
     previous_msgctxt: str | None
     previous_msgid: str | None
@@ -109,7 +109,7 @@ class POEntry(_BaseEntry):
 class MOEntry(_BaseEntry):
     comment: str
     tcomment: str
-    occurrences: list[tuple[str, int]]
+    occurrences: list[tuple[str, str]]
     flags: list[str]
     previous_msgctxt: str | None
     previous_msgid: str | None


### PR DESCRIPTION
The second line positions of `occurrences` are kept as a string, rather than parsed as an int: https://github.com/izimobil/polib/blob/85f6d1cf727452c2fcc7cf15f4c21e273d704b79/polib.py#L1570-L1577