### PR TITLE
Ensure stubtest gets an older version of `webcolors` when testing `jsonschema` in CI

### DIFF
--- a/stubs/jsonschema/METADATA.toml
+++ b/stubs/jsonschema/METADATA.toml
@@ -6,3 +6,4 @@ partial_stub = true
 [tool.stubtest]
 ignore_missing_stub = true
 extras = ["format"]
+stubtest_requirements = ["webcolors<24.6.0"]

--- a/stubs/jsonschema/METADATA.toml
+++ b/stubs/jsonschema/METADATA.toml
@@ -6,4 +6,5 @@ partial_stub = true
 [tool.stubtest]
 ignore_missing_stub = true
 extras = ["format"]
+# see https://github.com/python/typeshed/issues/12107 for the reason for the pin
 stubtest_requirements = ["webcolors<24.6.0"]


### PR DESCRIPTION
See #12107