### PR TITLE
Pin `croniter` to 2.0.6

### DIFF
--- a/stubs/croniter/METADATA.toml
+++ b/stubs/croniter/METADATA.toml
@@ -1,2 +1,2 @@
-version = "2.0.*"
+version = "2.0.6"
 upstream_repository = "https://github.com/kiorky/croniter"


### PR DESCRIPTION
Looks like we had two `croniter` releases in quick succession. Let's just pin to 2.0.6 for now.

Fixes #12355