### PR TITLE
Pin to older micro versions of Python for stdlib stubtest

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -36,7 +36,8 @@ jobs:
       matrix:
         # various modules aren't available on macos-13 and higher
         os: ["ubuntu-latest", "windows-latest", "macos-12"]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        # TODO: unpin 3.12 and 3.13 micro versions once https://github.com/actions/setup-python/issues/886 is resolved
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12.3", "3.13.0-beta.1"]
       fail-fast: false
 
     steps:

--- a/.github/workflows/stubtest_stdlib.yml
+++ b/.github/workflows/stubtest_stdlib.yml
@@ -32,7 +32,8 @@ jobs:
       matrix:
         # various modules aren't available on macos-13 and higher
         os: ["ubuntu-latest", "windows-latest", "macos-12"]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        # TODO: unpin 3.12 and 3.13 micro versions once https://github.com/actions/setup-python/issues/886 is resolved
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12.3", "3.13.0-beta.1"]
       fail-fast: false
 
     steps:


### PR DESCRIPTION
If you manually trigger a stubtest run on the main branch, it's very red right now due to the setup-python builds for 3.12.4 and 3.13.0b2 being very broken: https://github.com/actions/setup-python/issues/886