### PR TITLE
Use Final for `unittest` constants

### DIFF
--- a/stdlib/unittest/case.pyi
+++ b/stdlib/unittest/case.pyi
@@ -1,3 +1,4 @@
+from typing import Final
 import logging
 import sys
 import unittest.result
@@ -22,7 +23,7 @@ _E = TypeVar("_E", bound=BaseException)
 _FT = TypeVar("_FT", bound=Callable[..., Any])
 _P = ParamSpec("_P")
 
-DIFF_OMITTED: str
+DIFF_OMITTED: Final[str]
 
 class _BaseTestCaseContext:
     test_case: TestCase

--- a/stdlib/unittest/case.pyi
+++ b/stdlib/unittest/case.pyi
@@ -1,4 +1,3 @@
-from typing import Final
 import logging
 import sys
 import unittest.result
@@ -7,7 +6,20 @@ from collections.abc import Callable, Container, Iterable, Mapping, Sequence, Se
 from contextlib import AbstractContextManager
 from re import Pattern
 from types import TracebackType
-from typing import Any, AnyStr, ClassVar, Generic, NamedTuple, NoReturn, Protocol, SupportsAbs, SupportsRound, TypeVar, overload
+from typing import (
+    Any,
+    AnyStr,
+    ClassVar,
+    Final,
+    Generic,
+    NamedTuple,
+    NoReturn,
+    Protocol,
+    SupportsAbs,
+    SupportsRound,
+    TypeVar,
+    overload,
+)
 from typing_extensions import ParamSpec, Self, TypeAlias
 from warnings import WarningMessage
 

--- a/stdlib/unittest/loader.pyi
+++ b/stdlib/unittest/loader.pyi
@@ -1,11 +1,10 @@
-from typing import Final
 import sys
 import unittest.case
 import unittest.suite
 from collections.abc import Callable, Sequence
 from re import Pattern
 from types import ModuleType
-from typing import Any
+from typing import Any, Final
 from typing_extensions import TypeAlias, deprecated
 
 _SortComparisonMethod: TypeAlias = Callable[[str, str], int]

--- a/stdlib/unittest/loader.pyi
+++ b/stdlib/unittest/loader.pyi
@@ -1,3 +1,4 @@
+from typing import Final
 import sys
 import unittest.case
 import unittest.suite
@@ -10,7 +11,7 @@ from typing_extensions import TypeAlias, deprecated
 _SortComparisonMethod: TypeAlias = Callable[[str, str], int]
 _SuiteClass: TypeAlias = Callable[[list[unittest.case.TestCase]], unittest.suite.TestSuite]
 
-VALID_MODULE_NAME: Pattern[str]
+VALID_MODULE_NAME: Final[Pattern[str]]
 
 class TestLoader:
     errors: list[type[BaseException]]

--- a/stdlib/unittest/main.pyi
+++ b/stdlib/unittest/main.pyi
@@ -1,3 +1,4 @@
+from typing import Final
 import sys
 import unittest.case
 import unittest.loader
@@ -8,8 +9,8 @@ from types import ModuleType
 from typing import Any, Protocol
 from typing_extensions import deprecated
 
-MAIN_EXAMPLES: str
-MODULE_EXAMPLES: str
+MAIN_EXAMPLES: Final[str]
+MODULE_EXAMPLES: Final[str]
 
 class _TestRunner(Protocol):
     def run(self, test: unittest.suite.TestSuite | unittest.case.TestCase, /) -> unittest.result.TestResult: ...

--- a/stdlib/unittest/main.pyi
+++ b/stdlib/unittest/main.pyi
@@ -1,4 +1,3 @@
-from typing import Final
 import sys
 import unittest.case
 import unittest.loader
@@ -6,7 +5,7 @@ import unittest.result
 import unittest.suite
 from collections.abc import Iterable
 from types import ModuleType
-from typing import Any, Protocol
+from typing import Any, Final, Protocol
 from typing_extensions import deprecated
 
 MAIN_EXAMPLES: Final[str]

--- a/stdlib/unittest/result.pyi
+++ b/stdlib/unittest/result.pyi
@@ -1,3 +1,4 @@
+from typing import Final
 import sys
 import unittest.case
 from _typeshed import OptExcInfo
@@ -8,8 +9,8 @@ from typing_extensions import TypeAlias
 _F = TypeVar("_F", bound=Callable[..., Any])
 _DurationsType: TypeAlias = list[tuple[str, float]]
 
-STDOUT_LINE: str
-STDERR_LINE: str
+STDOUT_LINE: Final[str]
+STDERR_LINE: Final[str]
 
 # undocumented
 def failfast(method: _F) -> _F: ...

--- a/stdlib/unittest/result.pyi
+++ b/stdlib/unittest/result.pyi
@@ -1,9 +1,8 @@
-from typing import Final
 import sys
 import unittest.case
 from _typeshed import OptExcInfo
 from collections.abc import Callable
-from typing import Any, TextIO, TypeVar
+from typing import Any, Final, TextIO, TypeVar
 from typing_extensions import TypeAlias
 
 _F = TypeVar("_F", bound=Callable[..., Any])

--- a/stdlib/unittest/util.pyi
+++ b/stdlib/unittest/util.pyi
@@ -1,6 +1,5 @@
-from typing import Final
 from collections.abc import MutableSequence, Sequence
-from typing import Any, TypeVar
+from typing import Any, Final, TypeVar
 from typing_extensions import TypeAlias
 
 _T = TypeVar("_T")

--- a/stdlib/unittest/util.pyi
+++ b/stdlib/unittest/util.pyi
@@ -1,3 +1,4 @@
+from typing import Final
 from collections.abc import MutableSequence, Sequence
 from typing import Any, TypeVar
 from typing_extensions import TypeAlias
@@ -5,12 +6,12 @@ from typing_extensions import TypeAlias
 _T = TypeVar("_T")
 _Mismatch: TypeAlias = tuple[_T, _T, int]
 
-_MAX_LENGTH: int
-_PLACEHOLDER_LEN: int
-_MIN_BEGIN_LEN: int
-_MIN_END_LEN: int
-_MIN_COMMON_LEN: int
-_MIN_DIFF_LEN: int
+_MAX_LENGTH: Final[int]
+_PLACEHOLDER_LEN: Final[int]
+_MIN_BEGIN_LEN: Final[int]
+_MIN_END_LEN: Final[int]
+_MIN_COMMON_LEN: Final[int]
+_MIN_DIFF_LEN: Final[int]
 
 def _shorten(s: str, prefixlen: int, suffixlen: int) -> str: ...
 def _common_shorten_repr(*args: str) -> tuple[str, ...]: ...


### PR DESCRIPTION
Use Final for all `unittest` constants except https://docs.python.org/3/library/unittest.mock.html#default and https://docs.python.org/3/library/unittest.mock.html#filter-dir, which are documented and make sense to override in cases.