### PR TITLE
Enforce handling `sys.std{in,out,err} is None`

### DIFF
--- a/stdlib/sys/__init__.pyi
+++ b/stdlib/sys/__init__.pyi
@@ -1,5 +1,5 @@
 import sys
-from _typeshed import MaybeNone, OptExcInfo, ProfileFunction, TraceFunction, structseq
+from _typeshed import OptExcInfo, ProfileFunction, TraceFunction, structseq
 from _typeshed.importlib import MetaPathFinderProtocol, PathEntryFinderProtocol
 from builtins import object as _object
 from collections.abc import AsyncGenerator, Callable, Sequence
@@ -64,9 +64,9 @@ ps2: object
 #
 # if isinstance(sys.stdout, io.TextIOWrapper):
 #    sys.stdout.reconfigure(...)
-stdin: TextIO | MaybeNone
-stdout: TextIO | MaybeNone
-stderr: TextIO | MaybeNone
+stdin: TextIO | None
+stdout: TextIO | None
+stderr: TextIO | None
 
 if sys.version_info >= (3, 10):
     stdlib_module_names: frozenset[str]


### PR DESCRIPTION
Not sure if this will float but I thought I'd give it a go anyway...

As per the [Python docs](https://docs.python.org/3/library/sys.html#sys.__stderr__), the standard streams can be None (see https://github.com/python/cpython/issues/122633?notification_referrer_id=NT_kwDOAdgearQxMTc4OTE2ODgyNzozMDk0MDc3OA#issuecomment-2267146355 for a list of possible circumstances). The current usage of MaybeNone causes a false negative, which is a shame because spreading the little known knowledge that `sys.stderr.write()` is broken code is something that type checkers would otherwise be ideal at.