### PR TITLE
Flask-SocketIO: fix type hints

### DIFF
--- a/stubs/Flask-SocketIO/@tests/stubtest_allowlist.txt
+++ b/stubs/Flask-SocketIO/@tests/stubtest_allowlist.txt
@@ -1,3 +1,5 @@
 # private attributes / methods, not present in docs
+flask_socketio.SocketIOTestClient.clients
+flask_socketio.test_client.SocketIOTestClient.clients
 flask_socketio.gevent_socketio_found
 flask_socketio.call

--- a/stubs/Flask-SocketIO/@tests/stubtest_allowlist.txt
+++ b/stubs/Flask-SocketIO/@tests/stubtest_allowlist.txt
@@ -1,4 +1,3 @@
 # private attributes / methods, not present in docs
-flask_socketio.test_client.SocketIOTestClient.clients
 flask_socketio.gevent_socketio_found
 flask_socketio.call

--- a/stubs/Flask-SocketIO/flask_socketio/__init__.pyi
+++ b/stubs/Flask-SocketIO/flask_socketio/__init__.pyi
@@ -7,8 +7,8 @@ from typing_extensions import ParamSpec, TypeAlias
 from flask import Flask
 from flask.testing import FlaskClient
 
-from .namespace import Namespace
-from .test_client import SocketIOTestClient
+from .namespace import Namespace as Namespace
+from .test_client import SocketIOTestClient as SocketIOTestClient
 
 _P = ParamSpec("_P")
 _R_co = TypeVar("_R_co", covariant=True)
@@ -96,9 +96,9 @@ class SocketIO:
         port: int | None = None,
         *,
         debug: bool = True,
-        use_reloader: bool,
+        use_reloader: bool = ...,
         reloader_options: dict[str, Incomplete] = {},
-        log_output: bool,
+        log_output: bool = ...,
         allow_unsafe_werkzeug: bool = False,
         **kwargs,
     ) -> None: ...


### PR DESCRIPTION
#### Export `Namespace` and `SocketIOTestClient`

Reference: 
- https://flask-socketio.readthedocs.io/en/latest/getting_started.html#class-based-namespaces
- https://github.com/miguelgrinberg/Flask-SocketIO/blob/main/src/flask_socketio/__init__.py#L26
- https://flask-socketio.readthedocs.io/en/latest/api.html#flask_socketio.SocketIOTestClient

#### Add `...` as default value for `SocketIO.run`

Otherwise, [the example](https://flask-socketio.readthedocs.io/en/latest/getting_started.html#initialization) will complain about these arguments.
Also, they are [derived from `debug` argument](https://github.com/miguelgrinberg/Flask-SocketIO/blob/main/src/flask_socketio/__init__.py#L569-L581), so I have no idea how a better type hinting could be given.

Reference: 
- https://github.com/miguelgrinberg/Flask-SocketIO/blob/main/src/flask_socketio/__init__.py#L559

(Please squash merge, as useless commits have been created by me)