### PR TITLE
Fix DatagramRequestHandler.packet type hint.

### DIFF
--- a/stdlib/socketserver.pyi
+++ b/stdlib/socketserver.pyi
@@ -162,7 +162,7 @@ class StreamRequestHandler(BaseRequestHandler):
     wfile: BinaryIO
 
 class DatagramRequestHandler(BaseRequestHandler):
-    packet: _socket  # undocumented
+    packet: bytes  # undocumented
     socket: _socket  # undocumented
     rfile: BinaryIO
     wfile: BinaryIO


### PR DESCRIPTION
Fixed `DatagramRequestHandler.packet` type hint to be `bytes`. `typeshed` is currently typing it as a `socket`.

In Python's stdlib, `packet` is set in the following code located in socketserver.py.

```Python
class DatagramRequestHandler(BaseRequestHandler):

    """Define self.rfile and self.wfile for datagram sockets."""

    def setup(self):
        from io import BytesIO
        self.packet, self.socket = self.request
        self.rfile = BytesIO(self.packet)
        self.wfile = BytesIO()
```

`self.packet` is the first element in the `self.request` tuple which is a `typedshed._RequestType`.

```Python
_RequestType: TypeAlias = _socket | tuple[bytes, _socket]
```

Additionally, in the `setup()` method shown above `self.packet` is being passed to `BytesIO()`, so it is definitely a `bytes` object.
