### PR TITLE
Fix 'volumes' argument type hint for 'run' and 'create' functions in containers.pyi

### DIFF
--- a/stubs/docker/docker/models/containers.pyi
+++ b/stubs/docker/docker/models/containers.pyi
@@ -203,7 +203,7 @@ class ContainerCollection(Collection[Container]):
         uts_mode: str | None = None,
         version: str | None = None,
         volume_driver: str | None = None,
-        volumes: dict[str, str] | list[str] | None = None,
+        volumes: dict[str, dict[str, str]] | list[str] | None = None,
         volumes_from: list[str] | None = None,
         working_dir: str | None = None,
     ) -> bytes: ...  # TODO: This should return a stream, if `stream` is True
@@ -298,7 +298,7 @@ class ContainerCollection(Collection[Container]):
         uts_mode: str | None = None,
         version: str | None = None,
         volume_driver: str | None = None,
-        volumes: dict[str, str] | list[str] | None = None,
+        volumes: dict[str, dict[str, str]] | list[str] | None = None,
         volumes_from: list[str] | None = None,
         working_dir: str | None = None,
     ) -> Container: ...
@@ -389,7 +389,7 @@ class ContainerCollection(Collection[Container]):
         uts_mode: str | None = None,
         version: str | None = None,
         volume_driver: str | None = None,
-        volumes: dict[str, str] | list[str] | None = None,
+        volumes: dict[str, dict[str, str]] | list[str] | None = None,
         volumes_from: list[str] | None = None,
         working_dir: str | None = None,
     ) -> Container: ...


### PR DESCRIPTION
Instead of `dict[str, str] | ...` the `volumes` keyword argument accepts `dict[str, dict[str, str]] | ...` in **./docker/models/containers.pyi**

see documentation: [docker-py.readthedocs.io/en/stable/containers.html](https://docker-py.readthedocs.io/en/stable/containers.html#docker.models.containers.ContainerCollection.run) (at the moment version 7.1, but it is the same for older version too)
```
volumes (dict or list) –

A dictionary to configure volumes mounted inside the container. The key is either the host path or a volume name, and the value is a dictionary with the keys:

    bind The path to mount the volume inside the container

    mode Either rw to mount the volume read/write, or ro to mount it read-only.

For example:

{'/home/user1/': {'bind': '/mnt/vol2', 'mode': 'rw'},
 '/var/www': {'bind': '/mnt/vol1', 'mode': 'ro'}}
```
