### PR TITLE
Use Final for `multiprocessing` constants

### DIFF
--- a/stdlib/multiprocessing/forkserver.pyi
+++ b/stdlib/multiprocessing/forkserver.pyi
@@ -1,12 +1,12 @@
 from _typeshed import FileDescriptorLike, Unused
 from collections.abc import Sequence
 from struct import Struct
-from typing import Any
+from typing import Any, Final
 
 __all__ = ["ensure_running", "get_inherited_fds", "connect_to_new_process", "set_forkserver_preload"]
 
-MAXFDS_TO_SEND: int
-SIGNED_STRUCT: Struct
+MAXFDS_TO_SEND: Final = 256
+SIGNED_STRUCT: Final[Struct]
 
 class ForkServer:
     def set_forkserver_preload(self, modules_names: list[str]) -> None: ...

--- a/stdlib/multiprocessing/popen_spawn_win32.pyi
+++ b/stdlib/multiprocessing/popen_spawn_win32.pyi
@@ -1,3 +1,4 @@
+from typing import Final
 import sys
 from multiprocessing.process import BaseProcess
 from typing import ClassVar
@@ -7,10 +8,10 @@ from .util import Finalize
 if sys.platform == "win32":
     __all__ = ["Popen"]
 
-    TERMINATE: int
-    WINEXE: bool
-    WINSERVICE: bool
-    WINENV: bool
+    TERMINATE: Final[int]
+    WINEXE: Final[bool]
+    WINSERVICE: Final[bool]
+    WINENV: Final[bool]
 
     class Popen:
         finalizer: Finalize

--- a/stdlib/multiprocessing/popen_spawn_win32.pyi
+++ b/stdlib/multiprocessing/popen_spawn_win32.pyi
@@ -1,7 +1,6 @@
-from typing import Final
 import sys
 from multiprocessing.process import BaseProcess
-from typing import ClassVar
+from typing import ClassVar, Final
 
 from .util import Finalize
 

--- a/stdlib/multiprocessing/reduction.pyi
+++ b/stdlib/multiprocessing/reduction.pyi
@@ -15,7 +15,7 @@ if sys.platform == "win32":
 else:
     __all__ = ["send_handle", "recv_handle", "ForkingPickler", "register", "dump", "DupFd", "sendfds", "recvfds"]
 
-HAVE_SEND_HANDLE: bool
+HAVE_SEND_HANDLE: Final[bool]
 
 class ForkingPickler(pickle.Pickler):
     dispatch_table: _DispatchTableType

--- a/stdlib/multiprocessing/spawn.pyi
+++ b/stdlib/multiprocessing/spawn.pyi
@@ -1,3 +1,4 @@
+from typing import Final
 from collections.abc import Mapping, Sequence
 from types import ModuleType
 from typing import Any
@@ -12,8 +13,8 @@ __all__ = [
     "import_main_path",
 ]
 
-WINEXE: bool
-WINSERVICE: bool
+WINEXE: Final[bool]
+WINSERVICE: Final[bool]
 
 def set_executable(exe: str) -> None: ...
 def get_executable() -> str: ...

--- a/stdlib/multiprocessing/spawn.pyi
+++ b/stdlib/multiprocessing/spawn.pyi
@@ -1,7 +1,6 @@
-from typing import Final
 from collections.abc import Mapping, Sequence
 from types import ModuleType
-from typing import Any
+from typing import Any, Final
 
 __all__ = [
     "_main",

--- a/stdlib/multiprocessing/util.pyi
+++ b/stdlib/multiprocessing/util.pyi
@@ -1,9 +1,8 @@
-from typing import Final
 import threading
 from _typeshed import ConvertibleToInt, Incomplete, Unused
 from collections.abc import Callable, Iterable, Mapping, MutableMapping, Sequence
 from logging import Logger, _Level as _LoggingLevel
-from typing import Any, Generic, TypeVar, overload
+from typing import Any, Final, Generic, TypeVar, overload
 
 __all__ = [
     "sub_debug",

--- a/stdlib/multiprocessing/util.pyi
+++ b/stdlib/multiprocessing/util.pyi
@@ -1,3 +1,4 @@
+from typing import Final
 import threading
 from _typeshed import ConvertibleToInt, Incomplete, Unused
 from collections.abc import Callable, Iterable, Mapping, MutableMapping, Sequence
@@ -25,14 +26,14 @@ __all__ = [
 _T = TypeVar("_T")
 _R_co = TypeVar("_R_co", default=Any, covariant=True)
 
-NOTSET: int
-SUBDEBUG: int
-DEBUG: int
-INFO: int
-SUBWARNING: int
+NOTSET: Final[int]
+SUBDEBUG: Final[int]
+DEBUG: Final[int]
+INFO: Final[int]
+SUBWARNING: Final[int]
 
-LOGGER_NAME: str
-DEFAULT_LOGGING_FORMAT: str
+LOGGER_NAME: Final[str]
+DEFAULT_LOGGING_FORMAT: Final[str]
 
 def sub_debug(msg: object, *args: object) -> None: ...
 def debug(msg: object, *args: object) -> None: ...
@@ -92,7 +93,7 @@ class ForkAwareThreadLock:
 
 class ForkAwareLocal(threading.local): ...
 
-MAXFD: int
+MAXFD: Final[int]
 
 def close_all_fds_except(fds: Iterable[int]) -> None: ...
 def spawnv_passfds(path: bytes, args: Sequence[ConvertibleToInt], passfds: Sequence[int]) -> int: ...


### PR DESCRIPTION
Move `multiprocessing` constants to `Final` as none of these constants are documented.