### PR TITLE
Make `shutil.rmtree.onexc` parameter optional

### DIFF
--- a/stdlib/shutil.pyi
+++ b/stdlib/shutil.pyi
@@ -72,7 +72,7 @@ def copytree(
 ) -> _PathReturn: ...
 
 _OnErrorCallback: TypeAlias = Callable[[Callable[..., Any], str, Any], object]
-_OnExcCallback: TypeAlias = Callable[[Callable[..., Any], str, Exception], object]
+_OnExcCallback: TypeAlias = Callable[[Callable[..., Any], str, BaseException], object]
 
 class _RmtreeType(Protocol):
     avoids_symlink_attacks: bool

--- a/stdlib/shutil.pyi
+++ b/stdlib/shutil.pyi
@@ -78,8 +78,6 @@ class _RmtreeType(Protocol):
     avoids_symlink_attacks: bool
     if sys.version_info >= (3, 12):
         @overload
-        def __call__(self, path: StrOrBytesPath, ignore_errors: bool = False, *, dir_fd: int | None = None) -> None: ...
-        @overload
         @deprecated("The `onerror` parameter is deprecated and will be removed in Python 3.14. Use `onexc` instead.")
         def __call__(
             self,

--- a/stdlib/shutil.pyi
+++ b/stdlib/shutil.pyi
@@ -1,6 +1,6 @@
 import os
 import sys
-from _typeshed import BytesPath, FileDescriptorOrPath, StrOrBytesPath, StrPath, SupportsRead, SupportsWrite
+from _typeshed import BytesPath, ExcInfo, FileDescriptorOrPath, StrOrBytesPath, StrPath, SupportsRead, SupportsWrite
 from collections.abc import Callable, Iterable, Sequence
 from tarfile import _TarfileFilter
 from typing import Any, AnyStr, NamedTuple, Protocol, TypeVar, overload
@@ -71,7 +71,7 @@ def copytree(
     dirs_exist_ok: bool = False,
 ) -> _PathReturn: ...
 
-_OnErrorCallback: TypeAlias = Callable[[Callable[..., Any], str, Any], object]
+_OnErrorCallback: TypeAlias = Callable[[Callable[..., Any], str, ExcInfo], object]
 _OnExcCallback: TypeAlias = Callable[[Callable[..., Any], str, BaseException], object]
 
 class _RmtreeType(Protocol):

--- a/stdlib/shutil.pyi
+++ b/stdlib/shutil.pyi
@@ -91,7 +91,12 @@ class _RmtreeType(Protocol):
         ) -> None: ...
         @overload
         def __call__(
-            self, path: StrOrBytesPath, ignore_errors: bool = False, *, onexc: _OnExcCallback, dir_fd: int | None = None
+            self,
+            path: StrOrBytesPath,
+            ignore_errors: bool = False,
+            *,
+            onexc: _OnExcCallback | None = None,
+            dir_fd: int | None = None,
         ) -> None: ...
     elif sys.version_info >= (3, 11):
         def __call__(

--- a/stubs/setuptools/setuptools/compat/py311.pyi
+++ b/stubs/setuptools/setuptools/compat/py311.pyi
@@ -1,3 +1,4 @@
-from _typeshed import Incomplete, StrOrBytesPath
+from _typeshed import StrOrBytesPath
+from shutil import _OnExcCallback
 
-def shutil_rmtree(path: StrOrBytesPath, ignore_errors: bool = False, onexc: Incomplete | None = None): ...
+def shutil_rmtree(path: StrOrBytesPath, ignore_errors: bool = False, onexc: _OnExcCallback | None = None): ...


### PR DESCRIPTION
Noticed while adding pyright checks to setuptools (https://github.com/pypa/setuptools/pull/4192)

Doc reference: https://docs.python.org/3/library/shutil.html#shutil.rmtree

I also tested locally that the parameter is indeed optional.

---

I also changed the `Exception` type in `_OnExcCallback` for `baseException` so it works with `ExcInfo`:

![image](https://github.com/python/typeshed/assets/1350584/16ec7253-8c7b-4fc5-9e19-fcf500b0ac27)
```
Argument of type "_OnExcCallback | None" cannot be assigned to parameter "onexc" of type "_OnExcCallback" in function "__call__"
  Type "_OnExcCallback | None" is incompatible with type "_OnExcCallback"
    Type "None" is incompatible with type "_OnExcCallback"
```
`Argument 3 has incompatible type "BaseException"; expected "Exception"`

```py
def shutil_rmtree(
    path: StrOrBytesPath,
    ignore_errors: bool = False,
    onexc: shutil._OnExcCallback | None = None,
) -> None:
    if sys.version_info >= (3, 12):
        return shutil.rmtree(path, ignore_errors, onexc=onexc)

    def _handler(fn: Callable[..., Any], path: str, excinfo: ExcInfo) -> None:
        if onexc:
            onexc(fn, path, excinfo[1])

    return shutil.rmtree(path, ignore_errors, onerror=_handler)
```
xref https://github.com/pypa/setuptools/pull/4382