### PR TITLE
Improve the output of `tests/stubtest_third_party.py` when it fails

### DIFF
--- a/scripts/stubsabot.py
+++ b/scripts/stubsabot.py
@@ -498,6 +498,7 @@ async def determine_action(stub_path: Path, session: aiohttp.ClientSession) -> U
         "Release": f"{pypi_info.pypi_root}/{relevant_version}",
         "Homepage": project_urls.get("Homepage"),
         "Repository": stub_info.upstream_repository,
+        "Typeshed stubs": f"https://github.com/{TYPESHED_OWNER}/typeshed/tree/main/{stub_info.distribution}",
         "Changelog": project_urls.get("Changelog") or project_urls.get("Changes") or project_urls.get("Change Log"),
     }
     links = {k: v for k, v in maybe_links.items() if v is not None}

--- a/tests/stubtest_third_party.py
+++ b/tests/stubtest_third_party.py
@@ -13,7 +13,7 @@ from textwrap import dedent
 from typing import NoReturn
 
 from parse_metadata import NoSuchStubError, get_recursive_requirements, read_metadata
-from utils import PYTHON_VERSION, colored, get_mypy_req, print_error, print_success_msg
+from utils import PYTHON_VERSION, colored, get_mypy_req, print_divider, print_error, print_success_msg
 
 
 def run_stubtest(
@@ -132,17 +132,16 @@ def run_stubtest(
             subprocess.run(stubtest_cmd, env=stubtest_env, check=True, capture_output=True)
         except subprocess.CalledProcessError as e:
             print_error("fail\n")
-            divider = "*" * 70
 
-            print(divider)
+            print_divider()
             print("Commands run:")
             print_commands(dist, pip_cmd, stubtest_cmd, mypypath)
 
-            print(divider)
+            print_divider()
             print("Command output:\n")
             print_command_output(e)
 
-            print(divider)
+            print_divider()
             print(f"Upstream repository: {metadata.upstream_repository}")
             print(f"Typeshed source code: https://github.com/python/typeshed/tree/main/stubs/{dist.name}")
 
@@ -168,7 +167,7 @@ def run_stubtest(
                 ret = subprocess.run([*stubtest_cmd, "--generate-allowlist"], env=stubtest_env, capture_output=True)
                 print_command_output(ret)
 
-            print(divider)
+            print_divider()
 
             return False
         else:

--- a/tests/stubtest_third_party.py
+++ b/tests/stubtest_third_party.py
@@ -24,7 +24,7 @@ def run_stubtest(
         metadata = read_metadata(dist_name)
     except NoSuchStubError as e:
         parser.error(str(e))
-    print(f"{dist_name}... ", end="")
+    print(f"{dist_name}... ", end="", flush=True)
 
     stubtest_settings = metadata.stubtest_settings
     if stubtest_settings.skipped:
@@ -131,27 +131,44 @@ def run_stubtest(
         try:
             subprocess.run(stubtest_cmd, env=stubtest_env, check=True, capture_output=True)
         except subprocess.CalledProcessError as e:
-            print_error("fail")
+            print_error("fail\n")
+            divider = "*" * 70
+
+            print(divider)
+            print("Commands run:")
             print_commands(dist, pip_cmd, stubtest_cmd, mypypath)
+
+            print(divider)
+            print("Command output:\n")
             print_command_output(e)
 
-            print("Python version: ", file=sys.stderr)
+            print(divider)
+            print(f"Upstream repository: {metadata.upstream_repository}")
+            print(f"Typeshed source code: https://github.com/python/typeshed/tree/main/stubs/{dist.name}")
+
+            print("Python version: ", file=sys.stderr, end="", flush=True)
             ret = subprocess.run([sys.executable, "-VV"], capture_output=True)
             print_command_output(ret)
-
             print("Ran with the following environment:", file=sys.stderr)
             ret = subprocess.run([pip_exe, "freeze", "--all"], capture_output=True)
             print_command_output(ret)
 
+            allowlist_path_relative = allowlist_path.relative_to(Path.cwd())
             if allowlist_path.exists():
                 print(
-                    f'To fix "unused allowlist" errors, remove the corresponding entries from {allowlist_path}', file=sys.stderr
+                    f'To fix "unused allowlist" errors, remove the corresponding entries from {allowlist_path_relative}',
+                    file=sys.stderr
                 )
                 print(file=sys.stderr)
             else:
-                print(f"Re-running stubtest with --generate-allowlist.\nAdd the following to {allowlist_path}:", file=sys.stderr)
+                print(
+                    f"Re-running stubtest with --generate-allowlist.\nAdd the following to {allowlist_path_relative}:",
+                    file=sys.stderr
+                )
                 ret = subprocess.run([*stubtest_cmd, "--generate-allowlist"], env=stubtest_env, capture_output=True)
                 print_command_output(ret)
+
+            print(divider)
 
             return False
         else:

--- a/tests/stubtest_third_party.py
+++ b/tests/stubtest_third_party.py
@@ -157,13 +157,13 @@ def run_stubtest(
             if allowlist_path.exists():
                 print(
                     f'To fix "unused allowlist" errors, remove the corresponding entries from {allowlist_path_relative}',
-                    file=sys.stderr
+                    file=sys.stderr,
                 )
                 print(file=sys.stderr)
             else:
                 print(
                     f"Re-running stubtest with --generate-allowlist.\nAdd the following to {allowlist_path_relative}:",
-                    file=sys.stderr
+                    file=sys.stderr,
                 )
                 ret = subprocess.run([*stubtest_cmd, "--generate-allowlist"], env=stubtest_env, capture_output=True)
                 print_command_output(ret)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -56,6 +56,14 @@ def print_success_msg() -> None:
     print(colored("success", "green"))
 
 
+def print_divider() -> None:
+    """Print a row of * symbols across the screen.
+
+    This can be useful to divide terminal output into separate sections.
+    """
+    print("*" * 70)
+
+
 # ====================================================================
 # Dynamic venv creation
 # ====================================================================


### PR DESCRIPTION
Mostly changes to enable us to directly click through from the GitHub logs if the daily test fails, rather than having to manually figure out what the upstream repository is or where the typeshed stubs are located.

<details>
<summary>Previous output if it failed:</summary>

```
(typeshed) (main)⚡ % py tests/stubtest_third_party.py requests                                                                       ~/dev/typeshed
requests... Note: requests is not currently tested on darwin in typeshed's CI.
fail

/var/folders/gd/1czdxc454j15y8gns2krv8vc0000gn/T/tmpq5w04nqe/bin/pip install requests[socks]==2.31.* mypy==1.9.0 urllib3>=2
MYPYPATH=/Users/alexw/dev/typeshed/stubs/requests /var/folders/gd/1czdxc454j15y8gns2krv8vc0000gn/T/tmpq5w04nqe/bin/python -m mypy.stubtest --custom-typeshed-dir /Users/alexw/dev/typeshed requests --allowlist /Users/alexw/dev/typeshed/stubs/requests/@tests/stubtest_allowlist.txt

error: requests.FOO is not present at runtime
Stub: in file /Users/alexw/dev/typeshed/stubs/requests/requests/__init__.pyi:40
builtins.str
Runtime:
MISSING

note: unused allowlist entry requests.compat.bytes.__buffer__
Found 2 errors (checked 18 modules)

Python version: 
Python 3.12.2 (main, Feb 15 2024, 19:30:27) [Clang 15.0.0 (clang-1500.1.0.2.5)]

Ran with the following environment:
certifi==2024.2.2
charset-normalizer==3.3.2
idna==3.7
mypy==1.9.0
mypy-extensions==1.0.0
pip==24.0
PySocks==1.7.1
requests==2.31.0
typing_extensions==4.11.0
urllib3==2.2.1

To fix "unused allowlist" errors, remove the corresponding entries from /Users/alexw/dev/typeshed/stubs/requests/@tests/stubtest_allowlist.txt
```

</details>

<details>
<summary>Screenshot</summary>

![image](https://github.com/python/typeshed/assets/66076021/377f1f1e-6778-446c-bcb9-8a0dbcca7384)

</details>

<details>
<summary>New output</summary>

```
(typeshed) (helpful-tests)⚡ % py tests/stubtest_third_party.py requests                                                              ~/dev/typeshed
requests... Note: requests is not currently tested on darwin in typeshed's CI.
fail

**********************************************************************
Commands run:

/var/folders/gd/1czdxc454j15y8gns2krv8vc0000gn/T/tmpi8lk5p38/bin/pip install requests[socks]==2.31.* mypy==1.9.0 urllib3>=2
MYPYPATH=/Users/alexw/dev/typeshed/stubs/requests /var/folders/gd/1czdxc454j15y8gns2krv8vc0000gn/T/tmpi8lk5p38/bin/python -m mypy.stubtest --custom-typeshed-dir /Users/alexw/dev/typeshed requests --allowlist /Users/alexw/dev/typeshed/stubs/requests/@tests/stubtest_allowlist.txt

**********************************************************************
Command output:

error: requests.FOO is not present at runtime
Stub: in file /Users/alexw/dev/typeshed/stubs/requests/requests/__init__.pyi:40
builtins.str
Runtime:
MISSING

note: unused allowlist entry requests.compat.bytes.__buffer__
Found 2 errors (checked 18 modules)

**********************************************************************
Upstream repository: https://github.com/psf/requests
Typeshed source code: https://github.com/python/typeshed/tree/main/stubs/requests
Python version: Python 3.12.2 (main, Feb 15 2024, 19:30:27) [Clang 15.0.0 (clang-1500.1.0.2.5)]

Ran with the following environment:
certifi==2024.2.2
charset-normalizer==3.3.2
idna==3.7
mypy==1.9.0
mypy-extensions==1.0.0
pip==24.0
PySocks==1.7.1
requests==2.31.0
typing_extensions==4.11.0
urllib3==2.2.1

To fix "unused allowlist" errors, remove the corresponding entries from stubs/requests/@tests/stubtest_allowlist.txt

**********************************************************************
```

</details>

<details>
<summary>New screenshot</summary>

![image](https://github.com/python/typeshed/assets/66076021/a57560c1-7fbd-424a-8358-6c57c6adeaf1)

</details>