### PR TITLE
Update docker to 7.1.x

### DIFF
--- a/stubs/docker/METADATA.toml
+++ b/stubs/docker/METADATA.toml
@@ -1,3 +1,3 @@
-version = "7.0.*"
+version = "7.1.*"
 upstream_repository = "https://github.com/docker/docker-py"
 requires = ["types-requests", "urllib3>=2"]

--- a/stubs/docker/docker/api/client.pyi
+++ b/stubs/docker/docker/api/client.pyi
@@ -43,7 +43,7 @@ class APIClient(
         version: str | None = None,
         timeout: int = 60,
         tls: bool | TLSConfig = False,
-        user_agent: str = "docker-sdk-python/7.0.0",
+        user_agent: str = ...,
         num_pools: int | None = None,
         credstore_env: Mapping[Incomplete, Incomplete] | None = None,
         use_ssh_client: bool = False,


### PR DESCRIPTION
Closes https://github.com/python/typeshed/pull/12025

I propose removing the default value from this param, because it is version specific.