### PR TITLE
Re-order ruff runs in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,18 +14,25 @@ repos:
     rev: v0.3.5 # must match requirements-tests.txt
     hooks:
       - id: ruff
-        name: Run ruff on stubs, tests and scripts
-        args: ["--exit-non-zero-on-fix"]
-      - id: ruff
         # Run this separately because we don't really want
         # to use --unsafe-fixes for all rules
+        # Should be run first as it can leave unused imports behind
         name: Remove unnecessary `sys.version_info` blocks
         args: ["--exit-non-zero-on-fix", "--select=UP036", "--unsafe-fixes"]
+      - id: ruff
+        name: Run ruff on stubs, tests and scripts
+        args: ["--exit-non-zero-on-fix"]
       - id: ruff
         # Very few rules are useful to run on our test cases;
         # we explicitly enumerate them here:
         name: Run ruff on the test cases
-        args: ["--exit-non-zero-on-fix", "--select=FA,I,RUF100", "--no-force-exclude", "--unsafe-fixes"]
+        args:
+          [
+            "--exit-non-zero-on-fix",
+            "--select=FA,I,RUF100",
+            "--no-force-exclude",
+            "--unsafe-fixes",
+          ]
         files: '.*test_cases/.+\.py$'
   - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 24.3.0 # must match requirements-tests.txt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,12 +27,10 @@ repos:
         # we explicitly enumerate them here:
         name: Run ruff on the test cases
         args:
-          [
-            "--exit-non-zero-on-fix",
-            "--select=FA,I,RUF100",
-            "--no-force-exclude",
-            "--unsafe-fixes",
-          ]
+          - "--exit-non-zero-on-fix"
+          - "--select=FA,I,RUF100"
+          - "--no-force-exclude"
+          - "--unsafe-fixes"
         files: '.*test_cases/.+\.py$'
   - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 24.3.0 # must match requirements-tests.txt


### PR DESCRIPTION
Unnecessary `sys.version_info` blocks removal should be run first as it can leave unused imports behind.

Realistically this can probably be removed after #11694 and #11696 as the mypy-protobuf update no longer generate files with `UP036` violations. But that's a later consideration.