### PR TITLE
Fix signature of `CodecInfo.decode`

### DIFF
--- a/stdlib/codecs.pyi
+++ b/stdlib/codecs.pyi
@@ -80,7 +80,7 @@ class _Encoder(Protocol):
     def __call__(self, input: str, errors: str = ..., /) -> tuple[bytes, int]: ...  # signature of Codec().encode
 
 class _Decoder(Protocol):
-    def __call__(self, input: bytes, errors: str = ..., /) -> tuple[str, int]: ...  # signature of Codec().decode
+    def __call__(self, input: memoryview, errors: str = ..., /) -> tuple[str, int]: ...  # signature of Codec().decode
 
 class _StreamReader(Protocol):
     def __call__(self, stream: _ReadableStream, errors: str = ..., /) -> StreamReader: ...

--- a/stdlib/codecs.pyi
+++ b/stdlib/codecs.pyi
@@ -80,7 +80,7 @@ class _Encoder(Protocol):
     def __call__(self, input: str, errors: str = ..., /) -> tuple[bytes, int]: ...  # signature of Codec().encode
 
 class _Decoder(Protocol):
-    def __call__(self, input: memoryview, errors: str = ..., /) -> tuple[str, int]: ...  # signature of Codec().decode
+    def __call__(self, input: ReadableBuffer, errors: str = ..., /) -> tuple[str, int]: ...  # signature of Codec().decode
 
 class _StreamReader(Protocol):
     def __call__(self, stream: _ReadableStream, errors: str = ..., /) -> StreamReader: ...


### PR DESCRIPTION
Closes #10656 

I ran into the same issue recently. The actual type of input is `memoryview` which tripped me up because I was calling `input.decode("utf-8")` which of course fails for a `memoryview`.