### PR TITLE
Bump flake8-pyi to 24.9.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
       - id: flake8
         additional_dependencies:
           - "flake8-noqa==1.4.0"
-          - "flake8-pyi==24.6.0"
+          - "flake8-pyi==24.9.0"
         types: [file]
         types_or: [python, pyi]
   - repo: meta


### PR DESCRIPTION
Renovate won't update this dependency (no automated tools I know of will, sadly) because it exists in the `additional_dependencies` list for this hook.