### PR TITLE
python-xlib: use `_typeshed.Unused`

### DIFF
--- a/stubs/python-xlib/Xlib/_typing.pyi
+++ b/stubs/python-xlib/Xlib/_typing.pyi
@@ -7,4 +7,3 @@ from Xlib.protocol.rq import Request
 
 _T = TypeVar("_T")
 ErrorHandler: TypeAlias = Callable[[XError, Request | None], _T]
-Unused: TypeAlias = object

--- a/stubs/python-xlib/Xlib/ext/composite.pyi
+++ b/stubs/python-xlib/Xlib/ext/composite.pyi
@@ -1,8 +1,9 @@
+from _typeshed import Unused
 from collections.abc import Callable
 from typing import Any, Final
 from typing_extensions import TypeAlias
 
-from Xlib._typing import ErrorHandler, Unused
+from Xlib._typing import ErrorHandler
 from Xlib.display import Display
 from Xlib.protocol import rq
 from Xlib.xobject import drawable, resource

--- a/stubs/python-xlib/Xlib/ext/dpms.pyi
+++ b/stubs/python-xlib/Xlib/ext/dpms.pyi
@@ -1,6 +1,6 @@
+from _typeshed import Unused
 from typing import Final, Literal
 
-from Xlib._typing import Unused
 from Xlib.display import Display
 from Xlib.protocol import rq
 from Xlib.xobject import resource

--- a/stubs/python-xlib/Xlib/ext/ge.pyi
+++ b/stubs/python-xlib/Xlib/ext/ge.pyi
@@ -1,6 +1,6 @@
+from _typeshed import Unused
 from typing import Final
 
-from Xlib._typing import Unused
 from Xlib.display import Display
 from Xlib.protocol import rq
 from Xlib.xobject import resource

--- a/stubs/python-xlib/Xlib/ext/nvcontrol.pyi
+++ b/stubs/python-xlib/Xlib/ext/nvcontrol.pyi
@@ -1,6 +1,6 @@
+from _typeshed import Unused
 from typing import Final
 
-from Xlib._typing import Unused
 from Xlib.display import Display
 from Xlib.protocol import rq
 from Xlib.xobject import resource

--- a/stubs/python-xlib/Xlib/ext/record.pyi
+++ b/stubs/python-xlib/Xlib/ext/record.pyi
@@ -1,7 +1,7 @@
+from _typeshed import Unused
 from collections.abc import Callable, Sequence, Sized
 from typing import Any, Final, Literal, TypeVar
 
-from Xlib._typing import Unused
 from Xlib.display import Display
 from Xlib.protocol import display, rq
 from Xlib.xobject import resource

--- a/stubs/python-xlib/Xlib/ext/res.pyi
+++ b/stubs/python-xlib/Xlib/ext/res.pyi
@@ -1,7 +1,7 @@
+from _typeshed import Unused
 from collections.abc import Sequence
 from typing import Final
 
-from Xlib._typing import Unused
 from Xlib.display import Display
 from Xlib.protocol import rq
 from Xlib.xobject import resource

--- a/stubs/python-xlib/Xlib/ext/security.pyi
+++ b/stubs/python-xlib/Xlib/ext/security.pyi
@@ -1,6 +1,6 @@
+from _typeshed import Unused
 from typing import Final
 
-from Xlib._typing import Unused
 from Xlib.display import Display
 from Xlib.protocol import rq
 from Xlib.xobject import resource

--- a/stubs/python-xlib/Xlib/ext/xfixes.pyi
+++ b/stubs/python-xlib/Xlib/ext/xfixes.pyi
@@ -1,6 +1,6 @@
+from _typeshed import Unused
 from typing import Final
 
-from Xlib._typing import Unused
 from Xlib.display import Display
 from Xlib.protocol import request, rq
 from Xlib.xobject import drawable, resource

--- a/stubs/python-xlib/Xlib/ext/xinerama.pyi
+++ b/stubs/python-xlib/Xlib/ext/xinerama.pyi
@@ -1,6 +1,6 @@
+from _typeshed import Unused
 from typing import Final
 
-from Xlib._typing import Unused
 from Xlib.display import Display
 from Xlib.protocol import rq
 from Xlib.xobject import drawable, resource

--- a/stubs/python-xlib/Xlib/ext/xinput.pyi
+++ b/stubs/python-xlib/Xlib/ext/xinput.pyi
@@ -1,8 +1,7 @@
-from _typeshed import ConvertibleToFloat, SliceableBuffer
+from _typeshed import ConvertibleToFloat, SliceableBuffer, Unused
 from collections.abc import Iterable, Sequence
 from typing import Final, TypeVar
 
-from Xlib._typing import Unused
 from Xlib.display import Display
 from Xlib.protocol import display, request, rq
 from Xlib.xobject import drawable, resource

--- a/stubs/python-xlib/Xlib/ext/xtest.pyi
+++ b/stubs/python-xlib/Xlib/ext/xtest.pyi
@@ -1,6 +1,6 @@
+from _typeshed import Unused
 from typing import Final
 
-from Xlib._typing import Unused
 from Xlib.display import Display
 from Xlib.protocol import rq
 from Xlib.xobject import resource

--- a/stubs/python-xlib/Xlib/protocol/rq.pyi
+++ b/stubs/python-xlib/Xlib/protocol/rq.pyi
@@ -1,4 +1,4 @@
-from _typeshed import ConvertibleToInt, SliceableBuffer
+from _typeshed import ConvertibleToInt, SliceableBuffer, Unused
 from array import array
 
 # Avoid name collision with List.type
@@ -7,7 +7,7 @@ from collections.abc import Callable, Iterable, Sequence
 from typing import Any, Final, Literal, SupportsIndex, TypeVar, overload, type_check_only
 from typing_extensions import LiteralString, TypeAlias
 
-from Xlib._typing import ErrorHandler, Unused
+from Xlib._typing import ErrorHandler
 from Xlib.display import _BaseDisplay, _ResourceBaseClass
 from Xlib.error import XError
 from Xlib.ext.xinput import ClassInfoClass

--- a/stubs/python-xlib/Xlib/support/unix_connect.pyi
+++ b/stubs/python-xlib/Xlib/support/unix_connect.pyi
@@ -1,12 +1,11 @@
 import sys
 from _socket import _Address
+from _typeshed import Unused
 from platform import uname_result
 from re import Pattern
 from socket import socket
 from typing import Final, Literal
 from typing_extensions import TypeAlias
-
-from Xlib._typing import Unused
 
 if sys.platform == "darwin":
     SUPPORTED_PROTOCOLS: Final[tuple[None, Literal["tcp"], Literal["unix"], Literal["darwin"]]]

--- a/stubs/python-xlib/Xlib/support/vms_connect.pyi
+++ b/stubs/python-xlib/Xlib/support/vms_connect.pyi
@@ -1,9 +1,8 @@
 from _socket import _Address
+from _typeshed import Unused
 from re import Pattern
 from socket import socket
 from typing import Final
-
-from Xlib._typing import Unused
 
 display_re: Final[Pattern[str]]
 


### PR DESCRIPTION
A long overdue update I had forgotten about. There's been many mypy releases with stdlib stubs updates since then.