### PR TITLE
Simplify pyright version parsing

### DIFF
--- a/.github/workflows/meta_tests.yml
+++ b/.github/workflows/meta_tests.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Get pyright version
         id: pyright_version
         run: |
-          uv pip freeze | grep ^pyright== | cut -d = -f 3 | tee $GITHUB_OUTPUT
+          echo PYRIGHT_VERSION=$(uv pip freeze | grep ^pyright== | cut -d = -f 3) | tee $GITHUB_OUTPUT
       - name: Run pyright on typeshed
         uses: jakebailey/pyright-action@v2
         with:

--- a/.github/workflows/meta_tests.yml
+++ b/.github/workflows/meta_tests.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Get pyright version
         id: pyright_version
         run: |
-          echo PYRIGHT_VERSION=$(uv pip freeze | grep ^pyright== | cut -d = -f 3) | tee $GITHUB_OUTPUT
+          echo PYRIGHT_VERSION=$(uv pip freeze | grep -e ^pyright== | cut -d = -f 3) | tee $GITHUB_OUTPUT
       - name: Run pyright on typeshed
         uses: jakebailey/pyright-action@v2
         with:

--- a/.github/workflows/meta_tests.yml
+++ b/.github/workflows/meta_tests.yml
@@ -59,9 +59,7 @@ jobs:
       - name: Get pyright version
         id: pyright_version
         run: |
-          PYRIGHT_VERSION=$(grep pyright== requirements-tests.txt | cut -d "#" -f 1 | cut -d \; -f 1 | cut -d = -f 3)
-          echo pyright version: "${PYRIGHT_VERSION}"
-          echo PYRIGHT_VERSION="${PYRIGHT_VERSION}" >> "${GITHUB_OUTPUT}"
+          uv pip freeze | grep ^pyright== | cut -d = -f 3 | tee $GITHUB_OUTPUT
       - name: Run pyright on typeshed
         uses: jakebailey/pyright-action@v2
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -132,7 +132,7 @@ jobs:
       - name: Get pyright version
         id: pyright_version
         run: |
-          uv pip freeze | grep ^pyright== | cut -d = -f 3 | tee $GITHUB_OUTPUT
+          echo PYRIGHT_VERSION=$(uv pip freeze | grep ^pyright== | cut -d = -f 3) | tee $GITHUB_OUTPUT
       - name: Run pyright with basic settings on all the stubs
         uses: jakebailey/pyright-action@v2
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -132,7 +132,7 @@ jobs:
       - name: Get pyright version
         id: pyright_version
         run: |
-          echo PYRIGHT_VERSION=$(uv pip freeze | grep ^pyright== | cut -d = -f 3) | tee $GITHUB_OUTPUT
+          echo PYRIGHT_VERSION=$(uv pip freeze | grep -e ^pyright== | cut -d = -f 3) | tee $GITHUB_OUTPUT
       - name: Run pyright with basic settings on all the stubs
         uses: jakebailey/pyright-action@v2
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -132,9 +132,7 @@ jobs:
       - name: Get pyright version
         id: pyright_version
         run: |
-          PYRIGHT_VERSION=$(grep pyright== requirements-tests.txt | cut -d "#" -f 1 | cut -d \; -f 1 | cut -d = -f 3)
-          echo pyright version: "${PYRIGHT_VERSION}"
-          echo PYRIGHT_VERSION="${PYRIGHT_VERSION}" >> "${GITHUB_OUTPUT}"
+          uv pip freeze | grep ^pyright== | cut -d = -f 3 | tee $GITHUB_OUTPUT
       - name: Run pyright with basic settings on all the stubs
         uses: jakebailey/pyright-action@v2
         with:


### PR DESCRIPTION
The output of `pip freeze` is a subset of what `requirements.txt` files can contain, so it is easier to parse.

Instead of this, we could also teach the pyright action to parse `pyright --version` (see #11743).