### PR TITLE
py313: Consolidate `_pyrepl` allowlist entries

### DIFF
--- a/stdlib/@tests/stubtest_allowlists/darwin-py313.txt
+++ b/stdlib/@tests/stubtest_allowlists/darwin-py313.txt
@@ -1,10 +1,4 @@
 # new in py313
-_pyrepl.curses
-_pyrepl.fancy_termios
-_pyrepl.readline
-_pyrepl.simple_interact
-_pyrepl.unix_console
-_pyrepl.unix_eventqueue
 asyncio.unix_events.EventLoop
 asyncio.unix_events._UnixSelectorEventLoop.create_unix_server
 asyncio.unix_events.__all__

--- a/stdlib/@tests/stubtest_allowlists/linux-py313.txt
+++ b/stdlib/@tests/stubtest_allowlists/linux-py313.txt
@@ -1,11 +1,5 @@
 # TODO: triage these (new in py313)
 _decimal
-_pyrepl.curses
-_pyrepl.fancy_termios
-_pyrepl.readline
-_pyrepl.simple_interact
-_pyrepl.unix_console
-_pyrepl.unix_eventqueue
 _stat.SF_SETTABLE
 _stat.SF_SUPPORTED
 _stat.SF_SYNTHETIC

--- a/stdlib/@tests/stubtest_allowlists/py313.txt
+++ b/stdlib/@tests/stubtest_allowlists/py313.txt
@@ -12,17 +12,6 @@ _ctypes.alignment
 _ctypes.pointer
 _ctypes.sizeof
 _json.encode_basestring_ascii
-_pyrepl.commands
-_pyrepl.completing_reader
-_pyrepl.console
-_pyrepl.historical_reader
-_pyrepl.input
-_pyrepl.keymap
-_pyrepl.pager
-_pyrepl.reader
-_pyrepl.trace
-_pyrepl.types
-_pyrepl.utils
 _thread.interrupt_main
 _thread.lock
 _thread.stack_size
@@ -324,6 +313,9 @@ zoneinfo.ZoneInfo.from_file
 # ==========
 # Allowlist entries that cannot or should not be fixed
 # ==========
+
+# The internal implementation of the REPL on py313+; not for public consumption
+_pyrepl\..+
 
 # Runtime AST node runtime constructor behaviour is too loose.
 # For static typing, the loose behaviour is undesirable (https://github.com/python/typeshed/issues/8378).


### PR DESCRIPTION
This is an internal-only module; I don't think we should add stubs for any of the submodules