### PR TITLE
greenlet: Adds missing `__version__` variable

### DIFF
--- a/stubs/greenlet/greenlet/__init__.pyi
+++ b/stubs/greenlet/greenlet/__init__.pyi
@@ -1,3 +1,5 @@
+from typing import Final
+
 from ._greenlet import (
     _C_API as _C_API,
     GreenletExit as GreenletExit,
@@ -7,3 +9,5 @@ from ._greenlet import (
     greenlet as greenlet,
     settrace as settrace,
 )
+
+__version__: Final[str]


### PR DESCRIPTION
The title says it all.