### PR TITLE
Fix stubtest errors in tensorflow with `keras>=3.3.2`

### DIFF
--- a/stubs/tensorflow/METADATA.toml
+++ b/stubs/tensorflow/METADATA.toml
@@ -9,3 +9,4 @@ partial_stub = true
 
 [tool.stubtest]
 ignore_missing_stub = true
+stubtest_requirements = ["keras>=3.3.2"]

--- a/stubs/tensorflow/tensorflow/keras/layers/__init__.pyi
+++ b/stubs/tensorflow/tensorflow/keras/layers/__init__.pyi
@@ -291,6 +291,7 @@ class Embedding(Layer[tf.Tensor, tf.Tensor]):
         embeddings_regularizer: _Regularizer = None,
         embeddings_constraint: _Constraint = None,
         mask_zero: bool = False,
+        weights=None,
         lora_rank: int | None = None,
         *,
         input_length: int | None = None,


### PR DESCRIPTION
Helps with #11813