### PR TITLE
Use assignment instead of annotation in third party enums

### DIFF
--- a/stubs/antlr4-python3-runtime/antlr4/atn/ATNType.pyi
+++ b/stubs/antlr4-python3-runtime/antlr4/atn/ATNType.pyi
@@ -1,7 +1,7 @@
 from enum import IntEnum
 
 class ATNType(IntEnum):
-    LEXER: int
-    PARSER: int
+    LEXER = 0
+    PARSER = 1
     @classmethod
     def fromOrdinal(cls, i: int): ...

--- a/stubs/antlr4-python3-runtime/antlr4/atn/LexerAction.pyi
+++ b/stubs/antlr4-python3-runtime/antlr4/atn/LexerAction.pyi
@@ -4,14 +4,14 @@ from enum import IntEnum
 Lexer: Incomplete
 
 class LexerActionType(IntEnum):
-    CHANNEL: int
-    CUSTOM: int
-    MODE: int
-    MORE: int
-    POP_MODE: int
-    PUSH_MODE: int
-    SKIP: int
-    TYPE: int
+    CHANNEL = 0
+    CUSTOM = 1
+    MODE = 2
+    MORE = 3
+    POP_MODE = 4
+    PUSH_MODE = 5
+    SKIP = 6
+    TYPE = 7
 
 class LexerAction:
     actionType: Incomplete

--- a/stubs/antlr4-python3-runtime/antlr4/atn/PredictionMode.pyi
+++ b/stubs/antlr4-python3-runtime/antlr4/atn/PredictionMode.pyi
@@ -8,9 +8,9 @@ from antlr4.atn.ATNState import RuleStopState as RuleStopState
 from antlr4.atn.SemanticContext import SemanticContext as SemanticContext
 
 class PredictionMode(Enum):
-    SLL: int
-    LL: int
-    LL_EXACT_AMBIG_DETECTION: int
+    SLL = 0
+    LL = 1
+    LL_EXACT_AMBIG_DETECTION = 2
     @classmethod
     def hasSLLConflictTerminatingPrediction(cls, mode: PredictionMode, configs: ATNConfigSet): ...
     @classmethod

--- a/stubs/flake8/flake8/options/manager.pyi
+++ b/stubs/flake8/flake8/options/manager.pyi
@@ -3,14 +3,14 @@ from _typeshed import Incomplete
 from collections.abc import Callable, Sequence
 from enum import Enum
 from logging import Logger
-from typing import Any, Final
+from typing import Any
 
 from ..plugins.finder import Plugins
 
 LOG: Logger
 
 class _ARG(Enum):
-    NO: Final = 1
+    NO = 1
 
 class Option:
     short_option_name: Incomplete

--- a/stubs/flake8/flake8/style_guide.pyi
+++ b/stubs/flake8/flake8/style_guide.pyi
@@ -9,16 +9,16 @@ from .statistics import Statistics
 __all__ = ("StyleGuide",)
 
 class Selected(enum.Enum):
-    Explicitly: str
-    Implicitly: str
+    Explicitly = "explicitly selected"
+    Implicitly = "implicitly selected"
 
 class Ignored(enum.Enum):
-    Explicitly: str
-    Implicitly: str
+    Explicitly = "explicitly ignored"
+    Implicitly = "implicitly ignored"
 
 class Decision(enum.Enum):
-    Ignored: str
-    Selected: str
+    Ignored = "ignored error"
+    Selected = "selected error"
 
 class DecisionEngine:
     cache: Incomplete

--- a/stubs/fpdf2/fpdf/enums.pyi
+++ b/stubs/fpdf2/fpdf/enums.pyi
@@ -77,8 +77,8 @@ class TableCellFillMode(CoerciveEnum):
     def should_fill_cell(self, i: int, j: int) -> bool: ...
 
 class TableSpan(CoerciveEnum):
-    ROW: Literal["ROW"]
-    COL: Literal["COL"]
+    ROW = "ROW"
+    COL = "COL"
 
 class TableHeadingsDisplay(CoerciveIntEnum):
     NONE = 0

--- a/stubs/regex/regex/_regex_core.pyi
+++ b/stubs/regex/regex/_regex_core.pyi
@@ -44,42 +44,42 @@ class RegexFlag(enum.IntFlag):
     X = 0x40
     VERBOSE = X
 
