### PR TITLE
Filter pytype tests by stdlib/VERSIONS file

### DIFF
--- a/tests/_utils.py
+++ b/tests/_utils.py
@@ -132,6 +132,14 @@ def parse_stdlib_versions_file() -> SupportedVersionsDict:
     return result
 
 
+def supported_versions_for_module(module_versions: SupportedVersionsDict, module_name: str) -> tuple[VersionTuple, VersionTuple]:
+    while "." in module_name:
+        if module_name in module_versions:
+            return module_versions[module_name]
+        module_name = ".".join(module_name.split(".")[:-1])
+    return module_versions[module_name]
+
+
 def _parse_version(v_str: str) -> tuple[int, int]:
     m = VERSION_RE.match(v_str)
     assert m, f"invalid version: {v_str}"

--- a/tests/mypy_test.py
+++ b/tests/mypy_test.py
@@ -26,8 +26,6 @@ from _utils import (
     PYTHON_VERSION,
     STDLIB_PATH,
     TESTS_DIR,
-    SupportedVersionsDict,
-    VersionTuple,
     colored,
     get_gitignore_spec,
     get_mypy_req,
@@ -35,6 +33,7 @@ from _utils import (
     print_error,
     print_success_msg,
     spec_matches_path,
+    supported_versions_for_module,
     venv_python,
 )
 
@@ -373,14 +372,6 @@ def stdlib_module_name_from_path(path: Path) -> str:
         # TODO: Python 3.9+: Use removesuffix.
         parts.append(path.parts[-1][:-4])
     return ".".join(parts)
-
-
-def supported_versions_for_module(module_versions: SupportedVersionsDict, module_name: str) -> tuple[VersionTuple, VersionTuple]:
-    while "." in module_name:
-        if module_name in module_versions:
-            return module_versions[module_name]
-        module_name = ".".join(module_name.split(".")[:-1])
-    return module_versions[module_name]
 
 
 @dataclass

--- a/tests/pytype_test.py
+++ b/tests/pytype_test.py
@@ -25,7 +25,7 @@ from collections.abc import Iterable, Sequence
 from packaging.requirements import Requirement
 
 from _metadata import read_dependencies
-from _utils import SupportedVersionsDict, VersionTuple, parse_stdlib_versions_file
+from _utils import SupportedVersionsDict, parse_stdlib_versions_file, supported_versions_for_module
 
 if sys.platform == "win32":
     print("pytype does not support Windows.", file=sys.stderr)
@@ -158,16 +158,8 @@ def _is_supported_stdlib_version(module_versions: SupportedVersionsDict, filenam
     if parts[0] != "stdlib":
         return True
     module_name = _get_module_name(filename)
-    min_version, max_version = _supported_versions_for_module(module_versions, module_name)
+    min_version, max_version = supported_versions_for_module(module_versions, module_name)
     return min_version <= sys.version_info <= max_version
-
-
-def _supported_versions_for_module(module_versions: SupportedVersionsDict, module_name: str) -> tuple[VersionTuple, VersionTuple]:
-    while "." in module_name:
-        if module_name in module_versions:
-            return module_versions[module_name]
-        module_name = ".".join(module_name.split(".")[:-1])
-    return module_versions[module_name]
 
 
 def _get_pkgs_associated_with_requirement(req_name: str) -> list[str]:

--- a/tests/pytype_test.py
+++ b/tests/pytype_test.py
@@ -25,6 +25,7 @@ from collections.abc import Iterable, Sequence
 from packaging.requirements import Requirement
 
 from _metadata import read_dependencies
+from _utils import SupportedVersionsDict, VersionTuple, parse_stdlib_versions_file
 
 if sys.platform == "win32":
     print("pytype does not support Windows.", file=sys.stderr)
@@ -123,16 +124,19 @@ def check_subdirs_discoverable(subdir_paths: list[str]) -> None:
 
 
 def determine_files_to_test(*, paths: Sequence[str]) -> list[str]:
-    """Determine all files to test, checking if it's in the exclude list and which Python versions to use.
+    """Determine all files to test.
 
-    Returns a list of pairs of the file path and Python version as an int."""
+    Checks for files in the pytype exclude list and for the stdlib VERSIONS file.
+    """
     filenames = find_stubs_in_paths(paths)
     ts = typeshed.Typeshed()
-    skipped = set(ts.read_blacklist())
+    exclude_list = set(ts.read_blacklist())
+    stdlib_module_versions = parse_stdlib_versions_file()
     files = []
     for f in sorted(filenames):
-        rel = _get_relative(f)
-        if rel in skipped:
+        if _get_relative(f) in exclude_list:
+            continue
+        if not _is_supported_stdlib_version(stdlib_module_versions, f):
             continue
         files.append(f)
     return files
@@ -147,6 +151,23 @@ def find_stubs_in_paths(paths: Sequence[str]) -> list[str]:
         else:
             filenames.append(path)
     return filenames
+
+
+def _is_supported_stdlib_version(module_versions: SupportedVersionsDict, filename: str) -> bool:
+    parts = _get_relative(filename).split(os.path.sep)
+    if parts[0] != "stdlib":
+        return True
+    module_name = _get_module_name(filename)
+    min_version, max_version = _supported_versions_for_module(module_versions, module_name)
+    return min_version <= sys.version_info <= max_version
+
+
+def _supported_versions_for_module(module_versions: SupportedVersionsDict, module_name: str) -> tuple[VersionTuple, VersionTuple]:
+    while "." in module_name:
+        if module_name in module_versions:
+            return module_versions[module_name]
+        module_name = ".".join(module_name.split(".")[:-1])
+    return module_versions[module_name]
 
 
 def _get_pkgs_associated_with_requirement(req_name: str) -> list[str]:
@@ -208,9 +229,9 @@ def run_all_tests(*, files_to_test: Sequence[str], print_stderr: bool, dry_run: 
     errors = 0
     total_tests = len(files_to_test)
     missing_modules = get_missing_modules(files_to_test)
+    python_version = f"{sys.version_info.major}.{sys.version_info.minor}"
     print("Testing files with pytype...")
     for i, f in enumerate(files_to_test):
-        python_version = f"{sys.version_info.major}.{sys.version_info.minor}"
         if dry_run:
             stderr = None
         else:


### PR DESCRIPTION
Filter the files to run pytype tests on by stdlib/VERSIONS file. This becomes important for Python 3.12, where e.g. checking asynchat.pyi requires asyncore.pyi, both of which have been removed in 3.12.

The implementation was copied from mypy_test.py and adapted to fit into the existing pytype test setup.

---

We're in the process of releasing a new pytype version, which will include basic support for Python 3.12. (I plan to send a separate PR for that soon.) When running pytype_test.py with that new version under 3.12 we saw errors like

```
stdlib/asynchat.pyi (3.12): pytype.load_pytd.BadDependencyError: Can't find pyi for 'asyncore', referenced from 'asynchat'
```

As far as I understand the fix is to not run on stdlib/asynchat.pyi in the first place.