### PR TITLE
`tkinter`: add suggested `Listbox` `selectmode`s

### DIFF
--- a/stdlib/tkinter/__init__.pyi
+++ b/stdlib/tkinter/__init__.pyi
@@ -2148,11 +2148,12 @@ class Listbox(Widget, XView, YView):
         selectborderwidth: _ScreenUnits = 0,
         selectforeground: str = ...,
         # from listbox man page: "The value of the [selectmode] option may be
-        # arbitrary, but the default bindings expect it to be ..."
+        # arbitrary, but the default bindings expect it to be either single,
+        # browse, multiple, or extended"
         #
         # I have never seen anyone setting this to something else than what
         # "the default bindings expect", but let's support it anyway.
-        selectmode: str = "browse",
+        selectmode: Literal["single", "browse", "multiple", "extended"] | str = "browse",
         setgrid: bool = False,
         state: Literal["normal", "disabled"] = "normal",
         takefocus: _TakeFocusValue = "",

--- a/stdlib/tkinter/__init__.pyi
+++ b/stdlib/tkinter/__init__.pyi
@@ -2153,7 +2153,7 @@ class Listbox(Widget, XView, YView):
         #
         # I have never seen anyone setting this to something else than what
         # "the default bindings expect", but let's support it anyway.
-        selectmode: str | Literal["single", "browse", "multiple", "extended"] = "browse", # noqa: Y051
+        selectmode: str | Literal["single", "browse", "multiple", "extended"] = "browse",  # noqa: Y051
         setgrid: bool = False,
         state: Literal["normal", "disabled"] = "normal",
         takefocus: _TakeFocusValue = "",
@@ -2188,7 +2188,7 @@ class Listbox(Widget, XView, YView):
         selectbackground: str = ...,
         selectborderwidth: _ScreenUnits = ...,
         selectforeground: str = ...,
-        selectmode: str | Literal["single", "browse", "multiple", "extended"] | str = ..., # noqa: Y051
+        selectmode: str | Literal["single", "browse", "multiple", "extended"] = ...,  # noqa: Y051
         setgrid: bool = ...,
         state: Literal["normal", "disabled"] = ...,
         takefocus: _TakeFocusValue = ...,

--- a/stdlib/tkinter/__init__.pyi
+++ b/stdlib/tkinter/__init__.pyi
@@ -2153,7 +2153,7 @@ class Listbox(Widget, XView, YView):
         #
         # I have never seen anyone setting this to something else than what
         # "the default bindings expect", but let's support it anyway.
-        selectmode: Literal["single", "browse", "multiple", "extended"] | str = "browse",
+        selectmode: str | Literal["single", "browse", "multiple", "extended"] = "browse", # noqa: Y051
         setgrid: bool = False,
         state: Literal["normal", "disabled"] = "normal",
         takefocus: _TakeFocusValue = "",
@@ -2188,7 +2188,7 @@ class Listbox(Widget, XView, YView):
         selectbackground: str = ...,
         selectborderwidth: _ScreenUnits = ...,
         selectforeground: str = ...,
-        selectmode: str = ...,
+        selectmode: str | Literal["single", "browse", "multiple", "extended"] | str = ..., # noqa: Y051
         setgrid: bool = ...,
         state: Literal["normal", "disabled"] = ...,
         takefocus: _TakeFocusValue = ...,


### PR DESCRIPTION
There are common options (that are almost always used) for the Listbox `selectmode`, these are taken from the docs here https://tcl.tk/man/tcl8.6/TkCmd/listbox.htm#M9

My making the selectmode `Literal[...] | str` typecheckers will pass any string, but e.g. vscode will suggest the literal options.