-A: int
-ASCII: int
-B: int
-BESTMATCH: int
-D: int
-DEBUG: int
-E: int
-ENHANCEMATCH: int
-F: int
-FULLCASE: int
-I: int
-IGNORECASE: int
-L: int
-LOCALE: int
-M: int
-MULTILINE: int
-P: int
-POSIX: int
-R: int
-REVERSE: int
-T: int
-TEMPLATE: int
-S: int
-DOTALL: int
-U: int
-UNICODE: int
-V0: int
-VERSION0: int
-V1: int
-VERSION1: int
-W: int
-WORD: int
-X: int
-VERBOSE: int
+A = RegexFlag.A
+ASCII = RegexFlag.ASCII
+B = RegexFlag.B
+BESTMATCH = RegexFlag.BESTMATCH
+D = RegexFlag.D
+DEBUG = RegexFlag.DEBUG
+E = RegexFlag.E
+ENHANCEMATCH = RegexFlag.ENHANCEMATCH
+F = RegexFlag.F
+FULLCASE = RegexFlag.FULLCASE
+I = RegexFlag.I
+IGNORECASE = RegexFlag.IGNORECASE
+L = RegexFlag.L
+LOCALE = RegexFlag.LOCALE
+M = RegexFlag.M
+MULTILINE = RegexFlag.MULTILINE
+P = RegexFlag.P
+POSIX = RegexFlag.POSIX
+R = RegexFlag.R
+REVERSE = RegexFlag.REVERSE
+T = RegexFlag.T
+TEMPLATE = RegexFlag.TEMPLATE
+S = RegexFlag.S
+DOTALL = RegexFlag.DOTALL
+U = RegexFlag.U
+UNICODE = RegexFlag.UNICODE
+V0 = RegexFlag.V0
+VERSION0 = RegexFlag.VERSION0
+V1 = RegexFlag.V1
+VERSION1 = RegexFlag.VERSION1
+W = RegexFlag.W
+WORD = RegexFlag.WORD
+X = RegexFlag.X
+VERBOSE = RegexFlag.VERBOSE
 
-DEFAULT_VERSION: int
+DEFAULT_VERSION: RegexFlag
 
 _Lexicon: TypeAlias = list[tuple[AnyStr, Callable[[Scanner[AnyStr], AnyStr], Any]]]
 

--- a/stubs/regex/regex/_regex_core.pyi
+++ b/stubs/regex/regex/_regex_core.pyi
@@ -1,6 +1,6 @@
 import enum
 from collections.abc import Callable
-from typing import Any, AnyStr, Generic
+from typing import Any, AnyStr, Final, Generic
 from typing_extensions import TypeAlias
 
 from .regex import Pattern
@@ -44,40 +44,40 @@ class RegexFlag(enum.IntFlag):
     X = 0x40
     VERBOSE = X
 
-A = RegexFlag.A
-ASCII = RegexFlag.ASCII
-B = RegexFlag.B
-BESTMATCH = RegexFlag.BESTMATCH
-D = RegexFlag.D
-DEBUG = RegexFlag.DEBUG
-E = RegexFlag.E
-ENHANCEMATCH = RegexFlag.ENHANCEMATCH
-F = RegexFlag.F
-FULLCASE = RegexFlag.FULLCASE
-I = RegexFlag.I
-IGNORECASE = RegexFlag.IGNORECASE
-L = RegexFlag.L
-LOCALE = RegexFlag.LOCALE
-M = RegexFlag.M
-MULTILINE = RegexFlag.MULTILINE
-P = RegexFlag.P
-POSIX = RegexFlag.POSIX
-R = RegexFlag.R
-REVERSE = RegexFlag.REVERSE
-T = RegexFlag.T
-TEMPLATE = RegexFlag.TEMPLATE
-S = RegexFlag.S
-DOTALL = RegexFlag.DOTALL
-U = RegexFlag.U
-UNICODE = RegexFlag.UNICODE
-V0 = RegexFlag.V0
-VERSION0 = RegexFlag.VERSION0
-V1 = RegexFlag.V1
-VERSION1 = RegexFlag.VERSION1
-W = RegexFlag.W
-WORD = RegexFlag.WORD
-X = RegexFlag.X
-VERBOSE = RegexFlag.VERBOSE
+A: Final = RegexFlag.A
+ASCII: Final = RegexFlag.ASCII
+B: Final = RegexFlag.B
+BESTMATCH: Final = RegexFlag.BESTMATCH
+D: Final = RegexFlag.D
+DEBUG: Final = RegexFlag.DEBUG
+E: Final = RegexFlag.E
+ENHANCEMATCH: Final = RegexFlag.ENHANCEMATCH
+F: Final = RegexFlag.F
+FULLCASE: Final = RegexFlag.FULLCASE
+I: Final = RegexFlag.I
+IGNORECASE: Final = RegexFlag.IGNORECASE
+L: Final = RegexFlag.L
+LOCALE: Final = RegexFlag.LOCALE
+M: Final = RegexFlag.M
+MULTILINE: Final = RegexFlag.MULTILINE
+P: Final = RegexFlag.P
+POSIX: Final = RegexFlag.POSIX
+R: Final = RegexFlag.R
+REVERSE: Final = RegexFlag.REVERSE
+T: Final = RegexFlag.T
+TEMPLATE: Final = RegexFlag.TEMPLATE
+S: Final = RegexFlag.S
+DOTALL: Final = RegexFlag.DOTALL
+U: Final = RegexFlag.U
+UNICODE: Final = RegexFlag.UNICODE
+V0: Final = RegexFlag.V0
+VERSION0: Final = RegexFlag.VERSION0
+V1: Final = RegexFlag.V1
+VERSION1: Final = RegexFlag.VERSION1
+W: Final = RegexFlag.W
+WORD: Final = RegexFlag.WORD
+X: Final = RegexFlag.X
+VERBOSE: Final = RegexFlag.VERBOSE
 
 DEFAULT_VERSION: RegexFlag
 

