### PR TITLE
fix: fpdf2: Allow `"BI"` for `_FontStyle` in `fpdf.pyi`

### DIFF
--- a/stubs/fpdf2/fpdf/fpdf.pyi
+++ b/stubs/fpdf2/fpdf/fpdf.pyi
@@ -67,7 +67,7 @@ __all__ = [
 
 _Orientation: TypeAlias = Literal["", "portrait", "p", "P", "landscape", "l", "L"]
 _Format: TypeAlias = Literal["", "a3", "A3", "a4", "A4", "a5", "A5", "letter", "Letter", "legal", "Legal"]
-_FontStyle: TypeAlias = Literal["", "B", "I"]
+_FontStyle: TypeAlias = Literal["", "B", "I", "BI"]
 _FontStyles: TypeAlias = Literal["", "B", "I", "U", "BU", "UB", "BI", "IB", "IU", "UI", "BIU", "BUI", "IBU", "IUB", "UBI", "UIB"]
 
 FPDF_VERSION: Final[str]


### PR DESCRIPTION
"BI" usage in `FPDF.add_font()`'s `style` parameter (only place where the `_FontStyle` type is used) is supported by fpdf2's code and official documentation. ([doc](https://py-pdf.github.io/fpdf2/Unicode.html#adding-and-using-fonts)) ([code](https://github.com/py-pdf/fpdf2/blob/d9f5d3634ac17b81ba6e3c9e77be6c20c41a339c/fpdf/fpdf.py#L1918))

I believe this was typed incorrectly due to a [vague docstring](https://py-pdf.github.io/fpdf2/fpdf/fpdf.html#fpdf.fpdf.FPDF.add_font), which I'm looking to clarify in [this fpdf2 PR](https://github.com/py-pdf/fpdf2/pull/1263).

Sorry for the small PR but I felt it was appropriate.