### PR TITLE
Update `zipfile` for 3.13

### DIFF
--- a/stdlib/@tests/stubtest_allowlists/py313.txt
+++ b/stdlib/@tests/stubtest_allowlists/py313.txt
@@ -122,9 +122,6 @@ tkinter.Text.count
 tkinter.Wm.wm_attributes
 trace.CoverageResults.write_results
 types.MappingProxyType.get
-zipfile.CompleteDirs.inject
-zipfile.ZipInfo.compress_level
-zipfile._path.CompleteDirs.inject
 
 # ======================================
 # Pre-existing errors from Python <=3.12

--- a/stdlib/zipfile/__init__.pyi
+++ b/stdlib/zipfile/__init__.pyi
@@ -206,6 +206,9 @@ class ZipInfo:
     compress_size: int
     file_size: int
     orig_filename: str  # undocumented
+    if sys.version_info >= (3, 13):
+        compress_level: int | None
+
     def __init__(self, filename: str = "NoName", date_time: _DateTuple = (1980, 1, 1, 0, 0, 0)) -> None: ...
     @classmethod
     def from_file(cls, filename: StrPath, arcname: StrPath | None = None, *, strict_timestamps: bool = True) -> Self: ...

--- a/stdlib/zipfile/_path.pyi
+++ b/stdlib/zipfile/_path.pyi
@@ -26,6 +26,7 @@ if sys.version_info >= (3, 12):
         @classmethod
         def make(cls, source: StrPath | IO[bytes]) -> Self: ...
         if sys.version_info >= (3, 13):
+            @classmethod
             def inject(cls, zf: _ZF) -> _ZF: ...
 
     class Path:

--- a/stdlib/zipfile/_path.pyi
+++ b/stdlib/zipfile/_path.pyi
@@ -3,11 +3,13 @@ from _typeshed import StrPath
 from collections.abc import Iterator, Sequence
 from io import TextIOWrapper
 from os import PathLike
-from typing import IO, Literal, overload
+from typing import IO, Literal, TypeVar, overload
 from typing_extensions import Self, TypeAlias
 from zipfile import ZipFile
 
 _ReadWriteBinaryMode: TypeAlias = Literal["r", "w", "rb", "wb"]
+
+_ZF = TypeVar("_ZF", bound=ZipFile)
 
 if sys.version_info >= (3, 12):
     class InitializedState:
@@ -23,6 +25,8 @@ if sys.version_info >= (3, 12):
         @overload
         @classmethod
         def make(cls, source: StrPath | IO[bytes]) -> Self: ...
+        if sys.version_info >= (3, 13):
+            def inject(cls, zf: _ZF) -> _ZF: ...
 
     class Path:
         root: CompleteDirs


### PR DESCRIPTION
Add in the new `inject` method, and the a new `compress_level` property for `ZipInfo`.