### PR TITLE
remove generic 'context' from 'docutils.parsers.rst.RSTState'

### DIFF
--- a/stubs/docutils/docutils/parsers/rst/__init__.pyi
+++ b/stubs/docutils/docutils/parsers/rst/__init__.pyi
@@ -12,7 +12,7 @@ class Parser(parsers.Parser):
     settings_spec: ClassVar[Incomplete]
     config_section_dependencies: ClassVar[tuple[str, ...]]
     initial_state: Literal["Body", "RFC2822Body"]
-    state_classes: Sequence[type[RSTState[Incomplete]]]
+    state_classes: Sequence[type[RSTState]]
     inliner: Inliner | None
     def __init__(self, rfc2822: bool = False, inliner: Inliner | None = None) -> None: ...
     def get_transforms(self) -> list[type[Transform]]: ...
@@ -36,7 +36,7 @@ class Directive:
     lineno: int
     content_offset: int
     block_text: str
-    state: RSTState[Incomplete]
+    state: RSTState
     state_machine: RSTStateMachine = ...
     def __init__(
         self,
@@ -47,7 +47,7 @@ class Directive:
         lineno: int,
         content_offset: int,
         block_text: str,
-        state: RSTState[Incomplete],
+        state: RSTState,
         state_machine: RSTStateMachine,
     ) -> None: ...
     def run(self) -> Sequence[nodes.Node]: ...
@@ -61,7 +61,7 @@ class Directive:
     def add_name(self, node: nodes.Node) -> None: ...
 
 _DirectiveFn: TypeAlias = Callable[
-    [str, list[str], dict[str, Any], StringList, int, int, str, RSTState[Incomplete], RSTStateMachine], Directive
+    [str, list[str], dict[str, Any], StringList, int, int, str, RSTState, RSTStateMachine], Directive
 ]
 
 def convert_directive_function(directive_fn: _DirectiveFn) -> type[Directive]: ...

--- a/stubs/docutils/docutils/parsers/rst/states.pyi
+++ b/stubs/docutils/docutils/parsers/rst/states.pyi
@@ -2,20 +2,18 @@ from _typeshed import Incomplete
 from collections.abc import Callable, Sequence
 from re import Match, Pattern
 from types import ModuleType
-from typing import Any, TypeVar
+from typing import Any
 from typing_extensions import TypeAlias
 
 from docutils import nodes
 from docutils.statemachine import StateMachineWS, StateWS
 from docutils.utils import Reporter
 
-_Context = TypeVar("_Context")
-
 class Struct:
     def __init__(self, **keywordargs) -> None: ...
 
-class RSTState(StateWS[_Context]):
-    nested_sm: type[StateMachineWS[_Context]]
+class RSTState(StateWS[list[str]]):
+    nested_sm: type[StateMachineWS[list[str]]]
     nested_sm_cache: Incomplete
     nested_sm_kwargs: Incomplete
     def __init__(self, state_machine, debug: bool = False) -> None: ...


### PR DESCRIPTION
removes an unneeded generic from docutils `RSTState`.

see the discussion in https://github.com/sphinx-doc/sphinx/pull/12511