### PR TITLE
Update `Flask-Cors` extension stubs to accept Flask Blueprints

### DIFF
--- a/stubs/Flask-Cors/flask_cors/extension.pyi
+++ b/stubs/Flask-Cors/flask_cors/extension.pyi
@@ -10,7 +10,7 @@ LOG: Logger
 class CORS:
     def __init__(
         self,
-        app: flask.Flask | None = None,
+        app: flask.Flask | flask.Blueprint | None = None,
         *,
         resources: dict[str, dict[str, Any]] | list[str] | str | None = ...,
         origins: str | list[str] | None = ...,


### PR DESCRIPTION
`flask_cors.CORS` accepts `flask.Blueprint` objects, so update the stub to support that. Example from Flask-Cors' docs [here](https://flask-cors.readthedocs.io/en/latest/api.html#using-cors-with-blueprints).