### PR TITLE
fix: correct headers= kwarg in HTTP[S]Connection

### DIFF
--- a/stdlib/http/client.pyi
+++ b/stdlib/http/client.pyi
@@ -6,7 +6,7 @@ import types
 from _typeshed import ReadableBuffer, SupportsRead, SupportsReadline, WriteableBuffer
 from collections.abc import Callable, Iterable, Iterator, Mapping
 from socket import socket
-from typing import Any, BinaryIO, Protocol, TypeVar, overload
+from typing import Any, BinaryIO, TypeVar, overload
 from typing_extensions import Self, TypeAlias
 
 __all__ = [
@@ -34,11 +34,7 @@ __all__ = [
 _DataType: TypeAlias = SupportsRead[bytes] | Iterable[ReadableBuffer] | ReadableBuffer
 _T = TypeVar("_T")
 _MessageT = TypeVar("_MessageT", bound=email.message.Message)
-
-class _HasEncode(Protocol):
-    def encode(self, encoding: str) -> bytes: ...
-
-_HeaderValue = ReadableBuffer | _HasEncode | int
+_HeaderValue: TypeAlias = ReadableBuffer | str | int
 
 HTTP_PORT: int
 HTTPS_PORT: int
@@ -185,7 +181,7 @@ class HTTPConnection:
     def connect(self) -> None: ...
     def close(self) -> None: ...
     def putrequest(self, method: str, url: str, skip_host: bool = False, skip_accept_encoding: bool = False) -> None: ...
-    def putheader(self, header: str | bytes, *argument: _HeaderValue) -> None: ...
+    def putheader(self, header: str | bytes, *values: _HeaderValue) -> None: ...
     def endheaders(self, message_body: _DataType | None = None, *, encode_chunked: bool = False) -> None: ...
     def send(self, data: _DataType | str) -> None: ...
 

--- a/stdlib/http/client.pyi
+++ b/stdlib/http/client.pyi
@@ -37,7 +37,7 @@ _T = TypeVar("_T")
 _MessageT = TypeVar("_MessageT", bound=email.message.Message)
 
 class _HasEncode(Protocol):
-    def encode(encoding: str) -> bytes: ...
+    def encode(self, encoding: str) -> bytes: ...
 
 _HeaderValue = ReadableBuffer | _HasEncode | int
 

--- a/stdlib/http/client.pyi
+++ b/stdlib/http/client.pyi
@@ -3,6 +3,7 @@ import io
 import ssl
 import sys
 import types
+from typing import Protocol
 from _typeshed import ReadableBuffer, SupportsRead, SupportsReadline, WriteableBuffer
 from collections.abc import Callable, Iterable, Iterator, Mapping
 from socket import socket
@@ -34,6 +35,11 @@ __all__ = [
 _DataType: TypeAlias = SupportsRead[bytes] | Iterable[ReadableBuffer] | ReadableBuffer
 _T = TypeVar("_T")
 _MessageT = TypeVar("_MessageT", bound=email.message.Message)
+
+class _HasEncode(Protocol):
+    def encode(encoding: str) -> bytes: ...
+
+_HeaderValue = ReadableBuffer | _HasEncode | int
 
 HTTP_PORT: int
 HTTPS_PORT: int
@@ -167,7 +173,7 @@ class HTTPConnection:
         method: str,
         url: str,
         body: _DataType | str | None = None,
-        headers: Mapping[str, str] = {},
+        headers: Mapping[str, _HeaderValue] = {},
         *,
         encode_chunked: bool = False,
     ) -> None: ...
@@ -180,7 +186,7 @@ class HTTPConnection:
     def connect(self) -> None: ...
     def close(self) -> None: ...
     def putrequest(self, method: str, url: str, skip_host: bool = False, skip_accept_encoding: bool = False) -> None: ...
-    def putheader(self, header: str | bytes, *argument: str | bytes) -> None: ...
+    def putheader(self, header: str | bytes, *argument: _HeaderValue) -> None: ...
     def endheaders(self, message_body: _DataType | None = None, *, encode_chunked: bool = False) -> None: ...
     def send(self, data: _DataType | str) -> None: ...
 


### PR DESCRIPTION
I've found code in the library that in a nutshell did this:

```py
headers = {}
headers["Content-Length"] = len(data)

an_https_connection.request("PUT", url, data, headers)
```

And the type checker was not happy about an `int` as a header value.
Apparently Python stdlib allows:
- anything with `.encode("ascii")` since Python 3.0
- an int, explicitly, at least since Python 3.2
- anything that can be passed to `bytes.join`, which is a ReadableBuffer in typeshed

References:

https://github.com/python/cpython/blob/v3.0/Lib/http/client.py
https://github.com/python/cpython/blob/6046c5e0298c25515ea58abc8ab87f7413e3f743/Lib/http/client.py#L831-L834

https://github.com/python/cpython/blob/3.2/Lib/http/client.py
https://github.com/python/cpython/blob/076ca6c3c8df3030307e548d9be792ce3c1c6eea/Lib/http/client.py#L961-L966
