### PR TITLE
`time`: Python3.13 updates

### DIFF
--- a/stdlib/@tests/stubtest_allowlists/darwin-py313.txt
+++ b/stdlib/@tests/stubtest_allowlists/darwin-py313.txt
@@ -29,9 +29,6 @@ posix.unlockpt
 posix.waitid
 posix.waitid_result
 readline.backend
-time.clock_gettime_ns
-time.CLOCK_MONOTONIC_RAW_APPROX
-time.CLOCK_UPTIME_RAW_APPROX
 webbrowser.MacOSX
 
 # TODO: fix

--- a/stdlib/@tests/stubtest_allowlists/linux-py313.txt
+++ b/stdlib/@tests/stubtest_allowlists/linux-py313.txt
@@ -159,7 +159,6 @@ syslog.LOG_LAUNCHD
 syslog.LOG_NETINFO
 syslog.LOG_RAS
 syslog.LOG_REMOTEAUTH
-time.clock_gettime_ns
 
 # Exists on some Linux builds, and is documented,
 # but is unavailable in Github Actions on Linux with Python 3.12

--- a/stdlib/time.pyi
+++ b/stdlib/time.pyi
@@ -28,8 +28,8 @@ if sys.platform != "win32":
 if sys.platform == "darwin":
     CLOCK_UPTIME_RAW: int
     if sys.version_info >= (3, 13):
-	    CLOCK_UPTIME_RAW_APPROX: int
-	    CLOCK_MONOTONIC_RAW_APPROX: int
+        CLOCK_UPTIME_RAW_APPROX: int
+        CLOCK_MONOTONIC_RAW_APPROX: int
 
 if sys.version_info >= (3, 9) and sys.platform == "linux":
     CLOCK_TAI: int

--- a/stdlib/time.pyi
+++ b/stdlib/time.pyi
@@ -27,8 +27,9 @@ if sys.platform != "win32":
 
 if sys.platform == "darwin":
     CLOCK_UPTIME_RAW: int
-    CLOCK_UPTIME_RAW_APPROX: int
-    CLOCK_MONOTONIC_RAW_APPROX: int
+    if sys.version_info >= (3, 13):
+	    CLOCK_UPTIME_RAW_APPROX: int
+	    CLOCK_MONOTONIC_RAW_APPROX: int
 
 if sys.version_info >= (3, 9) and sys.platform == "linux":
     CLOCK_TAI: int

--- a/stdlib/time.pyi
+++ b/stdlib/time.pyi
@@ -27,6 +27,8 @@ if sys.platform != "win32":
 
 if sys.platform == "darwin":
     CLOCK_UPTIME_RAW: int
+    CLOCK_UPTIME_RAW_APPROX: int
+    CLOCK_MONOTONIC_RAW_APPROX: int
 
 if sys.version_info >= (3, 9) and sys.platform == "linux":
     CLOCK_TAI: int
@@ -94,7 +96,7 @@ if sys.platform != "win32":
     def clock_settime(clk_id: int, time: float, /) -> None: ...  # Unix only
 
 if sys.platform != "win32":
-    def clock_gettime_ns(clock_id: int, /) -> int: ...
+    def clock_gettime_ns(clk_id: int, /) -> int: ...
     def clock_settime_ns(clock_id: int, time: int, /) -> int: ...
 
 if sys.platform == "linux":


### PR DESCRIPTION
Update `time` module changes for Python3.13