### PR TITLE
Add typehints for `open` in `PIL.WallImageFile`

### DIFF
--- a/stubs/Pillow/PIL/WalImageFile.pyi
+++ b/stubs/Pillow/PIL/WalImageFile.pyi
@@ -1,3 +1,4 @@
+from _typeshed import StrOrBytesPath
 from typing import ClassVar, Literal
 
 from . import ImageFile
@@ -8,6 +9,6 @@ class WalImageFile(ImageFile.ImageFile):
     format_description: ClassVar[str]
     def load(self) -> _PixelAccessor: ...
 
-def open(filename): ...
+def open(filename: StrOrBytesPath) -> WalImageFile: ...
 
 quake2palette: bytes


### PR DESCRIPTION
Source: https://github.com/python-pillow/Pillow/blob/0cad346fc960bc07cde9d1d9135421978e2f28e8/src/PIL/WalImageFile.py#L61-L71

It calls `is_path` here (in the base class `__init__`): https://github.com/python-pillow/Pillow/blob/0cad346fc960bc07cde9d1d9135421978e2f28e8/src/PIL/ImageFile.py#L123-L127 
`is_path` returns `TypeGuard[StrOrBytesPath]`: https://github.com/python-pillow/Pillow/blob/0cad346fc960bc07cde9d1d9135421978e2f28e8/src/PIL/_util.py#L8-L11