### PR TITLE
Bump setuptools to 71.1.* and mark `pkg_resources` as obsolete

### DIFF
--- a/stubs/setuptools/METADATA.toml
+++ b/stubs/setuptools/METADATA.toml
@@ -1,5 +1,9 @@
-version = "71.0.*"
+version = "71.1.*"
 upstream_repository = "https://github.com/pypa/setuptools"
+extra_description = """\
+If using `setuptools >= 71.1` *only* for `pkg_resources`,
+you don't need `types-setuptools` since `pkg_resources` is now typed.\
+"""
 
 [tool.stubtest]
 # darwin is equivalent to linux for OS-specific methods

--- a/stubs/setuptools/pkg_resources/__init__.pyi
+++ b/stubs/setuptools/pkg_resources/__init__.pyi
@@ -1,3 +1,6 @@
+# `pkg_resources` package of `types-setuptools` is now obsolete.
+# Changes here should be mirrored to https://github.com/pypa/setuptools/tree/main/pkg_resources
+
 import types
 import zipimport
 from _typeshed import BytesPath, Incomplete, StrOrBytesPath, StrPath, Unused


### PR DESCRIPTION
As of https://setuptools.pypa.io/en/latest/history.html#v71-1-0 , `pkg_resources` is marked as `py.typed`.
I can't really use the `obsolete_since` marker, but I think an `extra_description` is good enough.

Closes #12399