### PR TITLE
more precise timezone-aware deprecation message

### DIFF
--- a/stdlib/datetime.pyi
+++ b/stdlib/datetime.pyi
@@ -2,7 +2,6 @@ import sys
 from abc import abstractmethod
 from time import struct_time
 from typing import ClassVar, Final, NamedTuple, NoReturn, SupportsIndex, final, overload
-
 from typing_extensions import Self, TypeAlias, deprecated
 
 if sys.version_info >= (3, 11):

--- a/stdlib/datetime.pyi
+++ b/stdlib/datetime.pyi
@@ -2,6 +2,7 @@ import sys
 from abc import abstractmethod
 from time import struct_time
 from typing import ClassVar, Final, NamedTuple, NoReturn, SupportsIndex, final, overload
+
 from typing_extensions import Self, TypeAlias, deprecated
 
 if sys.version_info >= (3, 11):
@@ -265,12 +266,12 @@ class datetime(date):
         def fromtimestamp(cls, timestamp: float, /, tz: _TzInfo | None = ...) -> Self: ...
 
     @classmethod
-    @deprecated("Use timezone-aware objects to represent datetimes in UTC; e.g. by calling .fromtimestamp(datetime.UTC)")
+    @deprecated("Use timezone-aware objects to represent datetimes in UTC; e.g. by calling .fromtimestamp(datetime.timezone.utc)")
     def utcfromtimestamp(cls, t: float, /) -> Self: ...
     @classmethod
     def now(cls, tz: _TzInfo | None = None) -> Self: ...
     @classmethod
-    @deprecated("Use timezone-aware objects to represent datetimes in UTC; e.g. by calling .now(datetime.UTC)")
+    @deprecated("Use timezone-aware objects to represent datetimes in UTC; e.g. by calling .now(datetime.timezone.utc)")
     def utcnow(cls) -> Self: ...
     @classmethod
     def combine(cls, date: _Date, time: _Time, tzinfo: _TzInfo | None = ...) -> Self: ...


### PR DESCRIPTION
First time contributor here. Please correct or reject if not needed.

This pull request is to address the imprecise deprecation messages regarding timezone-aware datetime objects

Issue: #12328 