### PR TITLE
Bump tensorflow to 2.16.1 in protobuf script

### DIFF
--- a/scripts/sync_tensorflow_protobuf_stubs.sh
+++ b/scripts/sync_tensorflow_protobuf_stubs.sh
@@ -7,20 +7,22 @@ set -euxo pipefail
 # Generally, new minor versions are a good time to update the stubs.
 REPO_ROOT="$(realpath "$(dirname "${BASH_SOURCE[0]}")"/..)"
 
-# This version should be consistent with the version in tensorflow's METADATA.toml.
-TENSORFLOW_VERSION=2.12.1
+# Whenever you update TENSORFLOW_VERSION here, version should be updated
+# in stubs/tensorflow/METADATA.toml and vice-versa.
+TENSORFLOW_VERSION=2.16.1
 # Latest mypy-protobuf has dependency on protobuf >4, which is incompatible at runtime
-# with tensorflow. However, the stubs produced do still work with tensorflow. So after
-# installing mypy-protobuf, before running stubtest on tensorflow you should downgrade
-# protobuf<4.
+# with tensorflow. However, the stubs produced do still work with tensorflow.
+# This issue is mitigated by using a different venv
 MYPY_PROTOBUF_VERSION=3.5.0
 
-pip install pre-commit mypy-protobuf=="$MYPY_PROTOBUF_VERSION"
-
-cd "$(dirname "$0")" > /dev/null
-cd ../stubs/tensorflow
+cd $REPO_ROOT/stubs/tensorflow > /dev/null
 mkdir -p repository
 pushd repository &> /dev/null
+    # Prepare virtualenv
+    uv venv .venv
+    source .venv/bin/activate
+    uv pip install pre-commit mypy-protobuf=="$MYPY_PROTOBUF_VERSION"
+
     # If the script fails halfway, it's nice to be able to re-run it immediately
     if [ ! -d "tensorflow" ] ; then
         git clone --depth 1 --branch v"$TENSORFLOW_VERSION" https://github.com/tensorflow/tensorflow.git
@@ -29,15 +31,15 @@ pushd repository &> /dev/null
         # Folders here cover the more commonly used protobufs externally and
         # their dependencies. Tensorflow has more protobufs and can be added if requested.
         protoc --mypy_out "relax_strict_optional_primitives:$REPO_ROOT/stubs/tensorflow" \
