### PR TITLE
Fix false positives from `@deprecated` for `shutil.rmtree`

### DIFF
--- a/stdlib/shutil.pyi
+++ b/stdlib/shutil.pyi
@@ -78,13 +78,25 @@ class _RmtreeType(Protocol):
     avoids_symlink_attacks: bool
     if sys.version_info >= (3, 12):
         @overload
-        @deprecated("The `onerror` parameter is deprecated and will be removed in Python 3.14. Use `onexc` instead.")
+        @deprecated("The `onerror` parameter is deprecated. Use `onexc` instead.")
+        def __call__(
+            self,
+            path: StrOrBytesPath,
+            ignore_errors: bool,
+            onerror: _OnErrorCallback,
+            *,
+            onexc: None = None,
+            dir_fd: int | None = None,
+        ) -> None: ...
+        @overload
+        @deprecated("The `onerror` parameter is deprecated. Use `onexc` instead.")
         def __call__(
             self,
             path: StrOrBytesPath,
             ignore_errors: bool = False,
-            onerror: _OnErrorCallback | None = None,
             *,
+            onerror: _OnErrorCallback,
+            onexc: None = None,
             dir_fd: int | None = None,
         ) -> None: ...
         @overload


### PR DESCRIPTION
- Adjust wording: the `onerror` parameter is no longer expected to be removed in Python 3.14
- Fix it so that type checkers only emit an error if an argument is actually passed for the `onerror` parameter. If no argument is passed, there's no need for type checkers to emit a diagnostic.

Fixes #12103