### PR TITLE
`SRE_FLAG_TEMPLATE` removed in 3.13

### DIFF
--- a/stdlib/@tests/stubtest_allowlists/py313.txt
+++ b/stdlib/@tests/stubtest_allowlists/py313.txt
@@ -90,9 +90,6 @@ pstats.FunctionProfile.__replace__
 pstats.StatsProfile.__replace__
 site.gethistoryfile
 site.register_readline
-sre_compile.SRE_FLAG_TEMPLATE
-sre_constants.SRE_FLAG_TEMPLATE
-sre_parse.SRE_FLAG_TEMPLATE
 tkinter.Misc.after_info
 tkinter.Misc.busy
 tkinter.Misc.busy_cget

--- a/stdlib/sre_constants.pyi
+++ b/stdlib/sre_constants.pyi
@@ -30,7 +30,8 @@ AT_LOCALE: dict[_NamedIntConstant, _NamedIntConstant]
 AT_UNICODE: dict[_NamedIntConstant, _NamedIntConstant]
 CH_LOCALE: dict[_NamedIntConstant, _NamedIntConstant]
 CH_UNICODE: dict[_NamedIntConstant, _NamedIntConstant]
-SRE_FLAG_TEMPLATE: int
+if sys.version_info < (3, 13):
+    SRE_FLAG_TEMPLATE: int
 SRE_FLAG_IGNORECASE: int
 SRE_FLAG_LOCALE: int
 SRE_FLAG_MULTILINE: int


### PR DESCRIPTION
Remove unused constant in 3.13.