### PR TITLE
More PEP-696 updates to `typing(_extensions)` stubs

### DIFF
--- a/stdlib/typing.pyi
+++ b/stdlib/typing.pyi
@@ -149,6 +149,21 @@ class TypeVar:
     if sys.version_info >= (3, 12):
         @property
         def __infer_variance__(self) -> bool: ...
+    if sys.version_info >= (3, 13):
+        @property
+        def __default__(self) -> Any: ...
+    if sys.version_info >= (3, 13):
+        def __init__(
+            self,
+            name: str,
+            *constraints: Any,
+            bound: Any | None = None,
+            contravariant: bool = False,
+            covariant: bool = False,
+            infer_variance: bool = False,
+            default: Any = ...,
+        ) -> None: ...
+    elif sys.version_info >= (3, 12):
         def __init__(
             self,
             name: str,
@@ -167,6 +182,8 @@ class TypeVar:
         def __ror__(self, left: Any) -> _SpecialForm: ...
     if sys.version_info >= (3, 11):
         def __typing_subst__(self, arg: Any) -> Any: ...
+    if sys.version_info >= (3, 13):
+        def has_default(self) -> bool: ...
 
 # Used for an undocumented mypy feature. Does not exist at runtime.
 _promote = object()
@@ -208,7 +225,15 @@ if sys.version_info >= (3, 11):
     class TypeVarTuple:
         @property
         def __name__(self) -> str: ...
-        def __init__(self, name: str) -> None: ...
+        if sys.version_info >= (3, 13):
+            @property
+            def __default__(self) -> Any: ...
+            def has_default(self) -> bool: ...
+        if sys.version_info >= (3, 13):
+            def __init__(self, name: str, *, default: Any = ...) -> None: ...
+        else:
+            def __init__(self, name: str) -> None: ...
+
         def __iter__(self) -> Any: ...
         def __typing_subst__(self, arg: Never) -> Never: ...
         def __typing_prepare_subst__(self, alias: Any, args: Any) -> tuple[Any, ...]: ...
@@ -241,6 +266,21 @@ if sys.version_info >= (3, 10):
         if sys.version_info >= (3, 12):
             @property
             def __infer_variance__(self) -> bool: ...
+        if sys.version_info >= (3, 13):
+            @property
+            def __default__(self) -> Any: ...
+        if sys.version_info >= (3, 13):
+            def __init__(
+                self,
+                name: str,
+                *,
+                bound: Any | None = None,
+                contravariant: bool = False,
+                covariant: bool = False,
+                infer_variance: bool = False,
+                default: Any = ...,
+            ) -> None: ...
+        elif sys.version_info >= (3, 12):
             def __init__(
                 self,
                 name: str,
@@ -265,6 +305,8 @@ if sys.version_info >= (3, 10):
 
         def __or__(self, right: Any) -> _SpecialForm: ...
         def __ror__(self, left: Any) -> _SpecialForm: ...
+        if sys.version_info >= (3, 13):
+            def has_default(self) -> bool: ...
 
     Concatenate: _SpecialForm
     TypeAlias: _SpecialForm

--- a/stdlib/typing_extensions.pyi
+++ b/stdlib/typing_extensions.pyi
@@ -3,13 +3,13 @@ import sys
 import typing
 from _collections_abc import dict_items, dict_keys, dict_values
 from _typeshed import IdentityFunction
+from contextlib import AbstractAsyncContextManager as AsyncContextManager, AbstractContextManager as ContextManager
 from typing import (  # noqa: Y022,Y037,Y038,Y039
     IO as IO,
     TYPE_CHECKING as TYPE_CHECKING,
     AbstractSet as AbstractSet,
     Any as Any,
     AnyStr as AnyStr,
-    AsyncContextManager as AsyncContextManager,
     AsyncGenerator as AsyncGenerator,
     AsyncIterable as AsyncIterable,
     AsyncIterator as AsyncIterator,
@@ -20,7 +20,6 @@ from typing import (  # noqa: Y022,Y037,Y038,Y039
     ClassVar as ClassVar,
     Collection as Collection,
     Container as Container,
-    ContextManager as ContextManager,
     Coroutine as Coroutine,
     Counter as Counter,
     DefaultDict as DefaultDict,
@@ -381,79 +380,6 @@ else:
             def __or__(self, other: Any) -> _SpecialForm: ...
             def __ror__(self, other: Any) -> _SpecialForm: ...
 
-# New things in 3.xx
-# The `default` parameter was added to TypeVar, ParamSpec, and TypeVarTuple (PEP 696)
-# The `infer_variance` parameter was added to TypeVar in 3.12 (PEP 695)
-# typing_extensions.override (PEP 698)
-@final
-class TypeVar:
-    @property
-    def __name__(self) -> str: ...
-    @property
-    def __bound__(self) -> Any | None: ...
-    @property
-    def __constraints__(self) -> tuple[Any, ...]: ...
-    @property
-    def __covariant__(self) -> bool: ...
-    @property
-    def __contravariant__(self) -> bool: ...
-    @property
-    def __infer_variance__(self) -> bool: ...
-    @property
-    def __default__(self) -> Any | None: ...
-    def __init__(
-        self,
-        name: str,
-        *constraints: Any,
-        bound: Any | None = None,
-        covariant: bool = False,
-        contravariant: bool = False,
-        default: Any | None = None,
-        infer_variance: bool = False,
-    ) -> None: ...
-    if sys.version_info >= (3, 10):
-        def __or__(self, right: Any) -> _SpecialForm: ...
-        def __ror__(self, left: Any) -> _SpecialForm: ...
-    if sys.version_info >= (3, 11):
-        def __typing_subst__(self, arg: Any) -> Any: ...
-
-@final
-class ParamSpec:
-    @property
-    def __name__(self) -> str: ...
-    @property
-    def __bound__(self) -> Any | None: ...
-    @property
-    def __covariant__(self) -> bool: ...
-    @property
-    def __contravariant__(self) -> bool: ...
-    @property
-    def __infer_variance__(self) -> bool: ...
-    @property
-    def __default__(self) -> Any | None: ...
-    def __init__(
-        self,
-        name: str,
-        *,
-        bound: None | type[Any] | str = None,
-        contravariant: bool = False,
-        covariant: bool = False,
-        default: type[Any] | str | None = None,
-    ) -> None: ...
-    @property
-    def args(self) -> ParamSpecArgs: ...
-    @property
-    def kwargs(self) -> ParamSpecKwargs: ...
-
-@final
-class TypeVarTuple:
-    @property
-    def __name__(self) -> str: ...
-    @property
-    def __default__(self) -> Any | None: ...
-    def __init__(self, name: str, *, default: Any | None = None) -> None: ...
-    def __iter__(self) -> Any: ...  # Unpack[Self]
-
 if sys.version_info >= (3, 12):
     from collections.abc import Buffer as Buffer
     from types import get_original_bases as get_original_bases
@@ -490,7 +416,14 @@ else:
 
 if sys.version_info >= (3, 13):
     from types import CapsuleType as CapsuleType
-    from typing import NoDefault as NoDefault, get_protocol_members as get_protocol_members, is_protocol as is_protocol
+    from typing import (
+        NoDefault as NoDefault,
+        ParamSpec as ParamSpec,
+        TypeVar as TypeVar,
+        TypeVarTuple as TypeVarTuple,
+        get_protocol_members as get_protocol_members,
+        is_protocol as is_protocol,
+    )
     from warnings import deprecated as deprecated
 else:
     def is_protocol(tp: type, /) -> bool: ...
@@ -508,6 +441,84 @@ else:
         stacklevel: int
         def __init__(self, message: LiteralString, /, *, category: type[Warning] | None = ..., stacklevel: int = 1) -> None: ...
         def __call__(self, arg: _T, /) -> _T: ...
+
+    @final
+    class TypeVar:
+        @property
+        def __name__(self) -> str: ...
+        @property
+        def __bound__(self) -> Any | None: ...
+        @property
+        def __constraints__(self) -> tuple[Any, ...]: ...
+        @property
+        def __covariant__(self) -> bool: ...
+        @property
+        def __contravariant__(self) -> bool: ...
+        @property
+        def __infer_variance__(self) -> bool: ...
+        @property
+        def __default__(self) -> Any: ...
+        def __init__(
+            self,
+            name: str,
+            *constraints: Any,
+            bound: Any | None = None,
+            covariant: bool = False,
+            contravariant: bool = False,
+            default: Any = ...,
+            infer_variance: bool = False,
+        ) -> None: ...
+        def has_default(self) -> bool: ...
+        def __typing_prepare_subst__(self, alias: Any, args: Any) -> tuple[Any, ...]: ...
+        if sys.version_info >= (3, 10):
+            def __or__(self, right: Any) -> _SpecialForm: ...
+            def __ror__(self, left: Any) -> _SpecialForm: ...
+        if sys.version_info >= (3, 11):
+            def __typing_subst__(self, arg: Any) -> Any: ...
+
+    @final
+    class ParamSpec:
+        @property
+        def __name__(self) -> str: ...
+        @property
+        def __bound__(self) -> Any | None: ...
+        @property
+        def __covariant__(self) -> bool: ...
+        @property
+        def __contravariant__(self) -> bool: ...
+        @property
+        def __infer_variance__(self) -> bool: ...
+        @property
+        def __default__(self) -> Any: ...
+        def __init__(
+            self,
+            name: str,
+            *,
+            bound: None | type[Any] | str = None,
+            contravariant: bool = False,
+            covariant: bool = False,
+            default: Any = ...,
+        ) -> None: ...
+        @property
+        def args(self) -> ParamSpecArgs: ...
+        @property
+        def kwargs(self) -> ParamSpecKwargs: ...
+        def has_default(self) -> bool: ...
+        def __typing_prepare_subst__(self, alias: Any, args: Any) -> tuple[Any, ...]: ...
+        if sys.version_info >= (3, 10):
+            def __or__(self, right: Any) -> _SpecialForm: ...
+            def __ror__(self, left: Any) -> _SpecialForm: ...
+
+    @final
+    class TypeVarTuple:
+        @property
+        def __name__(self) -> str: ...
+        @property
+        def __default__(self) -> Any: ...
+        def __init__(self, name: str, *, default: Any = ...) -> None: ...
+        def __iter__(self) -> Any: ...  # Unpack[Self]
+        def has_default(self) -> bool: ...
+        def __typing_prepare_subst__(self, alias: Any, args: Any) -> tuple[Any, ...]: ...
 
 class Doc:
     documentation: str


### PR DESCRIPTION
- Add the `__default__` property, the `default` parameter and the `has_default` method to the `typing.pyi` versions of `TypeVar`, `ParamSpec` and `TypeVarTuple`
- Change the `__default__` property in `typing_extensions` from `Any | None` to `Any`, now that it defaults to `NoDefault` rather than `Any`
- Add the `__typing_prepare_subst__` method to the typevarlike classes in `typing_extensions`. These are implementation details, but we included them in the `typing.pyi` versions of these classes; we should probably be consistent between `typing` and `typing_extensions` here
- Import `ContextManager` and `AsyncContextManager` from `contextlib` rather than `typing` in our `typing_extensions` stubs. The versions in `contextlib` always have defaults for the type parameters in our stubs (matching what `typing_extensions` does at runtime), whereas the versions in `typing` in our stubs only have defaults for the type parameters on Python 3.13+.
- Re-export `TypeVar`, `ParamSpec` and `TypeVarTuple` from `typing` on Python 3.13+ in `typing_extensions` (this is what we do at runtime)
- Add some missing PEP-604 methods to `typing_extensions.ParamSpec`