### PR TITLE
Use macos-12 for stdlib stubtest in CI

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -34,8 +34,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # various modules aren't available on macos-14 and higher
-        os: ["ubuntu-latest", "windows-latest", "macos-13"]
+        # various modules aren't available on macos-13 and higher
+        os: ["ubuntu-latest", "windows-latest", "macos-12"]
         # TODO unpin the 3.11 and 3.12 micro versions
         python-version: ["3.8", "3.9", "3.10", "3.11.8", "3.12.2", "3.13"]
       fail-fast: false

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -34,7 +34,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
+        # various modules aren't available on macos-14 and higher
+        os: ["ubuntu-latest", "windows-latest", "macos-13"]
         # TODO unpin the 3.11 and 3.12 micro versions
         python-version: ["3.8", "3.9", "3.10", "3.11.8", "3.12.2", "3.13"]
       fail-fast: false

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -34,8 +34,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # tkinter doesn't import on macOS-12
-        os: ["ubuntu-latest", "windows-latest", "macos-11"]
+        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
         # TODO unpin the 3.11 and 3.12 micro versions
         python-version: ["3.8", "3.9", "3.10", "3.11.8", "3.12.2", "3.13"]
       fail-fast: false

--- a/.github/workflows/stubtest_stdlib.yml
+++ b/.github/workflows/stubtest_stdlib.yml
@@ -30,8 +30,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # various modules aren't available on macos-14 and higher
-        os: ["ubuntu-latest", "windows-latest", "macos-13"]
+        # various modules aren't available on macos-13 and higher
+        os: ["ubuntu-latest", "windows-latest", "macos-12"]
         # TODO unpin 3.11 and 3.12 micro versions
         python-version: ["3.8", "3.9", "3.10", "3.11.8", "3.12.2", "3.13"]
       fail-fast: false

--- a/.github/workflows/stubtest_stdlib.yml
+++ b/.github/workflows/stubtest_stdlib.yml
@@ -30,7 +30,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
+        # various modules aren't available on macos-14 and higher
+        os: ["ubuntu-latest", "windows-latest", "macos-13"]
         # TODO unpin 3.11 and 3.12 micro versions
         python-version: ["3.8", "3.9", "3.10", "3.11.8", "3.12.2", "3.13"]
       fail-fast: false

--- a/.github/workflows/stubtest_stdlib.yml
+++ b/.github/workflows/stubtest_stdlib.yml
@@ -30,8 +30,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # tkinter doesn't import on macOS 12
-        os: ["ubuntu-latest", "windows-latest", "macos-11"]
+        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
         # TODO unpin 3.11 and 3.12 micro versions
         python-version: ["3.8", "3.9", "3.10", "3.11.8", "3.12.2", "3.13"]
       fail-fast: false


### PR DESCRIPTION
I got this email the other day, indicating that we need to move off macos-11:

![image](https://github.com/python/typeshed/assets/66076021/4a4fb10c-5553-46f6-ba28-bb98f65fe73d)

I tried macos-14 and macos-13, but various extension modules like `_tkinter` still can't be imported on Python with those runners. macos-12 seems best for now.