--- a/stubs/regex/regex/_regex_core.pyi
+++ b/stubs/regex/regex/_regex_core.pyi
@@ -1,6 +1,6 @@
 import enum
 from collections.abc import Callable
-from typing import Any, AnyStr, Final, Generic
+from typing import Any, AnyStr, Generic
 from typing_extensions import TypeAlias
 
 from .regex import Pattern
@@ -44,40 +44,40 @@ class RegexFlag(enum.IntFlag):
     X = 0x40
     VERBOSE = X
 
-A: Final = RegexFlag.A
-ASCII: Final = RegexFlag.ASCII
-B: Final = RegexFlag.B
-BESTMATCH: Final = RegexFlag.BESTMATCH
-D: Final = RegexFlag.D
-DEBUG: Final = RegexFlag.DEBUG
-E: Final = RegexFlag.E
-ENHANCEMATCH: Final = RegexFlag.ENHANCEMATCH
-F: Final = RegexFlag.F
-FULLCASE: Final = RegexFlag.FULLCASE
-I: Final = RegexFlag.I
-IGNORECASE: Final = RegexFlag.IGNORECASE
-L: Final = RegexFlag.L
-LOCALE: Final = RegexFlag.LOCALE
-M: Final = RegexFlag.M
-MULTILINE: Final = RegexFlag.MULTILINE
-P: Final = RegexFlag.P
-POSIX: Final = RegexFlag.POSIX
-R: Final = RegexFlag.R
-REVERSE: Final = RegexFlag.REVERSE
-T: Final = RegexFlag.T
-TEMPLATE: Final = RegexFlag.TEMPLATE
-S: Final = RegexFlag.S
-DOTALL: Final = RegexFlag.DOTALL
-U: Final = RegexFlag.U
-UNICODE: Final = RegexFlag.UNICODE
-V0: Final = RegexFlag.V0
-VERSION0: Final = RegexFlag.VERSION0
-V1: Final = RegexFlag.V1
-VERSION1: Final = RegexFlag.VERSION1
-W: Final = RegexFlag.W
-WORD: Final = RegexFlag.WORD
-X: Final = RegexFlag.X
-VERBOSE: Final = RegexFlag.VERBOSE
+A = RegexFlag.A
+ASCII = RegexFlag.ASCII
+B = RegexFlag.B
+BESTMATCH = RegexFlag.BESTMATCH
+D = RegexFlag.D
+DEBUG = RegexFlag.DEBUG
+E = RegexFlag.E
+ENHANCEMATCH = RegexFlag.ENHANCEMATCH
+F = RegexFlag.F
+FULLCASE = RegexFlag.FULLCASE
+I = RegexFlag.I
+IGNORECASE = RegexFlag.IGNORECASE
+L = RegexFlag.L
+LOCALE = RegexFlag.LOCALE
+M = RegexFlag.M
+MULTILINE = RegexFlag.MULTILINE
+P = RegexFlag.P
+POSIX = RegexFlag.POSIX
+R = RegexFlag.R
+REVERSE = RegexFlag.REVERSE
+T = RegexFlag.T
+TEMPLATE = RegexFlag.TEMPLATE
+S = RegexFlag.S
+DOTALL = RegexFlag.DOTALL
+U = RegexFlag.U
+UNICODE = RegexFlag.UNICODE
+V0 = RegexFlag.V0
+VERSION0 = RegexFlag.VERSION0
+V1 = RegexFlag.V1
+VERSION1 = RegexFlag.VERSION1
+W = RegexFlag.W
+WORD = RegexFlag.WORD
+X = RegexFlag.X
+VERBOSE = RegexFlag.VERBOSE
 
 DEFAULT_VERSION: RegexFlag
 


### PR DESCRIPTION
Follow up to #11956.

This PR handles all third party stubs except Pillow and pygit2 that I'll change in a follow up.