### PR TITLE
Use `TypeIs` for `is_protocol`

### DIFF
--- a/stdlib/typing.pyi
+++ b/stdlib/typing.pyi
@@ -1019,8 +1019,8 @@ if sys.version_info >= (3, 10):
 # in the case of narrowing a type to a protocol.
 @type_check_only
 class _Protocol(metaclass=_ProtocolMeta):
-    _is_protocol: Literal[True]
-    _is_runtime_protocol: bool
+    _is_protocol: ClassVar[Literal[True]]
+    _is_runtime_protocol: ClassVar[bool]
 
 def _type_repr(obj: object) -> str: ...
 

--- a/stdlib/typing.pyi
+++ b/stdlib/typing.pyi
@@ -21,7 +21,7 @@ from types import (
     TracebackType,
     WrapperDescriptorType,
 )
-from typing_extensions import Never as _Never, ParamSpec as _ParamSpec
+from typing_extensions import Never as _Never, ParamSpec as _ParamSpec, TypeIs as _TypeIs
 
 if sys.version_info >= (3, 9):
     from types import GenericAlias
@@ -1015,6 +1015,17 @@ class ForwardRef:
 if sys.version_info >= (3, 10):
     def is_typeddict(tp: object) -> bool: ...
 
+
+
+
+# It's invalid to use `Protocol` in a `TypeIs` context, but we need to define it for type checking
+# in the case of narrowing a type to a protocol.
+@type_check_only
+class _Protocol(metaclass=_ProtocolMeta):
+    _is_protocol: Literal[True]
+    _is_runtime_protocol: bool
+
+
 def _type_repr(obj: object) -> str: ...
 
 if sys.version_info >= (3, 12):
@@ -1040,7 +1051,7 @@ if sys.version_info >= (3, 12):
         def __ror__(self, left: Any) -> _SpecialForm: ...
 
 if sys.version_info >= (3, 13):
-    def is_protocol(tp: type, /) -> bool: ...
+    def is_protocol(tp: type, /) -> _TypeIs[type[_Protocol]]: ...
     def get_protocol_members(tp: type, /) -> frozenset[str]: ...
     @final
     class _NoDefaultType: ...

--- a/stdlib/typing.pyi
+++ b/stdlib/typing.pyi
@@ -1015,16 +1015,12 @@ class ForwardRef:
 if sys.version_info >= (3, 10):
     def is_typeddict(tp: object) -> bool: ...
 
-
-
-
 # It's invalid to use `Protocol` in a `TypeIs` context, but we need to define it for type checking
 # in the case of narrowing a type to a protocol.
 @type_check_only
 class _Protocol(metaclass=_ProtocolMeta):
     _is_protocol: Literal[True]
     _is_runtime_protocol: bool
-
 
 def _type_repr(obj: object) -> str: ...
 

--- a/stdlib/typing_extensions.pyi
+++ b/stdlib/typing_extensions.pyi
@@ -421,8 +421,8 @@ class _ProtocolMeta(abc.ABCMeta):
 # in the case of narrowing a type to a protocol.
 @type_check_only
 class _Protocol(metaclass=_ProtocolMeta):
-    _is_protocol: Literal[True]
-    _is_runtime_protocol: bool
+    _is_protocol: ClassVar[Literal[True]]
+    _is_runtime_protocol: ClassVar[bool]
 
 if sys.version_info >= (3, 13):
     from types import CapsuleType as CapsuleType

--- a/stdlib/typing_extensions.pyi
+++ b/stdlib/typing_extensions.pyi
@@ -415,8 +415,7 @@ else:
         def __buffer__(self, flags: int, /) -> memoryview: ...
 
 class _ProtocolMeta(abc.ABCMeta):
-    if sys.version_info >= (3, 12):
-        def __init__(cls, *args: Any, **kwargs: Any) -> None: ...
+    def __init__(cls, *args: Any, **kwargs: Any) -> None: ...
 
 # It's invalid to use `Protocol` in a `TypeIs` context, but we need to define it for type checking
 # in the case of narrowing a type to a protocol.

--- a/stdlib/typing_extensions.pyi
+++ b/stdlib/typing_extensions.pyi
@@ -414,13 +414,10 @@ else:
         # https://github.com/python/typeshed/issues/10224 for why we're defining it this way
         def __buffer__(self, flags: int, /) -> memoryview: ...
 
-class _ProtocolMeta(abc.ABCMeta):
-    def __init__(cls, *args: Any, **kwargs: Any) -> None: ...
-
 # It's invalid to use `Protocol` in a `TypeIs` context, but we need to define it for type checking
 # in the case of narrowing a type to a protocol.
 @type_check_only
-class _Protocol(metaclass=_ProtocolMeta):
+class _Protocol(metaclass=abc.ABCMeta):
     _is_protocol: ClassVar[Literal[True]]
     _is_runtime_protocol: ClassVar[bool]
 

--- a/stdlib/typing_extensions.pyi
+++ b/stdlib/typing_extensions.pyi
@@ -61,7 +61,6 @@ from typing import (  # noqa: Y022,Y037,Y038,Y039
     Union as Union,
     ValuesView as ValuesView,
     _Alias,
-    _ProtocolMeta,
     cast as cast,
     no_type_check as no_type_check,
     no_type_check_decorator as no_type_check_decorator,
@@ -414,6 +413,10 @@ else:
         # Not actually a Protocol at runtime; see
         # https://github.com/python/typeshed/issues/10224 for why we're defining it this way
         def __buffer__(self, flags: int, /) -> memoryview: ...
+
+class _ProtocolMeta(abc.ABCMeta):
+    if sys.version_info >= (3, 12):
+        def __init__(cls, *args: Any, **kwargs: Any) -> None: ...
 
 # It's invalid to use `Protocol` in a `TypeIs` context, but we need to define it for type checking
 # in the case of narrowing a type to a protocol.

--- a/stdlib/typing_extensions.pyi
+++ b/stdlib/typing_extensions.pyi
@@ -61,6 +61,7 @@ from typing import (  # noqa: Y022,Y037,Y038,Y039
     Union as Union,
     ValuesView as ValuesView,
     _Alias,
+    _ProtocolMeta,
     cast as cast,
     no_type_check as no_type_check,
     no_type_check_decorator as no_type_check_decorator,
@@ -414,6 +415,13 @@ else:
         # https://github.com/python/typeshed/issues/10224 for why we're defining it this way
         def __buffer__(self, flags: int, /) -> memoryview: ...
 
+# It's invalid to use `Protocol` in a `TypeIs` context, but we need to define it for type checking
+# in the case of narrowing a type to a protocol.
+@type_check_only
+class _Protocol(metaclass=_ProtocolMeta):
+    _is_protocol: Literal[True]
+    _is_runtime_protocol: bool
+
 if sys.version_info >= (3, 13):
     from types import CapsuleType as CapsuleType
     from typing import (
@@ -428,7 +436,7 @@ if sys.version_info >= (3, 13):
     )
     from warnings import deprecated as deprecated
 else:
-    def is_protocol(tp: type, /) -> bool: ...
+    def is_protocol(tp: type, /) -> TypeIs[type[_Protocol]]: ...
     def get_protocol_members(tp: type, /) -> frozenset[str]: ...
     @final
     class _NoDefaultType: ...


### PR DESCRIPTION
Utilize `TypeIs` for `is_protocol` to allow for narrowing in cases such as:

```python
def f(X: type[Any]) -> None:
    if is_protocol(X):
        X._is_runtime_protocol
        reveal_type(X._is_runtime_protocol)  # E: Revealed type is 'bool'