### PR TITLE
pyserial: serial: serialutil.pyi: fix excuslive float -> bool

### DIFF
--- a/stubs/pyserial/serial/serialutil.pyi
+++ b/stubs/pyserial/serial/serialutil.pyi
@@ -62,7 +62,7 @@ class SerialBase(io.RawIOBase):
         write_timeout: float | None = None,
         dsrdtr: bool = False,
         inter_byte_timeout: float | None = None,
-        exclusive: float | None = None,
+        exclusive: bool | None = None,
     ) -> None: ...
 
     # Return type:


### PR DESCRIPTION
Fixes #12034 

Reference: https://pyserial.readthedocs.io/en/latest/pyserial_api.html#serial.Serial