### PR TITLE
Add return types to docker container run

### DIFF
--- a/stubs/docker/docker/models/containers.pyi
+++ b/stubs/docker/docker/models/containers.pyi
@@ -101,6 +101,7 @@ class Container(Model):
 
 class ContainerCollection(Collection[Container]):
     model: type[Container]
+    @overload
     def run(
         self,
         image: str | Image,
@@ -108,8 +109,22 @@ class ContainerCollection(Collection[Container]):
         stdout: bool = True,
         stderr: bool = False,
         remove: bool = False,
+        *,
+        detach: Literal[False] = False,
         **kwargs,
-    ): ...
+    ) -> bytes: ...
+    @overload
+    def run(
+        self,
+        image: str | Image,
+        command: str | list[str] | None = None,
+        stdout: bool = True,
+        stderr: bool = False,
+        remove: bool = False,
+        *,
+        detach: Literal[True],
+        **kwargs,
+    ) -> Container: ...
     def create(self, image: str, command: str | list[str] | None = None, **kwargs) -> Container: ...  # type:ignore[override]
     def get(self, container_id: str) -> Container: ...
     def list(


### PR DESCRIPTION
See implementation at
https://github.com/docker/docker-py/blob/a3652028b1ead708bd9191efb286f909ba6c2a49/docker/models/containers.py#L534 which includes in the docstring:

```
If the ``detach`` argument is ``True``, it will start the container
and immediately return a :py:class:`Container` object, similar to
``docker run -d``.
```