### PR TITLE
Update pytype to 2024.09.13 and Python 3.12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,8 +41,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          # Max supported Python version as of pytype 2024.2.27.
-          python-version: "3.11"
+          # Max supported Python version as of pytype 2024.9.13.
+          python-version: "3.12"
       - name: Install uv
         run: curl -LsSf https://astral.sh/uv/install.sh | sh
       - run: uv pip install -r requirements-tests.txt --system

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -8,7 +8,7 @@ flake8-pyi==24.6.0       # must match .pre-commit-config.yaml
 mypy==1.11.1
 pre-commit-hooks==4.6.0  # must match .pre-commit-config.yaml
 pyright==1.1.379
-pytype==2024.4.11; platform_system != "Windows" and python_version < "3.12"
+pytype==2024.9.13; platform_system != "Windows" and python_version < "3.13"
 ruff==0.5.4              # must match .pre-commit-config.yaml
 
 # Libraries used by our various scripts.

--- a/tests/README.md
+++ b/tests/README.md
@@ -73,8 +73,8 @@ for this script.
 
 Note: this test cannot be run on Windows
 systems unless you are using Windows Subsystem for Linux.
-It also requires a Python version < 3.11 as pytype does not yet support
-Python 3.11 and above.
+It also requires a Python version < 3.13 as pytype does not yet support
+Python 3.13 and above.
 
 Run using:
 ```bash

--- a/tests/pytype_test.py
+++ b/tests/pytype_test.py
@@ -30,8 +30,8 @@ from _utils import SupportedVersionsDict, parse_stdlib_versions_file, supported_
 if sys.platform == "win32":
     print("pytype does not support Windows.", file=sys.stderr)
     sys.exit(1)
-if sys.version_info >= (3, 12):
-    print("pytype does not support Python 3.12+ yet.", file=sys.stderr)
+if sys.version_info >= (3, 13):
+    print("pytype does not support Python 3.13+ yet.", file=sys.stderr)
     sys.exit(1)
 
 # pytype is not py.typed https://github.com/google/pytype/issues/1325


### PR DESCRIPTION
pytype 2024.09.13 got released today and includes basic support for Python 3.12.

`python tests/pytype_test.py` runs successfully under Python 3.12 with the new version.