### PR TITLE
Use stricter pyright settings in CI for `assertpy`

### DIFF
--- a/pyrightconfig.stricter.json
+++ b/pyrightconfig.stricter.json
@@ -30,7 +30,6 @@
         "stdlib/xml/sax",
         "stubs/aiofiles/aiofiles/tempfile/temptypes.pyi",
         "stubs/antlr4-python3-runtime",
-        "stubs/assertpy",
         "stubs/aws-xray-sdk",
         "stubs/beautifulsoup4",
         "stubs/bleach/bleach/sanitizer.pyi",


### PR DESCRIPTION
Fixes https://github.com/AlexWaygood/typeshed-stats/issues/225