### PR TITLE
paramiko: add `ProxyCommand` to `_SocketLike`

### DIFF
--- a/stubs/paramiko/paramiko/transport.pyi
+++ b/stubs/paramiko/paramiko/transport.pyi
@@ -12,13 +12,14 @@ from paramiko.channel import Channel
 from paramiko.message import Message
 from paramiko.packet import Packetizer
 from paramiko.pkey import PKey
+from paramiko.proxy import ProxyCommand
 from paramiko.server import ServerInterface, SubsystemHandler
 from paramiko.sftp_client import SFTPClient
 from paramiko.ssh_gss import _SSH_GSSAuth
 from paramiko.util import ClosingContextManager
 
 _Addr: TypeAlias = tuple[str, int]
-_SocketLike: TypeAlias = str | _Addr | socket | Channel
+_SocketLike: TypeAlias = str | _Addr | socket | Channel | ProxyCommand
 
 class _KexEngine(Protocol):
     def start_kex(self) -> None: ...


### PR DESCRIPTION
According to https://docs.paramiko.org/en/latest/api/proxy.html, `ProxyCommand` is socket-like.