### PR TITLE
improvement: Add AST subclass constructors

### DIFF
--- a/stdlib/_ast.pyi
+++ b/stdlib/_ast.pyi
@@ -1,10 +1,13 @@
 import sys
 import typing_extensions
-from typing import Any, ClassVar, Literal
+from typing import Any, ClassVar, Generic, Literal, TypedDict, overload
 
 PyCF_ONLY_AST: Literal[1024]
 PyCF_TYPE_COMMENTS: Literal[4096]
 PyCF_ALLOW_TOP_LEVEL_AWAIT: Literal[8192]
+
+# Used for node end positions in constructor keyword arguments
+_EndPositionT = typing_extensions.TypeVar("_EndPositionT", int, int | None, default=int | None)  # noqa: Y023
 
 # Alias used for fields that must always be valid identifiers
 # A string `x` counts as a valid identifier if both the following are True
@@ -12,12 +15,23 @@ PyCF_ALLOW_TOP_LEVEL_AWAIT: Literal[8192]
 # (2) `keyword.iskeyword(x)` evaluates to `False`
 _Identifier: typing_extensions.TypeAlias = str
 
+# Corresponds to the names in the `_attributes` class variable which is non-empty in certain AST nodes
+class _Attributes(TypedDict, Generic[_EndPositionT], total=False):
+    lineno: int
+    col_offset: int
+    end_lineno: _EndPositionT
+    end_col_offset: _EndPositionT
+
+if sys.version_info >= (3, 9):
+    _SliceAttributes: typing_extensions.TypeAlias = _Attributes
+else:
+    class _SliceAttributes(TypedDict): ...
+
 class AST:
     if sys.version_info >= (3, 10):
         __match_args__ = ()
     _attributes: ClassVar[tuple[str, ...]]
     _fields: ClassVar[tuple[str, ...]]
-    def __init__(self, *args: Any, **kwargs: Any) -> None: ...
 
 class mod(AST): ...
 class type_ignore(AST): ...
@@ -27,34 +41,40 @@ class TypeIgnore(type_ignore):
         __match_args__ = ("lineno", "tag")
     lineno: int
     tag: str
+    def __init__(self, lineno: int, tag: str) -> None: ...
 
 class FunctionType(mod):
     if sys.version_info >= (3, 10):
         __match_args__ = ("argtypes", "returns")
     argtypes: list[expr]
     returns: expr
+    def __init__(self, argtypes: list[expr], returns: expr) -> None: ...
 
 class Module(mod):
     if sys.version_info >= (3, 10):
         __match_args__ = ("body", "type_ignores")
     body: list[stmt]
     type_ignores: list[TypeIgnore]
+    def __init__(self, body: list[stmt], type_ignores: list[TypeIgnore]) -> None: ...
 
 class Interactive(mod):
     if sys.version_info >= (3, 10):
         __match_args__ = ("body",)
     body: list[stmt]
+    def __init__(self, body: list[stmt]) -> None: ...
 
 class Expression(mod):
     if sys.version_info >= (3, 10):
         __match_args__ = ("body",)
     body: expr
+    def __init__(self, body: expr) -> None: ...
 
 class stmt(AST):
     lineno: int
     col_offset: int
     end_lineno: int | None
     end_col_offset: int | None
