### PR TITLE
Disable uwsgi, pyaudio, jack-client stubtest on macOS

### DIFF
--- a/stubs/JACK-Client/METADATA.toml
+++ b/stubs/JACK-Client/METADATA.toml
@@ -5,7 +5,7 @@ requires = ["numpy>=1.20", "types-cffi"]
 
 [tool.stubtest]
 # darwin and win32 are equivalent
-platforms = ["darwin", "linux"]
+platforms = ["linux"]
 apt_dependencies = ["libjack-dev"]
 brew_dependencies = ["jack"]
 # No need to install on the CI. Leaving here as information for Windows contributors.

--- a/stubs/JACK-Client/METADATA.toml
+++ b/stubs/JACK-Client/METADATA.toml
@@ -7,6 +7,6 @@ requires = ["numpy>=1.20", "types-cffi"]
 # darwin and win32 are equivalent
 platforms = ["linux"]
 apt_dependencies = ["libjack-dev"]
-brew_dependencies = ["jack"]
+# brew_dependencies = ["jack"]
 # No need to install on the CI. Leaving here as information for Windows contributors.
 # choco_dependencies = ["jack"]

--- a/stubs/pyaudio/METADATA.toml
+++ b/stubs/pyaudio/METADATA.toml
@@ -4,6 +4,6 @@ version = "0.2.*"
 
 [tool.stubtest]
 # linux and win32 are equivalent
-platforms = ["darwin", "linux"]
+platforms = ["linux"]
 apt_dependencies = ["portaudio19-dev"]
 brew_dependencies = ["portaudio"]

--- a/stubs/pyaudio/METADATA.toml
+++ b/stubs/pyaudio/METADATA.toml
@@ -6,4 +6,4 @@ version = "0.2.*"
 # linux and win32 are equivalent
 platforms = ["linux"]
 apt_dependencies = ["portaudio19-dev"]
-brew_dependencies = ["portaudio"]
+# brew_dependencies = ["portaudio"]

--- a/stubs/uWSGI/METADATA.toml
+++ b/stubs/uWSGI/METADATA.toml
@@ -9,7 +9,4 @@ extra_description = """\
 """
 
 [tool.stubtest]
-# Run stubtest on MacOS as well, to check that the
-# uWSGI-specific parts of stubtest_third_party.py
-# also work there
-platforms = ["linux", "darwin"]
+platforms = ["linux"]

--- a/tests/parse_metadata.py
+++ b/tests/parse_metadata.py
@@ -57,7 +57,7 @@ class StubtestSettings:
     Don't construct instances directly; use the `read_stubtest_settings` function.
     """
 
-    skipped: bool
+    skip: bool
     apt_dependencies: list[str]
     brew_dependencies: list[str]
     choco_dependencies: list[str]
@@ -79,7 +79,7 @@ def read_stubtest_settings(distribution: str) -> StubtestSettings:
     with Path("stubs", distribution, "METADATA.toml").open("rb") as f:
         data: dict[str, object] = tomli.load(f).get("tool", {}).get("stubtest", {})
 
-    skipped: object = data.get("skip", False)
+    skip: object = data.get("skip", False)
     apt_dependencies: object = data.get("apt_dependencies", [])
     brew_dependencies: object = data.get("brew_dependencies", [])
     choco_dependencies: object = data.get("choco_dependencies", [])
@@ -88,7 +88,7 @@ def read_stubtest_settings(distribution: str) -> StubtestSettings:
     specified_platforms: object = data.get("platforms", ["linux"])
     stubtest_requirements: object = data.get("stubtest_requirements", [])
 
-    assert type(skipped) is bool
+    assert type(skip) is bool
     assert type(ignore_missing_stub) is bool
 
     # It doesn't work for type-narrowing if we use a for loop here...
@@ -110,7 +110,7 @@ def read_stubtest_settings(distribution: str) -> StubtestSettings:
             )
 
     return StubtestSettings(
-        skipped=skipped,
+        skip=skip,
         apt_dependencies=apt_dependencies,
         brew_dependencies=brew_dependencies,
         choco_dependencies=choco_dependencies,

--- a/tests/stubtest_third_party.py
+++ b/tests/stubtest_third_party.py
@@ -27,7 +27,7 @@ def run_stubtest(
     print(f"{dist_name}... ", end="", flush=True)
 
     stubtest_settings = metadata.stubtest_settings
-    if stubtest_settings.skipped:
+    if stubtest_settings.skip:
         print(colored("skipping", "yellow"))
         return True
 


### PR DESCRIPTION
Fixes #11813

Just opening this as an option, feel free to close if there's some better fix