### PR TITLE
Update assertpy/extracting.pyi so that kwargs are not required

### DIFF
--- a/stubs/assertpy/assertpy/extracting.pyi
+++ b/stubs/assertpy/assertpy/extracting.pyi
@@ -8,6 +8,6 @@ class ExtractingMixin:
     def extracting(
         self,
         *names: str,
-        filter: str | Mapping[str, Any] | Callable[[Any], bool],
-        sort: str | _Iterable[str] | Callable[[Any], Any],
+        filter: str | Mapping[str, Any] | Callable[[Any], bool] = ...,
+        sort: str | _Iterable[str] | Callable[[Any], Any] = ...,
     ) -> Self: ...


### PR DESCRIPTION
The recent change to better type the `sort` and `filter` kwargs had the side effect of making them required. So we fix to supply a default argument.