-            tensorflow/compiler/xla/*.proto \
-            tensorflow/compiler/xla/service/*.proto \
+            third_party/xla/xla/*.proto \
+            third_party/xla/xla/service/*.proto \
             tensorflow/core/example/*.proto \
             tensorflow/core/framework/*.proto \
             tensorflow/core/protobuf/*.proto \
             tensorflow/core/protobuf/tpu/*.proto \
             tensorflow/core/util/*.proto \
             tensorflow/python/keras/protobuf/*.proto \
-            tensorflow/tsl/protobuf/*.proto
+            third_party/xla/third_party/tsl/tsl/protobuf/*.proto
     popd &> /dev/null
 popd &> /dev/null
 
@@ -45,10 +47,10 @@ popd &> /dev/null
 # included in the python wheel. They are likely only used for other
 # language builds. stubtest was used to identify them by looking for
 # ModuleNotFoundError.
-rm tensorflow/compiler/xla/service/hlo_execution_profile_data_pb2.pyi \
-   tensorflow/compiler/xla/service/hlo_profile_printer_data_pb2.pyi \
-   tensorflow/compiler/xla/service/test_compilation_environment_pb2.pyi \
-   tensorflow/compiler/xla/xla_pb2.pyi \
+rm third_party/xla/xla/service/hlo_execution_profile_data_pb2.pyi \
+   third_party/xla/xla/service/hlo_profile_printer_data_pb2.pyi \
+   third_party/xla/xla/service/test_compilation_environment_pb2.pyi \
+   third_party/xla/xla/xla_pb2.pyi \
    tensorflow/core/protobuf/autotuning_pb2.pyi \
    tensorflow/core/protobuf/conv_autotuning_pb2.pyi \
    tensorflow/core/protobuf/critical_section_pb2.pyi \
@@ -61,9 +63,6 @@ rm tensorflow/compiler/xla/service/hlo_execution_profile_data_pb2.pyi \
    tensorflow/core/protobuf/worker_service_pb2.pyi \
    tensorflow/core/util/example_proto_fast_parsing_test_pb2.pyi
 
-# use `|| true` so the script still continues even if a pre-commit hook
-# applies autofixes (which will result in a nonzero exit code)
-pre-commit run --files "$REPO_ROOT/stubs/tensorflow/tensorflow" || true
 
 sed --in-place="" \
     "s/extra_description = .*$/extra_description = \"Partially generated using [mypy-protobuf==$MYPY_PROTOBUF_VERSION](https:\/\/github.com\/nipunn1313\/mypy-protobuf\/tree\/v$MYPY_PROTOBUF_VERSION) on tensorflow==$TENSORFLOW_VERSION\"/" \
@@ -71,3 +70,11 @@ sed --in-place="" \
 
 # Cleanup last. If the script fails halfway, it's nice to be able to re-run it immediately
 rm -rf repository/
+
+# Keep pre-commit run after cleanup to reduce changed files. Or start using a temp folder for this script
+# use `|| true` so the script still continues even if a pre-commit hook
+# applies autofixes (which will result in a nonzero exit code)
+pre-commit run --files $(git ls-files -- "$REPO_ROOT/stubs/tensorflow/tensorflow/**.pyi") || true
+# Ruff takes two passes to fix everything, re-running all of pre-commit is *slow*
+# and we don't need --unsafe-fixes to remove imports
+ruff check "$REPO_ROOT/stubs/tensorflow/tensorflow" --fix --exit-zero

--- a/stubs/tensorflow/METADATA.toml
+++ b/stubs/tensorflow/METADATA.toml
@@ -1,8 +1,10 @@
-version = "2.15.*"
+# Whenever you update version here, TENSORFLOW_VERSION should be updated
+# in scripts/sync_tensorflow_protobuf_stubs.sh and vice-versa.
+version = "2.16.*"
 upstream_repository = "https://github.com/tensorflow/tensorflow"
 # requires a version of numpy with a `py.typed` file
 requires = ["numpy>=1.20", "types-protobuf", "types-requests"]
-extra_description = "Partially generated using [mypy-protobuf==3.5.0](https://github.com/nipunn1313/mypy-protobuf/tree/v3.5.0) on tensorflow==2.12.1"
+extra_description = "Partially generated using [mypy-protobuf==3.5.0](https://github.com/nipunn1313/mypy-protobuf/tree/v3.5.0) on tensorflow==2.15.1"
 partial_stub = true
 
 [tool.stubtest]


### PR DESCRIPTION
I skipped 2.15 because it didn't lead to any difference

This is as far as I managed to get it. 2.16 moved some files around, but is also causing new issues:

`Explicit 'optional' labels are disallowed in the Proto3 syntax.` example:
```
tensorflow/core/framework/optimized_function_graph.proto:43:12: Explicit 'optional' labels are disallowed in the Proto3 syntax. To define 'optional' fields in Proto3, simply remove the 'optional' 
label, as fields are 'optional' by default.
```
and plenty of `was not found or had errors.` for tsl and xla. For example:
```
tsl/protobuf/histogram.proto: File not found.
tensorflow/core/framework/summary.proto: Import "tsl/protobuf/histogram.proto" was not found or had errors.
tensorflow/core/framework/summary.proto:125:7: "HistogramProto" is not defined.
```
```
xla/autotuning.proto: File not found.
third_party/xla/xla/autotune_results.proto: Import "xla/autotuning.proto" was not found or had errors.
third_party/xla/xla/autotune_results.proto:36:5: "AutotuneResult" is not defined.
```
despite those files clearly existing. I'm a bit out of my depth here. Maybe @hoel-bagard you have an idea?