### PR TITLE
Make `FunctionType.__kwdefaults__` optional.

### DIFF
--- a/stdlib/types.pyi
+++ b/stdlib/types.pyi
@@ -81,7 +81,7 @@ class FunctionType:
     __name__: str
     __qualname__: str
     __annotations__: dict[str, Any]
-    __kwdefaults__: dict[str, Any]
+    __kwdefaults__: dict[str, Any] | None
     if sys.version_info >= (3, 10):
         @property
         def __builtins__(self) -> dict[str, Any]: ...


### PR DESCRIPTION
 `FunctionType.__kwdefaults__` can be `None` on 3.8 through 3.13 from my minimal checking. Should be reproducible by running the code below:

```py
def ex():
    ...

print(ex.__kwdefaults__)  # Output should be 'None'
```


Side note, unrelated to typeshed: The Python [docs](https://docs.python.org/3/reference/datamodel.html#function.__kwdefaults__) don't really indicate this attribute can be `None` either, so a slight clarification there might be warranted too. I might attempt that if this goes through.
>  `function.__kwdefaults__` - A dictionary containing defaults for keyword-only parameters.