### PR TITLE
 Change type of `logging.RotatingFileHandler.maxBytes` from str to int

### DIFF
--- a/stdlib/logging/handlers.pyi
+++ b/stdlib/logging/handlers.pyi
@@ -46,7 +46,7 @@ class BaseRotatingHandler(FileHandler):
     def rotate(self, source: str, dest: str) -> None: ...
 
 class RotatingFileHandler(BaseRotatingHandler):
-    maxBytes: str  # undocumented
+    maxBytes: int  # undocumented
     backupCount: int  # undocumented
     if sys.version_info >= (3, 9):
         def __init__(


### PR DESCRIPTION
Similar to [this issue](https://github.com/python/typeshed/issues/6130), which lead to [this PR](https://github.com/python/typeshed/pull/6128).

Just a few lines below `maxBytes` has type set to `int`.