### PR TITLE
Use TypeIs for `is_typeddict`

### DIFF
--- a/stdlib/typing.pyi
+++ b/stdlib/typing.pyi
@@ -21,7 +21,7 @@ from types import (
     TracebackType,
     WrapperDescriptorType,
 )
-from typing_extensions import Never as _Never, ParamSpec as _ParamSpec
+from typing_extensions import Never as _Never, ParamSpec as _ParamSpec, TypeIs as _TypeIs
 
 if sys.version_info >= (3, 9):
     from types import GenericAlias
@@ -1013,7 +1013,7 @@ class ForwardRef:
         def __ror__(self, other: Any) -> _SpecialForm: ...
 
 if sys.version_info >= (3, 10):
-    def is_typeddict(tp: object) -> bool: ...
+    def is_typeddict(tp: object) -> _TypeIs[type[_TypedDict]]: ...
 
 def _type_repr(obj: object) -> str: ...
 

--- a/stdlib/typing_extensions.pyi
+++ b/stdlib/typing_extensions.pyi
@@ -313,7 +313,7 @@ else:
     Concatenate: _SpecialForm
     TypeAlias: _SpecialForm
     TypeGuard: _SpecialForm
-    def is_typeddict(tp: object) -> bool: ...
+    def is_typeddict(tp: object) -> TypeIs[type[_TypedDict]]: ...
 
 # New and changed things in 3.11
 if sys.version_info >= (3, 11):


### PR DESCRIPTION
Use `TypeIs` for `is_typeddict`, which will allow code like this to be type-checked properly, similarly to: https://github.com/python/typeshed/pull/11929:

```python
def f(X: type[Any]) -> None:
    if is_typeddict(X):
        X.__required_keys__
        reveal_type(X.__required_keys__)  # E: Revealed type is 'frozenset[str]'
```
