### PR TITLE
Add missing `ETH_P_ALL` identifier to `socket`

### DIFF
--- a/stdlib/socket.pyi
+++ b/stdlib/socket.pyi
@@ -474,6 +474,13 @@ if sys.version_info >= (3, 12):
             ETHERTYPE_VLAN as ETHERTYPE_VLAN,
         )
 
+    if sys.platform == "linux":
+        from _socket import ETH_P_ALL as ETH_P_ALL
+
+    if sys.platform != "linux" and sys.platform != "win32" and sys.platform != "darwin":
+        # FreeBSD >= 14.0
+        from _socket import PF_DIVERT as PF_DIVERT
+
 # Re-exported from errno
 EBADF: int
 EAGAIN: int
@@ -525,6 +532,9 @@ class AddressFamily(IntEnum):
             AF_BLUETOOTH = 32
     if sys.platform == "win32" and sys.version_info >= (3, 12):
         AF_HYPERV = 34
+    if sys.platform != "linux" and sys.platform != "win32" and sys.platform != "darwin" and sys.version_info >= (3, 12):
+        # FreeBSD >= 14.0
+        AF_DIVERT = 44
 
 AF_INET = AddressFamily.AF_INET
 AF_INET6 = AddressFamily.AF_INET6
@@ -577,6 +587,9 @@ if sys.platform != "win32" or sys.version_info >= (3, 9):
 
 if sys.platform == "win32" and sys.version_info >= (3, 12):
     AF_HYPERV = AddressFamily.AF_HYPERV
+if sys.platform != "linux" and sys.platform != "win32" and sys.platform != "darwin" and sys.version_info >= (3, 12):
+    # FreeBSD >= 14.0
+    AF_DIVERT = AddressFamily.AF_DIVERT
 
 class SocketKind(IntEnum):
     SOCK_STREAM = 1


### PR DESCRIPTION
It seems #10247/#11219 missed a couple identifiers in the `socket` stub (the `_socket` stub seems good, though). This PR adds `socket.ETH_P_ALL` (https://docs.python.org/3/library/socket.html#socket.ETH_P_ALL).

There's also [`AF_DIVERT`](https://docs.python.org/3/library/socket.html#socket.AF_DIVERT) and [`PF_DIVERT`](https://docs.python.org/3/library/socket.html#socket.PF_DIVERT) missing from the `socket` stub, as well, but I've omitted those from this PR for a couple reasons. These are only available on FreeBSD systems, which was correctly noted in the comment above their type annotations in `_socket`, but the condition to check for this availability is (or at least seems to be) logically incorrect:
```python
if sys.version_info >= (3, 12) and sys.platform != "linux" and sys.platform != "win32" and sys.platform != "darwin":
    # Availability: FreeBSD >= 14.0
    AF_DIVERT: int
    PF_DIVERT: int
```
The [`sys.platform`](https://docs.python.org/3/library/sys.html#sys.platform) documentation shows the correct (or at least a more correct) conditional statement:
```python
if sys.platform.startswith('freebsd'):
    # Availability: FreeBSD >= 14.0
    AF_DIVERT: int
    PF_DIVERT: int
```
And similarly for the `socket` stub:
```python
if sys.platform.startswith('freebsd'):
    from _socket import (
        AF_DIVERT as AF_DIVERT,
        PF_DIVERT as PF_DIVERT,
    )
```
All this essentially to ask if the current check (`sys.platform != "linux" and sys.platform != "win32" and sys.platform != "darwin"`) is just how typeshed has decided to check for FreeBSD systems, or if it would be preferable to use the `sys.platform.startswith('freebsd')` check. And, if this would be preferred, should parsing and checking the version be included, as well?

I also don't have a FreeBSD system to personally test with, so wasn't sure if I should let someone on an actual FreeBSD 14 system handle this (although, I suppose it wouldn't be too much trouble to spin up a FreeBSD VM if necessary).