### PR TITLE
ExifReader: Fix `Reader.__iter__()`

### DIFF
--- a/stubs/ExifRead/exifread/_types.pyi
+++ b/stubs/ExifRead/exifread/_types.pyi
@@ -1,6 +1,7 @@
 # Stubs-only module with type aliases for ExifRead.
 
-from typing import Any, Iterator, Literal, Protocol
+from collections.abc import Iterator
+from typing import Any, Literal, Protocol
 from typing_extensions import TypeAlias
 
 # The second item of the value tuple - if it exists - can be a variety of types,

--- a/stubs/ExifRead/exifread/_types.pyi
+++ b/stubs/ExifRead/exifread/_types.pyi
@@ -1,6 +1,6 @@
 # Stubs-only module with type aliases for ExifRead.
 
-from typing import Any, Literal, Iterator, Protocol
+from typing import Any, Iterator, Literal, Protocol
 from typing_extensions import TypeAlias
 
 # The second item of the value tuple - if it exists - can be a variety of types,

--- a/stubs/ExifRead/exifread/_types.pyi
+++ b/stubs/ExifRead/exifread/_types.pyi
@@ -1,6 +1,6 @@
 # Stubs-only module with type aliases for ExifRead.
 
-from typing import Any, Literal, Protocol
+from typing import Any, Literal, Iterator, Protocol
 from typing_extensions import TypeAlias
 
 # The second item of the value tuple - if it exists - can be a variety of types,
@@ -8,7 +8,7 @@ from typing_extensions import TypeAlias
 TagDict: TypeAlias = dict[int, tuple[str] | tuple[str, Any]]
 
 class Reader(Protocol):
-    def __iter__(self) -> bytes: ...
+    def __iter__(self) -> Iterator[bytes]: ...
     def read(self, size: int, /) -> bytes: ...
     def tell(self) -> int: ...
     def seek(self, offset: int, whence: Literal[0, 1] = ..., /) -> object: ...


### PR DESCRIPTION
Changes return type for `Reader.__iter__()` from `bytes` to `Iterator[bytes]`.

**Related Issues:**

- Closes #12371