### PR TITLE
Xmlrpc: accept data:str|bytes and require method:str

### DIFF
--- a/stdlib/xmlrpc/client.pyi
+++ b/stdlib/xmlrpc/client.pyi
@@ -200,7 +200,7 @@ def dumps(
     allow_none: bool = False,
 ) -> str: ...
 def loads(
-    data: str, use_datetime: bool = False, use_builtin_types: bool = False
+    data: str | bytes, use_datetime: bool = False, use_builtin_types: bool = False
 ) -> tuple[tuple[_Marshallable, ...], str | None]: ...
 def gzip_encode(data: ReadableBuffer) -> bytes: ...  # undocumented
 def gzip_decode(data: ReadableBuffer, max_decode: int = 20971520) -> bytes: ...  # undocumented

--- a/stdlib/xmlrpc/server.pyi
+++ b/stdlib/xmlrpc/server.pyi
@@ -49,7 +49,7 @@ class SimpleXMLRPCDispatcher:  # undocumented
     def _marshaled_dispatch(
         self,
         data: str | bytes,
-        dispatch_method: Callable[[str | None, tuple[_Marshallable, ...]], Fault | tuple[_Marshallable, ...]] | None = None,
+        dispatch_method: Callable[str, tuple[_Marshallable, ...]], Fault | tuple[_Marshallable, ...]] | None = None,
         path: Any | None = None,
     ) -> bytes: ...  # undocumented
     def system_listMethods(self) -> list[str]: ...  # undocumented

--- a/stdlib/xmlrpc/server.pyi
+++ b/stdlib/xmlrpc/server.pyi
@@ -49,7 +49,7 @@ class SimpleXMLRPCDispatcher:  # undocumented
     def _marshaled_dispatch(
         self,
         data: str | bytes,
-        dispatch_method: Callable[str, tuple[_Marshallable, ...]], Fault | tuple[_Marshallable, ...]] | None = None,
+        dispatch_method: Callable[[str, tuple[_Marshallable, ...]], Fault | tuple[_Marshallable, ...]] | None = None,
         path: Any | None = None,
     ) -> bytes: ...  # undocumented
     def system_listMethods(self) -> list[str]: ...  # undocumented

--- a/stdlib/xmlrpc/server.pyi
+++ b/stdlib/xmlrpc/server.pyi
@@ -48,10 +48,10 @@ class SimpleXMLRPCDispatcher:  # undocumented
     def register_multicall_functions(self) -> None: ...
     def _marshaled_dispatch(
         self,
-        data: str,
+        data: str | bytes,
         dispatch_method: Callable[[str | None, tuple[_Marshallable, ...]], Fault | tuple[_Marshallable, ...]] | None = None,
         path: Any | None = None,
-    ) -> str: ...  # undocumented
+    ) -> bytes: ...  # undocumented
     def system_listMethods(self) -> list[str]: ...  # undocumented
     def system_methodSignature(self, method_name: str) -> str: ...  # undocumented
     def system_methodHelp(self, method_name: str) -> str: ...  # undocumented


### PR DESCRIPTION
Two minor fixed to the typeshed:
1. `data` may be both `str` and `bytes`; actually CPython uses it both ways
2. `method=None` does not make much sense and should never happen :crossed_fingers: 