### PR TITLE
Avoid using new `_typeshed` protocol in `pkg_resources` for now

### DIFF
--- a/stdlib/types.pyi
+++ b/stdlib/types.pyi
@@ -17,7 +17,7 @@ from collections.abc import (
 from importlib.machinery import ModuleSpec
 
 # pytype crashes if types.MappingProxyType inherits from collections.abc.Mapping instead of typing.Mapping
-from typing import Any, ClassVar, Literal, Mapping, Protocol, TypeVar, final, overload  # noqa: Y022
+from typing import Any, ClassVar, Literal, Mapping, TypeVar, final, overload  # noqa: Y022
 from typing_extensions import ParamSpec, Self, TypeVarTuple, deprecated
 
 __all__ = [
@@ -311,10 +311,6 @@ class SimpleNamespace:
     def __getattribute__(self, name: str, /) -> Any: ...
     def __setattr__(self, name: str, value: Any, /) -> None: ...
     def __delattr__(self, name: str, /) -> None: ...
-
-# TODO: Remove this symbol and its usages in 3rd-party stubs once mypy has included it in its vendored typeshed
-class _LoaderProtocol(Protocol):  # noqa: Y046
-    def load_module(self, fullname: str, /) -> ModuleType: ...
 
 class ModuleType:
     __name__: str

--- a/stdlib/types.pyi
+++ b/stdlib/types.pyi
@@ -313,7 +313,7 @@ class SimpleNamespace:
     def __delattr__(self, name: str, /) -> None: ...
 
 # TODO: Remove this symbol and its usages in 3rd-party stubs once mypy has included it in its vendored typeshed
-class _LoaderProtocol(Protocol):
+class _LoaderProtocol(Protocol):  # noqa: Y046
     def load_module(self, fullname: str, /) -> ModuleType: ...
 
 class ModuleType:

--- a/stdlib/types.pyi
+++ b/stdlib/types.pyi
@@ -17,7 +17,7 @@ from collections.abc import (
 from importlib.machinery import ModuleSpec
 
 # pytype crashes if types.MappingProxyType inherits from collections.abc.Mapping instead of typing.Mapping
-from typing import Any, ClassVar, Literal, Mapping, TypeVar, final, overload  # noqa: Y022
+from typing import Any, ClassVar, Literal, Mapping, Protocol, TypeVar, final, overload  # noqa: Y022
 from typing_extensions import ParamSpec, Self, TypeVarTuple, deprecated
 
 __all__ = [
@@ -311,6 +311,10 @@ class SimpleNamespace:
     def __getattribute__(self, name: str, /) -> Any: ...
     def __setattr__(self, name: str, value: Any, /) -> None: ...
     def __delattr__(self, name: str, /) -> None: ...
+
+# TODO: Remove this symbol and its usages in 3rd-party stubs once mypy has included it in its vendored typeshed
+class _LoaderProtocol(Protocol):
+    def load_module(self, fullname: str, /) -> ModuleType: ...
 
 class ModuleType:
     __name__: str

--- a/stubs/setuptools/pkg_resources/__init__.pyi
+++ b/stubs/setuptools/pkg_resources/__init__.pyi
@@ -6,12 +6,15 @@ from io import BytesIO
 from itertools import chain
 from pkgutil import get_importer as get_importer
 from re import Pattern
-from types import _LoaderProtocol
 from typing import IO, Any, ClassVar, Final, Literal, NoReturn, Protocol, TypeVar, overload, type_check_only
 from typing_extensions import Self, TypeAlias
 from zipfile import ZipInfo
 
 from ._vendored_packaging import requirements as packaging_requirements, version as packaging_version
+
+# TODO: Use _typeshed.importlib.LoaderProtocol once mypy has included it in its vendored typeshed
+class _LoaderProtocol(Protocol):
+    def load_module(self, fullname: str, /) -> types.ModuleType: ...
 
 _T = TypeVar("_T")
 _D = TypeVar("_D", bound=Distribution)
@@ -360,7 +363,6 @@ def evaluate_marker(text: str, extra: Incomplete | None = None) -> bool: ...
 class NullProvider:
     egg_name: str | None
     egg_info: str | None
-    # TODO: Use _typeshed.importlib.LoaderProtocol once mypy has included it in its vendored typeshed
     loader: _LoaderProtocol | None
     module_path: str | None
 

--- a/stubs/setuptools/pkg_resources/__init__.pyi
+++ b/stubs/setuptools/pkg_resources/__init__.pyi
@@ -1,12 +1,12 @@
 import types
 import zipimport
 from _typeshed import Incomplete, StrPath, Unused
-from _typeshed.importlib import LoaderProtocol
 from collections.abc import Callable, Generator, Iterable, Iterator, Sequence
 from io import BytesIO
 from itertools import chain
 from pkgutil import get_importer as get_importer
 from re import Pattern
+from types import _LoaderProtocol
 from typing import IO, Any, ClassVar, Final, Literal, NoReturn, Protocol, TypeVar, overload, type_check_only
 from typing_extensions import Self, TypeAlias
 from zipfile import ZipInfo
@@ -360,7 +360,8 @@ def evaluate_marker(text: str, extra: Incomplete | None = None) -> bool: ...
 class NullProvider:
     egg_name: str | None
     egg_info: str | None
-    loader: LoaderProtocol | None
+    # TODO: Use _typeshed.importlib.LoaderProtocol once mypy has included it in its vendored typeshed
+    loader: _LoaderProtocol | None
     module_path: str | None
 
     def __init__(self, module: _ModuleLike) -> None: ...


### PR DESCRIPTION
Ref: https://github.com/python/typeshed/pull/11890#discussion_r1597690434
Must be kept until next mypy release.
CC @AlexWaygood or @srittau 