### PR TITLE
stdlib: fix some enum definitions

### DIFF
--- a/stdlib/calendar.pyi
+++ b/stdlib/calendar.pyi
@@ -4,7 +4,7 @@ import sys
 from _typeshed import Unused
 from collections.abc import Iterable, Sequence
 from time import struct_time
-from typing import ClassVar, Literal
+from typing import ClassVar, Final
 from typing_extensions import TypeAlias
 
 __all__ = [
@@ -154,18 +154,18 @@ month_abbr: Sequence[str]
 
 if sys.version_info >= (3, 12):
     class Month(enum.IntEnum):
-        JANUARY: Literal[1]
-        FEBRUARY: Literal[2]
-        MARCH: Literal[3]
-        APRIL: Literal[4]
-        MAY: Literal[5]
-        JUNE: Literal[6]
-        JULY: Literal[7]
-        AUGUST: Literal[8]
-        SEPTEMBER: Literal[9]
-        OCTOBER: Literal[10]
-        NOVEMBER: Literal[11]
-        DECEMBER: Literal[12]
+        JANUARY = 1
+        FEBRUARY = 2
+        MARCH = 3
+        APRIL = 4
+        MAY = 5
+        JUNE = 6
+        JULY = 7
+        AUGUST = 8
+        SEPTEMBER = 9
+        OCTOBER = 10
+        NOVEMBER = 11
+        DECEMBER = 12
 
     JANUARY = Month.JANUARY
     FEBRUARY = Month.FEBRUARY
@@ -181,13 +181,13 @@ if sys.version_info >= (3, 12):
     DECEMBER = Month.DECEMBER
 
     class Day(enum.IntEnum):
-        MONDAY: Literal[0]
-        TUESDAY: Literal[1]
-        WEDNESDAY: Literal[2]
-        THURSDAY: Literal[3]
-        FRIDAY: Literal[4]
-        SATURDAY: Literal[5]
-        SUNDAY: Literal[6]
+        MONDAY = 0
+        TUESDAY = 1
+        WEDNESDAY = 2
+        THURSDAY = 3
+        FRIDAY = 4
+        SATURDAY = 5
+        SUNDAY = 6
 
     MONDAY = Day.MONDAY
     TUESDAY = Day.TUESDAY
@@ -197,12 +197,12 @@ if sys.version_info >= (3, 12):
     SATURDAY = Day.SATURDAY
     SUNDAY = Day.SUNDAY
 else:
-    MONDAY: Literal[0]
-    TUESDAY: Literal[1]
-    WEDNESDAY: Literal[2]
-    THURSDAY: Literal[3]
-    FRIDAY: Literal[4]
-    SATURDAY: Literal[5]
-    SUNDAY: Literal[6]
+    MONDAY: Final = 0
+    TUESDAY: Final = 1
+    WEDNESDAY: Final = 2
+    THURSDAY: Final = 3
+    FRIDAY: Final = 4
+    SATURDAY: Final = 5
+    SUNDAY: Final = 6
 
-EPOCH: Literal[1970]
+EPOCH: Final = 1970

--- a/stdlib/http/__init__.pyi
+++ b/stdlib/http/__init__.pyi
@@ -1,6 +1,5 @@
 import sys
 from enum import IntEnum
-from typing import Literal
 
 if sys.version_info >= (3, 11):
     from enum import StrEnum
@@ -75,9 +74,9 @@ class HTTPStatus(IntEnum):
     MISDIRECTED_REQUEST = 421
     UNAVAILABLE_FOR_LEGAL_REASONS = 451
     if sys.version_info >= (3, 9):
-        EARLY_HINTS: Literal[103]
-        IM_A_TEAPOT: Literal[418]
-        TOO_EARLY: Literal[425]
+        EARLY_HINTS = 103
+        IM_A_TEAPOT = 418
+        TOO_EARLY = 425
     if sys.version_info >= (3, 12):
         @property
         def is_informational(self) -> bool: ...

--- a/stdlib/re.pyi
+++ b/stdlib/re.pyi
@@ -201,7 +201,7 @@ class RegexFlag(enum.IntFlag):
     T = sre_compile.SRE_FLAG_TEMPLATE
     TEMPLATE = T
     if sys.version_info >= (3, 11):
-        NOFLAG: int
+        NOFLAG = 0
 
 A = RegexFlag.A
 ASCII = RegexFlag.ASCII


### PR DESCRIPTION
I was pointed recently to this issue https://github.com/python/typing-council/issues/11 which suggests changing the interpretation of annotated but not assigned attributes of enums to no longer be considered members of the enumeration so I looked in the stdlib for places where this exists and changed the annotations to assignments.

Note that there is a PR implementing this change in mypy https://github.com/python/mypy/pull/17207