### PR TITLE
Update `typing_extensions.deprecated` decorator to use `LiteralString`

### DIFF
--- a/stdlib/typing_extensions.pyi
+++ b/stdlib/typing_extensions.pyi
@@ -453,10 +453,10 @@ class TypeVarTuple:
     def __iter__(self) -> Any: ...  # Unpack[Self]
 
 class deprecated:
-    message: str
+    message: LiteralString
     category: type[Warning] | None
     stacklevel: int
-    def __init__(self, message: str, /, *, category: type[Warning] | None = ..., stacklevel: int = 1) -> None: ...
+    def __init__(self, message: LiteralString, /, *, category: type[Warning] | None = ..., stacklevel: int = 1) -> None: ...
     def __call__(self, arg: _T, /) -> _T: ...
 
 if sys.version_info >= (3, 12):


### PR DESCRIPTION
fixes #11699 