### PR TITLE
Fix the signatures of `@(async)contextmanager`

### DIFF
--- a/stdlib/contextlib.pyi
+++ b/stdlib/contextlib.pyi
@@ -77,7 +77,9 @@ class _GeneratorContextManager(AbstractContextManager[_T_co, bool | None], Conte
 @overload
 def contextmanager(func: Callable[_P, Generator[_T_co]]) -> Callable[_P, _GeneratorContextManager[_T_co]]: ...
 @overload
-@deprecated("Returning only an 'Iterator' from a function decorated with 'contextmanager' is deprecated. Use generator functions and 'Generator' instead.")
+@deprecated(
+    "Returning only an 'Iterator' from a function decorated with 'contextmanager' is deprecated. Use generator functions and 'Generator' instead."
+)
 def contextmanager(func: Callable[_P, Iterator[_T_co]]) -> Callable[_P, _GeneratorContextManager[_T_co]]: ...
 
 if sys.version_info >= (3, 10):
@@ -112,9 +114,10 @@ else:
 @overload
 def asynccontextmanager(func: Callable[_P, AsyncGenerator[_T_co]]) -> Callable[_P, _AsyncGeneratorContextManager[_T_co]]: ...
 @overload
-@deprecated("Returning only an 'AsyncIterator' from a function decorated with 'asynccontextmanager' is deprecated. Use async generator functions and 'AsyncGenerator' instead.")
+@deprecated(
+    "Returning only an 'AsyncIterator' from a function decorated with 'asynccontextmanager' is deprecated. Use async generator functions and 'AsyncGenerator' instead."
+)
 def asynccontextmanager(func: Callable[_P, AsyncIterator[_T_co]]) -> Callable[_P, _AsyncGeneratorContextManager[_T_co]]: ...
-
 
 class _SupportsClose(Protocol):
     def close(self) -> object: ...

--- a/stdlib/contextlib.pyi
+++ b/stdlib/contextlib.pyi
@@ -5,7 +5,7 @@ from abc import abstractmethod
 from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable, Generator, Iterator
 from types import TracebackType
 from typing import IO, Any, Generic, Protocol, TypeVar, overload, runtime_checkable
-from typing_extensions import ParamSpec, Self, TypeAlias
+from typing_extensions import ParamSpec, Self, TypeAlias, deprecated
 
 __all__ = [
     "contextmanager",
@@ -74,6 +74,14 @@ class _GeneratorContextManager(AbstractContextManager[_T_co, bool | None], Conte
             self, type: type[BaseException] | None, value: BaseException | None, traceback: TracebackType | None
         ) -> bool | None: ...
 
+
+@overload
+def contextmanager(func: Callable[_P, Generator[_T_co]]) -> Callable[_P, _GeneratorContextManager[_T_co]]: ...
+@overload
+@deprecated(
+    "Returning only an 'Iterator' from a function decorated with 'contextmanager' is deprecated. Use generator functions and "
+    "'Generator' instead."
+)
 def contextmanager(func: Callable[_P, Iterator[_T_co]]) -> Callable[_P, _GeneratorContextManager[_T_co]]: ...
 
 if sys.version_info >= (3, 10):

--- a/stdlib/contextlib.pyi
+++ b/stdlib/contextlib.pyi
@@ -77,10 +77,7 @@ class _GeneratorContextManager(AbstractContextManager[_T_co, bool | None], Conte
 @overload
 def contextmanager(func: Callable[_P, Generator[_T_co]]) -> Callable[_P, _GeneratorContextManager[_T_co]]: ...
 @overload
-@deprecated(
-    "Returning only an 'Iterator' from a function decorated with 'contextmanager' is deprecated. Use generator functions and "
-    "'Generator' instead."
-)
+@deprecated("Returning only an 'Iterator' from a function decorated with 'contextmanager' is deprecated. Use generator functions and 'Generator' instead.")
 def contextmanager(func: Callable[_P, Iterator[_T_co]]) -> Callable[_P, _GeneratorContextManager[_T_co]]: ...
 
 if sys.version_info >= (3, 10):
@@ -112,7 +109,12 @@ else:
             self, typ: type[BaseException] | None, value: BaseException | None, traceback: TracebackType | None
         ) -> bool | None: ...
 
+@overload
+def asynccontextmanager(func: Callable[_P, AsyncGenerator[_T_co]]) -> Callable[_P, _AsyncGeneratorContextManager[_T_co]]: ...
+@overload
+@deprecated("Returning only an 'AsyncIterator' from a function decorated with 'asynccontextmanager' is deprecated. Use async generator functions and 'AsyncGenerator' instead.")
 def asynccontextmanager(func: Callable[_P, AsyncIterator[_T_co]]) -> Callable[_P, _AsyncGeneratorContextManager[_T_co]]: ...
+
 
 class _SupportsClose(Protocol):
     def close(self) -> object: ...

--- a/stdlib/contextlib.pyi
+++ b/stdlib/contextlib.pyi
@@ -74,7 +74,6 @@ class _GeneratorContextManager(AbstractContextManager[_T_co, bool | None], Conte
             self, type: type[BaseException] | None, value: BaseException | None, traceback: TracebackType | None
         ) -> bool | None: ...
 
-
 @overload
 def contextmanager(func: Callable[_P, Generator[_T_co]]) -> Callable[_P, _GeneratorContextManager[_T_co]]: ...
 @overload


### PR DESCRIPTION
A continuation of the work and discussion in #2772, #2773, #7430, and #8698. Seemingly unblocked by #11867.

This attempts to deprecate the current less restrictive and less accurate signature of `contextlib.(async)contextmanager` using the `deprecated` decorator to provide users with a transition period (hopefully with less type-checker screaming than in previous attempts).

**Additional Rationale**
I'm not aware if there's any problems with using `deprecated` in this manner, but this might be as good a place as any to inspire such a discussion. I'd argue it's not the worst idea, since technically typeshed's signatures for these functions have been inconsistent with the runtime for ages. Thus, even if this usage isn't based on a runtime change as other uses of `deprecated` seem to be, it can still do what it's meant to: provide some sort of user feedback on a particular signature being explicitly less accurate than another, and potentially mark a predefined time frame for transitioning from one to the other.

Considering the major blocker in previous attempts to fix the signatures was the amount of "breakage" it would cause, this feels softer, arguably too soft if maintainers don't have some equivalent to pyright's `reportDeprecated` set in their type-checkers. Still, it's better than before; at least with the right type-checker setting on, there's *some* signal of the more correct signature.

**Potential Improvement**
- In the undeprecated overload, we could use custom protocols that aren't as narrow as `(Async)Generator` in place of the current parameter annotations, as outlined [here](https://github.com/python/typeshed/issues/2772#issuecomment-871438097). They would need to support `__(a)next__()`, `(a)throw()`, and maybe `(a)close()`, based on [what's used at runtime](https://github.com/python/cpython/blob/bd6d4ed6454378e48dab06f50a9be0bae6baa3a2/Lib/contextlib.py#L129)? Something like this, perhaps, going off of the linked example:

  ```py
  class ThrowableIterator(Protocol[_T]):
      def __next__(self) -> _T: ...
      # Note: The most accurate annotated signature for 'throw()' seem to require overloads,
      # if we're going off of 'Generator.throw()', but for the sake of being more succinct,
      # they aren't included here.
      def throw(
          self,
          exc_type: type[BaseException] | None,
          exc_inst: BaseException | None,
          exc_tb: TracebackType | None,
      ) -> Any: ...
      # The use of '(a)close()' in '(async)contextmanager' was backported all the way to 3.11.
      # See https://github.com/python/cpython/issues/110378.
      if sys.version_info >= (3, 11):
          def close(self) -> None: ...
          
  class AsyncThrowableIterator(Protocol[_T]): ...  # The async counterpart methods would be in here.
  ```