### PR TITLE
`mypy_test.py`: warn about incompatible python version only on tested files

### DIFF
--- a/tests/mypy_test.py
+++ b/tests/mypy_test.py
@@ -527,26 +527,26 @@ def test_third_party_stubs(args: TestConfig, tempdir: Path) -> TestSummary:
         if spec_matches_path(gitignore_spec, distribution_path):
             continue
 
-        metadata = read_metadata(distribution)
-        if not metadata.requires_python.contains(PYTHON_VERSION):
-            msg = (
-                f"skipping {distribution!r} (requires Python {metadata.requires_python}; "
-                f"test is being run using Python {PYTHON_VERSION})"
-            )
-            print(colored(msg, "yellow"))
-            summary.skip_package()
-            continue
-        if not metadata.requires_python.contains(args.version):
-            msg = f"skipping {distribution!r} for target Python {args.version} (requires Python {metadata.requires_python})"
-            print(colored(msg, "yellow"))
-            summary.skip_package()
-            continue
-
         if (
             distribution_path in args.filter
             or Path("stubs") in args.filter
             or any(distribution_path in path.parents for path in args.filter)
         ):
+            metadata = read_metadata(distribution)
+            if not metadata.requires_python.contains(PYTHON_VERSION):
+                msg = (
+                    f"skipping {distribution!r} (requires Python {metadata.requires_python}; "
+                    f"test is being run using Python {PYTHON_VERSION})"
+                )
+                print(colored(msg, "yellow"))
+                summary.skip_package()
+                continue
+            if not metadata.requires_python.contains(args.version):
+                msg = f"skipping {distribution!r} for target Python {args.version} (requires Python {metadata.requires_python})"
+                print(colored(msg, "yellow"))
+                summary.skip_package()
+                continue
+
             distributions_to_check[distribution] = get_recursive_requirements(distribution)
 
     # Setup the necessary virtual environments for testing the third-party stubs.

--- a/tests/regr_test.py
+++ b/tests/regr_test.py
@@ -292,14 +292,14 @@ def concurrently_run_testcases(
     for testcase_dir, tempdir in packageinfo_to_tempdir.items():
         pkg = testcase_dir.name
         requires_python = None
-        if not testcase_dir.is_stdlib:  # type: ignore[misc]  # mypy bug, already fixed on master
+        if not testcase_dir.is_stdlib:
             requires_python = read_metadata(pkg).requires_python
             if not requires_python.contains(PYTHON_VERSION):
                 msg = f"skipping {pkg!r} (requires Python {requires_python}; test is being run using Python {PYTHON_VERSION})"
                 print(colored(msg, "yellow"))
                 continue
         for version in versions_to_test:
-            if not testcase_dir.is_stdlib:  # type: ignore[misc]  # mypy bug, already fixed on master
+            if not testcase_dir.is_stdlib:
                 assert requires_python is not None
                 if not requires_python.contains(version):
                     msg = f"skipping {pkg!r} for target Python {version} (requires Python {requires_python})"


### PR DESCRIPTION
Before this change, mypy tests were printing a warning about seaborn requiring Python >= 3.9 even when the test invoked did not target seaborn (eg `python tests/mypy_test.py stubs/shapely`). With this change, the mentioned command does not warn about seaborn while both `python tests/mypy_test.py stubs/s*` and `python tests/mypy_test.py stubs/seaborn` still print the warning.