### PR TITLE
wtforms also allows a str as a valid choice of a SelectField

### DIFF
--- a/stubs/WTForms/@tests/test_cases/check_choices.py
+++ b/stubs/WTForms/@tests/test_cases/check_choices.py
@@ -4,12 +4,18 @@ from wtforms import SelectField
 
 # any way we can specify the choices inline with a literal should work
 
+# tuple of str
+SelectField(choices=("", ""))
+
 # tuple of tuples
 SelectField(choices=(("", ""),))
 SelectField(choices=((1, "1"),))
 SelectField(choices=(("", "", {}),))
 SelectField(choices=((True, "t", {}),))
 SelectField(choices=((True, "t"), (False, "f", {})))
+
+# list of str
+SelectField(choices=["", ""])
 
 # list of tuples
 SelectField(choices=[("", "")])
@@ -36,12 +42,18 @@ SelectField(choices={"a": [(True, "", {})], "b": [(False, "f")]})
 
 # the same should be true for lambdas
 
+# tuple of str
+SelectField(choices=lambda: ("", ""))
+
 # tuple of tuples
 SelectField(choices=lambda: (("", ""),))
 SelectField(choices=lambda: ((1, "1"),))
 SelectField(choices=lambda: (("", "", {}),))
 SelectField(choices=lambda: ((True, "t", {}),))
 SelectField(choices=lambda: ((True, "t"), (False, "f", {})))
+
+# list of str
+SelectField(choices=lambda: ["", ""])
 
 # list of tuples
 SelectField(choices=lambda: [("", "")])

--- a/stubs/WTForms/wtforms/fields/choices.pyi
+++ b/stubs/WTForms/wtforms/fields/choices.pyi
@@ -7,7 +7,7 @@ from wtforms.form import BaseForm
 from wtforms.meta import DefaultMeta, _SupportsGettextAndNgettext
 
 # technically this allows a list, but we're more strict for type safety
-_Choice: TypeAlias = tuple[Any, str] | tuple[Any, str, dict[str, Any]]
+_Choice: TypeAlias = tuple[Any, str] | tuple[Any, str, dict[str, Any]] | str
 # it's too difficult to get type safety here due to to nested partially invariant collections
 _GroupedChoices: TypeAlias = dict[str, Any]  # Any should be Collection[_Choice]
 _FullChoice: TypeAlias = tuple[Any, str, bool, dict[str, Any]]  # value, label, selected, render_kw


### PR DESCRIPTION
As far as I can see, `choices` of a `SelectField` also support an Iterable of just a `str`s, not only a `tuple[Any, str]`.

```python
SelectField(choices=["foo", "bar"])
```

This is apparently called "shortcut" in the tests

This is also tested:
https://github.com/wtforms/wtforms/blob/8211fc854f91aef184b6fc8766d7dad14b198387/tests/fields/test_select.py#L141-L152

...and as a return value of a callable

https://github.com/wtforms/wtforms/blob/8211fc854f91aef184b6fc8766d7dad14b198387/tests/fields/test_selectmultiple.py#L61

I am not 100% sure that's the correct fix? Happy to hear your feedback - I'm a newbie at typeshed 