### PR TITLE
`is_lazy_fixture` in `pytest-lazy-fixture` is a `TypeIs` function

### DIFF
--- a/stubs/pytest-lazy-fixture/pytest_lazyfixture.pyi
+++ b/stubs/pytest-lazy-fixture/pytest_lazyfixture.pyi
@@ -1,6 +1,6 @@
 from collections.abc import Iterable
 from typing import Any, overload
-from typing_extensions import TypeGuard
+from typing_extensions import TypeIs
 
 class LazyFixture:
     name: str
@@ -11,4 +11,4 @@ class LazyFixture:
 def lazy_fixture(names: str) -> LazyFixture: ...
 @overload
 def lazy_fixture(names: Iterable[str]) -> list[LazyFixture] | Any: ...
-def is_lazy_fixture(val: object) -> TypeGuard[LazyFixture]: ...
+def is_lazy_fixture(val: object) -> TypeIs[LazyFixture]: ...


### PR DESCRIPTION
Source code: https://github.com/TvoroG/pytest-lazy-fixture/blob/18ec85edb5e27c933733f748c685b2fd083198d7/pytest_lazyfixture.py#L185-L186