### PR TITLE
Remove `_msi` in 3.13

### DIFF
--- a/stdlib/@tests/stubtest_allowlists/darwin-py310.txt
+++ b/stdlib/@tests/stubtest_allowlists/darwin-py310.txt
@@ -2,5 +2,6 @@ webbrowser.MacOSX.__init__
 
 # Doesn't exist on macos:
 spwd
+_msi
 msilib(.[a-z]+)?
 ossaudiodev

--- a/stdlib/@tests/stubtest_allowlists/darwin-py311.txt
+++ b/stdlib/@tests/stubtest_allowlists/darwin-py311.txt
@@ -11,6 +11,7 @@ webbrowser.MacOSX.__init__
 
 # Doesn't exist on macos:
 spwd
+_msi
 msilib(.[a-z]+)?
 ossaudiodev
 

--- a/stdlib/@tests/stubtest_allowlists/darwin-py312.txt
+++ b/stdlib/@tests/stubtest_allowlists/darwin-py312.txt
@@ -11,6 +11,7 @@ webbrowser.MacOSX.__init__
 
 # Doesn't exist on macos:
 spwd
+_msi
 msilib(.[a-z]+)?
 ossaudiodev
 

--- a/stdlib/@tests/stubtest_allowlists/darwin-py38.txt
+++ b/stdlib/@tests/stubtest_allowlists/darwin-py38.txt
@@ -2,5 +2,6 @@ webbrowser.MacOSX.__init__
 
 # Doesn't exist on macos:
 spwd
+_msi
 msilib(.[a-z]+)?
 ossaudiodev

--- a/stdlib/@tests/stubtest_allowlists/darwin-py39.txt
+++ b/stdlib/@tests/stubtest_allowlists/darwin-py39.txt
@@ -5,4 +5,3 @@ spwd
 _msi
 msilib(.[a-z]+)?
 ossaudiodev
-

--- a/stdlib/@tests/stubtest_allowlists/darwin-py39.txt
+++ b/stdlib/@tests/stubtest_allowlists/darwin-py39.txt
@@ -2,5 +2,7 @@ webbrowser.MacOSX.__init__
 
 # Doesn't exist on macos:
 spwd
+_msi
 msilib(.[a-z]+)?
 ossaudiodev
+

--- a/stdlib/@tests/stubtest_allowlists/darwin.txt
+++ b/stdlib/@tests/stubtest_allowlists/darwin.txt
@@ -34,7 +34,6 @@ _ctypes.dlsym
 # ==========
 
 # Modules that do not exist on macos systems
-_msi
 _winapi
 asyncio.windows_events
 asyncio.windows_utils

--- a/stdlib/@tests/stubtest_allowlists/linux-py310.txt
+++ b/stdlib/@tests/stubtest_allowlists/linux-py310.txt
@@ -1,2 +1,3 @@
 # doesn't exist on linux
+_msi
 msilib(.[a-z]+)?

--- a/stdlib/@tests/stubtest_allowlists/linux-py311.txt
+++ b/stdlib/@tests/stubtest_allowlists/linux-py311.txt
@@ -1,2 +1,3 @@
 # doesn't exist on linux
+_msi
 msilib(.[a-z]+)?

--- a/stdlib/@tests/stubtest_allowlists/linux-py312.txt
+++ b/stdlib/@tests/stubtest_allowlists/linux-py312.txt
@@ -1,2 +1,3 @@
 # doesn't exist on linux
+_msi
 msilib(.[a-z]+)?

--- a/stdlib/@tests/stubtest_allowlists/linux-py38.txt
+++ b/stdlib/@tests/stubtest_allowlists/linux-py38.txt
@@ -3,4 +3,5 @@
 select.epoll.register
 
 # doesn't exist on linux
+_msi
 msilib(.[a-z]+)?

--- a/stdlib/@tests/stubtest_allowlists/linux-py39.txt
+++ b/stdlib/@tests/stubtest_allowlists/linux-py39.txt
@@ -3,4 +3,5 @@
 select.epoll.register
 
 # doesn't exist on linux
+_msi
 msilib(.[a-z]+)?

--- a/stdlib/@tests/stubtest_allowlists/linux.txt
+++ b/stdlib/@tests/stubtest_allowlists/linux.txt
@@ -17,7 +17,6 @@ _ctypes.dlsym
 # ==========
 
 # Modules that do not exist on Linux systems
-_msi
 _winapi
 asyncio.windows_events
 asyncio.windows_utils

--- a/stdlib/@tests/stubtest_allowlists/win32-py313.txt
+++ b/stdlib/@tests/stubtest_allowlists/win32-py313.txt
@@ -1,5 +1,4 @@
 # New in py313 (triage these!)
-_msi
 _winapi.BatchedWaitForMultipleObjects
 _winapi.CreateEventW
 _winapi.CreateMutexW

--- a/stdlib/VERSIONS
+++ b/stdlib/VERSIONS
@@ -41,7 +41,7 @@ _json: 3.0-
 _locale: 3.0-
 _lsprof: 3.0-
 _markupbase: 3.0-
-_msi: 3.0-
+_msi: 3.0-3.12
 _operator: 3.4-
 _osx_support: 3.0-
 _posixsubprocess: 3.2-


### PR DESCRIPTION
`_msi` was removed with the removal of `msilib`.