### PR TITLE
Update vscode `editor.codeActionsOnSave.source.*` settings

### DIFF
--- a/.vscode/settings.default.json
+++ b/.vscode/settings.default.json
@@ -9,7 +9,7 @@
     // Don't format on save for formatters we don't explicitely control
     "editor.formatOnSave": false,
     "editor.codeActionsOnSave": {
-        "source.fixAll": false
+        "source.fixAll": "never"
     },
     // Set file associations to support comments syntax highlight
     "files.associations": {
@@ -48,9 +48,7 @@
     "[json][jsonc][yaml][python][toml]": {
         "editor.formatOnSave": true,
         "editor.codeActionsOnSave": {
-            "source.fixAll": true,
-            // Allow isort or Ruff to organize imports
-            "source.organizeImports": true
+            "source.fixAll": "explicit"
         }
     },
     "[json][jsonc]": {
@@ -69,7 +67,11 @@
         "editor.rulers": [
             130
         ],
-        "editor.defaultFormatter": "ms-python.black-formatter"
+        "editor.defaultFormatter": "ms-python.black-formatter",
+        "editor.codeActionsOnSave": {
+            // Let Ruff lint fixes handle imports
+            "source.organizeImports": "never"
+        }
     },
     // python.analysis is Pylance (pyright) configurations
     "python.analysis.fixAll": [


### PR DESCRIPTION
I had to redo my local setup on a new laptop recently and noticed these were due for an update.
- `editor.codeActionsOnSave.source.*` settings now have 3 possible values represented by a string
- Ensure only Ruff sorts imports (something else was hooking the "organizeImports" option)