### PR TITLE
Use hyphenated options in black config in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.black]
-line_length = 130
-target_version = ["py310"]
-skip_magic_trailing_comma = true
+line-length = 130
+target-version = ["py310"]
+skip-magic-trailing-comma = true
 # Exclude protobuf files because they have long line lengths
 # Ideally, we could configure Black to allow longer line lengths
 # for just these files, but doesn't seem possible yet.


### PR DESCRIPTION
VS Code's json schema for pyproject.toml warned me about these fields. They are currently allowed but may get deprecated (see https://github.com/psf/black/issues/4178).