### PR TITLE
Use Python 3.11.8 for stdlib stubtest for now

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -36,7 +36,8 @@ jobs:
       matrix:
         # tkinter doesn't import on macOS-12
         os: ["ubuntu-latest", "windows-latest", "macos-11"]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        # TODO unpin the 3.11 micro version
+        python-version: ["3.8", "3.9", "3.10", "3.11.8", "3.12"]
       fail-fast: false
 
     steps:

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -36,8 +36,8 @@ jobs:
       matrix:
         # tkinter doesn't import on macOS-12
         os: ["ubuntu-latest", "windows-latest", "macos-11"]
-        # TODO unpin the 3.11 micro version
-        python-version: ["3.8", "3.9", "3.10", "3.11.8", "3.12"]
+        # TODO unpin the 3.11 and 3.12 micro versions
+        python-version: ["3.8", "3.9", "3.10", "3.11.8", "3.12.2"]
       fail-fast: false
 
     steps:

--- a/.github/workflows/stubtest_stdlib.yml
+++ b/.github/workflows/stubtest_stdlib.yml
@@ -32,8 +32,8 @@ jobs:
       matrix:
         # tkinter doesn't import on macOS 12
         os: ["ubuntu-latest", "windows-latest", "macos-11"]
-        # TODO unpin 3.11 micro version
-        python-version: ["3.8", "3.9", "3.10", "3.11.8", "3.12"]
+        # TODO unpin 3.11 and 3.12 micro versions
+        python-version: ["3.8", "3.9", "3.10", "3.11.8", "3.12.2"]
       fail-fast: false
 
     steps:

--- a/.github/workflows/stubtest_stdlib.yml
+++ b/.github/workflows/stubtest_stdlib.yml
@@ -32,7 +32,8 @@ jobs:
       matrix:
         # tkinter doesn't import on macOS 12
         os: ["ubuntu-latest", "windows-latest", "macos-11"]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        # TODO unpin 3.11 micro version
+        python-version: ["3.8", "3.9", "3.10", "3.11.8", "3.12"]
       fail-fast: false
 
     steps:


### PR DESCRIPTION
A quick fix to stop the bleeding, since it looks like there's a fair few changes in 3.11.9 for us to grapple with. Fixes #11712.