### PR TITLE
Remove `language_version` from black hook in `.pre-commit-config.yaml`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,6 @@ repos:
     rev: 24.3.0 # must match requirements-tests.txt
     hooks:
       - id: black
-        language_version: python3.10
   - repo: https://github.com/pycqa/flake8
     rev: 7.0.0 # must match requirements-tests.txt
     hooks:


### PR DESCRIPTION
This is causing pre-commit to fail for me locally on my newish macbook because it's trying to use a python3.10 executable for the hook, and I don't have a python3.10 executable available locally. I don't think we need this setting in .pre-commit-config.yaml, as we already have it set in pyproject.toml here; and removing it from .pre-commit-config.yaml makes pre-commit runnable for me locally:

https://github.com/python/typeshed/blob/fca4da54b1fe59e84560b682aa9155c4bfd96fb3/pyproject.toml#L3