### PR TITLE
Update `argparse.BooleanOptionalAction` for 3.14

### DIFF
--- a/stdlib/argparse.pyi
+++ b/stdlib/argparse.pyi
@@ -357,7 +357,18 @@ class Action(_AttributeHolder):
 
 if sys.version_info >= (3, 12):
     class BooleanOptionalAction(Action):
-        if sys.version_info >= (3, 13):
+        if sys.version_info >= (3, 14):
+            def __init__(
+                self,
+                option_strings: Sequence[str],
+                dest: str,
+                default: bool | None = None,
+                *,
+                required: bool = False,
+                help: str | None = None,
+                deprecated: bool = False,
+            ) -> None: ...
+        elif sys.version_info >= (3, 13):
             @overload
             def __init__(
                 self,

--- a/stdlib/argparse.pyi
+++ b/stdlib/argparse.pyi
@@ -363,7 +363,6 @@ if sys.version_info >= (3, 12):
                 option_strings: Sequence[str],
                 dest: str,
                 default: bool | None = None,
-                *,
                 required: bool = False,
                 help: str | None = None,
                 deprecated: bool = False,


### PR DESCRIPTION
Remove the deprecated overload for 3.14: https://docs.python.org/es/dev/whatsnew/3.14.html#argparse