### PR TITLE
Add reexport to RemoteCallbacks in pygit2

### DIFF
--- a/stubs/pygit2/pygit2/__init__.pyi
+++ b/stubs/pygit2/pygit2/__init__.pyi
@@ -15,7 +15,7 @@ from .blob import BlobIO as BlobIO
 from .callbacks import (
     CheckoutCallbacks as CheckoutCallbacks,
     Payload as Payload,
-    RemoteCallbacks,
+    RemoteCallbacks as RemoteCallbacks,
     StashApplyCallbacks as StashApplyCallbacks,
     get_credentials as get_credentials,
 )


### PR DESCRIPTION
The [pygit2](https://github.com/python/typeshed/tree/main/stubs/pygit2) stubs package was missing the `as` keyword (`import ... as ...`) for `pygit2.RemoteCallbacks` causing it to not be found by mypy.

This PR simply adds this so `RemoteCallbacks` is reexported from the module `pygit2`.