### PR TITLE
[February 2025] flake8-2020 is an archived repo

### DIFF
--- a/stubs/flake8-2020/METADATA.toml
+++ b/stubs/flake8-2020/METADATA.toml
@@ -1,2 +1,3 @@
 version = "1.8.*"
 upstream_repository = "https://github.com/asottile/flake8-2020"
+no_longer_updated = true


### PR DESCRIPTION
flake8-2020 is archived: https://github.com/asottile-archive/flake8-2020#archived & https://github.com/asottile-archive/flake8-2020#archived

Following our [Third-party library removal policy](https://github.com/python/typeshed/blob/main/CONTRIBUTING.md#third-party-library-removal-policy) and https://github.com/python/typeshed/pull/12538#issuecomment-2294940947, this should be merged in 6 months, then removed after the next run of stub_uploader.