### PR TITLE
[fpdf2] fix link type to support internal links

### DIFF
--- a/stubs/fpdf2/fpdf/fpdf.pyi
+++ b/stubs/fpdf2/fpdf/fpdf.pyi
@@ -450,7 +450,7 @@ class FPDF(GraphicsStateMixin):
         ln: int | Literal["DEPRECATED"] = "DEPRECATED",
         align: str | Align = ...,
         fill: bool = False,
-        link: str = "",
+        link: str | int = "",
         center: bool = False,
         markdown: bool = False,
         new_x: XPos | str = ...,
@@ -467,7 +467,7 @@ class FPDF(GraphicsStateMixin):
         align: str | Align = ...,
         fill: bool = False,
         split_only: bool = False,
-        link: str = "",
+        link: str | int = "",
         ln: int | Literal["DEPRECATED"] = "DEPRECATED",
         max_line_height: float | None = None,
         markdown: bool = False,
@@ -481,7 +481,7 @@ class FPDF(GraphicsStateMixin):
         padding: int = 0,
     ): ...
     def write(
-        self, h: float | None = None, text: str = "", link: str = "", print_sh: bool = False, wrapmode: WrapMode = ...
+        self, h: float | None = None, text: str = "", link: str | int = "", print_sh: bool = False, wrapmode: WrapMode = ...
     ) -> bool: ...
     def text_columns(
         self,
@@ -507,7 +507,7 @@ class FPDF(GraphicsStateMixin):
         w: float = 0,
         h: float = 0,
         type: str = "",
-        link: str = "",
+        link: str | int = "",
         title: str | None = None,
         alt_text: str | None = None,
         dims: tuple[float, float] | None = None,


### PR DESCRIPTION
Methods with the `link` argument can take an internal link (created via `add_link` which returns an `int`) or an external URL as per their docstring.

The type hint only allows for `str`.

`link` already has the correct type hint:

https://github.com/python/typeshed/blob/a94c927642eda093db226eb3e21c3a4681577f85/stubs/fpdf2/fpdf/fpdf.pyi#L343-L345

`add_link` returns an `int`:

https://github.com/python/typeshed/blob/a94c927642eda093db226eb3e21c3a4681577f85/stubs/fpdf2/fpdf/fpdf.pyi#L341

This PR changes the type hint to `str | int`.