### PR TITLE
Unify stubtest allowlist handling more

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -176,7 +176,9 @@ directly, with
 ```
 
 For each distribution, stubtest ignores definitions listed in a `@tests/stubtest_allowlist.txt` file,
-relative to the distribution. Additional packages that are needed to run stubtest for a
+relative to the distribution. Platform specific items can be ignored by listing them
+in a `@tests/stubtest_allowlist_{platform}.txt` file. Additional packages that are needed
+to run stubtest for a
 distribution can be added to `tool.stubtest.stubtest_requirements` in `METADATA.toml`.
 
 ### Using stubtest to find objects missing from the stubs

--- a/tests/stubtest_stdlib.py
+++ b/tests/stubtest_stdlib.py
@@ -17,11 +17,6 @@ from utils import allowlist_stubtest_arguments, allowlists_path
 
 
 def run_stubtest(typeshed_dir: Path) -> int:
-    version_allowlist = f"py{sys.version_info.major}{sys.version_info.minor}.txt"
-    combined_allowlist = f"{sys.platform}-py{sys.version_info.major}{sys.version_info.minor}.txt"
-    local_version_allowlist = version_allowlist + ".local"
-    extra_allowlists = [version_allowlist, combined_allowlist, local_version_allowlist]
-
     # Note when stubtest imports distutils, it will likely actually import setuptools._distutils
     # This is fine because we don't care about distutils and allowlist all errors from it
     # https://github.com/python/typeshed/pull/10253#discussion_r1216712404
@@ -33,7 +28,7 @@ def run_stubtest(typeshed_dir: Path) -> int:
         "--check-typeshed",
         "--custom-typeshed-dir",
         str(typeshed_dir),
-        *allowlist_stubtest_arguments("stdlib", extra_allowlists),
+        *allowlist_stubtest_arguments("stdlib"),
     ]
     if sys.version_info < (3, 10):
         # As discussed in https://github.com/python/typeshed/issues/3693, we only aim for

--- a/tests/stubtest_third_party.py
+++ b/tests/stubtest_third_party.py
@@ -109,6 +109,7 @@ def run_stubtest(
             *ignore_missing_stub,
             *packages_to_check,
             *modules_to_check,
+            *allowlist_stubtest_arguments(dist_name),
         ]
 
         stubs_dir = dist.parent
@@ -121,8 +122,6 @@ def run_stubtest(
         # because the CI fails if we pass only os.environ["DISPLAY"]. I didn't
         # "bisect" to see which variables are actually needed.
         stubtest_env = os.environ | {"MYPYPATH": mypypath, "MYPY_FORCE_COLOR": "1"}
-
-        stubtest_cmd += allowlist_stubtest_arguments(dist_name, [])
 
         # Perform some black magic in order to run stubtest inside uWSGI
         if dist_name == "uWSGI":

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -168,11 +168,19 @@ def allowlists_path(distribution_name: str) -> Path:
         return tests_path(distribution_name)
 
 
-def common_allowlists(distribution_name: str) -> list[str]:
+def allowlists(distribution_name: str) -> list[str]:
+    prefix = "" if distribution_name == "stdlib" else "stubtest_allowlist_"
+    version_id = f"py{sys.version_info.major}{sys.version_info.minor}"
+
+    platform_allowlist = f"{prefix}{sys.platform}.txt"
+    version_allowlist = f"{prefix}{version_id}.txt"
+    combined_allowlist = f"{prefix}{sys.platform}-{version_id}.txt"
+    local_version_allowlist = version_allowlist + ".local"
+
     if distribution_name == "stdlib":
-        return ["common.txt", f"{sys.platform}.txt"]
+        return ["common.txt", platform_allowlist, version_allowlist, combined_allowlist, local_version_allowlist]
     else:
-        return ["stubtest_allowlist.txt", f"stubtest_allowlist_{sys.platform}.txt"]
+        return ["stubtest_allowlist.txt", platform_allowlist]
 
 
 # ====================================================================
@@ -194,13 +202,13 @@ def spec_matches_path(spec: pathspec.PathSpec, path: Path) -> bool:
 
 
 # ====================================================================
-# mypy call
+# mypy/stubtest call
 # ====================================================================
 
 
-def allowlist_stubtest_arguments(distribution_name: str, additional_allowlists: list[str]) -> list[str]:
+def allowlist_stubtest_arguments(distribution_name: str) -> list[str]:
     stubtest_arguments: list[str] = []
-    for allowlist in common_allowlists(distribution_name) + additional_allowlists:
+    for allowlist in allowlists(distribution_name):
         path = allowlists_path(distribution_name) / allowlist
         if path.exists():
             stubtest_arguments.extend(["--allowlist", str(path)])


### PR DESCRIPTION
This makes it trivial to consistently extend supported allowlists in the future.