### PR TITLE
Add `os.waitid` for macos in 3.13

### DIFF
--- a/stdlib/@tests/stubtest_allowlists/darwin-py313.txt
+++ b/stdlib/@tests/stubtest_allowlists/darwin-py313.txt
@@ -18,8 +18,6 @@ os.grantpt
 os.posix_openpt
 os.ptsname
 os.unlockpt
-os.waitid
-os.waitid_result
 posix.grantpt
 posix.posix_openpt
 posix.ptsname

--- a/stdlib/os/__init__.pyi
+++ b/stdlib/os/__init__.pyi
@@ -971,7 +971,8 @@ else:
     def spawnvp(mode: int, file: StrOrBytesPath, args: _ExecVArgs) -> int: ...
     def spawnvpe(mode: int, file: StrOrBytesPath, args: _ExecVArgs, env: _ExecEnv) -> int: ...
     def wait() -> tuple[int, int]: ...  # Unix only
-    if sys.platform != "darwin":
+    # Added to MacOS in 3.13
+    if sys.platform != "darwin" or sys.version_info >= (3, 13):
         @final
         class waitid_result(structseq[int], tuple[int, int, int, int, int]):
             if sys.version_info >= (3, 10):


### PR DESCRIPTION
`os.waitid` and `os.waitid_result` were added for MacOS in 3.13