### PR TITLE
assertpy: improve type for extracting

### DIFF
--- a/stubs/assertpy/assertpy/extracting.pyi
+++ b/stubs/assertpy/assertpy/extracting.pyi
@@ -1,4 +1,4 @@
-from collections.abc import Callable, Mapping, Iterable as _Iterable
+from collections.abc import Callable, Iterable as _Iterable, Mapping
 from typing import Any
 from typing_extensions import Self
 

--- a/stubs/assertpy/assertpy/extracting.pyi
+++ b/stubs/assertpy/assertpy/extracting.pyi
@@ -1,4 +1,4 @@
-from collections.abc import Callable, Iterable, Mapping
+from collections.abc import Callable, _Iterable, Mapping
 from typing import Any
 from typing_extensions import Self
 
@@ -9,5 +9,5 @@ class ExtractingMixin:
         self,
         *names: str,
         filter: str | Mapping[str, Any] | Callable[[Any], bool],
-        sort: str | Iterable[str] | Callable[[Any], Any],
+        sort: str | _Iterable[str] | Callable[[Any], Any],
     ) -> Self: ...

--- a/stubs/assertpy/assertpy/extracting.pyi
+++ b/stubs/assertpy/assertpy/extracting.pyi
@@ -1,4 +1,4 @@
-from collections.abc import Callable, Mapping, _Iterable
+from collections.abc import Callable, Mapping, Iterable as _Iterable
 from typing import Any
 from typing_extensions import Self
 

--- a/stubs/assertpy/assertpy/extracting.pyi
+++ b/stubs/assertpy/assertpy/extracting.pyi
@@ -1,7 +1,13 @@
+from collections.abc import Callable, Iterable, Mapping
 from typing import Any
 from typing_extensions import Self
 
 __tracebackhide__: bool
 
 class ExtractingMixin:
-    def extracting(self, *names: Any, **kwargs: dict[str, Any]) -> Self: ...
+    def extracting(
+        self,
+        *names: str,
+        filter: str | Mapping[str, Any] | Callable[[Any], bool],
+        sort: str | Iterable[str] | Callable[[Any], Any],
+    ) -> Self: ...

--- a/stubs/assertpy/assertpy/extracting.pyi
+++ b/stubs/assertpy/assertpy/extracting.pyi
@@ -1,4 +1,4 @@
-from collections.abc import Callable, _Iterable, Mapping
+from collections.abc import Callable, Mapping, _Iterable
 from typing import Any
 from typing_extensions import Self
 


### PR DESCRIPTION
The `extracting` method support 2 kwargs: [`sort` and `filter`](https://github.com/assertpy/assertpy/blob/main/README.md#extracting-and-filtering). Each accepts different value types. `sort` accepts `str | Iterable | Callable` and `filter` accepts `str | dict | Callable`. Using a value type other than `dict` with the current stubs requires lots of `# type: ignore[arg-type]` comments in test code. So we change to use `Any` as the `kwargs` value type.