### PR TITLE
`stubtest_third_party.py`, `mypy_test.py`: just print everything to stdout

### DIFF
--- a/tests/stubtest_third_party.py
+++ b/tests/stubtest_third_party.py
@@ -24,23 +24,21 @@ def run_stubtest(
         metadata = read_metadata(dist_name)
     except NoSuchStubError as e:
         parser.error(str(e))
-    print(f"{dist_name}... ", end="", flush=True, file=sys.stderr)
+    print(f"{dist_name}... ", end="", flush=True)
 
     stubtest_settings = metadata.stubtest_settings
     if stubtest_settings.skipped:
-        print(colored("skipping", "yellow"), file=sys.stderr)
+        print(colored("skipping", "yellow"))
         return True
 
     if sys.platform not in stubtest_settings.platforms:
         if specified_platforms_only:
-            print(colored("skipping (platform not specified in METADATA.toml)", "yellow"), file=sys.stderr)
+            print(colored("skipping (platform not specified in METADATA.toml)", "yellow"))
             return True
-        print(
-            colored(f"Note: {dist_name} is not currently tested on {sys.platform} in typeshed's CI.", "yellow"), file=sys.stderr
-        )
+        print(colored(f"Note: {dist_name} is not currently tested on {sys.platform} in typeshed's CI.", "yellow"))
 
     if not metadata.requires_python.contains(PYTHON_VERSION):
-        print(colored(f"skipping (requires Python {metadata.requires_python})", "yellow"), file=sys.stderr)
+        print(colored(f"skipping (requires Python {metadata.requires_python})", "yellow"))
         return True
 
     with tempfile.TemporaryDirectory() as tmp:
@@ -136,40 +134,34 @@ def run_stubtest(
             print_error("fail")
 
             print_divider()
-            print("Commands run:", file=sys.stderr)
+            print("Commands run:")
             print_commands(dist, pip_cmd, stubtest_cmd, mypypath)
 
             print_divider()
-            print("Command output:\n", file=sys.stderr)
+            print("Command output:\n")
             print_command_output(e)
 
             print_divider()
-            print("Python version: ", file=sys.stderr, end="", flush=True)
+            print("Python version: ", end="", flush=True)
             ret = subprocess.run([sys.executable, "-VV"], capture_output=True)
             print_command_output(ret)
-            print("\nRan with the following environment:", file=sys.stderr)
+            print("\nRan with the following environment:")
             ret = subprocess.run([pip_exe, "freeze", "--all"], capture_output=True)
             print_command_output(ret)
 
             print_divider()
             allowlist_path_relative = allowlist_path.relative_to(Path.cwd())
             if allowlist_path.exists():
-                print(
-                    f'To fix "unused allowlist" errors, remove the corresponding entries from {allowlist_path_relative}',
-                    file=sys.stderr,
-                )
-                print(file=sys.stderr)
+                print(f'To fix "unused allowlist" errors, remove the corresponding entries from {allowlist_path_relative}')
+                print()
             else:
-                print(
-                    f"Re-running stubtest with --generate-allowlist.\nAdd the following to {allowlist_path_relative}:",
-                    file=sys.stderr,
-                )
+                print(f"Re-running stubtest with --generate-allowlist.\nAdd the following to {allowlist_path_relative}:")
                 ret = subprocess.run([*stubtest_cmd, "--generate-allowlist"], env=stubtest_env, capture_output=True)
                 print_command_output(ret)
 
             print_divider()
-            print(f"Upstream repository: {metadata.upstream_repository}", file=sys.stderr)
-            print(f"Typeshed source code: https://github.com/python/typeshed/tree/main/stubs/{dist.name}", file=sys.stderr)
+            print(f"Upstream repository: {metadata.upstream_repository}")
+            print(f"Typeshed source code: https://github.com/python/typeshed/tree/main/stubs/{dist.name}")
 
             print_divider()
 
@@ -342,21 +334,21 @@ def setup_uwsgi_stubtest_command(dist: Path, venv_dir: Path, stubtest_cmd: list[
 
 
 def print_commands(dist: Path, pip_cmd: list[str], stubtest_cmd: list[str], mypypath: str) -> None:
-    print(file=sys.stderr)
-    print(" ".join(pip_cmd), file=sys.stderr)
-    print(f"MYPYPATH={mypypath}", " ".join(stubtest_cmd), file=sys.stderr)
+    print()
+    print(" ".join(pip_cmd))
+    print(f"MYPYPATH={mypypath}", " ".join(stubtest_cmd))
 
 
 def print_command_failure(message: str, e: subprocess.CalledProcessError) -> None:
     print_error("fail")
-    print(file=sys.stderr)
-    print(message, file=sys.stderr)
+    print()
+    print(message)
     print_command_output(e)
 
 
 def print_command_output(e: subprocess.CalledProcessError | subprocess.CompletedProcess[bytes]) -> None:
-    print(e.stdout.decode(), end="", file=sys.stderr)
-    print(e.stderr.decode(), end="", file=sys.stderr)
+    print(e.stdout.decode(), end="")
+    print(e.stderr.decode(), end="")
 
 
 def main() -> NoReturn:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -41,19 +41,19 @@ def strip_comments(text: str) -> str:
 def print_command(cmd: str | Iterable[str]) -> None:
     if not isinstance(cmd, str):
         cmd = " ".join(cmd)
-    print(colored(f"Running: {cmd}", "blue"), file=sys.stderr)
+    print(colored(f"Running: {cmd}", "blue"))
 
 
 def print_error(error: str, end: str = "\n", fix_path: tuple[str, str] = ("", "")) -> None:
     error_split = error.split("\n")
     old, new = fix_path
     for line in error_split[:-1]:
-        print(colored(line.replace(old, new), "red"), file=sys.stderr)
-    print(colored(error_split[-1], "red"), end=end, file=sys.stderr)
+        print(colored(line.replace(old, new), "red"))
+    print(colored(error_split[-1], "red"), end=end)
 
 
 def print_success_msg() -> None:
-    print(colored("success", "green"), file=sys.stderr)
+    print(colored("success", "green"))
 
 
 def print_divider() -> None:
@@ -61,9 +61,9 @@ def print_divider() -> None:
 
     This can be useful to divide terminal output into separate sections.
     """
-    print(file=sys.stderr, flush=True)
-    print("*" * 70, file=sys.stderr)
-    print(file=sys.stderr, flush=True)
+    print()
+    print("*" * 70)
+    print()
 
 
 # ====================================================================

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -61,9 +61,9 @@ def print_divider() -> None:
 
     This can be useful to divide terminal output into separate sections.
     """
-    print(file=sys.stderr)
+    print(file=sys.stderr, flush=True)
     print("*" * 70, file=sys.stderr)
-    print(file=sys.stderr)
+    print(file=sys.stderr, flush=True)
 
 
 # ====================================================================


### PR DESCRIPTION
In GitHub Actions, all stderr appears above stdout, even if things are printed to stdout chronologically earlier than being printed to stderr. That is, if you have something like

```py
print("foo")
print("bar", file=sys.stderr)
```

The output in GitHub Actions will be

```
bar
foo
```

Recent changes I made to `stubtest_third_party.py` made the output go funny because some things were being printed to stderr in CI and some things to stdout. I fixed most of that in #11799, but not all of it (the output still isn't quite right in https://github.com/python/typeshed/actions/runs/8776498752), and now the output of `mypy_test.py` is all screwed up because of that fix (https://github.com/python/typeshed/actions/runs/8782468512/job/24096628717?pr=11808).

I think it's easier if we just print everything to stdout rather than passing `file=sys.stderr` anywhere, because if you forget to do it in one place then you end up with bizarre output in CI. Ideally some of this information would be going to stderr rather than stdout, but I don't think it matters _that_ much for our purposes; mostly our scripts are just keeping us up to date with where they're at.