### PR TITLE
Correct requests `cookies` argument

### DIFF
--- a/stubs/requests/requests/api.pyi
+++ b/stubs/requests/requests/api.pyi
@@ -1,9 +1,10 @@
 from _typeshed import Incomplete
 from collections.abc import Mapping
+from http.cookiejar import CookieJar
 from typing_extensions import TypeAlias
 
 from .models import Response
-from .sessions import RequestsCookieJar, _Auth, _Cert, _Data, _Files, _HooksInput, _Params, _TextMapping, _Timeout, _Verify
+from .sessions import _Auth, _Cert, _Data, _Files, _HooksInput, _Params, _TextMapping, _Timeout, _Verify
 
 _HeadersMapping: TypeAlias = Mapping[str, str | bytes | None]
 
@@ -14,7 +15,7 @@ def request(
     params: _Params | None = ...,
     data: _Data | None = ...,
     headers: _HeadersMapping | None = ...,
-    cookies: RequestsCookieJar | _TextMapping | None = ...,
+    cookies: CookieJar | _TextMapping | None = ...,
     files: _Files | None = ...,
     auth: _Auth | None = ...,
     timeout: _Timeout | None = ...,
@@ -32,7 +33,7 @@ def get(
     *,
     data: _Data | None = ...,
     headers: _HeadersMapping | None = ...,
-    cookies: RequestsCookieJar | _TextMapping | None = ...,
+    cookies: CookieJar | _TextMapping | None = ...,
     files: _Files | None = ...,
     auth: _Auth | None = ...,
     timeout: _Timeout | None = ...,
@@ -50,7 +51,7 @@ def options(
     params: _Params | None = ...,
     data: _Data | None = ...,
     headers: _HeadersMapping | None = ...,
-    cookies: RequestsCookieJar | _TextMapping | None = ...,
+    cookies: CookieJar | _TextMapping | None = ...,
     files: _Files | None = ...,
     auth: _Auth | None = ...,
     timeout: _Timeout | None = ...,
@@ -68,7 +69,7 @@ def head(
     params: _Params | None = ...,
     data: _Data | None = ...,
     headers: _HeadersMapping | None = ...,
-    cookies: RequestsCookieJar | _TextMapping | None = ...,
+    cookies: CookieJar | _TextMapping | None = ...,
     files: _Files | None = ...,
     auth: _Auth | None = ...,
     timeout: _Timeout | None = ...,
@@ -87,7 +88,7 @@ def post(
     *,
     params: _Params | None = ...,
     headers: _HeadersMapping | None = ...,
-    cookies: RequestsCookieJar | _TextMapping | None = ...,
+    cookies: CookieJar | _TextMapping | None = ...,
     files: _Files | None = ...,
     auth: _Auth | None = ...,
     timeout: _Timeout | None = ...,
@@ -104,7 +105,7 @@ def put(
     *,
     params: _Params | None = ...,
     headers: _HeadersMapping | None = ...,
-    cookies: RequestsCookieJar | _TextMapping | None = ...,
+    cookies: CookieJar | _TextMapping | None = ...,
     files: _Files | None = ...,
     auth: _Auth | None = ...,
     timeout: _Timeout | None = ...,
@@ -122,7 +123,7 @@ def patch(
     *,
     params: _Params | None = ...,
     headers: _HeadersMapping | None = ...,
-    cookies: RequestsCookieJar | _TextMapping | None = ...,
+    cookies: CookieJar | _TextMapping | None = ...,
     files: _Files | None = ...,
     auth: _Auth | None = ...,
     timeout: _Timeout | None = ...,
@@ -140,7 +141,7 @@ def delete(
     params: _Params | None = ...,
     data: _Data | None = ...,
     headers: _HeadersMapping | None = ...,
-    cookies: RequestsCookieJar | _TextMapping | None = ...,
+    cookies: CookieJar | _TextMapping | None = ...,
     files: _Files | None = ...,
     auth: _Auth | None = ...,
     timeout: _Timeout | None = ...,


### PR DESCRIPTION
Utilize `http.cookiejar.CookieJar` instead of the internal `RequestsCookieJar`.

Fixes: https://github.com/python/typeshed/issues/12593