### PR TITLE
requests: Add connection property (type HTTPAdapter) to the Response class

### DIFF
--- a/stubs/requests/requests/models.pyi
+++ b/stubs/requests/requests/models.pyi
@@ -8,9 +8,9 @@ from typing_extensions import Self
 from urllib3 import exceptions as urllib3_exceptions, fields, filepost, util
 
 from . import auth, cookies, exceptions, hooks, status_codes, utils
+from .adapters import HTTPAdapter
 from .cookies import RequestsCookieJar
 from .structures import CaseInsensitiveDict as CaseInsensitiveDict
-from .adapters import HTTPAdapter
 
 default_hooks = hooks.default_hooks
 HTTPBasicAuth = auth.HTTPBasicAuth

--- a/stubs/requests/requests/models.pyi
+++ b/stubs/requests/requests/models.pyi
@@ -10,6 +10,7 @@ from urllib3 import exceptions as urllib3_exceptions, fields, filepost, util
 from . import auth, cookies, exceptions, hooks, status_codes, utils
 from .cookies import RequestsCookieJar
 from .structures import CaseInsensitiveDict as CaseInsensitiveDict
+from .adapters import HTTPAdapter
 
 default_hooks = hooks.default_hooks
 HTTPBasicAuth = auth.HTTPBasicAuth
@@ -123,6 +124,7 @@ class Response:
     cookies: RequestsCookieJar
     elapsed: datetime.timedelta
     request: PreparedRequest
+    connection: HTTPAdapter
     def __init__(self) -> None: ...
     def __bool__(self) -> bool: ...
     def __nonzero__(self) -> bool: ...


### PR DESCRIPTION
This PR is a type fix for the `requests` library to add `connection: HTTPAdapter` to `Response`.

The `Response` instance is built by `HTTPAdapter`. When built, a property called [`connection` is added to the `Response`](https://github.com/psf/requests/blob/0e322af87745eff34caffe4df68456ebc20d9068/src/requests/adapters.py#L392) that points back to the `HTTPAdapter` that created it. For example, the `requests` library's [`HTTPDigestAuth` class remakes requests](https://github.com/psf/requests/blob/0e322af87745eff34caffe4df68456ebc20d9068/src/requests/auth.py#L276) with credentials after authorization is requested by a server.