### PR TITLE
Bump pyinstaller to 6.6.*

### DIFF
--- a/stubs/pyinstaller/METADATA.toml
+++ b/stubs/pyinstaller/METADATA.toml
@@ -1,4 +1,4 @@
-version = "6.5.*"
+version = "6.6.*"
 upstream_repository = "https://github.com/pyinstaller/pyinstaller"
 requires = ["types-setuptools"]
 

--- a/stubs/pyinstaller/PyInstaller/building/build_main.pyi
+++ b/stubs/pyinstaller/PyInstaller/building/build_main.pyi
@@ -1,6 +1,6 @@
 from _typeshed import Incomplete, StrPath
 from collections.abc import Iterable
-from typing import Any
+from typing import Any, Literal
 
 from PyInstaller.building import _PyiBlockCipher
 from PyInstaller.building.datastruct import Target, _TOCTuple
@@ -39,4 +39,5 @@ class Analysis(Target):
         win_private_assemblies: bool = False,
         noarchive: bool = False,
         module_collection_mode: Incomplete | None = None,
+        optimize: Literal[-1, 0, 1, 2] | None = -1,
     ) -> None: ...


### PR DESCRIPTION
Closes #11751

The only public API change is a new "Bytecode Optimization Level" option for `Analysis` (the values `None`, `-1`, `0`, `1`, `2` are explicitly being checked for)