### PR TITLE
Fixup some pyright CI configuration details

### DIFF
--- a/.github/workflows/meta_tests.yml
+++ b/.github/workflows/meta_tests.yml
@@ -61,7 +61,6 @@ jobs:
           version: PATH
           python-platform: ${{ matrix.python-platform }}
           python-version: "3.9" # Oldest version supported for running scripts and tests
-          extra-args: --threads
           project: ./pyrightconfig.scripts_and_tests.json
   stubsabot-dry-run:
     name: Stubsabot dry run

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -145,7 +145,6 @@ jobs:
           version: PATH
           python-platform: ${{ matrix.python-platform }}
           python-version: ${{ matrix.python-version }}
-          extra-args: --threads
           annotate: ${{ matrix.python-version == '3.12' && matrix.python-platform == 'Linux' }} # Having each job create the same comment is too noisy.
       - name: Run pyright with stricter settings on some of the stubs
         uses: jakebailey/pyright-action@v2
@@ -153,7 +152,6 @@ jobs:
           version: PATH
           python-platform: ${{ matrix.python-platform }}
           python-version: ${{ matrix.python-version }}
-          extra-args: --threads
           annotate: ${{ matrix.python-version == '3.12' && matrix.python-platform == 'Linux' }} # Having each job create the same comment is too noisy.
           project: ./pyrightconfig.stricter.json
       - name: Run pyright on the test cases
@@ -162,7 +160,6 @@ jobs:
           version: PATH
           python-platform: ${{ matrix.python-platform }}
           python-version: ${{ matrix.python-version }}
-          extra-args: --threads
           annotate: ${{ matrix.python-version == '3.12' && matrix.python-platform == 'Linux' }} # Having each job create the same comment is too noisy.
           project: ./pyrightconfig.testcases.json
 

--- a/pyrightconfig.stricter.json
+++ b/pyrightconfig.stricter.json
@@ -100,7 +100,6 @@
         "stubs/vobject",
         "stubs/workalendar",
         "stubs/wurlitzer",
-        "stubs/xdgenvpy"
     ],
     "typeCheckingMode": "strict",
     // TODO: Complete incomplete stubs

--- a/tests/pyright_test.py
+++ b/tests/pyright_test.py
@@ -37,7 +37,7 @@ def main() -> None:
     # version installed into the virtual environment, due to failures on some
     # platforms. https://github.com/python/typeshed/issues/11614
     os.environ["PYRIGHT_PYTHON_FORCE_VERSION"] = pyright_version
-    command = [npx, f"pyright@{pyright_version}"] + sys.argv[1:] + ["--threads"]
+    command = [npx, f"pyright@{pyright_version}"] + sys.argv[1:]
     print_command(command)
 
     ret = subprocess.run(command).returncode


### PR DESCRIPTION
This reverts commit f0e16b8.

See conversation in #12688: for this repo, it seems like the argument actually makes pyright run slower, rather than faster.

This PR also switches us to use stricter pyright settings for `xdgenvpy` in CI, which fixes https://github.com/AlexWaygood/typeshed-stats/issues/246, fixes https://github.com/AlexWaygood/typeshed-stats/issues/254, fixes https://github.com/AlexWaygood/typeshed-stats/issues/255, fixes https://github.com/AlexWaygood/typeshed-stats/issues/256, fixes https://github.com/AlexWaygood/typeshed-stats/issues/257, fixes https://github.com/AlexWaygood/typeshed-stats/issues/258, fixes https://github.com/AlexWaygood/typeshed-stats/issues/259, fixes https://github.com/AlexWaygood/typeshed-stats/issues/260, fixes https://github.com/AlexWaygood/typeshed-stats/issues/261, fixes https://github.com/AlexWaygood/typeshed-stats/issues/262, fixes https://github.com/AlexWaygood/typeshed-stats/issues/263 and fixes https://github.com/AlexWaygood/typeshed-stats/issues/264
