### PR TITLE
Add dimensions for openpyxl Image.

### DIFF
--- a/stubs/openpyxl/openpyxl/drawing/image.pyi
+++ b/stubs/openpyxl/openpyxl/drawing/image.pyi
@@ -14,6 +14,8 @@ PILImage: ModuleType | Literal[False]
 class Image:
     anchor: str
     ref: _PILImageImage | _PILImageFilePath
+    width: int
+    height: int
     format: str
     def __init__(self, img: _PILImageImage | _PILImageFilePath) -> None: ...
     @property


### PR DESCRIPTION
`Image` has `height` and `width` set in the constructor, but they are missing from the stub.