### PR TITLE
Fix `syslog` 3.13 issues

### DIFF
--- a/stdlib/@tests/stubtest_allowlists/linux-py313.txt
+++ b/stdlib/@tests/stubtest_allowlists/linux-py313.txt
@@ -42,8 +42,4 @@ posix.timerfd_settime_ns
 readline.backend
 stat.SF_SUPPORTED
 stat.SF_SYNTHETIC
-syslog.LOG_INSTALL
-syslog.LOG_LAUNCHD
-syslog.LOG_NETINFO
-syslog.LOG_RAS
-syslog.LOG_REMOTEAUTH
+

--- a/stdlib/@tests/stubtest_allowlists/linux-py313.txt
+++ b/stdlib/@tests/stubtest_allowlists/linux-py313.txt
@@ -42,4 +42,3 @@ posix.timerfd_settime_ns
 readline.backend
 stat.SF_SUPPORTED
 stat.SF_SYNTHETIC
-

--- a/stdlib/syslog.pyi
+++ b/stdlib/syslog.pyi
@@ -38,11 +38,13 @@ if sys.platform != "win32":
 
     if sys.version_info >= (3, 13):
         LOG_FTP: Final = 88
-        LOG_INSTALL: Final = 112
-        LOG_LAUNCHD: Final = 192
-        LOG_NETINFO: Final = 96
-        LOG_RAS: Final = 120
-        LOG_REMOTEAUTH: Final = 104
+
+        if sys.platform == "darwin":
+            LOG_INSTALL: Final = 112
+            LOG_LAUNCHD: Final = 192
+            LOG_NETINFO: Final = 96
+            LOG_RAS: Final = 120
+            LOG_REMOTEAUTH: Final = 104
 
     def LOG_MASK(pri: int, /) -> int: ...
     def LOG_UPTO(pri: int, /) -> int: ...


### PR DESCRIPTION
The following constants don't exist in the Linux kernel, and the constant definitions match what we have in xnu: https://opensource.apple.com/source/xnu/xnu-201.5/bsd/sys/syslog.h.auto.html