### PR TITLE
Update jsonschema.protocols

### DIFF
--- a/stubs/jsonschema/jsonschema/protocols.pyi
+++ b/stubs/jsonschema/jsonschema/protocols.pyi
@@ -1,29 +1,34 @@
 from _typeshed import Incomplete
 from collections.abc import Iterator, Mapping, Sequence
 from typing import ClassVar, Protocol
-from typing_extensions import TypeAlias
+from typing_extensions import TypeAlias, deprecated
 
+from jsonschema import _typing
 from jsonschema._format import FormatChecker
 from jsonschema._types import TypeChecker
 from jsonschema.exceptions import ValidationError
 from jsonschema.validators import RefResolver
+import referencing
 
 _JsonParameter: TypeAlias = str | int | float | bool | None | Mapping[str, _JsonParameter] | Sequence[_JsonParameter]
 
 class Validator(Protocol):
-    META_SCHEMA: ClassVar[dict[Incomplete, Incomplete]]
-    VALIDATORS: ClassVar[dict[Incomplete, Incomplete]]
+    META_SCHEMA: ClassVar[Mapping[Incomplete, Incomplete]]
+    VALIDATORS: ClassVar[Mapping[Incomplete, Incomplete]g]
     TYPE_CHECKER: ClassVar[TypeChecker]
     FORMAT_CHECKER: ClassVar[FormatChecker]
-    schema: dict[Incomplete, Incomplete] | bool
+    ID_OF: _typing.id_of
+    schema: Mapping[Incomplete, Incomplete] | bool
     def __init__(
         self,
-        schema: dict[Incomplete, Incomplete] | bool,
+        schema: Mapping[Incomplete, Incomplete] | bool,
+        registry: referencing.jsonschema.SchemaRegistry,
+        @deprecated("'RefResolver' has been deprecated in favor of 'referencing'")
         resolver: RefResolver | None = None,
         format_checker: FormatChecker | None = None,
     ) -> None: ...
     @classmethod
-    def check_schema(cls, schema: dict[Incomplete, Incomplete]) -> None: ...
+    def check_schema(cls, schema: Mapping[Incomplete, Incomplete]) -> None: ...
     def is_type(self, instance: _JsonParameter, type: str) -> bool: ...
     def is_valid(self, instance: _JsonParameter) -> bool: ...
     def iter_errors(self, instance: _JsonParameter) -> Iterator[ValidationError]: ...


### PR DESCRIPTION
I'm very inexperienced with type annotations so I hope my conclusions were correct. Recently, when working on a project using jsonschema I had trouble with the following error raised by mypy:

     error: Unexpected keyword argument "registry" for "Validator"  [call-arg]

However, ever since [jsonschema 4.18](https://github.com/python-jsonschema/jsonschema/blob/main/CHANGELOG.rst#v4180) ([commit](https://github.com/python-jsonschema/jsonschema/commit/e8266294408521daf38d879ba35c45a4b0ef5180#diff-ed969da06a0d21d851d46136a2a642ddf6bd28d9a5988a2077307926000cafa0)), the Validator protocol's `__init__()` method has a a `registry` parameter. 

From what I gather, the `protocols.pyi` stubs were never updated to reflect this change.

I basically only copied the signatures from the current version to `protocols.pyi`. Here's hoping that's what I'm supposed to do.