### PR TITLE
Update `shelve.open` to support path-like objects

### DIFF
--- a/stdlib/shelve.pyi
+++ b/stdlib/shelve.pyi
@@ -3,6 +3,7 @@ from dbm import _TFlags
 from types import TracebackType
 from typing import Any, TypeVar, overload
 from typing_extensions import Self
+from _typeshed import StrOrBytesPath
 
 __all__ = ["Shelf", "BsdDbShelf", "DbfilenameShelf", "open"]
 
@@ -41,6 +42,6 @@ class BsdDbShelf(Shelf[_VT]):
     def last(self) -> tuple[str, _VT]: ...
 
 class DbfilenameShelf(Shelf[_VT]):
-    def __init__(self, filename: str, flag: _TFlags = "c", protocol: int | None = None, writeback: bool = False) -> None: ...
+    def __init__(self, filename: StrOrBytesPath, flag: _TFlags = "c", protocol: int | None = None, writeback: bool = False) -> None: ...
 
-def open(filename: str, flag: _TFlags = "c", protocol: int | None = None, writeback: bool = False) -> Shelf[Any]: ...
+def open(filename: StrOrBytesPath, flag: _TFlags = "c", protocol: int | None = None, writeback: bool = False) -> Shelf[Any]: ...


### PR DESCRIPTION
Finally `os.fsencode` is called on `filename` argument here: https://github.com/python/cpython/blob/c0d257cc69a943d2c211fe7ad54e706f1085ba1a/Lib/dbm/__init__.py#L112

Which has this type: https://github.com/python/typeshed/blob/72623c6b151db070817ce4b1c1ad70a6a2007197/stdlib/os/__init__.pyi#L484

Closes #11856