### PR TITLE
Fix inferred type of `is_dataclass(Any)`

### DIFF
--- a/stdlib/@tests/test_cases/check_dataclasses.py
+++ b/stdlib/@tests/test_cases/check_dataclasses.py
@@ -41,6 +41,21 @@ if dc.is_dataclass(f):
     assert_type(f, Foo)
 
 
+def is_dataclass_any(arg: Any) -> None:
+    if dc.is_dataclass(arg):
+        assert_type(arg, DataclassInstance | type[DataclassInstance])
+
+
+def is_dataclass_object(arg: object) -> None:
+    if dc.is_dataclass(arg):
+        assert_type(arg, DataclassInstance | type[DataclassInstance])
+
+
+def is_dataclass_type(arg: type) -> None:
+    if dc.is_dataclass(arg):
+        assert_type(arg, type[DataclassInstance])
+
+
 def check_other_isdataclass_overloads(x: type, y: object) -> None:
     # TODO: pyright correctly emits an error on this, but mypy does not -- why?
     # dc.fields(x)

--- a/stdlib/@tests/test_cases/check_dataclasses.py
+++ b/stdlib/@tests/test_cases/check_dataclasses.py
@@ -43,17 +43,17 @@ if dc.is_dataclass(f):
 
 def is_dataclass_any(arg: Any) -> None:
     if dc.is_dataclass(arg):
-        assert_type(arg, DataclassInstance | type[DataclassInstance])
+        assert_type(arg, Union["DataclassInstance", Type["DataclassInstance"]])
 
 
 def is_dataclass_object(arg: object) -> None:
     if dc.is_dataclass(arg):
-        assert_type(arg, DataclassInstance | type[DataclassInstance])
+        assert_type(arg, Union["DataclassInstance", Type["DataclassInstance"]])
 
 
 def is_dataclass_type(arg: type) -> None:
     if dc.is_dataclass(arg):
-        assert_type(arg, type[DataclassInstance])
+        assert_type(arg, Type["DataclassInstance"])
 
 
 def check_other_isdataclass_overloads(x: type, y: object) -> None:

--- a/stdlib/dataclasses.pyi
+++ b/stdlib/dataclasses.pyi
@@ -5,7 +5,7 @@ from _typeshed import DataclassInstance
 from builtins import type as Type  # alias to avoid name clashes with fields named "type"
 from collections.abc import Callable, Iterable, Mapping
 from typing import Any, Generic, Literal, Protocol, TypeVar, overload
-from typing_extensions import TypeAlias, TypeIs
+from typing_extensions import Never, TypeAlias, TypeIs
 
 if sys.version_info >= (3, 9):
     from types import GenericAlias
@@ -213,6 +213,10 @@ else:
     ) -> Any: ...
 
 def fields(class_or_instance: DataclassInstance | type[DataclassInstance]) -> tuple[Field[Any], ...]: ...
+
+# HACK: `obj: Never` typing matches if object argument is using `Any` type.
+@overload
+def is_dataclass(obj: Never) -> TypeIs[DataclassInstance | type[DataclassInstance]]: ...  # type: ignore[narrowed-type-not-subtype]  # pyright: ignore[reportGeneralTypeIssues]
 @overload
 def is_dataclass(obj: type) -> TypeIs[type[DataclassInstance]]: ...
 @overload


### PR DESCRIPTION
Fixes #12401 by adding a hack, in the form of overload `def is_dataclass(obj: Never)` -- because `Any` is compatible with `Never`, but no real type is.

Previously `is_dataclass(Any)` matched the wrong overload rule and inferred incorrect return type.
