### PR TITLE
Xmlrpc: accept data:str|bytes and require method:str

### DIFF
--- a/stdlib/xmlrpc/client.pyi
+++ b/stdlib/xmlrpc/client.pyi
@@ -200,9 +200,7 @@ def dumps(
     allow_none: bool = False,
 ) -> str: ...
 def loads(
-    data: str | ReadableBuffer,
-    use_datetime: bool = False,
-    use_builtin_types: bool = False,
+    data: str | ReadableBuffer, use_datetime: bool = False, use_builtin_types: bool = False
 ) -> tuple[tuple[_Marshallable, ...], str | None]: ...
 def gzip_encode(data: ReadableBuffer) -> bytes: ...  # undocumented
 def gzip_decode(data: ReadableBuffer, max_decode: int = 20971520) -> bytes: ...  # undocumented

--- a/stdlib/xmlrpc/client.pyi
+++ b/stdlib/xmlrpc/client.pyi
@@ -200,7 +200,9 @@ def dumps(
     allow_none: bool = False,
 ) -> str: ...
 def loads(
-    data: str, use_datetime: bool = False, use_builtin_types: bool = False
+    data: str | ReadableBuffer,
+    use_datetime: bool = False,
+    use_builtin_types: bool = False,
 ) -> tuple[tuple[_Marshallable, ...], str | None]: ...
 def gzip_encode(data: ReadableBuffer) -> bytes: ...  # undocumented
 def gzip_decode(data: ReadableBuffer, max_decode: int = 20971520) -> bytes: ...  # undocumented

--- a/stdlib/xmlrpc/server.pyi
+++ b/stdlib/xmlrpc/server.pyi
@@ -50,7 +50,7 @@ class SimpleXMLRPCDispatcher:  # undocumented
     def _marshaled_dispatch(
         self,
         data: str | ReadableBuffer,
-        dispatch_method: Callable[[str | None, tuple[_Marshallable, ...]], Fault | tuple[_Marshallable, ...]] | None = None,
+        dispatch_method: Callable[[str, tuple[_Marshallable, ...]], Fault | tuple[_Marshallable, ...]] | None = None,
         path: Any | None = None,
     ) -> str: ...  # undocumented
     def system_listMethods(self) -> list[str]: ...  # undocumented

--- a/stdlib/xmlrpc/server.pyi
+++ b/stdlib/xmlrpc/server.pyi
@@ -1,6 +1,7 @@
 import http.server
 import pydoc
 import socketserver
+from _typeshed import ReadableBuffer
 from collections.abc import Callable, Iterable, Mapping
 from re import Pattern
 from typing import Any, ClassVar, Protocol
@@ -48,7 +49,7 @@ class SimpleXMLRPCDispatcher:  # undocumented
     def register_multicall_functions(self) -> None: ...
     def _marshaled_dispatch(
         self,
-        data: str,
+        data: str | ReadableBuffer,
         dispatch_method: Callable[[str | None, tuple[_Marshallable, ...]], Fault | tuple[_Marshallable, ...]] | None = None,
         path: Any | None = None,
     ) -> str: ...  # undocumented


### PR DESCRIPTION
Two minor fixed to the typeshed:

1.    data may be both `str` and `bytes`; actually CPython uses it both ways
2.    `method=None` does not make much sense and should never happen 🤞

@JelleZijlstra This PR replaces https://github.com/python/typeshed/pull/12071 as I no longer work for @univention and thus no longer have access to the old repository.