### PR TITLE
Add indent argument to HTMLFormatter and XMLFormatter inits

### DIFF
--- a/stubs/beautifulsoup4/bs4/formatter.pyi
+++ b/stubs/beautifulsoup4/bs4/formatter.pyi
@@ -34,6 +34,7 @@ class HTMLFormatter(Formatter):
         entity_substitution: _EntitySubstitution | None = ...,
         void_element_close_prefix: str = ...,
         cdata_containing_tags: list[str] | None = ...,
+        indent: int = 1,
     ) -> None: ...
 
 class XMLFormatter(Formatter):
@@ -43,4 +44,5 @@ class XMLFormatter(Formatter):
         entity_substitution: _EntitySubstitution | None = ...,
         void_element_close_prefix: str = ...,
         cdata_containing_tags: list[str] | None = ...,
+        indent: int = 1,
     ) -> None: ...

--- a/stubs/beautifulsoup4/bs4/formatter.pyi
+++ b/stubs/beautifulsoup4/bs4/formatter.pyi
@@ -34,6 +34,7 @@ class HTMLFormatter(Formatter):
         entity_substitution: _EntitySubstitution | None = ...,
         void_element_close_prefix: str = ...,
         cdata_containing_tags: list[str] | None = ...,
+        empty_attributes_are_booleans: bool = False,
         indent: int = 1,
     ) -> None: ...
 
@@ -44,5 +45,6 @@ class XMLFormatter(Formatter):
         entity_substitution: _EntitySubstitution | None = ...,
         void_element_close_prefix: str = ...,
         cdata_containing_tags: list[str] | None = ...,
+        empty_attributes_are_booleans: bool = False,
         indent: int = 1,
     ) -> None: ...


### PR DESCRIPTION
Does what the title says.

This should fix issues like this:
```
formatter = bs4.formatter.HTMLFormatter(indent=4)
```
The code above does not pass e.g. mypy checks, because the tools think HTMLFormatter does not support the indent parameter, which is rather annoying.