+    def __init__(self, **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
 
 class FunctionDef(stmt):
     if sys.version_info >= (3, 12):
@@ -69,6 +89,42 @@ class FunctionDef(stmt):
     type_comment: str | None
     if sys.version_info >= (3, 12):
         type_params: list[type_param]
+        @overload
+        def __init__(
+            self,
+            name: _Identifier,
+            args: arguments,
+            body: list[stmt],
+            decorator_list: list[expr],
+            returns: expr | None,
+            type_comment: str | None,
+            type_params: list[type_param],
+            **kwargs: typing_extensions.Unpack[_Attributes],
+        ) -> None: ...
+        @overload
+        def __init__(
+            self,
+            name: _Identifier,
+            args: arguments,
+            body: list[stmt],
+            decorator_list: list[expr],
+            returns: expr | None = None,
+            *,
+            type_comment: str | None = None,
+            type_params: list[type_param],
+            **kwargs: typing_extensions.Unpack[_Attributes],
+        ) -> None: ...
+    else:
+        def __init__(
+            self,
+            name: _Identifier,
+            args: arguments,
+            body: list[stmt],
+            decorator_list: list[expr],
+            returns: expr | None = None,
+            type_comment: str | None = None,
+            **kwargs: typing_extensions.Unpack[_Attributes],
+        ) -> None: ...
 
 class AsyncFunctionDef(stmt):
     if sys.version_info >= (3, 12):
@@ -83,6 +139,42 @@ class AsyncFunctionDef(stmt):
     type_comment: str | None
     if sys.version_info >= (3, 12):
         type_params: list[type_param]
+        @overload
+        def __init__(
+            self,
+            name: _Identifier,
+            args: arguments,
+            body: list[stmt],
+            decorator_list: list[expr],
+            returns: expr | None,
+            type_comment: str | None,
+            type_params: list[type_param],
+            **kwargs: typing_extensions.Unpack[_Attributes],
+        ) -> None: ...
+        @overload
+        def __init__(
+            self,
+            name: _Identifier,
+            args: arguments,
+            body: list[stmt],
+            decorator_list: list[expr],
+            returns: expr | None = None,
+            *,
+            type_comment: str | None = None,
+            type_params: list[type_param],
+            **kwargs: typing_extensions.Unpack[_Attributes],
+        ) -> None: ...
+    else:
+        def __init__(
+            self,
+            name: _Identifier,
+            args: arguments,
+            body: list[stmt],
+            decorator_list: list[expr],
+            returns: expr | None = None,
+            type_comment: str | None = None,
+            **kwargs: typing_extensions.Unpack[_Attributes],
+        ) -> None: ...
 
 class ClassDef(stmt):
     if sys.version_info >= (3, 12):
@@ -96,16 +188,38 @@ class ClassDef(stmt):
     decorator_list: list[expr]
     if sys.version_info >= (3, 12):
         type_params: list[type_param]
+        def __init__(
+            self,
+            name: _Identifier,
+            bases: list[expr],
+            keywords: list[keyword],
+            body: list[stmt],
+            decorator_list: list[expr],
+            type_params: list[type_param],
+            **kwargs: typing_extensions.Unpack[_Attributes],
+        ) -> None: ...
+    else:
+        def __init__(
+            self,
+            name: _Identifier,
+            bases: list[expr],
+            keywords: list[keyword],
+            body: list[stmt],
+            decorator_list: list[expr],
+            **kwargs: typing_extensions.Unpack[_Attributes],
+        ) -> None: ...
 
 class Return(stmt):
     if sys.version_info >= (3, 10):
         __match_args__ = ("value",)
     value: expr | None
+    def __init__(self, value: expr | None = None, **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
 
 class Delete(stmt):
     if sys.version_info >= (3, 10):
         __match_args__ = ("targets",)
     targets: list[expr]
+    def __init__(self, targets: list[expr], **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
 
 class Assign(stmt):
     if sys.version_info >= (3, 10):
@@ -113,6 +227,9 @@ class Assign(stmt):
     targets: list[expr]
     value: expr
     type_comment: str | None
+    def __init__(
+        self, targets: list[expr], value: expr, type_comment: str | None = None, **kwargs: typing_extensions.Unpack[_Attributes]
+    ) -> None: ...
 
 class AugAssign(stmt):
     if sys.version_info >= (3, 10):
@@ -120,6 +237,9 @@ class AugAssign(stmt):
     target: Name | Attribute | Subscript
     op: operator
     value: expr
+    def __init__(
+        self, target: Name | Attribute | Subscript, op: operator, value: expr, **kwargs: typing_extensions.Unpack[_Attributes]
+    ) -> None: ...
 
 class AnnAssign(stmt):
     if sys.version_info >= (3, 10):
@@ -128,6 +248,25 @@ class AnnAssign(stmt):
     annotation: expr
     value: expr | None
     simple: int
+    @overload
+    def __init__(
+        self,
+        target: Name | Attribute | Subscript,
+        annotation: expr,
+        value: expr | None,
+        simple: int,
+        **kwargs: typing_extensions.Unpack[_Attributes],
+    ) -> None: ...
+    @overload
+    def __init__(
+        self,
+        target: Name | Attribute | Subscript,
+        annotation: expr,
+        value: expr | None = None,
+        *,
+        simple: int,
+        **kwargs: typing_extensions.Unpack[_Attributes],
+    ) -> None: ...
 
 class For(stmt):
     if sys.version_info >= (3, 10):
@@ -137,6 +276,15 @@ class For(stmt):
     body: list[stmt]
     orelse: list[stmt]
     type_comment: str | None
+    def __init__(
+        self,
+        target: expr,
+        iter: expr,
+        body: list[stmt],
+        orelse: list[stmt],
+        type_comment: str | None = None,
+        **kwargs: typing_extensions.Unpack[_Attributes],
+    ) -> None: ...
 
 class AsyncFor(stmt):
     if sys.version_info >= (3, 10):
@@ -146,6 +294,15 @@ class AsyncFor(stmt):
     body: list[stmt]
     orelse: list[stmt]
     type_comment: str | None
+    def __init__(
+        self,
+        target: expr,
+        iter: expr,
+        body: list[stmt],
+        orelse: list[stmt],
+        type_comment: str | None = None,
+        **kwargs: typing_extensions.Unpack[_Attributes],
+    ) -> None: ...
 
 class While(stmt):
     if sys.version_info >= (3, 10):
@@ -153,6 +310,9 @@ class While(stmt):
     test: expr
     body: list[stmt]
     orelse: list[stmt]
+    def __init__(
+        self, test: expr, body: list[stmt], orelse: list[stmt], **kwargs: typing_extensions.Unpack[_Attributes]
+    ) -> None: ...
 
 class If(stmt):
     if sys.version_info >= (3, 10):
@@ -160,6 +320,9 @@ class If(stmt):
     test: expr
     body: list[stmt]
     orelse: list[stmt]
+    def __init__(
+        self, test: expr, body: list[stmt], orelse: list[stmt], **kwargs: typing_extensions.Unpack[_Attributes]
+    ) -> None: ...
 
 class With(stmt):
     if sys.version_info >= (3, 10):
@@ -167,6 +330,13 @@ class With(stmt):
     items: list[withitem]
     body: list[stmt]
     type_comment: str | None
+    def __init__(
+        self,
+        items: list[withitem],
+        body: list[stmt],
+        type_comment: str | None = None,
+        **kwargs: typing_extensions.Unpack[_Attributes],
+    ) -> None: ...
 
 class AsyncWith(stmt):
     if sys.version_info >= (3, 10):
@@ -174,12 +344,22 @@ class AsyncWith(stmt):
     items: list[withitem]
     body: list[stmt]
     type_comment: str | None
+    def __init__(
+        self,
+        items: list[withitem],
+        body: list[stmt],
+        type_comment: str | None = None,
+        **kwargs: typing_extensions.Unpack[_Attributes],
+    ) -> None: ...
 
 class Raise(stmt):
     if sys.version_info >= (3, 10):
         __match_args__ = ("exc", "cause")
     exc: expr | None
     cause: expr | None
+    def __init__(
+        self, exc: expr | None = None, cause: expr | None = None, **kwargs: typing_extensions.Unpack[_Attributes]
+    ) -> None: ...
 
 class Try(stmt):
     if sys.version_info >= (3, 10):
@@ -188,6 +368,14 @@ class Try(stmt):
     handlers: list[ExceptHandler]
     orelse: list[stmt]
     finalbody: list[stmt]
+    def __init__(
+        self,
+        body: list[stmt],
+        handlers: list[ExceptHandler],
+        orelse: list[stmt],
+        finalbody: list[stmt],
+        **kwargs: typing_extensions.Unpack[_Attributes],
+    ) -> None: ...
 
 if sys.version_info >= (3, 11):
     class TryStar(stmt):
@@ -196,17 +384,27 @@ if sys.version_info >= (3, 11):
         handlers: list[ExceptHandler]
         orelse: list[stmt]
         finalbody: list[stmt]
+        def __init__(
+            self,
+            body: list[stmt],
+            handlers: list[ExceptHandler],
+            orelse: list[stmt],
+            finalbody: list[stmt],
+            **kwargs: typing_extensions.Unpack[_Attributes],
+        ) -> None: ...
 
 class Assert(stmt):
     if sys.version_info >= (3, 10):
         __match_args__ = ("test", "msg")
     test: expr
     msg: expr | None
+    def __init__(self, test: expr, msg: expr | None = None, **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
 
 class Import(stmt):
     if sys.version_info >= (3, 10):
         __match_args__ = ("names",)
     names: list[alias]
+    def __init__(self, names: list[alias], **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
 
 class ImportFrom(stmt):
     if sys.version_info >= (3, 10):
@@ -214,21 +412,32 @@ class ImportFrom(stmt):
     module: str | None
     names: list[alias]
     level: int
+    @overload
+    def __init__(
+        self, module: str | None, names: list[alias], level: int, **kwargs: typing_extensions.Unpack[_Attributes]
+    ) -> None: ...
+    @overload
+    def __init__(
+        self, module: str | None = None, *, names: list[alias], level: int, **kwargs: typing_extensions.Unpack[_Attributes]
+    ) -> None: ...
 
 class Global(stmt):
     if sys.version_info >= (3, 10):
         __match_args__ = ("names",)
     names: list[_Identifier]
+    def __init__(self, names: list[_Identifier], **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
 
 class Nonlocal(stmt):
     if sys.version_info >= (3, 10):
         __match_args__ = ("names",)
     names: list[_Identifier]
+    def __init__(self, names: list[_Identifier], **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
 
 class Expr(stmt):
     if sys.version_info >= (3, 10):
         __match_args__ = ("value",)
     value: expr
+    def __init__(self, value: expr, **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
 
 class Pass(stmt): ...
 class Break(stmt): ...
@@ -239,12 +448,14 @@ class expr(AST):
     col_offset: int
     end_lineno: int | None
     end_col_offset: int | None
+    def __init__(self, **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
 
 class BoolOp(expr):
     if sys.version_info >= (3, 10):
         __match_args__ = ("op", "values")
     op: boolop
     values: list[expr]
+    def __init__(self, op: boolop, values: list[expr], **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
 
 class BinOp(expr):
     if sys.version_info >= (3, 10):
@@ -252,18 +463,21 @@ class BinOp(expr):
     left: expr
     op: operator
     right: expr
+    def __init__(self, left: expr, op: operator, right: expr, **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
 
 class UnaryOp(expr):
     if sys.version_info >= (3, 10):
         __match_args__ = ("op", "operand")
     op: unaryop
     operand: expr
+    def __init__(self, op: unaryop, operand: expr, **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
 
 class Lambda(expr):
     if sys.version_info >= (3, 10):
         __match_args__ = ("args", "body")
     args: arguments
     body: expr
+    def __init__(self, args: arguments, body: expr, **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
 
 class IfExp(expr):
     if sys.version_info >= (3, 10):
@@ -271,29 +485,34 @@ class IfExp(expr):
     test: expr
     body: expr
     orelse: expr
+    def __init__(self, test: expr, body: expr, orelse: expr, **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
 
 class Dict(expr):
     if sys.version_info >= (3, 10):
         __match_args__ = ("keys", "values")
     keys: list[expr | None]
     values: list[expr]
+    def __init__(self, keys: list[expr | None], values: list[expr], **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
 
 class Set(expr):
     if sys.version_info >= (3, 10):
         __match_args__ = ("elts",)
     elts: list[expr]
+    def __init__(self, elts: list[expr], **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
 
 class ListComp(expr):
     if sys.version_info >= (3, 10):
         __match_args__ = ("elt", "generators")
     elt: expr
     generators: list[comprehension]
+    def __init__(self, elt: expr, generators: list[comprehension], **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
 
 class SetComp(expr):
     if sys.version_info >= (3, 10):
         __match_args__ = ("elt", "generators")
     elt: expr
     generators: list[comprehension]
+    def __init__(self, elt: expr, generators: list[comprehension], **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
 
 class DictComp(expr):
     if sys.version_info >= (3, 10):
@@ -301,27 +520,34 @@ class DictComp(expr):
     key: expr
     value: expr
     generators: list[comprehension]
+    def __init__(
+        self, key: expr, value: expr, generators: list[comprehension], **kwargs: typing_extensions.Unpack[_Attributes]
+    ) -> None: ...
 
 class GeneratorExp(expr):
     if sys.version_info >= (3, 10):
         __match_args__ = ("elt", "generators")
     elt: expr
     generators: list[comprehension]
+    def __init__(self, elt: expr, generators: list[comprehension], **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
 
 class Await(expr):
     if sys.version_info >= (3, 10):
         __match_args__ = ("value",)
     value: expr
+    def __init__(self, value: expr, **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
 
 class Yield(expr):
     if sys.version_info >= (3, 10):
         __match_args__ = ("value",)
     value: expr | None
+    def __init__(self, value: expr | None = None, **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
 
 class YieldFrom(expr):
     if sys.version_info >= (3, 10):
         __match_args__ = ("value",)
     value: expr
+    def __init__(self, value: expr, **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
 
 class Compare(expr):
     if sys.version_info >= (3, 10):
@@ -329,6 +555,9 @@ class Compare(expr):
     left: expr
     ops: list[cmpop]
     comparators: list[expr]
+    def __init__(
+        self, left: expr, op: list[cmpop], comparators: list[expr], **kwargs: typing_extensions.Unpack[_Attributes]
+    ) -> None: ...
 
 class Call(expr):
     if sys.version_info >= (3, 10):
@@ -336,6 +565,9 @@ class Call(expr):
     func: expr
     args: list[expr]
     keywords: list[keyword]
+    def __init__(
+        self, func: expr, args: list[expr], keywords: list[keyword], **kwargs: typing_extensions.Unpack[_Attributes]
+    ) -> None: ...
 
 class FormattedValue(expr):
     if sys.version_info >= (3, 10):
@@ -343,11 +575,15 @@ class FormattedValue(expr):
     value: expr
     conversion: int
     format_spec: expr | None
+    def __init__(
+        self, value: expr, conversion: int, format_spec: expr | None = None, **kwargs: typing_extensions.Unpack[_Attributes]
+    ) -> None: ...
 
 class JoinedStr(expr):
     if sys.version_info >= (3, 10):
         __match_args__ = ("values",)
     values: list[expr]
+    def __init__(self, values: list[expr], **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
 
 class Constant(expr):
     if sys.version_info >= (3, 10):
@@ -357,12 +593,14 @@ class Constant(expr):
     # Aliases for value, for backwards compatibility
     s: Any
     n: int | float | complex
+    def __init__(self, value: Any, kind: str | None = None, **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
 
 class NamedExpr(expr):
     if sys.version_info >= (3, 10):
         __match_args__ = ("target", "value")
     target: Name
     value: expr
+    def __init__(self, target: Name, value: expr, **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
 
 class Attribute(expr):
     if sys.version_info >= (3, 10):
@@ -370,6 +608,9 @@ class Attribute(expr):
     value: expr
     attr: _Identifier
     ctx: expr_context
+    def __init__(
+        self, value: expr, attr: _Identifier, ctx: expr_context, **kwargs: typing_extensions.Unpack[_Attributes]
+    ) -> None: ...
 
 if sys.version_info >= (3, 9):
     _Slice: typing_extensions.TypeAlias = expr
@@ -383,13 +624,22 @@ class Slice(_Slice):
     lower: expr | None
     upper: expr | None
     step: expr | None
+    def __init__(
+        self,
+        lower: expr | None = None,
+        upper: expr | None = None,
+        step: expr | None = None,
+        **kwargs: typing_extensions.Unpack[_SliceAttributes],
+    ) -> None: ...
 
 if sys.version_info < (3, 9):
     class ExtSlice(slice):
         dims: list[slice]
+        def __init__(self, dims: list[slice], **kwargs: typing_extensions.Unpack[_SliceAttributes]) -> None: ...
 
     class Index(slice):
         value: expr
+        def __init__(self, value: expr, **kwargs: typing_extensions.Unpack[_SliceAttributes]) -> None: ...
 
 class Subscript(expr):
     if sys.version_info >= (3, 10):
@@ -397,24 +647,30 @@ class Subscript(expr):
     value: expr
     slice: _Slice
     ctx: expr_context
+    def __init__(
+        self, value: expr, slice: _Slice, ctx: expr_context, **kwargs: typing_extensions.Unpack[_Attributes]
+    ) -> None: ...
 
 class Starred(expr):
     if sys.version_info >= (3, 10):
         __match_args__ = ("value", "ctx")
     value: expr
     ctx: expr_context
+    def __init__(self, value: expr, ctx: expr_context, **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
 
 class Name(expr):
     if sys.version_info >= (3, 10):
         __match_args__ = ("id", "ctx")
     id: _Identifier
     ctx: expr_context
+    def __init__(self, id: _Identifier, ctx: expr_context, **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
 
 class List(expr):
     if sys.version_info >= (3, 10):
         __match_args__ = ("elts", "ctx")
     elts: list[expr]
     ctx: expr_context
+    def __init__(self, elts: list[expr], ctx: expr_context, **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
 
 class Tuple(expr):
     if sys.version_info >= (3, 10):
@@ -423,6 +679,8 @@ class Tuple(expr):
     ctx: expr_context
     if sys.version_info >= (3, 9):
         dims: list[expr]
+
+    def __init__(self, elts: list[expr], ctx: expr_context, **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
 
 class expr_context(AST): ...
 
@@ -433,6 +691,7 @@ if sys.version_info < (3, 9):
 
     class Suite(mod):
         body: list[stmt]
+        def __init__(self, body: list[stmt]) -> None: ...
 
 class Del(expr_context): ...
 class Load(expr_context): ...
@@ -478,12 +737,14 @@ class comprehension(AST):
     iter: expr
     ifs: list[expr]
     is_async: int
+    def __init__(self, target: expr, iter: expr, ifs: list[expr], is_async: int) -> None: ...
 
 class excepthandler(AST):
     lineno: int
     col_offset: int
     end_lineno: int | None
     end_col_offset: int | None
+    def __init__(self, **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
 
 class ExceptHandler(excepthandler):
     if sys.version_info >= (3, 10):
@@ -491,6 +752,19 @@ class ExceptHandler(excepthandler):
     type: expr | None
     name: _Identifier | None
     body: list[stmt]
+    @overload
+    def __init__(
+        self, type: expr | None, name: _Identifier | None, body: list[stmt], **kwargs: typing_extensions.Unpack[_Attributes]
+    ) -> None: ...
+    @overload
+    def __init__(
+        self,
+        type: expr | None = None,
+        name: _Identifier | None = None,
+        *,
+        body: list[stmt],
+        **kwargs: typing_extensions.Unpack[_Attributes],
+    ) -> None: ...
 
 class arguments(AST):
     if sys.version_info >= (3, 10):
@@ -502,6 +776,41 @@ class arguments(AST):
     kw_defaults: list[expr | None]
     kwarg: arg | None
     defaults: list[expr]
+    @overload
+    def __init__(
+        self,
+        posonlyargs: list[arg],
+        args: list[arg],
+        vararg: arg | None,
+        kwonlyargs: list[arg],
+        kw_defaults: list[expr | None],
+        kwarg: arg | None,
+        defaults: list[expr],
+    ) -> None: ...
+    @overload
+    def __init__(
+        self,
+        posonlyargs: list[arg],
+        args: list[arg],
+        vararg: arg | None,
+        kwonlyargs: list[arg],
+        kw_defaults: list[expr | None],
+        kwarg: arg | None = None,
+        *,
+        defaults: list[expr],
+    ) -> None: ...
+    @overload
+    def __init__(
+        self,
+        posonlyargs: list[arg],
+        args: list[arg],
+        vararg: arg | None = None,
+        *,
+        kwonlyargs: list[arg],
+        kw_defaults: list[expr | None],
+        kwarg: arg | None = None,
+        defaults: list[expr],
+    ) -> None: ...
 
 class arg(AST):
     lineno: int
@@ -513,6 +822,13 @@ class arg(AST):
     arg: _Identifier
     annotation: expr | None
     type_comment: str | None
+    def __init__(
+        self,
+        arg: _Identifier,
+        annotation: expr | None = None,
+        type_comment: str | None = None,
+        **kwargs: typing_extensions.Unpack[_Attributes],
+    ) -> None: ...
 
 class keyword(AST):
     lineno: int
@@ -523,6 +839,12 @@ class keyword(AST):
         __match_args__ = ("arg", "value")
     arg: _Identifier | None
     value: expr
+    @overload
+    def __init__(self, arg: _Identifier | None, value: expr, **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
+    @overload
+    def __init__(
+        self, arg: _Identifier | None = None, *, value: expr, **kwargs: typing_extensions.Unpack[_Attributes]
+    ) -> None: ...
 
 class alias(AST):
     lineno: int
@@ -533,24 +855,28 @@ class alias(AST):
         __match_args__ = ("name", "asname")
     name: str
     asname: _Identifier | None
+    def __init__(self, name: str, asname: _Identifier | None = None, **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
 
 class withitem(AST):
     if sys.version_info >= (3, 10):
         __match_args__ = ("context_expr", "optional_vars")
     context_expr: expr
     optional_vars: expr | None
+    def __init__(self, context_expr: expr, optional_vars: expr | None = None) -> None: ...
 
 if sys.version_info >= (3, 10):
     class Match(stmt):
         __match_args__ = ("subject", "cases")
         subject: expr
         cases: list[match_case]
+        def __init__(self, subject: expr, cases: list[match_case], **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
 
     class pattern(AST):
         lineno: int
         col_offset: int
         end_lineno: int
         end_col_offset: int
+        def __init__(self, **kwargs: typing_extensions.Unpack[_Attributes[int]]) -> None: ...
 
     # Without the alias, Pyright complains variables named pattern are recursively defined
     _Pattern: typing_extensions.TypeAlias = pattern
@@ -560,28 +886,43 @@ if sys.version_info >= (3, 10):
         pattern: _Pattern
         guard: expr | None
         body: list[stmt]
+        @overload
+        def __init__(self, pattern: _Pattern, guard: expr | None, body: list[stmt]) -> None: ...
+        @overload
+        def __init__(self, pattern: _Pattern, guard: expr | None = None, *, body: list[stmt]) -> None: ...
 
     class MatchValue(pattern):
         __match_args__ = ("value",)
         value: expr
+        def __init__(self, value: expr, **kwargs: typing_extensions.Unpack[_Attributes[int]]) -> None: ...
 
     class MatchSingleton(pattern):
         __match_args__ = ("value",)
         value: Literal[True, False] | None
+        def __init__(self, value: Literal[True, False] | None, **kwargs: typing_extensions.Unpack[_Attributes[int]]) -> None: ...
 
     class MatchSequence(pattern):
         __match_args__ = ("patterns",)
         patterns: list[pattern]
+        def __init__(self, patterns: list[pattern], **kwargs: typing_extensions.Unpack[_Attributes[int]]) -> None: ...
 
     class MatchStar(pattern):
         __match_args__ = ("name",)
         name: _Identifier | None
+        def __init__(self, name: _Identifier | None, **kwargs: typing_extensions.Unpack[_Attributes[int]]) -> None: ...
 
     class MatchMapping(pattern):
         __match_args__ = ("keys", "patterns", "rest")
         keys: list[expr]
         patterns: list[pattern]
         rest: _Identifier | None
+        def __init__(
+            self,
+            keys: list[expr],
+            patterns: list[pattern],
+            rest: _Identifier | None = None,
+            **kwargs: typing_extensions.Unpack[_Attributes[int]],
+        ) -> None: ...
 
     class MatchClass(pattern):
         __match_args__ = ("cls", "patterns", "kwd_attrs", "kwd_patterns")
@@ -589,15 +930,30 @@ if sys.version_info >= (3, 10):
         patterns: list[pattern]
         kwd_attrs: list[_Identifier]
         kwd_patterns: list[pattern]
+        def __init__(
+            self,
+            cls: expr,
+            patterns: list[pattern],
+            kwd_attrs: list[_Identifier],
+            kwd_patterns: list[pattern],
+            **kwargs: typing_extensions.Unpack[_Attributes[int]],
+        ) -> None: ...
 
     class MatchAs(pattern):
         __match_args__ = ("pattern", "name")
         pattern: _Pattern | None
         name: _Identifier | None
+        def __init__(
+            self,
+            pattern: _Pattern | None = None,
+            name: _Identifier | None = None,
+            **kwargs: typing_extensions.Unpack[_Attributes[int]],
+        ) -> None: ...
 
     class MatchOr(pattern):
         __match_args__ = ("patterns",)
         patterns: list[pattern]
+        def __init__(self, patterns: list[pattern], **kwargs: typing_extensions.Unpack[_Attributes[int]]) -> None: ...
 
 if sys.version_info >= (3, 12):
     class type_param(AST):
@@ -605,22 +961,31 @@ if sys.version_info >= (3, 12):
         col_offset: int
         end_lineno: int
         end_col_offset: int
+        def __init__(self, **kwargs: typing_extensions.Unpack[_Attributes[int]]) -> None: ...
 
     class TypeVar(type_param):
         __match_args__ = ("name", "bound")
         name: _Identifier
         bound: expr | None
+        def __init__(
+            self, name: _Identifier, bound: expr | None = None, **kwargs: typing_extensions.Unpack[_Attributes[int]]
+        ) -> None: ...
 
     class ParamSpec(type_param):
         __match_args__ = ("name",)
         name: _Identifier
+        def __init__(self, name: _Identifier, **kwargs: typing_extensions.Unpack[_Attributes[int]]) -> None: ...
 
     class TypeVarTuple(type_param):
         __match_args__ = ("name",)
         name: _Identifier
+        def __init__(self, name: _Identifier, **kwargs: typing_extensions.Unpack[_Attributes[int]]) -> None: ...
 
     class TypeAlias(stmt):
         __match_args__ = ("name", "type_params", "value")
         name: Name
         type_params: list[type_param]
         value: expr
+        def __init__(
+            self, name: Name, type_params: list[type_param], value: expr, **kwargs: typing_extensions.Unpack[_Attributes[int]]
+        ) -> None: ...

--- a/stdlib/_ast.pyi
+++ b/stdlib/_ast.pyi
@@ -18,8 +18,6 @@ class AST:
     _attributes: ClassVar[tuple[str, ...]]
     _fields: ClassVar[tuple[str, ...]]
     def __init__(self, *args: Any, **kwargs: Any) -> None: ...
-    # TODO: Not all nodes have all of the following attributes
-    type_comment: str | None
 
 class mod(AST): ...
 class type_ignore(AST): ...
@@ -67,6 +65,7 @@ class FunctionDef(stmt):
     body: list[stmt]
     decorator_list: list[expr]
     returns: expr | None
+    type_comment: str | None
     if sys.version_info >= (3, 12):
         type_params: list[type_param]
 
@@ -80,6 +79,7 @@ class AsyncFunctionDef(stmt):
     body: list[stmt]
     decorator_list: list[expr]
     returns: expr | None
+    type_comment: str | None
     if sys.version_info >= (3, 12):
         type_params: list[type_param]
 
@@ -111,6 +111,7 @@ class Assign(stmt):
         __match_args__ = ("targets", "value", "type_comment")
     targets: list[expr]
     value: expr
+    type_comment: str | None
 
 class AugAssign(stmt):
     if sys.version_info >= (3, 10):
@@ -134,6 +135,7 @@ class For(stmt):
     iter: expr
     body: list[stmt]
     orelse: list[stmt]
+    type_comment: str | None
 
 class AsyncFor(stmt):
     if sys.version_info >= (3, 10):
@@ -142,6 +144,7 @@ class AsyncFor(stmt):
     iter: expr
     body: list[stmt]
     orelse: list[stmt]
+    type_comment: str | None
 
 class While(stmt):
     if sys.version_info >= (3, 10):
@@ -162,12 +165,14 @@ class With(stmt):
         __match_args__ = ("items", "body", "type_comment")
     items: list[withitem]
     body: list[stmt]
+    type_comment: str | None
 
 class AsyncWith(stmt):
     if sys.version_info >= (3, 10):
         __match_args__ = ("items", "body", "type_comment")
     items: list[withitem]
     body: list[stmt]
+    type_comment: str | None
 
 class Raise(stmt):
     if sys.version_info >= (3, 10):
@@ -506,6 +511,7 @@ class arg(AST):
         __match_args__ = ("arg", "annotation", "type_comment")
     arg: _Identifier
     annotation: expr | None
+    type_comment: str | None
 
 class keyword(AST):
     lineno: int

--- a/stdlib/_ast.pyi
+++ b/stdlib/_ast.pyi
@@ -110,8 +110,8 @@ class FunctionDef(stmt):
             body: list[stmt],
             decorator_list: list[expr],
             returns: expr | None = None,
-            *,
             type_comment: str | None = None,
+            *,
             type_params: list[type_param],
             **kwargs: Unpack[_Attributes],
         ) -> None: ...
@@ -160,8 +160,8 @@ class AsyncFunctionDef(stmt):
             body: list[stmt],
             decorator_list: list[expr],
             returns: expr | None = None,
-            *,
             type_comment: str | None = None,
+            *,
             type_params: list[type_param],
             **kwargs: Unpack[_Attributes],
         ) -> None: ...

--- a/stdlib/_ast.pyi
+++ b/stdlib/_ast.pyi
@@ -1,6 +1,7 @@
 import sys
 import typing_extensions
 from typing import Any, ClassVar, Generic, Literal, TypedDict, overload
+from typing_extensions import Unpack
 
 PyCF_ONLY_AST: Literal[1024]
 PyCF_TYPE_COMMENTS: Literal[4096]
@@ -74,7 +75,7 @@ class stmt(AST):
     col_offset: int
     end_lineno: int | None
     end_col_offset: int | None
-    def __init__(self, **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
+    def __init__(self, **kwargs: Unpack[_Attributes]) -> None: ...
 
 class FunctionDef(stmt):
     if sys.version_info >= (3, 12):
@@ -99,7 +100,7 @@ class FunctionDef(stmt):
             returns: expr | None,
             type_comment: str | None,
             type_params: list[type_param],
-            **kwargs: typing_extensions.Unpack[_Attributes],
+            **kwargs: Unpack[_Attributes],
         ) -> None: ...
         @overload
         def __init__(
@@ -112,7 +113,7 @@ class FunctionDef(stmt):
             *,
             type_comment: str | None = None,
             type_params: list[type_param],
-            **kwargs: typing_extensions.Unpack[_Attributes],
+            **kwargs: Unpack[_Attributes],
         ) -> None: ...
     else:
         def __init__(
@@ -123,7 +124,7 @@ class FunctionDef(stmt):
             decorator_list: list[expr],
             returns: expr | None = None,
             type_comment: str | None = None,
-            **kwargs: typing_extensions.Unpack[_Attributes],
+            **kwargs: Unpack[_Attributes],
         ) -> None: ...
 
 class AsyncFunctionDef(stmt):
@@ -149,7 +150,7 @@ class AsyncFunctionDef(stmt):
             returns: expr | None,
             type_comment: str | None,
             type_params: list[type_param],
-            **kwargs: typing_extensions.Unpack[_Attributes],
+            **kwargs: Unpack[_Attributes],
         ) -> None: ...
         @overload
         def __init__(
@@ -162,7 +163,7 @@ class AsyncFunctionDef(stmt):
             *,
             type_comment: str | None = None,
             type_params: list[type_param],
-            **kwargs: typing_extensions.Unpack[_Attributes],
+            **kwargs: Unpack[_Attributes],
         ) -> None: ...
     else:
         def __init__(
@@ -173,7 +174,7 @@ class AsyncFunctionDef(stmt):
             decorator_list: list[expr],
             returns: expr | None = None,
             type_comment: str | None = None,
-            **kwargs: typing_extensions.Unpack[_Attributes],
+            **kwargs: Unpack[_Attributes],
         ) -> None: ...
 
 class ClassDef(stmt):
@@ -196,7 +197,7 @@ class ClassDef(stmt):
             body: list[stmt],
             decorator_list: list[expr],
             type_params: list[type_param],
-            **kwargs: typing_extensions.Unpack[_Attributes],
+            **kwargs: Unpack[_Attributes],
         ) -> None: ...
     else:
         def __init__(
@@ -206,20 +207,20 @@ class ClassDef(stmt):
             keywords: list[keyword],
             body: list[stmt],
             decorator_list: list[expr],
-            **kwargs: typing_extensions.Unpack[_Attributes],
+            **kwargs: Unpack[_Attributes],
         ) -> None: ...
 
 class Return(stmt):
     if sys.version_info >= (3, 10):
         __match_args__ = ("value",)
     value: expr | None
-    def __init__(self, value: expr | None = None, **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
+    def __init__(self, value: expr | None = None, **kwargs: Unpack[_Attributes]) -> None: ...
 
 class Delete(stmt):
     if sys.version_info >= (3, 10):
         __match_args__ = ("targets",)
     targets: list[expr]
-    def __init__(self, targets: list[expr], **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
+    def __init__(self, targets: list[expr], **kwargs: Unpack[_Attributes]) -> None: ...
 
 class Assign(stmt):
     if sys.version_info >= (3, 10):
@@ -228,7 +229,7 @@ class Assign(stmt):
     value: expr
     type_comment: str | None
     def __init__(
-        self, targets: list[expr], value: expr, type_comment: str | None = None, **kwargs: typing_extensions.Unpack[_Attributes]
+        self, targets: list[expr], value: expr, type_comment: str | None = None, **kwargs: Unpack[_Attributes]
     ) -> None: ...
 
 class AugAssign(stmt):
@@ -238,7 +239,7 @@ class AugAssign(stmt):
     op: operator
     value: expr
     def __init__(
-        self, target: Name | Attribute | Subscript, op: operator, value: expr, **kwargs: typing_extensions.Unpack[_Attributes]
+        self, target: Name | Attribute | Subscript, op: operator, value: expr, **kwargs: Unpack[_Attributes]
     ) -> None: ...
 
 class AnnAssign(stmt):
@@ -255,7 +256,7 @@ class AnnAssign(stmt):
         annotation: expr,
         value: expr | None,
         simple: int,
-        **kwargs: typing_extensions.Unpack[_Attributes],
+        **kwargs: Unpack[_Attributes],
     ) -> None: ...
     @overload
     def __init__(
@@ -265,7 +266,7 @@ class AnnAssign(stmt):
         value: expr | None = None,
         *,
         simple: int,
-        **kwargs: typing_extensions.Unpack[_Attributes],
+        **kwargs: Unpack[_Attributes],
     ) -> None: ...
 
 class For(stmt):
@@ -283,7 +284,7 @@ class For(stmt):
         body: list[stmt],
         orelse: list[stmt],
         type_comment: str | None = None,
-        **kwargs: typing_extensions.Unpack[_Attributes],
+        **kwargs: Unpack[_Attributes],
     ) -> None: ...
 
 class AsyncFor(stmt):
@@ -301,7 +302,7 @@ class AsyncFor(stmt):
         body: list[stmt],
         orelse: list[stmt],
         type_comment: str | None = None,
-        **kwargs: typing_extensions.Unpack[_Attributes],
+        **kwargs: Unpack[_Attributes],
     ) -> None: ...
 
 class While(stmt):
@@ -310,9 +311,7 @@ class While(stmt):
     test: expr
     body: list[stmt]
     orelse: list[stmt]
-    def __init__(
-        self, test: expr, body: list[stmt], orelse: list[stmt], **kwargs: typing_extensions.Unpack[_Attributes]
-    ) -> None: ...
+    def __init__(self, test: expr, body: list[stmt], orelse: list[stmt], **kwargs: Unpack[_Attributes]) -> None: ...
 
 class If(stmt):
     if sys.version_info >= (3, 10):
@@ -320,9 +319,7 @@ class If(stmt):
     test: expr
     body: list[stmt]
     orelse: list[stmt]
-    def __init__(
-        self, test: expr, body: list[stmt], orelse: list[stmt], **kwargs: typing_extensions.Unpack[_Attributes]
-    ) -> None: ...
+    def __init__(self, test: expr, body: list[stmt], orelse: list[stmt], **kwargs: Unpack[_Attributes]) -> None: ...
 
 class With(stmt):
     if sys.version_info >= (3, 10):
@@ -331,11 +328,7 @@ class With(stmt):
     body: list[stmt]
     type_comment: str | None
     def __init__(
-        self,
-        items: list[withitem],
-        body: list[stmt],
-        type_comment: str | None = None,
-        **kwargs: typing_extensions.Unpack[_Attributes],
+        self, items: list[withitem], body: list[stmt], type_comment: str | None = None, **kwargs: Unpack[_Attributes]
     ) -> None: ...
 
 class AsyncWith(stmt):
@@ -345,11 +338,7 @@ class AsyncWith(stmt):
     body: list[stmt]
     type_comment: str | None
     def __init__(
-        self,
-        items: list[withitem],
-        body: list[stmt],
-        type_comment: str | None = None,
-        **kwargs: typing_extensions.Unpack[_Attributes],
+        self, items: list[withitem], body: list[stmt], type_comment: str | None = None, **kwargs: Unpack[_Attributes]
     ) -> None: ...
 
 class Raise(stmt):
@@ -357,9 +346,7 @@ class Raise(stmt):
         __match_args__ = ("exc", "cause")
     exc: expr | None
     cause: expr | None
-    def __init__(
-        self, exc: expr | None = None, cause: expr | None = None, **kwargs: typing_extensions.Unpack[_Attributes]
-    ) -> None: ...
+    def __init__(self, exc: expr | None = None, cause: expr | None = None, **kwargs: Unpack[_Attributes]) -> None: ...
 
 class Try(stmt):
     if sys.version_info >= (3, 10):
@@ -374,7 +361,7 @@ class Try(stmt):
         handlers: list[ExceptHandler],
         orelse: list[stmt],
         finalbody: list[stmt],
-        **kwargs: typing_extensions.Unpack[_Attributes],
+        **kwargs: Unpack[_Attributes],
     ) -> None: ...
 
 if sys.version_info >= (3, 11):
@@ -390,7 +377,7 @@ if sys.version_info >= (3, 11):
             handlers: list[ExceptHandler],
             orelse: list[stmt],
             finalbody: list[stmt],
-            **kwargs: typing_extensions.Unpack[_Attributes],
+            **kwargs: Unpack[_Attributes],
         ) -> None: ...
 
 class Assert(stmt):
@@ -398,13 +385,13 @@ class Assert(stmt):
         __match_args__ = ("test", "msg")
     test: expr
     msg: expr | None
-    def __init__(self, test: expr, msg: expr | None = None, **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
+    def __init__(self, test: expr, msg: expr | None = None, **kwargs: Unpack[_Attributes]) -> None: ...
 
 class Import(stmt):
     if sys.version_info >= (3, 10):
         __match_args__ = ("names",)
     names: list[alias]
-    def __init__(self, names: list[alias], **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
+    def __init__(self, names: list[alias], **kwargs: Unpack[_Attributes]) -> None: ...
 
 class ImportFrom(stmt):
     if sys.version_info >= (3, 10):
@@ -413,31 +400,27 @@ class ImportFrom(stmt):
     names: list[alias]
     level: int
     @overload
-    def __init__(
-        self, module: str | None, names: list[alias], level: int, **kwargs: typing_extensions.Unpack[_Attributes]
-    ) -> None: ...
+    def __init__(self, module: str | None, names: list[alias], level: int, **kwargs: Unpack[_Attributes]) -> None: ...
     @overload
-    def __init__(
-        self, module: str | None = None, *, names: list[alias], level: int, **kwargs: typing_extensions.Unpack[_Attributes]
-    ) -> None: ...
+    def __init__(self, module: str | None = None, *, names: list[alias], level: int, **kwargs: Unpack[_Attributes]) -> None: ...
 
 class Global(stmt):
     if sys.version_info >= (3, 10):
         __match_args__ = ("names",)
     names: list[_Identifier]
-    def __init__(self, names: list[_Identifier], **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
+    def __init__(self, names: list[_Identifier], **kwargs: Unpack[_Attributes]) -> None: ...
 
 class Nonlocal(stmt):
     if sys.version_info >= (3, 10):
         __match_args__ = ("names",)
     names: list[_Identifier]
-    def __init__(self, names: list[_Identifier], **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
+    def __init__(self, names: list[_Identifier], **kwargs: Unpack[_Attributes]) -> None: ...
 
 class Expr(stmt):
     if sys.version_info >= (3, 10):
         __match_args__ = ("value",)
     value: expr
-    def __init__(self, value: expr, **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
+    def __init__(self, value: expr, **kwargs: Unpack[_Attributes]) -> None: ...
 
 class Pass(stmt): ...
 class Break(stmt): ...
@@ -448,14 +431,14 @@ class expr(AST):
     col_offset: int
     end_lineno: int | None
     end_col_offset: int | None
-    def __init__(self, **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
+    def __init__(self, **kwargs: Unpack[_Attributes]) -> None: ...
 
 class BoolOp(expr):
     if sys.version_info >= (3, 10):
         __match_args__ = ("op", "values")
     op: boolop
     values: list[expr]
-    def __init__(self, op: boolop, values: list[expr], **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
+    def __init__(self, op: boolop, values: list[expr], **kwargs: Unpack[_Attributes]) -> None: ...
 
 class BinOp(expr):
     if sys.version_info >= (3, 10):
@@ -463,21 +446,21 @@ class BinOp(expr):
     left: expr
     op: operator
     right: expr
-    def __init__(self, left: expr, op: operator, right: expr, **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
+    def __init__(self, left: expr, op: operator, right: expr, **kwargs: Unpack[_Attributes]) -> None: ...
 
 class UnaryOp(expr):
     if sys.version_info >= (3, 10):
         __match_args__ = ("op", "operand")
     op: unaryop
     operand: expr
-    def __init__(self, op: unaryop, operand: expr, **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
+    def __init__(self, op: unaryop, operand: expr, **kwargs: Unpack[_Attributes]) -> None: ...
 
 class Lambda(expr):
     if sys.version_info >= (3, 10):
         __match_args__ = ("args", "body")
     args: arguments
     body: expr
-    def __init__(self, args: arguments, body: expr, **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
+    def __init__(self, args: arguments, body: expr, **kwargs: Unpack[_Attributes]) -> None: ...
 
 class IfExp(expr):
     if sys.version_info >= (3, 10):
@@ -485,34 +468,34 @@ class IfExp(expr):
     test: expr
     body: expr
     orelse: expr
-    def __init__(self, test: expr, body: expr, orelse: expr, **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
+    def __init__(self, test: expr, body: expr, orelse: expr, **kwargs: Unpack[_Attributes]) -> None: ...
 
 class Dict(expr):
     if sys.version_info >= (3, 10):
         __match_args__ = ("keys", "values")
     keys: list[expr | None]
     values: list[expr]
-    def __init__(self, keys: list[expr | None], values: list[expr], **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
+    def __init__(self, keys: list[expr | None], values: list[expr], **kwargs: Unpack[_Attributes]) -> None: ...
 
 class Set(expr):
     if sys.version_info >= (3, 10):
         __match_args__ = ("elts",)
     elts: list[expr]
-    def __init__(self, elts: list[expr], **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
+    def __init__(self, elts: list[expr], **kwargs: Unpack[_Attributes]) -> None: ...
 
 class ListComp(expr):
     if sys.version_info >= (3, 10):
         __match_args__ = ("elt", "generators")
     elt: expr
     generators: list[comprehension]
-    def __init__(self, elt: expr, generators: list[comprehension], **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
+    def __init__(self, elt: expr, generators: list[comprehension], **kwargs: Unpack[_Attributes]) -> None: ...
 
 class SetComp(expr):
     if sys.version_info >= (3, 10):
         __match_args__ = ("elt", "generators")
     elt: expr
     generators: list[comprehension]
-    def __init__(self, elt: expr, generators: list[comprehension], **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
+    def __init__(self, elt: expr, generators: list[comprehension], **kwargs: Unpack[_Attributes]) -> None: ...
 
 class DictComp(expr):
     if sys.version_info >= (3, 10):
@@ -520,34 +503,32 @@ class DictComp(expr):
     key: expr
     value: expr
     generators: list[comprehension]
-    def __init__(
-        self, key: expr, value: expr, generators: list[comprehension], **kwargs: typing_extensions.Unpack[_Attributes]
-    ) -> None: ...
+    def __init__(self, key: expr, value: expr, generators: list[comprehension], **kwargs: Unpack[_Attributes]) -> None: ...
 
 class GeneratorExp(expr):
     if sys.version_info >= (3, 10):
         __match_args__ = ("elt", "generators")
     elt: expr
     generators: list[comprehension]
-    def __init__(self, elt: expr, generators: list[comprehension], **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
+    def __init__(self, elt: expr, generators: list[comprehension], **kwargs: Unpack[_Attributes]) -> None: ...
 
 class Await(expr):
     if sys.version_info >= (3, 10):
         __match_args__ = ("value",)
     value: expr
-    def __init__(self, value: expr, **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
+    def __init__(self, value: expr, **kwargs: Unpack[_Attributes]) -> None: ...
 
 class Yield(expr):
     if sys.version_info >= (3, 10):
         __match_args__ = ("value",)
     value: expr | None
-    def __init__(self, value: expr | None = None, **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
+    def __init__(self, value: expr | None = None, **kwargs: Unpack[_Attributes]) -> None: ...
 
 class YieldFrom(expr):
     if sys.version_info >= (3, 10):
         __match_args__ = ("value",)
     value: expr
-    def __init__(self, value: expr, **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
+    def __init__(self, value: expr, **kwargs: Unpack[_Attributes]) -> None: ...
 
 class Compare(expr):
     if sys.version_info >= (3, 10):
@@ -555,9 +536,7 @@ class Compare(expr):
     left: expr
     ops: list[cmpop]
     comparators: list[expr]
-    def __init__(
-        self, left: expr, ops: list[cmpop], comparators: list[expr], **kwargs: typing_extensions.Unpack[_Attributes]
-    ) -> None: ...
+    def __init__(self, left: expr, ops: list[cmpop], comparators: list[expr], **kwargs: Unpack[_Attributes]) -> None: ...
 
 class Call(expr):
     if sys.version_info >= (3, 10):
@@ -565,9 +544,7 @@ class Call(expr):
     func: expr
     args: list[expr]
     keywords: list[keyword]
-    def __init__(
-        self, func: expr, args: list[expr], keywords: list[keyword], **kwargs: typing_extensions.Unpack[_Attributes]
-    ) -> None: ...
+    def __init__(self, func: expr, args: list[expr], keywords: list[keyword], **kwargs: Unpack[_Attributes]) -> None: ...
 
 class FormattedValue(expr):
     if sys.version_info >= (3, 10):
@@ -575,15 +552,13 @@ class FormattedValue(expr):
     value: expr
     conversion: int
     format_spec: expr | None
-    def __init__(
-        self, value: expr, conversion: int, format_spec: expr | None = None, **kwargs: typing_extensions.Unpack[_Attributes]
-    ) -> None: ...
+    def __init__(self, value: expr, conversion: int, format_spec: expr | None = None, **kwargs: Unpack[_Attributes]) -> None: ...
 
 class JoinedStr(expr):
     if sys.version_info >= (3, 10):
         __match_args__ = ("values",)
     values: list[expr]
-    def __init__(self, values: list[expr], **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
+    def __init__(self, values: list[expr], **kwargs: Unpack[_Attributes]) -> None: ...
 
 class Constant(expr):
     if sys.version_info >= (3, 10):
@@ -593,14 +568,14 @@ class Constant(expr):
     # Aliases for value, for backwards compatibility
     s: Any
     n: int | float | complex
-    def __init__(self, value: Any, kind: str | None = None, **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
+    def __init__(self, value: Any, kind: str | None = None, **kwargs: Unpack[_Attributes]) -> None: ...
 
 class NamedExpr(expr):
     if sys.version_info >= (3, 10):
         __match_args__ = ("target", "value")
     target: Name
     value: expr
-    def __init__(self, target: Name, value: expr, **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
+    def __init__(self, target: Name, value: expr, **kwargs: Unpack[_Attributes]) -> None: ...
 
 class Attribute(expr):
     if sys.version_info >= (3, 10):
@@ -608,9 +583,7 @@ class Attribute(expr):
     value: expr
     attr: _Identifier
     ctx: expr_context
-    def __init__(
-        self, value: expr, attr: _Identifier, ctx: expr_context, **kwargs: typing_extensions.Unpack[_Attributes]
-    ) -> None: ...
+    def __init__(self, value: expr, attr: _Identifier, ctx: expr_context, **kwargs: Unpack[_Attributes]) -> None: ...
 
 if sys.version_info >= (3, 9):
     _Slice: typing_extensions.TypeAlias = expr
@@ -625,21 +598,17 @@ class Slice(_Slice):
     upper: expr | None
     step: expr | None
     def __init__(
-        self,
-        lower: expr | None = None,
-        upper: expr | None = None,
-        step: expr | None = None,
-        **kwargs: typing_extensions.Unpack[_SliceAttributes],
+        self, lower: expr | None = None, upper: expr | None = None, step: expr | None = None, **kwargs: Unpack[_SliceAttributes]
     ) -> None: ...
 
 if sys.version_info < (3, 9):
     class ExtSlice(slice):
         dims: list[slice]
-        def __init__(self, dims: list[slice], **kwargs: typing_extensions.Unpack[_SliceAttributes]) -> None: ...
+        def __init__(self, dims: list[slice], **kwargs: Unpack[_SliceAttributes]) -> None: ...
 
     class Index(slice):
         value: expr
-        def __init__(self, value: expr, **kwargs: typing_extensions.Unpack[_SliceAttributes]) -> None: ...
+        def __init__(self, value: expr, **kwargs: Unpack[_SliceAttributes]) -> None: ...
 
 class Subscript(expr):
     if sys.version_info >= (3, 10):
@@ -647,30 +616,28 @@ class Subscript(expr):
     value: expr
     slice: _Slice
     ctx: expr_context
-    def __init__(
-        self, value: expr, slice: _Slice, ctx: expr_context, **kwargs: typing_extensions.Unpack[_Attributes]
-    ) -> None: ...
+    def __init__(self, value: expr, slice: _Slice, ctx: expr_context, **kwargs: Unpack[_Attributes]) -> None: ...
 
 class Starred(expr):
     if sys.version_info >= (3, 10):
         __match_args__ = ("value", "ctx")
     value: expr
     ctx: expr_context
-    def __init__(self, value: expr, ctx: expr_context, **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
+    def __init__(self, value: expr, ctx: expr_context, **kwargs: Unpack[_Attributes]) -> None: ...
 
 class Name(expr):
     if sys.version_info >= (3, 10):
         __match_args__ = ("id", "ctx")
     id: _Identifier
     ctx: expr_context
-    def __init__(self, id: _Identifier, ctx: expr_context, **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
+    def __init__(self, id: _Identifier, ctx: expr_context, **kwargs: Unpack[_Attributes]) -> None: ...
 
 class List(expr):
     if sys.version_info >= (3, 10):
         __match_args__ = ("elts", "ctx")
     elts: list[expr]
     ctx: expr_context
-    def __init__(self, elts: list[expr], ctx: expr_context, **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
+    def __init__(self, elts: list[expr], ctx: expr_context, **kwargs: Unpack[_Attributes]) -> None: ...
 
 class Tuple(expr):
     if sys.version_info >= (3, 10):
@@ -680,7 +647,7 @@ class Tuple(expr):
     if sys.version_info >= (3, 9):
         dims: list[expr]
 
-    def __init__(self, elts: list[expr], ctx: expr_context, **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
+    def __init__(self, elts: list[expr], ctx: expr_context, **kwargs: Unpack[_Attributes]) -> None: ...
 
 class expr_context(AST): ...
 
@@ -744,7 +711,7 @@ class excepthandler(AST):
     col_offset: int
     end_lineno: int | None
     end_col_offset: int | None
-    def __init__(self, **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
+    def __init__(self, **kwargs: Unpack[_Attributes]) -> None: ...
 
 class ExceptHandler(excepthandler):
     if sys.version_info >= (3, 10):
@@ -753,17 +720,10 @@ class ExceptHandler(excepthandler):
     name: _Identifier | None
     body: list[stmt]
     @overload
-    def __init__(
-        self, type: expr | None, name: _Identifier | None, body: list[stmt], **kwargs: typing_extensions.Unpack[_Attributes]
-    ) -> None: ...
+    def __init__(self, type: expr | None, name: _Identifier | None, body: list[stmt], **kwargs: Unpack[_Attributes]) -> None: ...
     @overload
     def __init__(
-        self,
-        type: expr | None = None,
-        name: _Identifier | None = None,
-        *,
-        body: list[stmt],
-        **kwargs: typing_extensions.Unpack[_Attributes],
+        self, type: expr | None = None, name: _Identifier | None = None, *, body: list[stmt], **kwargs: Unpack[_Attributes]
     ) -> None: ...
 
 class arguments(AST):
@@ -823,11 +783,7 @@ class arg(AST):
     annotation: expr | None
     type_comment: str | None
     def __init__(
-        self,
-        arg: _Identifier,
-        annotation: expr | None = None,
-        type_comment: str | None = None,
-        **kwargs: typing_extensions.Unpack[_Attributes],
+        self, arg: _Identifier, annotation: expr | None = None, type_comment: str | None = None, **kwargs: Unpack[_Attributes]
     ) -> None: ...
 
 class keyword(AST):
@@ -840,11 +796,9 @@ class keyword(AST):
     arg: _Identifier | None
     value: expr
     @overload
-    def __init__(self, arg: _Identifier | None, value: expr, **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
+    def __init__(self, arg: _Identifier | None, value: expr, **kwargs: Unpack[_Attributes]) -> None: ...
     @overload
-    def __init__(
-        self, arg: _Identifier | None = None, *, value: expr, **kwargs: typing_extensions.Unpack[_Attributes]
-    ) -> None: ...
+    def __init__(self, arg: _Identifier | None = None, *, value: expr, **kwargs: Unpack[_Attributes]) -> None: ...
 
 class alias(AST):
     lineno: int
@@ -855,7 +809,7 @@ class alias(AST):
         __match_args__ = ("name", "asname")
     name: str
     asname: _Identifier | None
-    def __init__(self, name: str, asname: _Identifier | None = None, **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
+    def __init__(self, name: str, asname: _Identifier | None = None, **kwargs: Unpack[_Attributes]) -> None: ...
 
 class withitem(AST):
     if sys.version_info >= (3, 10):
@@ -869,14 +823,14 @@ if sys.version_info >= (3, 10):
         __match_args__ = ("subject", "cases")
         subject: expr
         cases: list[match_case]
-        def __init__(self, subject: expr, cases: list[match_case], **kwargs: typing_extensions.Unpack[_Attributes]) -> None: ...
+        def __init__(self, subject: expr, cases: list[match_case], **kwargs: Unpack[_Attributes]) -> None: ...
 
     class pattern(AST):
         lineno: int
         col_offset: int
         end_lineno: int
         end_col_offset: int
-        def __init__(self, **kwargs: typing_extensions.Unpack[_Attributes[int]]) -> None: ...
+        def __init__(self, **kwargs: Unpack[_Attributes[int]]) -> None: ...
 
     # Without the alias, Pyright complains variables named pattern are recursively defined
     _Pattern: typing_extensions.TypeAlias = pattern
@@ -894,22 +848,22 @@ if sys.version_info >= (3, 10):
     class MatchValue(pattern):
         __match_args__ = ("value",)
         value: expr
-        def __init__(self, value: expr, **kwargs: typing_extensions.Unpack[_Attributes[int]]) -> None: ...
+        def __init__(self, value: expr, **kwargs: Unpack[_Attributes[int]]) -> None: ...
 
     class MatchSingleton(pattern):
         __match_args__ = ("value",)
         value: Literal[True, False] | None
-        def __init__(self, value: Literal[True, False] | None, **kwargs: typing_extensions.Unpack[_Attributes[int]]) -> None: ...
+        def __init__(self, value: Literal[True, False] | None, **kwargs: Unpack[_Attributes[int]]) -> None: ...
 
     class MatchSequence(pattern):
         __match_args__ = ("patterns",)
         patterns: list[pattern]
-        def __init__(self, patterns: list[pattern], **kwargs: typing_extensions.Unpack[_Attributes[int]]) -> None: ...
+        def __init__(self, patterns: list[pattern], **kwargs: Unpack[_Attributes[int]]) -> None: ...
 
     class MatchStar(pattern):
         __match_args__ = ("name",)
         name: _Identifier | None
-        def __init__(self, name: _Identifier | None, **kwargs: typing_extensions.Unpack[_Attributes[int]]) -> None: ...
+        def __init__(self, name: _Identifier | None, **kwargs: Unpack[_Attributes[int]]) -> None: ...
 
     class MatchMapping(pattern):
         __match_args__ = ("keys", "patterns", "rest")
@@ -917,11 +871,7 @@ if sys.version_info >= (3, 10):
         patterns: list[pattern]
         rest: _Identifier | None
         def __init__(
-            self,
-            keys: list[expr],
-            patterns: list[pattern],
-            rest: _Identifier | None = None,
-            **kwargs: typing_extensions.Unpack[_Attributes[int]],
+            self, keys: list[expr], patterns: list[pattern], rest: _Identifier | None = None, **kwargs: Unpack[_Attributes[int]]
         ) -> None: ...
 
     class MatchClass(pattern):
@@ -936,7 +886,7 @@ if sys.version_info >= (3, 10):
             patterns: list[pattern],
             kwd_attrs: list[_Identifier],
             kwd_patterns: list[pattern],
-            **kwargs: typing_extensions.Unpack[_Attributes[int]],
+            **kwargs: Unpack[_Attributes[int]],
         ) -> None: ...
 
     class MatchAs(pattern):
@@ -944,16 +894,13 @@ if sys.version_info >= (3, 10):
         pattern: _Pattern | None
         name: _Identifier | None
         def __init__(
-            self,
-            pattern: _Pattern | None = None,
-            name: _Identifier | None = None,
-            **kwargs: typing_extensions.Unpack[_Attributes[int]],
+            self, pattern: _Pattern | None = None, name: _Identifier | None = None, **kwargs: Unpack[_Attributes[int]]
         ) -> None: ...
 
     class MatchOr(pattern):
         __match_args__ = ("patterns",)
         patterns: list[pattern]
-        def __init__(self, patterns: list[pattern], **kwargs: typing_extensions.Unpack[_Attributes[int]]) -> None: ...
+        def __init__(self, patterns: list[pattern], **kwargs: Unpack[_Attributes[int]]) -> None: ...
 
 if sys.version_info >= (3, 12):
     class type_param(AST):
@@ -961,25 +908,23 @@ if sys.version_info >= (3, 12):
         col_offset: int
         end_lineno: int
         end_col_offset: int
-        def __init__(self, **kwargs: typing_extensions.Unpack[_Attributes[int]]) -> None: ...
+        def __init__(self, **kwargs: Unpack[_Attributes[int]]) -> None: ...
 
     class TypeVar(type_param):
         __match_args__ = ("name", "bound")
         name: _Identifier
         bound: expr | None
-        def __init__(
-            self, name: _Identifier, bound: expr | None = None, **kwargs: typing_extensions.Unpack[_Attributes[int]]
-        ) -> None: ...
+        def __init__(self, name: _Identifier, bound: expr | None = None, **kwargs: Unpack[_Attributes[int]]) -> None: ...
 
     class ParamSpec(type_param):
         __match_args__ = ("name",)
         name: _Identifier
-        def __init__(self, name: _Identifier, **kwargs: typing_extensions.Unpack[_Attributes[int]]) -> None: ...
+        def __init__(self, name: _Identifier, **kwargs: Unpack[_Attributes[int]]) -> None: ...
 
     class TypeVarTuple(type_param):
         __match_args__ = ("name",)
         name: _Identifier
-        def __init__(self, name: _Identifier, **kwargs: typing_extensions.Unpack[_Attributes[int]]) -> None: ...
+        def __init__(self, name: _Identifier, **kwargs: Unpack[_Attributes[int]]) -> None: ...
 
     class TypeAlias(stmt):
         __match_args__ = ("name", "type_params", "value")
@@ -987,5 +932,5 @@ if sys.version_info >= (3, 12):
         type_params: list[type_param]
         value: expr
         def __init__(
-            self, name: Name, type_params: list[type_param], value: expr, **kwargs: typing_extensions.Unpack[_Attributes[int]]
+            self, name: Name, type_params: list[type_param], value: expr, **kwargs: Unpack[_Attributes[int]]
         ) -> None: ...

--- a/stdlib/_ast.pyi
+++ b/stdlib/_ast.pyi
@@ -556,7 +556,7 @@ class Compare(expr):
     ops: list[cmpop]
     comparators: list[expr]
     def __init__(
-        self, left: expr, op: list[cmpop], comparators: list[expr], **kwargs: typing_extensions.Unpack[_Attributes]
+        self, left: expr, ops: list[cmpop], comparators: list[expr], **kwargs: typing_extensions.Unpack[_Attributes]
     ) -> None: ...
 
 class Call(expr):

--- a/stdlib/_ast.pyi
+++ b/stdlib/_ast.pyi
@@ -1161,20 +1161,51 @@ if sys.version_info >= (3, 12):
         def __init__(self, **kwargs: Unpack[_Attributes[int]]) -> None: ...
 
     class TypeVar(type_param):
-        __match_args__ = ("name", "bound")
+        if sys.version_info >= (3, 13):
+            __match_args__ = ("name", "bound", "default_value")
+        else:
+            __match_args__ = ("name", "bound")
         name: _Identifier
         bound: expr | None
-        def __init__(self, name: _Identifier, bound: expr | None = None, **kwargs: Unpack[_Attributes[int]]) -> None: ...
+        if sys.version_info >= (3, 13):
+            default_value: expr | None
+            def __init__(
+                self,
+                name: _Identifier,
+                bound: expr | None = None,
+                default_value: expr | None = None,
+                **kwargs: Unpack[_Attributes[int]],
+            ) -> None: ...
+        else:
+            def __init__(self, name: _Identifier, bound: expr | None = None, **kwargs: Unpack[_Attributes[int]]) -> None: ...
 
     class ParamSpec(type_param):
-        __match_args__ = ("name",)
+        if sys.version_info >= (3, 13):
+            __match_args__ = ("name", "default_value")
+        else:
+            __match_args__ = ("name",)
         name: _Identifier
-        def __init__(self, name: _Identifier, **kwargs: Unpack[_Attributes[int]]) -> None: ...
+        if sys.version_info >= (3, 13):
+            default_value: expr | None
+            def __init__(
+                self, name: _Identifier, default_value: expr | None = None, **kwargs: Unpack[_Attributes[int]]
+            ) -> None: ...
+        else:
+            def __init__(self, name: _Identifier, **kwargs: Unpack[_Attributes[int]]) -> None: ...
 
     class TypeVarTuple(type_param):
-        __match_args__ = ("name",)
+        if sys.version_info >= (3, 13):
+            __match_args__ = ("name", "default_value")
+        else:
+            __match_args__ = ("name",)
         name: _Identifier
-        def __init__(self, name: _Identifier, **kwargs: Unpack[_Attributes[int]]) -> None: ...
+        if sys.version_info >= (3, 13):
+            default_value: expr | None
+            def __init__(
+                self, name: _Identifier, default_value: expr | None = None, **kwargs: Unpack[_Attributes[int]]
+            ) -> None: ...
+        else:
+            def __init__(self, name: _Identifier, **kwargs: Unpack[_Attributes[int]]) -> None: ...
 
     class TypeAlias(stmt):
         __match_args__ = ("name", "type_params", "value")

--- a/stdlib/_ast.pyi
+++ b/stdlib/_ast.pyi
@@ -23,11 +23,6 @@ class _Attributes(TypedDict, Generic[_EndPositionT], total=False):
     end_lineno: _EndPositionT
     end_col_offset: _EndPositionT
 
-if sys.version_info >= (3, 9):
-    _SliceAttributes: typing_extensions.TypeAlias = _Attributes
-else:
-    class _SliceAttributes(TypedDict): ...
-
 class AST:
     if sys.version_info >= (3, 10):
         __match_args__ = ()
@@ -774,9 +769,11 @@ class Attribute(expr):
 
 if sys.version_info >= (3, 9):
     _Slice: typing_extensions.TypeAlias = expr
+    _SliceAttributes: typing_extensions.TypeAlias = _Attributes
 else:
     class slice(AST): ...
     _Slice: typing_extensions.TypeAlias = slice
+    class _SliceAttributes(TypedDict): ...
 
 class Slice(_Slice):
     if sys.version_info >= (3, 10):

--- a/stdlib/_ast.pyi
+++ b/stdlib/_ast.pyi
@@ -25,6 +25,7 @@ class type_ignore(AST): ...
 class TypeIgnore(type_ignore):
     if sys.version_info >= (3, 10):
         __match_args__ = ("lineno", "tag")
+    lineno: int
     tag: str
 
 class FunctionType(mod):

--- a/stdlib/_ast.pyi
+++ b/stdlib/_ast.pyi
@@ -160,6 +160,8 @@ class AsyncFunctionDef(stmt):
     decorator_list: list[expr]
     returns: expr | None
     type_comment: str | None
+    if sys.version_info >= (3, 12):
+        type_params: list[type_param]
     if sys.version_info >= (3, 13):
         def __init__(
             self,
@@ -173,7 +175,6 @@ class AsyncFunctionDef(stmt):
             **kwargs: Unpack[_Attributes],
         ) -> None: ...
     elif sys.version_info >= (3, 12):
-        type_params: list[type_param]
         @overload
         def __init__(
             self,

--- a/stdlib/_ast.pyi
+++ b/stdlib/_ast.pyi
@@ -773,6 +773,7 @@ if sys.version_info >= (3, 9):
 else:
     class slice(AST): ...
     _Slice: typing_extensions.TypeAlias = slice
+
     class _SliceAttributes(TypedDict): ...
 
 class Slice(_Slice):

--- a/stdlib/_ast.pyi
+++ b/stdlib/_ast.pyi
@@ -19,10 +19,6 @@ class AST:
     _fields: ClassVar[tuple[str, ...]]
     def __init__(self, *args: Any, **kwargs: Any) -> None: ...
     # TODO: Not all nodes have all of the following attributes
-    lineno: int
-    col_offset: int
-    end_lineno: int | None
-    end_col_offset: int | None
     type_comment: str | None
 
 class mod(AST): ...
@@ -55,7 +51,11 @@ class Expression(mod):
         __match_args__ = ("body",)
     body: expr
 
-class stmt(AST): ...
+class stmt(AST):
+    lineno: int
+    col_offset: int
+    end_lineno: int | None
+    end_col_offset: int | None
 
 class FunctionDef(stmt):
     if sys.version_info >= (3, 12):
@@ -227,7 +227,12 @@ class Expr(stmt):
 class Pass(stmt): ...
 class Break(stmt): ...
 class Continue(stmt): ...
-class expr(AST): ...
+
+class expr(AST):
+    lineno: int
+    col_offset: int
+    end_lineno: int | None
+    end_col_offset: int | None
 
 class BoolOp(expr):
     if sys.version_info >= (3, 10):
@@ -468,7 +473,11 @@ class comprehension(AST):
     ifs: list[expr]
     is_async: int
 
-class excepthandler(AST): ...
+class excepthandler(AST):
+    lineno: int
+    col_offset: int
+    end_lineno: int | None
+    end_col_offset: int | None
 
 class ExceptHandler(excepthandler):
     if sys.version_info >= (3, 10):
@@ -489,18 +498,30 @@ class arguments(AST):
     defaults: list[expr]
 
 class arg(AST):
+    lineno: int
+    col_offset: int
+    end_lineno: int | None
+    end_col_offset: int | None
     if sys.version_info >= (3, 10):
         __match_args__ = ("arg", "annotation", "type_comment")
     arg: _Identifier
     annotation: expr | None
 
 class keyword(AST):
+    lineno: int
+    col_offset: int
+    end_lineno: int | None
+    end_col_offset: int | None
     if sys.version_info >= (3, 10):
         __match_args__ = ("arg", "value")
     arg: _Identifier | None
     value: expr
 
 class alias(AST):
+    lineno: int
+    col_offset: int
+    end_lineno: int | None
+    end_col_offset: int | None
     if sys.version_info >= (3, 10):
         __match_args__ = ("name", "asname")
     name: str
@@ -518,7 +539,12 @@ if sys.version_info >= (3, 10):
         subject: expr
         cases: list[match_case]
 
-    class pattern(AST): ...
+    class pattern(AST):
+        lineno: int
+        col_offset: int
+        end_lineno: int
+        end_col_offset: int
+
     # Without the alias, Pyright complains variables named pattern are recursively defined
     _Pattern: typing_extensions.TypeAlias = pattern
 
@@ -568,6 +594,8 @@ if sys.version_info >= (3, 10):
 
 if sys.version_info >= (3, 12):
     class type_param(AST):
+        lineno: int
+        col_offset: int
         end_lineno: int
         end_col_offset: int
 

--- a/stdlib/_ast.pyi
+++ b/stdlib/_ast.pyi
@@ -28,6 +28,8 @@ class AST:
         __match_args__ = ()
     _attributes: ClassVar[tuple[str, ...]]
     _fields: ClassVar[tuple[str, ...]]
+    if sys.version_info >= (3, 13):
+        _field_types: ClassVar[dict[str, Any]]
 
 class mod(AST): ...
 class type_ignore(AST): ...

--- a/stdlib/_ast.pyi
+++ b/stdlib/_ast.pyi
@@ -49,20 +49,32 @@ class FunctionType(mod):
         __match_args__ = ("argtypes", "returns")
     argtypes: list[expr]
     returns: expr
-    def __init__(self, argtypes: list[expr], returns: expr) -> None: ...
+    if sys.version_info >= (3, 13):
+        @overload
+        def __init__(self, argtypes: list[expr], returns: expr) -> None: ...
+        @overload
+        def __init__(self, argtypes: list[expr] = ..., *, returns: expr) -> None: ...
+    else:
+        def __init__(self, argtypes: list[expr], returns: expr) -> None: ...
 
 class Module(mod):
     if sys.version_info >= (3, 10):
         __match_args__ = ("body", "type_ignores")
     body: list[stmt]
     type_ignores: list[TypeIgnore]
-    def __init__(self, body: list[stmt], type_ignores: list[TypeIgnore]) -> None: ...
+    if sys.version_info >= (3, 13):
+        def __init__(self, body: list[stmt] = ..., type_ignores: list[TypeIgnore] = ...) -> None: ...
+    else:
+        def __init__(self, body: list[stmt], type_ignores: list[TypeIgnore]) -> None: ...
 
 class Interactive(mod):
     if sys.version_info >= (3, 10):
         __match_args__ = ("body",)
     body: list[stmt]
-    def __init__(self, body: list[stmt]) -> None: ...
+    if sys.version_info >= (3, 13):
+        def __init__(self, body: list[stmt] = ...) -> None: ...
+    else:
+        def __init__(self, body: list[stmt]) -> None: ...
 
 class Expression(mod):
     if sys.version_info >= (3, 10):
@@ -90,6 +102,19 @@ class FunctionDef(stmt):
     type_comment: str | None
     if sys.version_info >= (3, 12):
         type_params: list[type_param]
+    if sys.version_info >= (3, 13):
+        def __init__(
+            self,
+            name: _Identifier,
+            args: arguments,
+            body: list[stmt] = ...,
+            decorator_list: list[expr] = ...,
+            returns: expr | None = None,
+            type_comment: str | None = None,
+            type_params: list[type_param] = ...,
+            **kwargs: Unpack[_Attributes],
+        ) -> None: ...
+    elif sys.version_info >= (3, 12):
         @overload
         def __init__(
             self,
@@ -138,7 +163,19 @@ class AsyncFunctionDef(stmt):
     decorator_list: list[expr]
     returns: expr | None
     type_comment: str | None
-    if sys.version_info >= (3, 12):
+    if sys.version_info >= (3, 13):
+        def __init__(
+            self,
+            name: _Identifier,
+            args: arguments,
+            body: list[stmt] = ...,
+            decorator_list: list[expr] = ...,
+            returns: expr | None = None,
+            type_comment: str | None = None,
+            type_params: list[type_param] = ...,
+            **kwargs: Unpack[_Attributes],
+        ) -> None: ...
+    elif sys.version_info >= (3, 12):
         type_params: list[type_param]
         @overload
         def __init__(
@@ -189,6 +226,18 @@ class ClassDef(stmt):
     decorator_list: list[expr]
     if sys.version_info >= (3, 12):
         type_params: list[type_param]
+    if sys.version_info >= (3, 13):
+        def __init__(
+            self,
+            name: _Identifier,
+            bases: list[expr] = ...,
+            keywords: list[keyword] = ...,
+            body: list[stmt] = ...,
+            decorator_list: list[expr] = ...,
+            type_params: list[type_param] = ...,
+            **kwargs: Unpack[_Attributes],
+        ) -> None: ...
+    elif sys.version_info >= (3, 12):
         def __init__(
             self,
             name: _Identifier,
@@ -220,7 +269,10 @@ class Delete(stmt):
     if sys.version_info >= (3, 10):
         __match_args__ = ("targets",)
     targets: list[expr]
-    def __init__(self, targets: list[expr], **kwargs: Unpack[_Attributes]) -> None: ...
+    if sys.version_info >= (3, 13):
+        def __init__(self, targets: list[expr] = ..., **kwargs: Unpack[_Attributes]) -> None: ...
+    else:
+        def __init__(self, targets: list[expr], **kwargs: Unpack[_Attributes]) -> None: ...
 
 class Assign(stmt):
     if sys.version_info >= (3, 10):
@@ -228,9 +280,19 @@ class Assign(stmt):
     targets: list[expr]
     value: expr
     type_comment: str | None
-    def __init__(
-        self, targets: list[expr], value: expr, type_comment: str | None = None, **kwargs: Unpack[_Attributes]
-    ) -> None: ...
+    if sys.version_info >= (3, 13):
+        @overload
+        def __init__(
+            self, targets: list[expr], value: expr, type_comment: str | None = None, **kwargs: Unpack[_Attributes]
+        ) -> None: ...
+        @overload
+        def __init__(
+            self, targets: list[expr] = ..., *, value: expr, type_comment: str | None = None, **kwargs: Unpack[_Attributes]
+        ) -> None: ...
+    else:
+        def __init__(
+            self, targets: list[expr], value: expr, type_comment: str | None = None, **kwargs: Unpack[_Attributes]
+        ) -> None: ...
 
 class AugAssign(stmt):
     if sys.version_info >= (3, 10):
@@ -277,15 +339,26 @@ class For(stmt):
     body: list[stmt]
     orelse: list[stmt]
     type_comment: str | None
-    def __init__(
-        self,
-        target: expr,
-        iter: expr,
-        body: list[stmt],
-        orelse: list[stmt],
-        type_comment: str | None = None,
-        **kwargs: Unpack[_Attributes],
-    ) -> None: ...
+    if sys.version_info >= (3, 13):
+        def __init__(
+            self,
+            target: expr,
+            iter: expr,
+            body: list[stmt] = ...,
+            orelse: list[stmt] = ...,
+            type_comment: str | None = None,
+            **kwargs: Unpack[_Attributes],
+        ) -> None: ...
+    else:
+        def __init__(
+            self,
+            target: expr,
+            iter: expr,
+            body: list[stmt],
+            orelse: list[stmt],
+            type_comment: str | None = None,
+            **kwargs: Unpack[_Attributes],
+        ) -> None: ...
 
 class AsyncFor(stmt):
     if sys.version_info >= (3, 10):
@@ -295,15 +368,26 @@ class AsyncFor(stmt):
     body: list[stmt]
     orelse: list[stmt]
     type_comment: str | None
-    def __init__(
-        self,
-        target: expr,
-        iter: expr,
-        body: list[stmt],
-        orelse: list[stmt],
-        type_comment: str | None = None,
-        **kwargs: Unpack[_Attributes],
-    ) -> None: ...
+    if sys.version_info >= (3, 13):
+        def __init__(
+            self,
+            target: expr,
+            iter: expr,
+            body: list[stmt] = ...,
+            orelse: list[stmt] = ...,
+            type_comment: str | None = None,
+            **kwargs: Unpack[_Attributes],
+        ) -> None: ...
+    else:
+        def __init__(
+            self,
+            target: expr,
+            iter: expr,
+            body: list[stmt],
+            orelse: list[stmt],
+            type_comment: str | None = None,
+            **kwargs: Unpack[_Attributes],
+        ) -> None: ...
 
 class While(stmt):
     if sys.version_info >= (3, 10):
@@ -311,7 +395,12 @@ class While(stmt):
     test: expr
     body: list[stmt]
     orelse: list[stmt]
-    def __init__(self, test: expr, body: list[stmt], orelse: list[stmt], **kwargs: Unpack[_Attributes]) -> None: ...
+    if sys.version_info >= (3, 13):
+        def __init__(
+            self, test: expr, body: list[stmt] = ..., orelse: list[stmt] = ..., **kwargs: Unpack[_Attributes]
+        ) -> None: ...
+    else:
+        def __init__(self, test: expr, body: list[stmt], orelse: list[stmt], **kwargs: Unpack[_Attributes]) -> None: ...
 
 class If(stmt):
     if sys.version_info >= (3, 10):
@@ -319,7 +408,12 @@ class If(stmt):
     test: expr
     body: list[stmt]
     orelse: list[stmt]
-    def __init__(self, test: expr, body: list[stmt], orelse: list[stmt], **kwargs: Unpack[_Attributes]) -> None: ...
+    if sys.version_info >= (3, 13):
+        def __init__(
+            self, test: expr, body: list[stmt] = ..., orelse: list[stmt] = ..., **kwargs: Unpack[_Attributes]
+        ) -> None: ...
+    else:
+        def __init__(self, test: expr, body: list[stmt], orelse: list[stmt], **kwargs: Unpack[_Attributes]) -> None: ...
 
 class With(stmt):
     if sys.version_info >= (3, 10):
@@ -327,9 +421,18 @@ class With(stmt):
     items: list[withitem]
     body: list[stmt]
     type_comment: str | None
-    def __init__(
-        self, items: list[withitem], body: list[stmt], type_comment: str | None = None, **kwargs: Unpack[_Attributes]
-    ) -> None: ...
+    if sys.version_info >= (3, 13):
+        def __init__(
+            self,
+            items: list[withitem] = ...,
+            body: list[stmt] = ...,
+            type_comment: str | None = None,
+            **kwargs: Unpack[_Attributes],
+        ) -> None: ...
+    else:
+        def __init__(
+            self, items: list[withitem], body: list[stmt], type_comment: str | None = None, **kwargs: Unpack[_Attributes]
+        ) -> None: ...
 
 class AsyncWith(stmt):
     if sys.version_info >= (3, 10):
@@ -337,9 +440,18 @@ class AsyncWith(stmt):
     items: list[withitem]
     body: list[stmt]
     type_comment: str | None
-    def __init__(
-        self, items: list[withitem], body: list[stmt], type_comment: str | None = None, **kwargs: Unpack[_Attributes]
-    ) -> None: ...
+    if sys.version_info >= (3, 13):
+        def __init__(
+            self,
+            items: list[withitem] = ...,
+            body: list[stmt] = ...,
+            type_comment: str | None = None,
+            **kwargs: Unpack[_Attributes],
+        ) -> None: ...
+    else:
+        def __init__(
+            self, items: list[withitem], body: list[stmt], type_comment: str | None = None, **kwargs: Unpack[_Attributes]
+        ) -> None: ...
 
 class Raise(stmt):
     if sys.version_info >= (3, 10):
@@ -355,22 +467,16 @@ class Try(stmt):
     handlers: list[ExceptHandler]
     orelse: list[stmt]
     finalbody: list[stmt]
-    def __init__(
-        self,
-        body: list[stmt],
-        handlers: list[ExceptHandler],
-        orelse: list[stmt],
-        finalbody: list[stmt],
-        **kwargs: Unpack[_Attributes],
-    ) -> None: ...
-
-if sys.version_info >= (3, 11):
-    class TryStar(stmt):
-        __match_args__ = ("body", "handlers", "orelse", "finalbody")
-        body: list[stmt]
-        handlers: list[ExceptHandler]
-        orelse: list[stmt]
-        finalbody: list[stmt]
+    if sys.version_info >= (3, 13):
+        def __init__(
+            self,
+            body: list[stmt] = ...,
+            handlers: list[ExceptHandler] = ...,
+            orelse: list[stmt] = ...,
+            finalbody: list[stmt] = ...,
+            **kwargs: Unpack[_Attributes],
+        ) -> None: ...
+    else:
         def __init__(
             self,
             body: list[stmt],
@@ -379,6 +485,32 @@ if sys.version_info >= (3, 11):
             finalbody: list[stmt],
             **kwargs: Unpack[_Attributes],
         ) -> None: ...
+
+if sys.version_info >= (3, 11):
+    class TryStar(stmt):
+        __match_args__ = ("body", "handlers", "orelse", "finalbody")
+        body: list[stmt]
+        handlers: list[ExceptHandler]
+        orelse: list[stmt]
+        finalbody: list[stmt]
+        if sys.version_info >= (3, 13):
+            def __init__(
+                self,
+                body: list[stmt] = ...,
+                handlers: list[ExceptHandler] = ...,
+                orelse: list[stmt] = ...,
+                finalbody: list[stmt] = ...,
+                **kwargs: Unpack[_Attributes],
+            ) -> None: ...
+        else:
+            def __init__(
+                self,
+                body: list[stmt],
+                handlers: list[ExceptHandler],
+                orelse: list[stmt],
+                finalbody: list[stmt],
+                **kwargs: Unpack[_Attributes],
+            ) -> None: ...
 
 class Assert(stmt):
     if sys.version_info >= (3, 10):
@@ -391,7 +523,10 @@ class Import(stmt):
     if sys.version_info >= (3, 10):
         __match_args__ = ("names",)
     names: list[alias]
-    def __init__(self, names: list[alias], **kwargs: Unpack[_Attributes]) -> None: ...
+    if sys.version_info >= (3, 13):
+        def __init__(self, names: list[alias] = ..., **kwargs: Unpack[_Attributes]) -> None: ...
+    else:
+        def __init__(self, names: list[alias], **kwargs: Unpack[_Attributes]) -> None: ...
 
 class ImportFrom(stmt):
     if sys.version_info >= (3, 10):
@@ -399,22 +534,38 @@ class ImportFrom(stmt):
     module: str | None
     names: list[alias]
     level: int
-    @overload
-    def __init__(self, module: str | None, names: list[alias], level: int, **kwargs: Unpack[_Attributes]) -> None: ...
-    @overload
-    def __init__(self, module: str | None = None, *, names: list[alias], level: int, **kwargs: Unpack[_Attributes]) -> None: ...
+    if sys.version_info >= (3, 13):
+        @overload
+        def __init__(self, module: str | None, names: list[alias], level: int, **kwargs: Unpack[_Attributes]) -> None: ...
+        @overload
+        def __init__(
+            self, module: str | None = None, names: list[alias] = ..., *, level: int, **kwargs: Unpack[_Attributes]
+        ) -> None: ...
+    else:
+        @overload
+        def __init__(self, module: str | None, names: list[alias], level: int, **kwargs: Unpack[_Attributes]) -> None: ...
+        @overload
+        def __init__(
+            self, module: str | None = None, *, names: list[alias], level: int, **kwargs: Unpack[_Attributes]
+        ) -> None: ...
 
 class Global(stmt):
     if sys.version_info >= (3, 10):
         __match_args__ = ("names",)
     names: list[_Identifier]
-    def __init__(self, names: list[_Identifier], **kwargs: Unpack[_Attributes]) -> None: ...
+    if sys.version_info >= (3, 13):
+        def __init__(self, names: list[_Identifier] = ..., **kwargs: Unpack[_Attributes]) -> None: ...
+    else:
+        def __init__(self, names: list[_Identifier], **kwargs: Unpack[_Attributes]) -> None: ...
 
 class Nonlocal(stmt):
     if sys.version_info >= (3, 10):
         __match_args__ = ("names",)
     names: list[_Identifier]
-    def __init__(self, names: list[_Identifier], **kwargs: Unpack[_Attributes]) -> None: ...
+    if sys.version_info >= (3, 13):
+        def __init__(self, names: list[_Identifier] = ..., **kwargs: Unpack[_Attributes]) -> None: ...
+    else:
+        def __init__(self, names: list[_Identifier], **kwargs: Unpack[_Attributes]) -> None: ...
 
 class Expr(stmt):
     if sys.version_info >= (3, 10):
@@ -438,7 +589,10 @@ class BoolOp(expr):
         __match_args__ = ("op", "values")
     op: boolop
     values: list[expr]
-    def __init__(self, op: boolop, values: list[expr], **kwargs: Unpack[_Attributes]) -> None: ...
+    if sys.version_info >= (3, 13):
+        def __init__(self, op: boolop, values: list[expr] = ..., **kwargs: Unpack[_Attributes]) -> None: ...
+    else:
+        def __init__(self, op: boolop, values: list[expr], **kwargs: Unpack[_Attributes]) -> None: ...
 
 class BinOp(expr):
     if sys.version_info >= (3, 10):
@@ -475,27 +629,39 @@ class Dict(expr):
         __match_args__ = ("keys", "values")
     keys: list[expr | None]
     values: list[expr]
-    def __init__(self, keys: list[expr | None], values: list[expr], **kwargs: Unpack[_Attributes]) -> None: ...
+    if sys.version_info >= (3, 13):
+        def __init__(self, keys: list[expr | None] = ..., values: list[expr] = ..., **kwargs: Unpack[_Attributes]) -> None: ...
+    else:
+        def __init__(self, keys: list[expr | None], values: list[expr], **kwargs: Unpack[_Attributes]) -> None: ...
 
 class Set(expr):
     if sys.version_info >= (3, 10):
         __match_args__ = ("elts",)
     elts: list[expr]
-    def __init__(self, elts: list[expr], **kwargs: Unpack[_Attributes]) -> None: ...
+    if sys.version_info >= (3, 13):
+        def __init__(self, elts: list[expr] = ..., **kwargs: Unpack[_Attributes]) -> None: ...
+    else:
+        def __init__(self, elts: list[expr], **kwargs: Unpack[_Attributes]) -> None: ...
 
 class ListComp(expr):
     if sys.version_info >= (3, 10):
         __match_args__ = ("elt", "generators")
     elt: expr
     generators: list[comprehension]
-    def __init__(self, elt: expr, generators: list[comprehension], **kwargs: Unpack[_Attributes]) -> None: ...
+    if sys.version_info >= (3, 13):
+        def __init__(self, elt: expr, generators: list[comprehension] = ..., **kwargs: Unpack[_Attributes]) -> None: ...
+    else:
+        def __init__(self, elt: expr, generators: list[comprehension], **kwargs: Unpack[_Attributes]) -> None: ...
 
 class SetComp(expr):
     if sys.version_info >= (3, 10):
         __match_args__ = ("elt", "generators")
     elt: expr
     generators: list[comprehension]
-    def __init__(self, elt: expr, generators: list[comprehension], **kwargs: Unpack[_Attributes]) -> None: ...
+    if sys.version_info >= (3, 13):
+        def __init__(self, elt: expr, generators: list[comprehension] = ..., **kwargs: Unpack[_Attributes]) -> None: ...
+    else:
+        def __init__(self, elt: expr, generators: list[comprehension], **kwargs: Unpack[_Attributes]) -> None: ...
 
 class DictComp(expr):
     if sys.version_info >= (3, 10):
@@ -503,14 +669,22 @@ class DictComp(expr):
     key: expr
     value: expr
     generators: list[comprehension]
-    def __init__(self, key: expr, value: expr, generators: list[comprehension], **kwargs: Unpack[_Attributes]) -> None: ...
+    if sys.version_info >= (3, 13):
+        def __init__(
+            self, key: expr, value: expr, generators: list[comprehension] = ..., **kwargs: Unpack[_Attributes]
+        ) -> None: ...
+    else:
+        def __init__(self, key: expr, value: expr, generators: list[comprehension], **kwargs: Unpack[_Attributes]) -> None: ...
 
 class GeneratorExp(expr):
     if sys.version_info >= (3, 10):
         __match_args__ = ("elt", "generators")
     elt: expr
     generators: list[comprehension]
-    def __init__(self, elt: expr, generators: list[comprehension], **kwargs: Unpack[_Attributes]) -> None: ...
+    if sys.version_info >= (3, 13):
+        def __init__(self, elt: expr, generators: list[comprehension] = ..., **kwargs: Unpack[_Attributes]) -> None: ...
+    else:
+        def __init__(self, elt: expr, generators: list[comprehension], **kwargs: Unpack[_Attributes]) -> None: ...
 
 class Await(expr):
     if sys.version_info >= (3, 10):
@@ -536,7 +710,12 @@ class Compare(expr):
     left: expr
     ops: list[cmpop]
     comparators: list[expr]
-    def __init__(self, left: expr, ops: list[cmpop], comparators: list[expr], **kwargs: Unpack[_Attributes]) -> None: ...
+    if sys.version_info >= (3, 13):
+        def __init__(
+            self, left: expr, ops: list[cmpop] = ..., comparators: list[expr] = ..., **kwargs: Unpack[_Attributes]
+        ) -> None: ...
+    else:
+        def __init__(self, left: expr, ops: list[cmpop], comparators: list[expr], **kwargs: Unpack[_Attributes]) -> None: ...
 
 class Call(expr):
     if sys.version_info >= (3, 10):
@@ -544,7 +723,12 @@ class Call(expr):
     func: expr
     args: list[expr]
     keywords: list[keyword]
-    def __init__(self, func: expr, args: list[expr], keywords: list[keyword], **kwargs: Unpack[_Attributes]) -> None: ...
+    if sys.version_info >= (3, 13):
+        def __init__(
+            self, func: expr, args: list[expr] = ..., keywords: list[keyword] = ..., **kwargs: Unpack[_Attributes]
+        ) -> None: ...
+    else:
+        def __init__(self, func: expr, args: list[expr], keywords: list[keyword], **kwargs: Unpack[_Attributes]) -> None: ...
 
 class FormattedValue(expr):
     if sys.version_info >= (3, 10):
@@ -558,7 +742,10 @@ class JoinedStr(expr):
     if sys.version_info >= (3, 10):
         __match_args__ = ("values",)
     values: list[expr]
-    def __init__(self, values: list[expr], **kwargs: Unpack[_Attributes]) -> None: ...
+    if sys.version_info >= (3, 13):
+        def __init__(self, values: list[expr] = ..., **kwargs: Unpack[_Attributes]) -> None: ...
+    else:
+        def __init__(self, values: list[expr], **kwargs: Unpack[_Attributes]) -> None: ...
 
 class Constant(expr):
     if sys.version_info >= (3, 10):
@@ -637,7 +824,10 @@ class List(expr):
         __match_args__ = ("elts", "ctx")
     elts: list[expr]
     ctx: expr_context  # Not present in Python < 3.13 if not passed to `__init__`
-    def __init__(self, elts: list[expr], ctx: expr_context = ..., **kwargs: Unpack[_Attributes]) -> None: ...
+    if sys.version_info >= (3, 13):
+        def __init__(self, elts: list[expr] = ..., ctx: expr_context = ..., **kwargs: Unpack[_Attributes]) -> None: ...
+    else:
+        def __init__(self, elts: list[expr], ctx: expr_context = ..., **kwargs: Unpack[_Attributes]) -> None: ...
 
 class Tuple(expr):
     if sys.version_info >= (3, 10):
@@ -646,8 +836,10 @@ class Tuple(expr):
     ctx: expr_context  # Not present in Python < 3.13 if not passed to `__init__`
     if sys.version_info >= (3, 9):
         dims: list[expr]
-
-    def __init__(self, elts: list[expr], ctx: expr_context = ..., **kwargs: Unpack[_Attributes]) -> None: ...
+    if sys.version_info >= (3, 13):
+        def __init__(self, elts: list[expr] = ..., ctx: expr_context = ..., **kwargs: Unpack[_Attributes]) -> None: ...
+    else:
+        def __init__(self, elts: list[expr], ctx: expr_context = ..., **kwargs: Unpack[_Attributes]) -> None: ...
 
 class expr_context(AST): ...
 
@@ -704,7 +896,13 @@ class comprehension(AST):
     iter: expr
     ifs: list[expr]
     is_async: int
-    def __init__(self, target: expr, iter: expr, ifs: list[expr], is_async: int) -> None: ...
+    if sys.version_info >= (3, 13):
+        @overload
+        def __init__(self, target: expr, iter: expr, ifs: list[expr], is_async: int) -> None: ...
+        @overload
+        def __init__(self, target: expr, iter: expr, ifs: list[expr] = ..., *, is_async: int) -> None: ...
+    else:
+        def __init__(self, target: expr, iter: expr, ifs: list[expr], is_async: int) -> None: ...
 
 class excepthandler(AST):
     lineno: int
@@ -719,12 +917,19 @@ class ExceptHandler(excepthandler):
     type: expr | None
     name: _Identifier | None
     body: list[stmt]
-    @overload
-    def __init__(self, type: expr | None, name: _Identifier | None, body: list[stmt], **kwargs: Unpack[_Attributes]) -> None: ...
-    @overload
-    def __init__(
-        self, type: expr | None = None, name: _Identifier | None = None, *, body: list[stmt], **kwargs: Unpack[_Attributes]
-    ) -> None: ...
+    if sys.version_info >= (3, 13):
+        def __init__(
+            self, type: expr | None = None, name: _Identifier | None = None, body: list[stmt] = ..., **kwargs: Unpack[_Attributes]
+        ) -> None: ...
+    else:
+        @overload
+        def __init__(
+            self, type: expr | None, name: _Identifier | None, body: list[stmt], **kwargs: Unpack[_Attributes]
+        ) -> None: ...
+        @overload
+        def __init__(
+            self, type: expr | None = None, name: _Identifier | None = None, *, body: list[stmt], **kwargs: Unpack[_Attributes]
+        ) -> None: ...
 
 class arguments(AST):
     if sys.version_info >= (3, 10):
@@ -736,41 +941,53 @@ class arguments(AST):
     kw_defaults: list[expr | None]
     kwarg: arg | None
     defaults: list[expr]
-    @overload
-    def __init__(
-        self,
-        posonlyargs: list[arg],
-        args: list[arg],
-        vararg: arg | None,
-        kwonlyargs: list[arg],
-        kw_defaults: list[expr | None],
-        kwarg: arg | None,
-        defaults: list[expr],
-    ) -> None: ...
-    @overload
-    def __init__(
-        self,
-        posonlyargs: list[arg],
-        args: list[arg],
-        vararg: arg | None,
-        kwonlyargs: list[arg],
-        kw_defaults: list[expr | None],
-        kwarg: arg | None = None,
-        *,
-        defaults: list[expr],
-    ) -> None: ...
-    @overload
-    def __init__(
-        self,
-        posonlyargs: list[arg],
-        args: list[arg],
-        vararg: arg | None = None,
-        *,
-        kwonlyargs: list[arg],
-        kw_defaults: list[expr | None],
-        kwarg: arg | None = None,
-        defaults: list[expr],
-    ) -> None: ...
+    if sys.version_info >= (3, 13):
+        def __init__(
+            self,
+            posonlyargs: list[arg] = ...,
+            args: list[arg] = ...,
+            vararg: arg | None = None,
+            kwonlyargs: list[arg] = ...,
+            kw_defaults: list[expr | None] = ...,
+            kwarg: arg | None = None,
+            defaults: list[expr] = ...,
+        ) -> None: ...
+    else:
+        @overload
+        def __init__(
+            self,
+            posonlyargs: list[arg],
+            args: list[arg],
+            vararg: arg | None,
+            kwonlyargs: list[arg],
+            kw_defaults: list[expr | None],
+            kwarg: arg | None,
+            defaults: list[expr],
+        ) -> None: ...
+        @overload
+        def __init__(
+            self,
+            posonlyargs: list[arg],
+            args: list[arg],
+            vararg: arg | None,
+            kwonlyargs: list[arg],
+            kw_defaults: list[expr | None],
+            kwarg: arg | None = None,
+            *,
+            defaults: list[expr],
+        ) -> None: ...
+        @overload
+        def __init__(
+            self,
+            posonlyargs: list[arg],
+            args: list[arg],
+            vararg: arg | None = None,
+            *,
+            kwonlyargs: list[arg],
+            kw_defaults: list[expr | None],
+            kwarg: arg | None = None,
+            defaults: list[expr],
+        ) -> None: ...
 
 class arg(AST):
     lineno: int
@@ -823,7 +1040,10 @@ if sys.version_info >= (3, 10):
         __match_args__ = ("subject", "cases")
         subject: expr
         cases: list[match_case]
-        def __init__(self, subject: expr, cases: list[match_case], **kwargs: Unpack[_Attributes]) -> None: ...
+        if sys.version_info >= (3, 13):
+            def __init__(self, subject: expr, cases: list[match_case] = ..., **kwargs: Unpack[_Attributes]) -> None: ...
+        else:
+            def __init__(self, subject: expr, cases: list[match_case], **kwargs: Unpack[_Attributes]) -> None: ...
 
     class pattern(AST):
         lineno: int
@@ -840,10 +1060,13 @@ if sys.version_info >= (3, 10):
         pattern: _Pattern
         guard: expr | None
         body: list[stmt]
-        @overload
-        def __init__(self, pattern: _Pattern, guard: expr | None, body: list[stmt]) -> None: ...
-        @overload
-        def __init__(self, pattern: _Pattern, guard: expr | None = None, *, body: list[stmt]) -> None: ...
+        if sys.version_info >= (3, 13):
+            def __init__(self, pattern: _Pattern, guard: expr | None = None, body: list[stmt] = ...) -> None: ...
+        else:
+            @overload
+            def __init__(self, pattern: _Pattern, guard: expr | None, body: list[stmt]) -> None: ...
+            @overload
+            def __init__(self, pattern: _Pattern, guard: expr | None = None, *, body: list[stmt]) -> None: ...
 
     class MatchValue(pattern):
         __match_args__ = ("value",)
@@ -858,7 +1081,10 @@ if sys.version_info >= (3, 10):
     class MatchSequence(pattern):
         __match_args__ = ("patterns",)
         patterns: list[pattern]
-        def __init__(self, patterns: list[pattern], **kwargs: Unpack[_Attributes[int]]) -> None: ...
+        if sys.version_info >= (3, 13):
+            def __init__(self, patterns: list[pattern] = ..., **kwargs: Unpack[_Attributes[int]]) -> None: ...
+        else:
+            def __init__(self, patterns: list[pattern], **kwargs: Unpack[_Attributes[int]]) -> None: ...
 
     class MatchStar(pattern):
         __match_args__ = ("name",)
@@ -870,9 +1096,22 @@ if sys.version_info >= (3, 10):
         keys: list[expr]
         patterns: list[pattern]
         rest: _Identifier | None
-        def __init__(
-            self, keys: list[expr], patterns: list[pattern], rest: _Identifier | None = None, **kwargs: Unpack[_Attributes[int]]
-        ) -> None: ...
+        if sys.version_info >= (3, 13):
+            def __init__(
+                self,
+                keys: list[expr] = ...,
+                patterns: list[pattern] = ...,
+                rest: _Identifier | None = None,
+                **kwargs: Unpack[_Attributes[int]],
+            ) -> None: ...
+        else:
+            def __init__(
+                self,
+                keys: list[expr],
+                patterns: list[pattern],
+                rest: _Identifier | None = None,
+                **kwargs: Unpack[_Attributes[int]],
+            ) -> None: ...
 
     class MatchClass(pattern):
         __match_args__ = ("cls", "patterns", "kwd_attrs", "kwd_patterns")
@@ -880,14 +1119,24 @@ if sys.version_info >= (3, 10):
         patterns: list[pattern]
         kwd_attrs: list[_Identifier]
         kwd_patterns: list[pattern]
-        def __init__(
-            self,
-            cls: expr,
-            patterns: list[pattern],
-            kwd_attrs: list[_Identifier],
-            kwd_patterns: list[pattern],
-            **kwargs: Unpack[_Attributes[int]],
-        ) -> None: ...
+        if sys.version_info >= (3, 13):
+            def __init__(
+                self,
+                cls: expr,
+                patterns: list[pattern] = ...,
+                kwd_attrs: list[_Identifier] = ...,
+                kwd_patterns: list[pattern] = ...,
+                **kwargs: Unpack[_Attributes[int]],
+            ) -> None: ...
+        else:
+            def __init__(
+                self,
+                cls: expr,
+                patterns: list[pattern],
+                kwd_attrs: list[_Identifier],
+                kwd_patterns: list[pattern],
+                **kwargs: Unpack[_Attributes[int]],
+            ) -> None: ...
 
     class MatchAs(pattern):
         __match_args__ = ("pattern", "name")
@@ -900,7 +1149,10 @@ if sys.version_info >= (3, 10):
     class MatchOr(pattern):
         __match_args__ = ("patterns",)
         patterns: list[pattern]
-        def __init__(self, patterns: list[pattern], **kwargs: Unpack[_Attributes[int]]) -> None: ...
+        if sys.version_info >= (3, 13):
+            def __init__(self, patterns: list[pattern] = ..., **kwargs: Unpack[_Attributes[int]]) -> None: ...
+        else:
+            def __init__(self, patterns: list[pattern], **kwargs: Unpack[_Attributes[int]]) -> None: ...
 
 if sys.version_info >= (3, 12):
     class type_param(AST):
@@ -931,6 +1183,16 @@ if sys.version_info >= (3, 12):
         name: Name
         type_params: list[type_param]
         value: expr
-        def __init__(
-            self, name: Name, type_params: list[type_param], value: expr, **kwargs: Unpack[_Attributes[int]]
-        ) -> None: ...
+        if sys.version_info >= (3, 13):
+            @overload
+            def __init__(
+                self, name: Name, type_params: list[type_param], value: expr, **kwargs: Unpack[_Attributes[int]]
+            ) -> None: ...
+            @overload
+            def __init__(
+                self, name: Name, type_params: list[type_param] = ..., *, value: expr, **kwargs: Unpack[_Attributes[int]]
+            ) -> None: ...
+        else:
+            def __init__(
+                self, name: Name, type_params: list[type_param], value: expr, **kwargs: Unpack[_Attributes[int]]
+            ) -> None: ...

--- a/stdlib/_ast.pyi
+++ b/stdlib/_ast.pyi
@@ -582,8 +582,8 @@ class Attribute(expr):
         __match_args__ = ("value", "attr", "ctx")
     value: expr
     attr: _Identifier
-    ctx: expr_context
-    def __init__(self, value: expr, attr: _Identifier, ctx: expr_context, **kwargs: Unpack[_Attributes]) -> None: ...
+    ctx: expr_context  # Not present in Python < 3.13 if not passed to `__init__`
+    def __init__(self, value: expr, attr: _Identifier, ctx: expr_context = ..., **kwargs: Unpack[_Attributes]) -> None: ...
 
 if sys.version_info >= (3, 9):
     _Slice: typing_extensions.TypeAlias = expr
@@ -615,39 +615,39 @@ class Subscript(expr):
         __match_args__ = ("value", "slice", "ctx")
     value: expr
     slice: _Slice
-    ctx: expr_context
-    def __init__(self, value: expr, slice: _Slice, ctx: expr_context, **kwargs: Unpack[_Attributes]) -> None: ...
+    ctx: expr_context  # Not present in Python < 3.13 if not passed to `__init__`
+    def __init__(self, value: expr, slice: _Slice, ctx: expr_context = ..., **kwargs: Unpack[_Attributes]) -> None: ...
 
 class Starred(expr):
     if sys.version_info >= (3, 10):
         __match_args__ = ("value", "ctx")
     value: expr
-    ctx: expr_context
-    def __init__(self, value: expr, ctx: expr_context, **kwargs: Unpack[_Attributes]) -> None: ...
+    ctx: expr_context  # Not present in Python < 3.13 if not passed to `__init__`
+    def __init__(self, value: expr, ctx: expr_context = ..., **kwargs: Unpack[_Attributes]) -> None: ...
 
 class Name(expr):
     if sys.version_info >= (3, 10):
         __match_args__ = ("id", "ctx")
     id: _Identifier
-    ctx: expr_context
-    def __init__(self, id: _Identifier, ctx: expr_context, **kwargs: Unpack[_Attributes]) -> None: ...
+    ctx: expr_context  # Not present in Python < 3.13 if not passed to `__init__`
+    def __init__(self, id: _Identifier, ctx: expr_context = ..., **kwargs: Unpack[_Attributes]) -> None: ...
 
 class List(expr):
     if sys.version_info >= (3, 10):
         __match_args__ = ("elts", "ctx")
     elts: list[expr]
-    ctx: expr_context
-    def __init__(self, elts: list[expr], ctx: expr_context, **kwargs: Unpack[_Attributes]) -> None: ...
+    ctx: expr_context  # Not present in Python < 3.13 if not passed to `__init__`
+    def __init__(self, elts: list[expr], ctx: expr_context = ..., **kwargs: Unpack[_Attributes]) -> None: ...
 
 class Tuple(expr):
     if sys.version_info >= (3, 10):
         __match_args__ = ("elts", "ctx")
     elts: list[expr]
-    ctx: expr_context
+    ctx: expr_context  # Not present in Python < 3.13 if not passed to `__init__`
     if sys.version_info >= (3, 9):
         dims: list[expr]
 
-    def __init__(self, elts: list[expr], ctx: expr_context, **kwargs: Unpack[_Attributes]) -> None: ...
+    def __init__(self, elts: list[expr], ctx: expr_context = ..., **kwargs: Unpack[_Attributes]) -> None: ...
 
 class expr_context(AST): ...
 

--- a/tests/stubtest_allowlists/py310.txt
+++ b/tests/stubtest_allowlists/py310.txt
@@ -129,6 +129,11 @@ os.path.join
 # Allowlist entries that cannot or should not be fixed
 # ==========
 
+# Runtime AST node runtime constructor behaviour is too loose.
+# For static typing, the loose behaviour is undesirable (https://github.com/python/typeshed/issues/8378).
+# For the runtime, the loose behaviour is deprecated in Python 3.13 (https://github.com/python/cpython/issues/105858)
+_?ast.pattern.__init__
+
 # Side effects from module initialization
 _compat_pickle.excname
 email.contentmanager.maintype

--- a/tests/stubtest_allowlists/py311.txt
+++ b/tests/stubtest_allowlists/py311.txt
@@ -74,6 +74,11 @@ os.path.join
 # Allowlist entries that cannot or should not be fixed
 # ==========
 
+# Runtime AST node runtime constructor behaviour is too loose.
+# For static typing, the loose behaviour is undesirable (https://github.com/python/typeshed/issues/8378).
+# For the runtime, the loose behaviour is deprecated in Python 3.13 (https://github.com/python/cpython/issues/105858)
+_?ast.pattern.__init__
+
 _ast.ImportFrom.level  # None on the class, but never None on instances
 _collections_abc.AsyncGenerator.athrow  # async at runtime, deliberately not in the stub, see #7491. Pos-only differences also.
 _weakref.ProxyType.__reversed__  # Doesn't really exist

--- a/tests/stubtest_allowlists/py312.txt
+++ b/tests/stubtest_allowlists/py312.txt
@@ -57,6 +57,12 @@ zoneinfo.ZoneInfo.from_file
 # Allowlist entries that cannot or should not be fixed
 # ==========
 
+# Runtime AST node runtime constructor behaviour is too loose.
+# For static typing, the loose behaviour is undesirable (https://github.com/python/typeshed/issues/8378).
+# For the runtime, the loose behaviour is deprecated in Python 3.13 (https://github.com/python/cpython/issues/105858)
+_?ast.pattern.__init__
+_?ast.type_param.__init__
+
 _ast.ImportFrom.level  # None on the class, but never None on instances
 _collections_abc.AsyncGenerator.athrow  # async at runtime, deliberately not in the stub, see #7491. Pos-only differences also.
 _weakref.ProxyType.__reversed__  # Doesn't really exist

--- a/tests/stubtest_allowlists/py3_common.txt
+++ b/tests/stubtest_allowlists/py3_common.txt
@@ -328,7 +328,6 @@ _ctypes.call_function
 _?ast.AST.__init__
 _?ast.excepthandler.__init__
 _?ast.expr.__init__
-_?ast.pattern.__init__
 _?ast.stmt.__init__
 
 # async at runtime, deliberately not in the stub, see #7491

--- a/tests/stubtest_allowlists/py3_common.txt
+++ b/tests/stubtest_allowlists/py3_common.txt
@@ -322,6 +322,15 @@ _ctypes.call_function
 # Allowlist entries that cannot or should not be fixed
 # ==========
 
+# Runtime AST node runtime constructor behaviour is too loose.
+# For static typing, the loose behaviour is undesirable (https://github.com/python/typeshed/issues/8378).
+# For the runtime, the loose behaviour is deprecated in Python 3.13 (https://github.com/python/cpython/issues/105858)
+_?ast.AST.__init__
+_?ast.excepthandler.__init__
+_?ast.expr.__init__
+_?ast.pattern.__init__
+_?ast.stmt.__init__
+
 # async at runtime, deliberately not in the stub, see #7491
 _collections_abc.AsyncGenerator.asend  # pos-only differences also.
 _collections_abc.AsyncGenerator.__anext__


### PR DESCRIPTION
Fixes #8378

- `ast.AST` no longer owns attributes which may not exist on all subclasses (node locations, `type_comment`). These are all shifted to subclasses which actually own the attributes (https://github.com/python/typeshed/commit/d5e0838348559641ddc02b5495dd84bb0a00aea4, https://github.com/python/typeshed/commit/75a2e8e1af712de4fb3a81c0edfc9a40223120a9, https://github.com/python/typeshed/commit/f9a2cb9ee8b93a9d8daa4f6afab5ad4d6567f58b)
- `ast.AST` no longer has the constructor `__init__(self, *args: Any, **kwargs: Any)`.
- All subclasses of `ast.AST` which have a non-empty `_fields: ClassVar[tuple[str, ...]]` or `_attributes: ClassVar[tuple[str, ...]]` now have their own `__init__` constructor (https://github.com/python/typeshed/commit/d886a4511043fb531ee261d688dbaca9454f4ba4). The constructor has:
   - Positional-or-keyword arguments in the order in which they appear in `_fields`, and
   - Non-mandatory keyword-only arguments from `_attributes`. These are expressed using a combination of `typing.TypedDict` and `typing_extensions.Unpack`.
      - These are non-mandatory because I expect most users won't pass explicit locations, but rather use something like `ast.fix_missing_locations`.

---

Updates:

- Arguments of type `ast.expr_context` are not required to be passed to the constructor, but they will not exist on node instances for Python < 3.13.
- Arguments of type `list` are not required to be passed to the constructor for Python >= 3.13.