### PR TITLE
Add `__call__` attribute to `function`

### DIFF
--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -991,6 +991,7 @@ class function:
         __type_params__: tuple[TypeVar | ParamSpec | TypeVarTuple, ...]
 
     __module__: str
+    def __call__(self, *args: Any, **kwargs: Any) -> Any: ...
     # mypy uses `builtins.function.__get__` to represent methods, properties, and getset_descriptors so we type the return as Any.
     def __get__(self, instance: object, owner: type | None = None, /) -> Any: ...
 


### PR DESCRIPTION
I guess the lack of this attribute causes mypy and pyright to emit a false positive error for the following code.

```python
def a(): pass
a.__call__
```

mypy:
```
file.py:2: error: "Callable[[], Any]" not callable  [operator]
```

pyright:
```
file.py
  file.py:2:3 - error: Cannot access attribute "__call__" for class "function"
    Attribute "__call__" is unknown (reportFunctionMemberAccess)
```