### PR TITLE
Move Ruff unsafe-fixes from pre-commit to config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,12 +14,6 @@ repos:
     rev: v0.3.7 # must match requirements-tests.txt
     hooks:
       - id: ruff
-        # Run this separately because we don't really want
-        # to use --unsafe-fixes for all rules
-        # Should be run first as it can leave unused imports behind
-        name: Remove unnecessary `sys.version_info` blocks
-        args: ["--exit-non-zero-on-fix", "--select=UP036", "--unsafe-fixes"]
-      - id: ruff
         name: Run ruff on stubs, tests and scripts
         args: ["--exit-non-zero-on-fix"]
       - id: ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,9 @@ select = [
     "PYI055", # multiple `type[T]` usages in a union
     "PYI058", # use `Iterator` as the return type for `__iter__` methods
 ]
+extend-safe-fixes = [
+    "UP036", # Remove unnecessary `sys.version_info` blocks
+]
 ignore = [
     ###
     # Rules that can conflict with the formatter (Black)


### PR DESCRIPTION
Spotted in https://github.com/python/typeshed/pull/11777#discussion_r1569249303

This has the following advantages:
- Picked up by IDEs for autofix commands
- Is included when running `ruff check`
- Less overhead in pre-commit runs