### PR TITLE
Bump xdgenvpy to 3.0.*

### DIFF
--- a/stubs/xdgenvpy/METADATA.toml
+++ b/stubs/xdgenvpy/METADATA.toml
@@ -1,2 +1,2 @@
-version = "2.4.*"
+version = "3.0.*"
 upstream_repository = "https://gitlab.com/deliberist-group/xdgenvpy"

--- a/stubs/xdgenvpy/xdgenvpy/__init__.pyi
+++ b/stubs/xdgenvpy/xdgenvpy/__init__.pyi
@@ -1,3 +1,0 @@
-from xdgenvpy.xdgenv import XDG as XDG, XDGPackage as XDGPackage, XDGPedanticPackage as XDGPedanticPackage
-
-__all__ = ("XDG", "XDGPackage", "XDGPedanticPackage")


### PR DESCRIPTION
Diff: https://gitlab.com/deliberist-group/xdgenvpy/-/compare/release%2F2.4.0...release%2F3.0.0?from_project_id=12517320&straight=false

Closes https://github.com/python/typeshed/pull/12665