### PR TITLE
[warnings]: Update `_ActionKind` to match Python 3.14

### DIFF
--- a/stdlib/warnings.pyi
+++ b/stdlib/warnings.pyi
@@ -21,8 +21,10 @@ if sys.version_info >= (3, 13):
 
 _T = TypeVar("_T")
 _W = TypeVar("_W", bound=list[WarningMessage] | None)
-_ActionKind: TypeAlias = Literal["default", "error", "ignore", "always", "module", "once"]
-
+if sys.version_info >= (3, 14):
+    _ActionKind: TypeAlias = Literal["default", "error", "ignore", "always", "module", "once"]
+else:
+    _ActionKind: TypeAlias = Literal["default", "error", "ignore", "always", "all", "module", "once"]
 filters: Sequence[tuple[str, str | None, type[Warning], str | None, int]]  # undocumented, do not mutate
 
 def showwarning(


### PR DESCRIPTION
"all" as a valid alias for "always" action has been added in the https://github.com/python/cpython/pull/121164