### PR TITLE
requests: export `packages` and `utils`

### DIFF
--- a/stubs/requests/requests/__init__.pyi
+++ b/stubs/requests/requests/__init__.pyi
@@ -1,3 +1,4 @@
+from . import packages as packages, utils as utils
 from .__version__ import (
     __author__ as __author__,
     __author_email__ as __author_email__,


### PR DESCRIPTION
[These lines](https://github.com/psf/requests/blob/main/src/requests/__init__.py#L147) has been in `requests` for [at least 7 years](https://github.com/psf/requests/blame/main/src/requests/__init__.py#L147).
For me, this PR allows the following code, which make life easier (not having to import `requests.utils`):
```python
import requests
requests.utils.cookiejar_from_dict(...)
```