### PR TITLE
Optional pytype install on Windows (no CI)

### DIFF
--- a/.github/workflows/meta_tests.yml
+++ b/.github/workflows/meta_tests.yml
@@ -52,8 +52,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          # Max supported Python version as of pytype 2024.2.27.
-          python-version: "3.11"
+          python-version: "3.12"
       - run: curl -LsSf https://astral.sh/uv/install.sh | sh
       - run: uv pip install -r requirements-tests.txt --system
       - name: Run pyright on typeshed
@@ -61,7 +60,7 @@ jobs:
         with:
           version: PATH
           python-platform: ${{ matrix.python-platform }}
-          python-version: "3.9" # The Python version to test against.
+          python-version: "3.9" # Oldest version supported for running scripts and tests
           project: ./pyrightconfig.scripts_and_tests.json
   stubsabot-dry-run:
     name: Stubsabot dry run

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          # Max supported Python version as of pytype 2024.9.13.
+          # Max supported Python version as of pytype 2024.9.13
           python-version: "3.12"
       - name: Install uv
         run: curl -LsSf https://astral.sh/uv/install.sh | sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,6 @@ range of Python users and Python codebases. If you're trying a type
 checker on your Python code, your experience and what you can contribute
 are important to the project's success.
 
-
 ## The contribution process at a glance
 
 1. [Prepare your environment](#preparing-the-environment).
@@ -51,10 +50,10 @@ please refer to this
 
 Note that some tests require extra setup steps to install the required dependencies.
 
-### Linux/Mac OS
+### Linux/Mac OS/WSL
 
 On Linux and Mac OS, you will be able to run the full test suite on Python
-3.9, 3.10, or 3.11.
+3.9-3.12.
 To install the necessary requirements, run the following commands from a
 terminal window:
 
@@ -67,22 +66,20 @@ $ source .venv/bin/activate
 
 ### Windows
 
-If you are using a Windows operating system, you will not be able to run the pytype
-tests, as pytype
-[does not currently support running on Windows](https://github.com/google/pytype#requirements).
-One option is to install
-[Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/faq),
-which will allow you to run the full suite of tests. If you choose to install
-WSL, follow the Linux/Mac OS instructions above.
-
-If you do not wish to install WSL, run the following commands from a Windows
-terminal to install all non-pytype requirements:
+Run the following commands from a Windows terminal to install all requirements:
 
 ```powershell
 > python -m venv .venv
-> .venv\scripts\activate
+> .venv\Scripts\activate
 (.venv) > pip install -U pip
 (.venv) > pip install -r "requirements-tests.txt"
+```
+
+To be able to run pytype tests, you'll also need to install it manually
+as it's currently excluded from the requirements file:
+
+```powershell
+(.venv) > pip install -U pytype
 ```
 
 ## Code formatting

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -8,6 +8,7 @@ flake8-pyi==24.6.0       # must match .pre-commit-config.yaml
 mypy==1.11.1
 pre-commit-hooks==4.6.0  # must match .pre-commit-config.yaml
 pyright==1.1.379
+# pytype can be installed on Windows, but requires building wheels, let's not do that on the CI
 pytype==2024.9.13; platform_system != "Windows" and python_version < "3.13"
 ruff==0.5.4              # must match .pre-commit-config.yaml
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -71,9 +71,7 @@ for this script.
 
 ## pytype\_test.py
 
-Note: this test cannot be run on Windows
-systems unless you are using Windows Subsystem for Linux.
-It also requires a Python version < 3.13 as pytype does not yet support
+Note: This test cannot be run on Python version < 3.13 as pytype does not yet support
 Python 3.13 and above.
 
 Run using:

--- a/tests/pytype_test.py
+++ b/tests/pytype_test.py
@@ -14,29 +14,32 @@ will also discover incorrect usage of imported modules.
 
 from __future__ import annotations
 
+import sys
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    assert sys.platform != "win32", "pytype isn't yet installed in CI, but wheels can be built on Windows"
+if sys.version_info >= (3, 13):
+    print("pytype does not support Python 3.13+ yet.", file=sys.stderr)
+    sys.exit(1)
+
+
 import argparse
 import importlib.metadata
+import importlib.util
 import inspect
 import os
-import sys
 import traceback
 from collections.abc import Iterable, Sequence
 
 from packaging.requirements import Requirement
 
-from _metadata import read_dependencies
-from _utils import SupportedVersionsDict, parse_stdlib_versions_file, supported_versions_for_module
-
-if sys.platform == "win32":
-    print("pytype does not support Windows.", file=sys.stderr)
-    sys.exit(1)
-if sys.version_info >= (3, 13):
-    print("pytype does not support Python 3.13+ yet.", file=sys.stderr)
-    sys.exit(1)
-
 # pytype is not py.typed https://github.com/google/pytype/issues/1325
 from pytype import config as pytype_config, load_pytd  # type: ignore[import]
 from pytype.imports import typeshed  # type: ignore[import]
+
+from _metadata import read_dependencies
+from _utils import SupportedVersionsDict, parse_stdlib_versions_file, supported_versions_for_module
 
 TYPESHED_SUBDIRS = ["stdlib", "stubs"]
 TYPESHED_HOME = "TYPESHED_HOME"

--- a/tests/pytype_test.py
+++ b/tests/pytype_test.py
@@ -26,7 +26,6 @@ if sys.version_info >= (3, 13):
 
 import argparse
 import importlib.metadata
-import importlib.util
 import inspect
 import os
 import traceback

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -7,6 +7,7 @@ import os
 import re
 import subprocess
 import sys
+from importlib.util import find_spec
 from pathlib import Path
 from typing import Any
 
@@ -127,11 +128,11 @@ def main() -> None:
     else:
         print(colored("\nSkipping stubtest since mypy failed.", "yellow"))
 
-    if sys.platform == "win32":
-        print(colored("\nSkipping pytype on Windows. You can run the test with WSL.", "yellow"))
-    else:
+    if find_spec("pytype"):
         print("\nRunning pytype...")
         pytype_result = subprocess.run([sys.executable, "tests/pytype_test.py", path])
+    else:
+        print(colored("\nSkipping pytype on Windows. You need to install it first: `pip install pytype`", "yellow"))
 
     cases_path = test_cases_path(stub if folder == "stubs" else "stdlib")
     if not cases_path.exists():

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -132,7 +132,7 @@ def main() -> None:
         print("\nRunning pytype...")
         pytype_result = subprocess.run([sys.executable, "tests/pytype_test.py", path])
     else:
-        print(colored("\nSkipping pytype on Windows. You need to install it first: `pip install pytype`", "yellow"))
+        print(colored("\nSkipping pytype on Windows. You need to install it first: `pip install pytype`.", "yellow"))
 
     cases_path = test_cases_path(stub if folder == "stubs" else "stdlib")
     if not cases_path.exists():

--- a/tests/typecheck_typeshed.py
+++ b/tests/typecheck_typeshed.py
@@ -69,8 +69,6 @@ def run_mypy_as_subprocess(directory: str, platform: str, version: str) -> Retur
         "--custom-typeshed-dir",
         ".",
     ]
-    if directory == "tests" and platform == "win32":
-        command.extend(["--exclude", "tests/pytype_test.py"])
     result = subprocess.run(command, capture_output=True, text=True)
     if result.stderr:
         print_error(result.stderr)


### PR DESCRIPTION
Similar to https://github.com/python/typeshed/pull/12547 , allowing pytype to be run on Windows, but makes it optional and avoids installing it on the CI (until prebuilt wheels are available). See https://github.com/python/typeshed/pull/12547#issuecomment-2348775900 and https://github.com/google/pytype/pull/1756

Closes #12547 (I think it's obvious from this PR which comments/docs need to be updated or removed once prebuilt wheels are available)