### PR TITLE
Fix divider lines in `stubtest_third_party.py`

### DIFF
--- a/scripts/stubsabot.py
+++ b/scripts/stubsabot.py
@@ -498,7 +498,7 @@ async def determine_action(stub_path: Path, session: aiohttp.ClientSession) -> U
         "Release": f"{pypi_info.pypi_root}/{relevant_version}",
         "Homepage": project_urls.get("Homepage"),
         "Repository": stub_info.upstream_repository,
-        "Typeshed stubs": f"https://github.com/{TYPESHED_OWNER}/typeshed/tree/main/{stub_info.distribution}",
+        "Typeshed stubs": f"https://github.com/{TYPESHED_OWNER}/typeshed/tree/main/stubs/{stub_info.distribution}",
         "Changelog": project_urls.get("Changelog") or project_urls.get("Changes") or project_urls.get("Change Log"),
     }
     links = {k: v for k, v in maybe_links.items() if v is not None}

--- a/tests/stubtest_third_party.py
+++ b/tests/stubtest_third_party.py
@@ -134,11 +134,11 @@ def run_stubtest(
             print_error("fail\n")
 
             print_divider()
-            print("Commands run:")
+            print("Commands run:", file=sys.stderr)
             print_commands(dist, pip_cmd, stubtest_cmd, mypypath)
 
             print_divider()
-            print("Command output:\n")
+            print("Command output:\n", file=sys.stderr)
             print_command_output(e)
 
             print_divider()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -41,19 +41,19 @@ def strip_comments(text: str) -> str:
 def print_command(cmd: str | Iterable[str]) -> None:
     if not isinstance(cmd, str):
         cmd = " ".join(cmd)
-    print(colored(f"Running: {cmd}", "blue"))
+    print(colored(f"Running: {cmd}", "blue"), file=sys.stderr)
 
 
 def print_error(error: str, end: str = "\n", fix_path: tuple[str, str] = ("", "")) -> None:
     error_split = error.split("\n")
     old, new = fix_path
     for line in error_split[:-1]:
-        print(colored(line.replace(old, new), "red"))
-    print(colored(error_split[-1], "red"), end=end)
+        print(colored(line.replace(old, new), "red"), file=sys.stderr)
+    print(colored(error_split[-1], "red"), end=end, file=sys.stderr)
 
 
 def print_success_msg() -> None:
-    print(colored("success", "green"))
+    print(colored("success", "green"), file=sys.stderr)
 
 
 def print_divider() -> None:
@@ -61,7 +61,9 @@ def print_divider() -> None:
 
     This can be useful to divide terminal output into separate sections.
     """
-    print("*" * 70)
+    print(file=sys.stderr)
+    print("*" * 70, file=sys.stderr)
+    print(file=sys.stderr)
 
 
 # ====================================================================


### PR DESCRIPTION
Fixes https://github.com/python/typeshed/pull/11763#issuecomment-2067622376. Things were appearing out of order in CI because some things were being printed to `stderr` and other things to `stdout`. Also stubsabot is giving the wrong URL to the typeshed stubs in its PR summaries due to a silly typo that was also introduced in https://github.com/python/typeshed/pull/11763 (see https://github.com/python/typeshed/pull/11727 for an example of the bad link in the PR description).

Demonstration that proves printing everything to `sys.stderr` fixes the bug: https://github.com/AlexWaygood/typeshed/pull/30