### PR TITLE
`tkinter.tix` is removed in Python 3.13

### DIFF
--- a/stdlib/@tests/stubtest_allowlists/py313.txt
+++ b/stdlib/@tests/stubtest_allowlists/py313.txt
@@ -155,7 +155,6 @@ tkinter.PhotoImage.write
 tkinter.PhotoImage.zoom
 tkinter.Text.count
 tkinter.Wm.wm_attributes
-tkinter.tix
 trace.CoverageResults.write_results
 turtle.RawTurtle.settiltangle
 turtle.__all__

--- a/stdlib/VERSIONS
+++ b/stdlib/VERSIONS
@@ -270,6 +270,7 @@ threading: 3.0-
 time: 3.0-
 timeit: 3.0-
 tkinter: 3.0-
+tkinter.tix: 3.0-3.12
 token: 3.0-
 tokenize: 3.0-
 tomllib: 3.11-


### PR DESCRIPTION
From [What's new in Python 3.13](https://docs.python.org/3.13/whatsnew/3.13.html) ...

> Also removed were the `tkinter.tix`