### PR TITLE
Update Ruff and enable F821 in stubs

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,7 @@
 [flake8]
 # NQA: Ruff won't warn about redundant `# noqa: Y`
 # Y: Flake8 is only used to run flake8-pyi, everything else is in Ruff
-# F821: Until https://github.com/astral-sh/ruff/issues/3011 is fixed, we need flake8-pyi's monkeypatching
+# F821: Typeshed is a testing ground for flake8-pyi, which monkeypatches F821
 select = NQA, Y, F821
 # Ignore rules normally excluded by default
 extend-ignore = Y090

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
         args: [--fix=lf]
       - id: check-case-conflict
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.3.5 # must match requirements-tests.txt
+    rev: v0.3.7 # must match requirements-tests.txt
     hooks:
       - id: ruff
         # Run this separately because we don't really want

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,8 +91,6 @@ ignore = [
     "E501", # Line too long
     "E741", # ambiguous variable name
     "F403", # `from . import *` used; unable to detect undefined names
-    # False positives in stubs
-    "F821", # Undefined name: https://github.com/astral-sh/ruff/issues/3011
     # Stubs can sometimes re-export entire modules.
     # Issues with using a star-imported name will be caught by type-checkers.
     "F405", # may be undefined, or defined from star imports

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -9,7 +9,7 @@ mypy==1.9.0
 pre-commit-hooks==4.5.0  # must match .pre-commit-config.yaml
 pyright==1.1.358
 pytype==2024.4.11; platform_system != "Windows" and python_version < "3.12"
-ruff==0.3.5              # must match .pre-commit-config.yaml
+ruff==0.3.7              # must match .pre-commit-config.yaml
 
 # Libraries used by our various scripts.
 aiohttp==3.9.3

--- a/stdlib/typing.pyi
+++ b/stdlib/typing.pyi
@@ -132,9 +132,6 @@ if sys.version_info >= (3, 12):
 ContextManager = AbstractContextManager
 AsyncContextManager = AbstractAsyncContextManager
 
-# This itself is only available during type checking
-def type_check_only(func_or_cls: _F) -> _F: ...
-
 Any = object()
 
 def final(f: _T) -> _T: ...
@@ -182,12 +179,6 @@ class _SpecialForm:
     if sys.version_info >= (3, 10):
         def __or__(self, other: Any) -> _SpecialForm: ...
         def __ror__(self, other: Any) -> _SpecialForm: ...
-
-_F = TypeVar("_F", bound=Callable[..., Any])
-_P = _ParamSpec("_P")
-_T = TypeVar("_T")
-
-def overload(func: _F) -> _F: ...
 
 Union: _SpecialForm
 Generic: _SpecialForm
@@ -295,6 +286,10 @@ if sys.version_info >= (3, 10):
 else:
     def NewType(name: str, tp: Any) -> Any: ...
 
+_F = TypeVar("_F", bound=Callable[..., Any])
+_P = _ParamSpec("_P")
+_T = TypeVar("_T")
+
 # These type variables are used by the container types.
 _S = TypeVar("_S")
 _KT = TypeVar("_KT")  # Key type.
@@ -304,8 +299,12 @@ _KT_co = TypeVar("_KT_co", covariant=True)  # Key type covariant containers.
 _VT_co = TypeVar("_VT_co", covariant=True)  # Value type covariant containers.
 _TC = TypeVar("_TC", bound=type[object])
 
+def overload(func: _F) -> _F: ...
 def no_type_check(arg: _F) -> _F: ...
 def no_type_check_decorator(decorator: Callable[_P, _T]) -> Callable[_P, _T]: ...
+
+# This itself is only available during type checking
+def type_check_only(func_or_cls: _F) -> _F: ...
 
 # Type aliases and type constructors
 

--- a/stubs/hdbcli/hdbcli/dbapi.pyi
+++ b/stubs/hdbcli/hdbcli/dbapi.pyi
@@ -11,7 +11,6 @@ from .resultrow import ResultRow
 apilevel: str
 threadsafety: int
 paramstyle: tuple[str, ...]  # hdbcli defines it as a tuple which does not follow PEP 249
-connect = Connection
 
 class Connection:
     def __init__(
@@ -39,6 +38,8 @@ class Connection:
     def rollback(self) -> None: ...
     def setautocommit(self, auto: bool = ...) -> None: ...
     def setclientinfo(self, key: str, value: str | None = ...) -> None: ...
+
+connect = Connection
 
 class LOB:
     def __init__(self, *args: Any, **kwargs: Any) -> None: ...


### PR DESCRIPTION
Thanks to @AlexWaygood 's work on https://github.com/astral-sh/ruff/issues/3011 , we no longer need to ignore `F821` in Ruff configs, whilst still preferring to avoid forward-references.

I've left in `F821` from Flake8 as per my in-code comment: typeshed being a testing ground for F821, it's great to catch changes to the monkeypatching of `F821`