### PR TITLE
improvement: `submodule_search_locations` is not always a `list`

### DIFF
--- a/stdlib/importlib/machinery.pyi
+++ b/stdlib/importlib/machinery.pyi
@@ -20,7 +20,7 @@ class ModuleSpec:
     name: str
     loader: importlib.abc.Loader | None
     origin: str | None
-    submodule_search_locations: list[str] | None
+    submodule_search_locations: MutableSequence[str] | None
     loader_state: Any
     cached: str | None
     @property


### PR DESCRIPTION
Despite the CPython documentation for [`importlib.machinery.ModuleSpec.submodule_search_locations`](https://docs.python.org/3/library/importlib.html#importlib.machinery.ModuleSpec.submodule_search_locations), this attribute may not be a `list` - and for CPython at least it is a `importlib._bootstrap_external._NamespacePath` object for namespace packages. MRE:

```pycon
>>> from importlib.util import find_spec
>>> find_spec("existing_namespace_package_name").spec.submodule_search_locations
_NamespacePath(['/path/to/existing_namespace_package_name'])
```

The type of `.submodule_search_locations` mirrors that of `types.ModuleType.__path__`.

https://github.com/python/typeshed/blob/1af9de664f41b51bd3b71dac349564c5c25df810/stdlib/types.pyi#L325

(See also https://github.com/python/typeshed/pull/6200)