### PR TITLE
Support environment markers in requires fields

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,10 +48,11 @@ jobs:
       - run: uv pip install -r requirements-tests.txt --system
       - name: Install external dependencies for 3rd-party stubs
         run: |
-          DEPENDENCIES=$(python tests/get_external_stub_requirements.py)
+          mapfile -t DEPENDENCIES < <( python tests/get_external_stub_requirements.py )
           if [ -n "$DEPENDENCIES" ]; then
-            echo "Installing packages: $DEPENDENCIES"
-            uv pip install $DEPENDENCIES --system
+              echo "Installing packages:"
+              for DEP in "${DEPENDENCIES[@]}"; do echo "  ${DEP}"; done
+              uv pip install "${DEPENDENCIES[@]}" --system
           fi
       - run: uv pip freeze
       - run: ./tests/pytype_test.py --print-stderr
@@ -129,11 +130,14 @@ jobs:
         run: uv venv .venv
       - name: Install 3rd-party stub dependencies
         run: |
-          DEPENDENCIES=$(python tests/get_external_stub_requirements.py)
+          mapfile -t DEPENDENCIES < <( python tests/get_external_stub_requirements.py )
           if [ -n "$DEPENDENCIES" ]; then
-            source .venv/bin/activate
-            echo "Installing packages: $DEPENDENCIES"
-            uv pip install $DEPENDENCIES
+              echo "Installing packages:"
+              for DEP in "${DEPENDENCIES[@]}"; do echo "  ${DEP}"; done
+              # TODO: We need to specify the platform here, but the platforms
+              # strings supported by uv are different from the ones supported by
+              # pyright.
+              uv pip install --python-version ${{ matrix.python-version }} "${DEPENDENCIES[@]}"
           fi
       - name: Activate the isolated venv for the rest of the job
         run: echo "$PWD/.venv/bin" >> $GITHUB_PATH

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -6,6 +6,9 @@
         "stubs",
     ],
     "exclude": [
+        // Stubs that don't work in all Python versions
+        "stubs/seaborn",
+        "stubs/shapely",
         // test cases use a custom config file
         "**/@tests/test_cases",
     ],

--- a/stubs/seaborn/METADATA.toml
+++ b/stubs/seaborn/METADATA.toml
@@ -2,7 +2,15 @@ version = "0.13.2"
 # Requires a version of numpy and matplotlib with a `py.typed` file
 # see https://github.com/python/typeshed/issues/12551
 # on why we need the upper bound for numpy
-requires = ["matplotlib>=3.8", "numpy>=1.20,<2.1.0", "pandas-stubs"]
+#
+# TODO: Specifying the python-version for matplotlib should not be necessary,
+# because of the requires_python field. However, this needs changes to
+# get_typeshed_stub_version.py (see there).
+requires = [
+    "matplotlib>=3.8; python_version>='3.9'",
+    "numpy>=1.20,<2.1.0",
+    "pandas-stubs",
+]
 # matplotlib>=3.8 requires Python >=3.9
 requires_python = ">=3.9"
 upstream_repository = "https://github.com/mwaskom/seaborn"

--- a/tests/README.md
+++ b/tests/README.md
@@ -28,8 +28,8 @@ You can list or install all of a stubs package's external dependencies using the
 (.venv3)$ python tests/get_external_stub_requirements.py <third_party_stub1> <third_party_stub2>  # List external dependencies for <third_party_stub1> and <third_party_stub2>
 (.venv3)$ python tests/get_external_stub_requirements.py  # List external dependencies for all third-party stubs in typeshed
 # Install external dependencies for all third-party stubs in typeshed
-(.venv3)$ DEPENDENCIES=$(python tests/get_external_stub_requirements.py)
-(.venv3)$ if [ -n "$DEPENDENCIES" ]; then pip install $DEPENDENCIES; fi
+(.venv3)$ mapfile -t DEPENDENCIES < <( python tests/get_external_stub_requirements.py )
+(.venv3)$ if [ -n "$DEPENDENCIES" ]; then pip install "${DEPENDENCIES[@]}"; fi
 ```
 
 ## Run all tests for a specific stub

--- a/tests/_metadata.py
+++ b/tests/_metadata.py
@@ -289,8 +289,6 @@ def read_metadata(distribution: str) -> StubMetadata:
 
 def parse_requires(distribution: str, req: object) -> Requirement:
     assert isinstance(req, str), f"Invalid requirement {req!r} for {distribution!r}"
-    for space in " \t\n":
-        assert space not in req, f"For consistency, requirement should not have whitespace: {req!r}"
     return Requirement(req)
 
 

--- a/tests/get_external_stub_requirements.py
+++ b/tests/get_external_stub_requirements.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 
+# TODO: It should be possible to specify the Python version and platform
+# and limit the output to the packages that are compatible with that version
+# and platform.
+
 from __future__ import annotations
 
 import os

--- a/tests/pytype_test.py
+++ b/tests/pytype_test.py
@@ -163,7 +163,12 @@ def _is_supported_stdlib_version(module_versions: SupportedVersionsDict, filenam
 
 
 def _get_pkgs_associated_with_requirement(req_name: str) -> list[str]:
-    dist = importlib.metadata.distribution(req_name)
+    try:
+        dist = importlib.metadata.distribution(req_name)
+    except importlib.metadata.PackageNotFoundError:
+        # The package wasn't installed, probably because an environment
+        # marker excluded it.
+        return []
     toplevel_txt_contents = dist.read_text("top_level.txt")
     if toplevel_txt_contents is None:
         if dist.files is None:


### PR DESCRIPTION
This still has limitations and exposes problems:

* Platform markers don't work yet, since pyright and uv have different ideas what platforms exist.
* Typed matplotlib is only available for Python 3.9+. Currently, the pyright tests use the same dependencies for all Python versions, making it impossible to test packages with a dependency on matplotlib.
