### PR TITLE
Make `distutils.dist.Distribution.get_command_obj` not return `None` by default

### DIFF
--- a/stdlib/distutils/dist.pyi
+++ b/stdlib/distutils/dist.pyi
@@ -2,7 +2,7 @@ from _typeshed import FileDescriptorOrPath, Incomplete, SupportsWrite
 from collections.abc import Iterable, Mapping
 from distutils.cmd import Command
 from re import Pattern
-from typing import IO, Any, ClassVar, TypeVar, overload
+from typing import IO, Any, ClassVar, Literal, TypeVar, overload
 from typing_extensions import TypeAlias
 
 command_re: Pattern[str]
@@ -63,7 +63,10 @@ class Distribution:
     def __init__(self, attrs: Mapping[str, Any] | None = None) -> None: ...
     def get_option_dict(self, command: str) -> dict[str, tuple[str, str]]: ...
     def parse_config_files(self, filenames: Iterable[str] | None = None) -> None: ...
-    def get_command_obj(self, command: str, create: bool = True) -> Command | None: ...
+    @overload
+    def get_command_obj(self, command: str, create: Literal[1, True] = 1) -> Command: ...
+    @overload
+    def get_command_obj(self, command: str, create: Literal[0, False]) -> Command | None: ...
     global_options: ClassVar[_OptionsList]
     common_usage: ClassVar[str]
     display_options: ClassVar[_OptionsList]

--- a/stubs/setuptools/@tests/stubtest_allowlist.txt
+++ b/stubs/setuptools/@tests/stubtest_allowlist.txt
@@ -3,9 +3,6 @@ pkg_resources.PathMetadata.egg_info
 pkg_resources.EggMetadata.loader
 pkg_resources.ZipProvider.loader
 
-# 1 used for True as a default value
-setuptools._distutils.dist.Distribution.get_command_obj
-
 # Dynamically created in __init__
 setuptools._distutils.dist.Distribution.get_name
 setuptools._distutils.dist.Distribution.get_version

--- a/stubs/setuptools/setuptools/_distutils/dist.pyi
+++ b/stubs/setuptools/setuptools/_distutils/dist.pyi
@@ -1,7 +1,7 @@
 from _typeshed import FileDescriptorOrPath, Incomplete, SupportsWrite
 from collections.abc import Iterable, Mapping
 from re import Pattern
-from typing import IO, Any, ClassVar, TypeVar, overload
+from typing import IO, Any, ClassVar, Literal, TypeVar, overload
 from typing_extensions import TypeAlias
 
 from .cmd import Command
@@ -64,7 +64,10 @@ class Distribution:
     def __init__(self, attrs: Mapping[str, Any] | None = None) -> None: ...
     def get_option_dict(self, command: str) -> dict[str, tuple[str, str]]: ...
     def parse_config_files(self, filenames: Iterable[str] | None = None) -> None: ...
-    def get_command_obj(self, command: str, create: bool = True) -> Command | None: ...
+    @overload
+    def get_command_obj(self, command: str, create: Literal[1, True] = 1) -> Command: ...
+    @overload
+    def get_command_obj(self, command: str, create: Literal[0, False]) -> Command | None: ...
     global_options: ClassVar[_OptionsList]
     common_usage: ClassVar[str]
     display_options: ClassVar[_OptionsList]


### PR DESCRIPTION
Addresses these setuptools TODOs: https://github.com/pypa/setuptools/blob/main/setuptools/command/editable_wheel.py#L250-L251 & https://github.com/pypa/setuptools/blob/main/setuptools/command/editable_wheel.py#L450-L451
so it can start running mypy on Python 3.12: https://github.com/pypa/setuptools/pull/4352#issuecomment-2116537842