### PR TITLE
Fixed definitions of EnumCheck and FlagBoundary enum members

### DIFF
--- a/stdlib/enum.pyi
+++ b/stdlib/enum.pyi
@@ -267,9 +267,9 @@ if sys.version_info >= (3, 11):
         def _generate_next_value_(name: str, start: int, count: int, last_values: list[str]) -> str: ...
 
     class EnumCheck(StrEnum):
-        CONTINUOUS: str
-        NAMED_FLAGS: str
-        UNIQUE: str
+        CONTINUOUS = "no skipped integer values"
+        NAMED_FLAGS = "multi-flag aliases may not contain unnamed flags"
+        UNIQUE = "one name per value"
 
     CONTINUOUS = EnumCheck.CONTINUOUS
     NAMED_FLAGS = EnumCheck.NAMED_FLAGS
@@ -280,10 +280,10 @@ if sys.version_info >= (3, 11):
         def __call__(self, enumeration: _EnumerationT) -> _EnumerationT: ...
 
     class FlagBoundary(StrEnum):
-        STRICT: str
-        CONFORM: str
-        EJECT: str
-        KEEP: str
+        STRICT = "strict"
+        CONFORM = "conform"
+        EJECT = "eject"
+        KEEP = "keep"
 
     STRICT = FlagBoundary.STRICT
     CONFORM = FlagBoundary.CONFORM


### PR DESCRIPTION
Fixed definitions of EnumCheck and FlagBoundary enum members so they conform to the recently updated typing standard.

This was reported as a [bug in pyright 1.1.366](https://github.com/microsoft/pyright/issues/8079), which implements the recent changes in the typing spec related to enums. I thought we had found and fixed all Enum class definitions in typeshed, but these two were missed.