### PR TITLE
Use Python 3.12 for mypy_primer

### DIFF
--- a/.github/workflows/mypy_primer.yml
+++ b/.github/workflows/mypy_primer.yml
@@ -31,9 +31,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
-          # TODO: As of 2024-03-08, confluent-kafka fails to install with
-          # Python 3.12.
-          python-version: "3.11"
+          python-version: "3.12"
       - name: Install dependencies
         run: pip install git+https://github.com/hauntsaninja/mypy_primer.git
       - name: Run mypy_primer


### PR DESCRIPTION
I'd like for us to cover projects that use Python 3.12 only syntax