### PR TITLE
Allow Image type for docker container run image parameter

### DIFF
--- a/stubs/docker/docker/models/containers.pyi
+++ b/stubs/docker/docker/models/containers.pyi
@@ -1,6 +1,7 @@
 from _typeshed import Incomplete
 from typing import NamedTuple
 
+from .images import Image
 from .resource import Collection, Model
 
 class Container(Model):
@@ -58,7 +59,7 @@ class ContainerCollection(Collection[Container]):
     model: type[Container]
     def run(
         self,
-        image: str,
+        image: str | Image,
         command: str | list[str] | None = None,
         stdout: bool = True,
         stderr: bool = False,


### PR DESCRIPTION
The docstring says that this must be a string, but the implementation explicitly allows an Image:

https://github.com/docker/docker-py/blob/b6464dbed92b14b2c61d5ee49805fce041a3e083/docker/models/containers.py#L850-L851

```python
if isinstance(image, Image):
    image = image.id
```