### PR TITLE
Lock stubdefaulter to python_version < "3.13" due to missing 3.13 libcst wheels

### DIFF
--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -16,7 +16,7 @@ pathspec>=0.11.1
 pre-commit
 # Required by create_baseline_stubs.py. Must match .pre-commit-config.yaml.
 ruff==0.6.9
-stubdefaulter==0.1.0
+stubdefaulter==0.1.0; python_version < "3.13" # Requires libcst which doesn't have 3.13 wheels yet and requires a Rust compiler
 termcolor>=2.3
 tomli==2.0.2
 tomlkit==0.13.2


### PR DESCRIPTION
I'm surprised I'm the first to mention this, maybe the CI and other maintainers (that are using 3.13) have Rust compilation tools already installed and didn't notice?

On Windows, python 3.13, running `python3.13 -m pip install -r .\requirements-tests.txt` results in the following error:
```
Building wheels for collected packages: libcst
  Building wheel for libcst (pyproject.toml) ... error
  error: subprocess-exited-with-error

  × Building wheel for libcst (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [397 lines of output]
      C:\Users\Avasam\AppData\Local\Temp\pip-build-env-3pmjtsds\overlay\Lib\site-packages\setuptools\_distutils\dist.py:261: UserWarning: Unknown distribution option: 'test_suite'
        warnings.warn(msg)
      WARNING setuptools_scm.pyproject_reading toml section missing 'pyproject.toml does not contain a tool.setuptools_scm section'
      Traceback (most recent call last):
        File "C:\Users\Avasam\AppData\Local\Temp\pip-build-env-3pmjtsds\overlay\Lib\site-packages\setuptools_scm\_integration\pyproject_reading.py", line 36, in read_pyproject
          section = defn.get("tool", {})[tool_name]
                    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
      KeyError: 'setuptools_scm'
      running bdist_wheel
      running build
      running build_py
      creating build\lib.win-amd64-cpython-313\libcst
      copying libcst\tool.py -> build\lib.win-amd64-cpython-313\libcst
      copying libcst\_add_slots.py -> build\lib.win-amd64-cpython-313\libcst
      copying libcst\_batched_visitor.py -> build\lib.win-amd64-cpython-313\libcst
      copying libcst\_exceptions.py -> build\lib.win-amd64-cpython-313\libcst
      copying libcst\_flatten_sentinel.py -> build\lib.win-amd64-cpython-313\libcst
      copying libcst\_maybe_sentinel.py -> build\lib.win-amd64-cpython-313\libcst
      copying libcst\_metadata_dependent.py -> build\lib.win-amd64-cpython-313\libcst
      copying libcst\_position.py -> build\lib.win-amd64-cpython-313\libcst
      copying libcst\_removal_sentinel.py -> build\lib.win-amd64-cpython-313\libcst
      copying libcst\_tabs.py -> build\lib.win-amd64-cpython-313\libcst
      copying libcst\_typed_visitor.py -> build\lib.win-amd64-cpython-313\libcst
      copying libcst\_typed_visitor_base.py -> build\lib.win-amd64-cpython-313\libcst
      copying libcst\_types.py -> build\lib.win-amd64-cpython-313\libcst
      copying libcst\_type_enforce.py -> build\lib.win-amd64-cpython-313\libcst
      copying libcst\_version.py -> build\lib.win-amd64-cpython-313\libcst
      copying libcst\_visitors.py -> build\lib.win-amd64-cpython-313\libcst
      copying libcst\__init__.py -> build\lib.win-amd64-cpython-313\libcst
      creating build\lib.win-amd64-cpython-313\libcst\codegen
      copying libcst\codegen\gather.py -> build\lib.win-amd64-cpython-313\libcst\codegen
      copying libcst\codegen\generate.py -> build\lib.win-amd64-cpython-313\libcst\codegen
      copying libcst\codegen\gen_matcher_classes.py -> build\lib.win-amd64-cpython-313\libcst\codegen
      copying libcst\codegen\gen_type_mapping.py -> build\lib.win-amd64-cpython-313\libcst\codegen
      copying libcst\codegen\gen_visitor_functions.py -> build\lib.win-amd64-cpython-313\libcst\codegen
      copying libcst\codegen\transforms.py -> build\lib.win-amd64-cpython-313\libcst\codegen
      copying libcst\codegen\__init__.py -> build\lib.win-amd64-cpython-313\libcst\codegen
      creating build\lib.win-amd64-cpython-313\libcst\codemod
      copying libcst\codemod\_cli.py -> build\lib.win-amd64-cpython-313\libcst\codemod
      copying libcst\codemod\_codemod.py -> build\lib.win-amd64-cpython-313\libcst\codemod
      copying libcst\codemod\_command.py -> build\lib.win-amd64-cpython-313\libcst\codemod
      copying libcst\codemod\_context.py -> build\lib.win-amd64-cpython-313\libcst\codemod
      copying libcst\codemod\_dummy_pool.py -> build\lib.win-amd64-cpython-313\libcst\codemod
      copying libcst\codemod\_runner.py -> build\lib.win-amd64-cpython-313\libcst\codemod
      copying libcst\codemod\_testing.py -> build\lib.win-amd64-cpython-313\libcst\codemod
      copying libcst\codemod\_visitor.py -> build\lib.win-amd64-cpython-313\libcst\codemod
      copying libcst\codemod\__init__.py -> build\lib.win-amd64-cpython-313\libcst\codemod
      creating build\lib.win-amd64-cpython-313\libcst\display
      copying libcst\display\graphviz.py -> build\lib.win-amd64-cpython-313\libcst\display
      copying libcst\display\text.py -> build\lib.win-amd64-cpython-313\libcst\display
      copying libcst\display\__init__.py -> build\lib.win-amd64-cpython-313\libcst\display
      creating build\lib.win-amd64-cpython-313\libcst\helpers
      copying libcst\helpers\common.py -> build\lib.win-amd64-cpython-313\libcst\helpers
      copying libcst\helpers\expression.py -> build\lib.win-amd64-cpython-313\libcst\helpers
      copying libcst\helpers\module.py -> build\lib.win-amd64-cpython-313\libcst\helpers
      copying libcst\helpers\node_fields.py -> build\lib.win-amd64-cpython-313\libcst\helpers
      copying libcst\helpers\paths.py -> build\lib.win-amd64-cpython-313\libcst\helpers
      copying libcst\helpers\_template.py -> build\lib.win-amd64-cpython-313\libcst\helpers
      copying libcst\helpers\__init__.py -> build\lib.win-amd64-cpython-313\libcst\helpers
      creating build\lib.win-amd64-cpython-313\libcst\matchers
      copying libcst\matchers\_decorators.py -> build\lib.win-amd64-cpython-313\libcst\matchers
      copying libcst\matchers\_matcher_base.py -> build\lib.win-amd64-cpython-313\libcst\matchers
      copying libcst\matchers\_return_types.py -> build\lib.win-amd64-cpython-313\libcst\matchers
      copying libcst\matchers\_visitors.py -> build\lib.win-amd64-cpython-313\libcst\matchers
      copying libcst\matchers\__init__.py -> build\lib.win-amd64-cpython-313\libcst\matchers
      creating build\lib.win-amd64-cpython-313\libcst\metadata
      copying libcst\metadata\accessor_provider.py -> build\lib.win-amd64-cpython-313\libcst\metadata
      copying libcst\metadata\base_provider.py -> build\lib.win-amd64-cpython-313\libcst\metadata
      copying libcst\metadata\expression_context_provider.py -> build\lib.win-amd64-cpython-313\libcst\metadata
      copying libcst\metadata\file_path_provider.py -> build\lib.win-amd64-cpython-313\libcst\metadata
      copying libcst\metadata\full_repo_manager.py -> build\lib.win-amd64-cpython-313\libcst\metadata
      copying libcst\metadata\name_provider.py -> build\lib.win-amd64-cpython-313\libcst\metadata
      copying libcst\metadata\parent_node_provider.py -> build\lib.win-amd64-cpython-313\libcst\metadata
      copying libcst\metadata\position_provider.py -> build\lib.win-amd64-cpython-313\libcst\metadata
      copying libcst\metadata\reentrant_codegen.py -> build\lib.win-amd64-cpython-313\libcst\metadata
      copying libcst\metadata\scope_provider.py -> build\lib.win-amd64-cpython-313\libcst\metadata
      copying libcst\metadata\span_provider.py -> build\lib.win-amd64-cpython-313\libcst\metadata
      copying libcst\metadata\type_inference_provider.py -> build\lib.win-amd64-cpython-313\libcst\metadata
      copying libcst\metadata\wrapper.py -> build\lib.win-amd64-cpython-313\libcst\metadata
      copying libcst\metadata\__init__.py -> build\lib.win-amd64-cpython-313\libcst\metadata
      creating build\lib.win-amd64-cpython-313\libcst\testing
      copying libcst\testing\utils.py -> build\lib.win-amd64-cpython-313\libcst\testing
      copying libcst\testing\__init__.py -> build\lib.win-amd64-cpython-313\libcst\testing
      creating build\lib.win-amd64-cpython-313\libcst\tests
      copying libcst\tests\test_add_slots.py -> build\lib.win-amd64-cpython-313\libcst\tests
      copying libcst\tests\test_batched_visitor.py -> build\lib.win-amd64-cpython-313\libcst\tests
      copying libcst\tests\test_deep_clone.py -> build\lib.win-amd64-cpython-313\libcst\tests
      copying libcst\tests\test_deep_replace.py -> build\lib.win-amd64-cpython-313\libcst\tests
      copying libcst\tests\test_e2e.py -> build\lib.win-amd64-cpython-313\libcst\tests
      copying libcst\tests\test_exceptions.py -> build\lib.win-amd64-cpython-313\libcst\tests
      copying libcst\tests\test_fuzz.py -> build\lib.win-amd64-cpython-313\libcst\tests
      copying libcst\tests\test_pyre_integration.py -> build\lib.win-amd64-cpython-313\libcst\tests
      copying libcst\tests\test_roundtrip.py -> build\lib.win-amd64-cpython-313\libcst\tests
      copying libcst\tests\test_tabs.py -> build\lib.win-amd64-cpython-313\libcst\tests
      copying libcst\tests\test_type_enforce.py -> build\lib.win-amd64-cpython-313\libcst\tests
      copying libcst\tests\test_visitor.py -> build\lib.win-amd64-cpython-313\libcst\tests
      copying libcst\tests\__init__.py -> build\lib.win-amd64-cpython-313\libcst\tests
      copying libcst\tests\__main__.py -> build\lib.win-amd64-cpython-313\libcst\tests
      creating build\lib.win-amd64-cpython-313\libcst\_nodes
      copying libcst\_nodes\base.py -> build\lib.win-amd64-cpython-313\libcst\_nodes
      copying libcst\_nodes\deep_equals.py -> build\lib.win-amd64-cpython-313\libcst\_nodes
      copying libcst\_nodes\expression.py -> build\lib.win-amd64-cpython-313\libcst\_nodes
      copying libcst\_nodes\internal.py -> build\lib.win-amd64-cpython-313\libcst\_nodes
      copying libcst\_nodes\module.py -> build\lib.win-amd64-cpython-313\libcst\_nodes
      copying libcst\_nodes\op.py -> build\lib.win-amd64-cpython-313\libcst\_nodes
      copying libcst\_nodes\statement.py -> build\lib.win-amd64-cpython-313\libcst\_nodes
      copying libcst\_nodes\whitespace.py -> build\lib.win-amd64-cpython-313\libcst\_nodes
      copying libcst\_nodes\__init__.py -> build\lib.win-amd64-cpython-313\libcst\_nodes
      creating build\lib.win-amd64-cpython-313\libcst\_parser
      copying libcst\_parser\base_parser.py -> build\lib.win-amd64-cpython-313\libcst\_parser
      copying libcst\_parser\custom_itertools.py -> build\lib.win-amd64-cpython-313\libcst\_parser
      copying libcst\_parser\detect_config.py -> build\lib.win-amd64-cpython-313\libcst\_parser
      copying libcst\_parser\entrypoints.py -> build\lib.win-amd64-cpython-313\libcst\_parser
      copying libcst\_parser\grammar.py -> build\lib.win-amd64-cpython-313\libcst\_parser
      copying libcst\_parser\production_decorator.py -> build\lib.win-amd64-cpython-313\libcst\_parser
      copying libcst\_parser\python_parser.py -> build\lib.win-amd64-cpython-313\libcst\_parser
      copying libcst\_parser\py_whitespace_parser.py -> build\lib.win-amd64-cpython-313\libcst\_parser
      copying libcst\_parser\whitespace_parser.py -> build\lib.win-amd64-cpython-313\libcst\_parser
      copying libcst\_parser\wrapped_tokenize.py -> build\lib.win-amd64-cpython-313\libcst\_parser
      copying libcst\_parser\__init__.py -> build\lib.win-amd64-cpython-313\libcst\_parser
      creating build\lib.win-amd64-cpython-313\libcst\codegen\tests
      copying libcst\codegen\tests\test_codegen_clean.py -> build\lib.win-amd64-cpython-313\libcst\codegen\tests        
      copying libcst\codegen\tests\__init__.py -> build\lib.win-amd64-cpython-313\libcst\codegen\tests
      creating build\lib.win-amd64-cpython-313\libcst\codemod\commands
      copying libcst\codemod\commands\add_pyre_directive.py -> build\lib.win-amd64-cpython-313\libcst\codemod\commands  
      copying libcst\codemod\commands\add_trailing_commas.py -> build\lib.win-amd64-cpython-313\libcst\codemod\commands 
      copying libcst\codemod\commands\convert_format_to_fstring.py -> build\lib.win-amd64-cpython-313\libcst\codemod\commands
      copying libcst\codemod\commands\convert_namedtuple_to_dataclass.py -> build\lib.win-amd64-cpython-313\libcst\codemod\commands
      copying libcst\codemod\commands\convert_percent_format_to_fstring.py -> build\lib.win-amd64-cpython-313\libcst\codemod\commands
      copying libcst\codemod\commands\convert_type_comments.py -> build\lib.win-amd64-cpython-313\libcst\codemod\commands
      copying libcst\codemod\commands\ensure_import_present.py -> build\lib.win-amd64-cpython-313\libcst\codemod\commands
      copying libcst\codemod\commands\fix_pyre_directives.py -> build\lib.win-amd64-cpython-313\libcst\codemod\commands 
      copying libcst\codemod\commands\noop.py -> build\lib.win-amd64-cpython-313\libcst\codemod\commands
      copying libcst\codemod\commands\remove_pyre_directive.py -> build\lib.win-amd64-cpython-313\libcst\codemod\commands
      copying libcst\codemod\commands\remove_unused_imports.py -> build\lib.win-amd64-cpython-313\libcst\codemod\commands
      copying libcst\codemod\commands\rename.py -> build\lib.win-amd64-cpython-313\libcst\codemod\commands
      copying libcst\codemod\commands\strip_strings_from_types.py -> build\lib.win-amd64-cpython-313\libcst\codemod\commands
      copying libcst\codemod\commands\unnecessary_format_string.py -> build\lib.win-amd64-cpython-313\libcst\codemod\commands
      copying libcst\codemod\commands\__init__.py -> build\lib.win-amd64-cpython-313\libcst\codemod\commands
      creating build\lib.win-amd64-cpython-313\libcst\codemod\tests
      copying libcst\codemod\tests\test_codemod.py -> build\lib.win-amd64-cpython-313\libcst\codemod\tests
      copying libcst\codemod\tests\test_codemod_cli.py -> build\lib.win-amd64-cpython-313\libcst\codemod\tests
      copying libcst\codemod\tests\test_metadata.py -> build\lib.win-amd64-cpython-313\libcst\codemod\tests
      copying libcst\codemod\tests\test_runner.py -> build\lib.win-amd64-cpython-313\libcst\codemod\tests
      copying libcst\codemod\tests\__init__.py -> build\lib.win-amd64-cpython-313\libcst\codemod\tests
      creating build\lib.win-amd64-cpython-313\libcst\codemod\visitors
      copying libcst\codemod\visitors\_add_imports.py -> build\lib.win-amd64-cpython-313\libcst\codemod\visitors        
      copying libcst\codemod\visitors\_apply_type_annotations.py -> build\lib.win-amd64-cpython-313\libcst\codemod\visitors
      copying libcst\codemod\visitors\_gather_comments.py -> build\lib.win-amd64-cpython-313\libcst\codemod\visitors    
      copying libcst\codemod\visitors\_gather_exports.py -> build\lib.win-amd64-cpython-313\libcst\codemod\visitors     
      copying libcst\codemod\visitors\_gather_global_names.py -> build\lib.win-amd64-cpython-313\libcst\codemod\visitors      copying libcst\codemod\visitors\_gather_imports.py -> build\lib.win-amd64-cpython-313\libcst\codemod\visitors     
      copying libcst\codemod\visitors\_gather_string_annotation_names.py -> build\lib.win-amd64-cpython-313\libcst\codemod\visitors
      copying libcst\codemod\visitors\_gather_unused_imports.py -> build\lib.win-amd64-cpython-313\libcst\codemod\visitors
      copying libcst\codemod\visitors\_imports.py -> build\lib.win-amd64-cpython-313\libcst\codemod\visitors
      copying libcst\codemod\visitors\_remove_imports.py -> build\lib.win-amd64-cpython-313\libcst\codemod\visitors     
      copying libcst\codemod\visitors\__init__.py -> build\lib.win-amd64-cpython-313\libcst\codemod\visitors
      creating build\lib.win-amd64-cpython-313\libcst\codemod\commands\tests
      copying libcst\codemod\commands\tests\test_add_pyre_directive.py -> build\lib.win-amd64-cpython-313\libcst\codemod\commands\tests
      copying libcst\codemod\commands\tests\test_add_trailing_commas.py -> build\lib.win-amd64-cpython-313\libcst\codemod\commands\tests
      copying libcst\codemod\commands\tests\test_convert_format_to_fstring.py -> build\lib.win-amd64-cpython-313\libcst\codemod\commands\tests
      copying libcst\codemod\commands\tests\test_convert_namedtuple_to_dataclass.py -> build\lib.win-amd64-cpython-313\libcst\codemod\commands\tests
      copying libcst\codemod\commands\tests\test_convert_percent_format_to_fstring.py -> build\lib.win-amd64-cpython-313\libcst\codemod\commands\tests
      copying libcst\codemod\commands\tests\test_convert_type_comments.py -> build\lib.win-amd64-cpython-313\libcst\codemod\commands\tests
      copying libcst\codemod\commands\tests\test_ensure_import_present.py -> build\lib.win-amd64-cpython-313\libcst\codemod\commands\tests
      copying libcst\codemod\commands\tests\test_fix_pyre_directives.py -> build\lib.win-amd64-cpython-313\libcst\codemod\commands\tests
      copying libcst\codemod\commands\tests\test_noop.py -> build\lib.win-amd64-cpython-313\libcst\codemod\commands\tests
      copying libcst\codemod\commands\tests\test_remove_pyre_directive.py -> build\lib.win-amd64-cpython-313\libcst\codemod\commands\tests
      copying libcst\codemod\commands\tests\test_remove_unused_imports.py -> build\lib.win-amd64-cpython-313\libcst\codemod\commands\tests
      copying libcst\codemod\commands\tests\test_rename.py -> build\lib.win-amd64-cpython-313\libcst\codemod\commands\tests
      copying libcst\codemod\commands\tests\test_strip_strings_from_types.py -> build\lib.win-amd64-cpython-313\libcst\codemod\commands\tests
      copying libcst\codemod\commands\tests\test_unnecessary_format_string.py -> build\lib.win-amd64-cpython-313\libcst\codemod\commands\tests
      copying libcst\codemod\commands\tests\__init__.py -> build\lib.win-amd64-cpython-313\libcst\codemod\commands\tests      creating build\lib.win-amd64-cpython-313\libcst\codemod\visitors\tests
      copying libcst\codemod\visitors\tests\test_add_imports.py -> build\lib.win-amd64-cpython-313\libcst\codemod\visitors\tests
      copying libcst\codemod\visitors\tests\test_apply_type_annotations.py -> build\lib.win-amd64-cpython-313\libcst\codemod\visitors\tests
      copying libcst\codemod\visitors\tests\test_gather_comments.py -> build\lib.win-amd64-cpython-313\libcst\codemod\visitors\tests
      copying libcst\codemod\visitors\tests\test_gather_exports.py -> build\lib.win-amd64-cpython-313\libcst\codemod\visitors\tests
      copying libcst\codemod\visitors\tests\test_gather_global_names.py -> build\lib.win-amd64-cpython-313\libcst\codemod\visitors\tests
      copying libcst\codemod\visitors\tests\test_gather_imports.py -> build\lib.win-amd64-cpython-313\libcst\codemod\visitors\tests
      copying libcst\codemod\visitors\tests\test_gather_string_annotation_names.py -> build\lib.win-amd64-cpython-313\libcst\codemod\visitors\tests
      copying libcst\codemod\visitors\tests\test_gather_unused_imports.py -> build\lib.win-amd64-cpython-313\libcst\codemod\visitors\tests
      copying libcst\codemod\visitors\tests\test_remove_imports.py -> build\lib.win-amd64-cpython-313\libcst\codemod\visitors\tests
      copying libcst\codemod\visitors\tests\__init__.py -> build\lib.win-amd64-cpython-313\libcst\codemod\visitors\tests      creating build\lib.win-amd64-cpython-313\libcst\display\tests
      copying libcst\display\tests\test_dump_graphviz.py -> build\lib.win-amd64-cpython-313\libcst\display\tests        
      copying libcst\display\tests\test_dump_text.py -> build\lib.win-amd64-cpython-313\libcst\display\tests
      copying libcst\display\tests\__init__.py -> build\lib.win-amd64-cpython-313\libcst\display\tests
      creating build\lib.win-amd64-cpython-313\libcst\helpers\tests
      copying libcst\helpers\tests\test_expression.py -> build\lib.win-amd64-cpython-313\libcst\helpers\tests
      copying libcst\helpers\tests\test_module.py -> build\lib.win-amd64-cpython-313\libcst\helpers\tests
      copying libcst\helpers\tests\test_node_fields.py -> build\lib.win-amd64-cpython-313\libcst\helpers\tests
      copying libcst\helpers\tests\test_paths.py -> build\lib.win-amd64-cpython-313\libcst\helpers\tests
      copying libcst\helpers\tests\test_template.py -> build\lib.win-amd64-cpython-313\libcst\helpers\tests
      copying libcst\helpers\tests\__init__.py -> build\lib.win-amd64-cpython-313\libcst\helpers\tests
      creating build\lib.win-amd64-cpython-313\libcst\matchers\tests
      copying libcst\matchers\tests\test_decorators.py -> build\lib.win-amd64-cpython-313\libcst\matchers\tests
      copying libcst\matchers\tests\test_extract.py -> build\lib.win-amd64-cpython-313\libcst\matchers\tests
      copying libcst\matchers\tests\test_findall.py -> build\lib.win-amd64-cpython-313\libcst\matchers\tests
      copying libcst\matchers\tests\test_matchers.py -> build\lib.win-amd64-cpython-313\libcst\matchers\tests
      copying libcst\matchers\tests\test_matchers_with_metadata.py -> build\lib.win-amd64-cpython-313\libcst\matchers\tests
      copying libcst\matchers\tests\test_replace.py -> build\lib.win-amd64-cpython-313\libcst\matchers\tests
      copying libcst\matchers\tests\test_visitors.py -> build\lib.win-amd64-cpython-313\libcst\matchers\tests
      copying libcst\matchers\tests\__init__.py -> build\lib.win-amd64-cpython-313\libcst\matchers\tests
      creating build\lib.win-amd64-cpython-313\libcst\metadata\tests
      copying libcst\metadata\tests\test_accessor_provider.py -> build\lib.win-amd64-cpython-313\libcst\metadata\tests  
      copying libcst\metadata\tests\test_base_provider.py -> build\lib.win-amd64-cpython-313\libcst\metadata\tests      
      copying libcst\metadata\tests\test_expression_context_provider.py -> build\lib.win-amd64-cpython-313\libcst\metadata\tests
      copying libcst\metadata\tests\test_file_path_provider.py -> build\lib.win-amd64-cpython-313\libcst\metadata\tests 
      copying libcst\metadata\tests\test_full_repo_manager.py -> build\lib.win-amd64-cpython-313\libcst\metadata\tests  
      copying libcst\metadata\tests\test_metadata_provider.py -> build\lib.win-amd64-cpython-313\libcst\metadata\tests  
      copying libcst\metadata\tests\test_metadata_wrapper.py -> build\lib.win-amd64-cpython-313\libcst\metadata\tests   
      copying libcst\metadata\tests\test_name_provider.py -> build\lib.win-amd64-cpython-313\libcst\metadata\tests      
      copying libcst\metadata\tests\test_parent_node_provider.py -> build\lib.win-amd64-cpython-313\libcst\metadata\tests
      copying libcst\metadata\tests\test_position_provider.py -> build\lib.win-amd64-cpython-313\libcst\metadata\tests  
      copying libcst\metadata\tests\test_reentrant_codegen.py -> build\lib.win-amd64-cpython-313\libcst\metadata\tests  
      copying libcst\metadata\tests\test_scope_provider.py -> build\lib.win-amd64-cpython-313\libcst\metadata\tests     
      copying libcst\metadata\tests\test_span_provider.py -> build\lib.win-amd64-cpython-313\libcst\metadata\tests      
      copying libcst\metadata\tests\test_type_inference_provider.py -> build\lib.win-amd64-cpython-313\libcst\metadata\tests
      copying libcst\metadata\tests\__init__.py -> build\lib.win-amd64-cpython-313\libcst\metadata\tests
      creating build\lib.win-amd64-cpython-313\libcst\_nodes\tests
      copying libcst\_nodes\tests\base.py -> build\lib.win-amd64-cpython-313\libcst\_nodes\tests
      copying libcst\_nodes\tests\test_assert.py -> build\lib.win-amd64-cpython-313\libcst\_nodes\tests
      copying libcst\_nodes\tests\test_assign.py -> build\lib.win-amd64-cpython-313\libcst\_nodes\tests
      copying libcst\_nodes\tests\test_atom.py -> build\lib.win-amd64-cpython-313\libcst\_nodes\tests
      copying libcst\_nodes\tests\test_attribute.py -> build\lib.win-amd64-cpython-313\libcst\_nodes\tests
      copying libcst\_nodes\tests\test_await.py -> build\lib.win-amd64-cpython-313\libcst\_nodes\tests
      copying libcst\_nodes\tests\test_binary_op.py -> build\lib.win-amd64-cpython-313\libcst\_nodes\tests
      copying libcst\_nodes\tests\test_boolean_op.py -> build\lib.win-amd64-cpython-313\libcst\_nodes\tests
      copying libcst\_nodes\tests\test_call.py -> build\lib.win-amd64-cpython-313\libcst\_nodes\tests
      copying libcst\_nodes\tests\test_classdef.py -> build\lib.win-amd64-cpython-313\libcst\_nodes\tests
      copying libcst\_nodes\tests\test_comment.py -> build\lib.win-amd64-cpython-313\libcst\_nodes\tests
      copying libcst\_nodes\tests\test_comparison.py -> build\lib.win-amd64-cpython-313\libcst\_nodes\tests
      copying libcst\_nodes\tests\test_cst_node.py -> build\lib.win-amd64-cpython-313\libcst\_nodes\tests
      copying libcst\_nodes\tests\test_del.py -> build\lib.win-amd64-cpython-313\libcst\_nodes\tests
      copying libcst\_nodes\tests\test_dict.py -> build\lib.win-amd64-cpython-313\libcst\_nodes\tests
      copying libcst\_nodes\tests\test_dict_comp.py -> build\lib.win-amd64-cpython-313\libcst\_nodes\tests
      copying libcst\_nodes\tests\test_docstring.py -> build\lib.win-amd64-cpython-313\libcst\_nodes\tests
      copying libcst\_nodes\tests\test_else.py -> build\lib.win-amd64-cpython-313\libcst\_nodes\tests
      copying libcst\_nodes\tests\test_empty_line.py -> build\lib.win-amd64-cpython-313\libcst\_nodes\tests
      copying libcst\_nodes\tests\test_flatten_behavior.py -> build\lib.win-amd64-cpython-313\libcst\_nodes\tests       
      copying libcst\_nodes\tests\test_for.py -> build\lib.win-amd64-cpython-313\libcst\_nodes\tests
      copying libcst\_nodes\tests\test_funcdef.py -> build\lib.win-amd64-cpython-313\libcst\_nodes\tests
      copying libcst\_nodes\tests\test_global.py -> build\lib.win-amd64-cpython-313\libcst\_nodes\tests
      copying libcst\_nodes\tests\test_if.py -> build\lib.win-amd64-cpython-313\libcst\_nodes\tests
      copying libcst\_nodes\tests\test_ifexp.py -> build\lib.win-amd64-cpython-313\libcst\_nodes\tests
      copying libcst\_nodes\tests\test_import.py -> build\lib.win-amd64-cpython-313\libcst\_nodes\tests
      copying libcst\_nodes\tests\test_indented_block.py -> build\lib.win-amd64-cpython-313\libcst\_nodes\tests
      copying libcst\_nodes\tests\test_lambda.py -> build\lib.win-amd64-cpython-313\libcst\_nodes\tests
      copying libcst\_nodes\tests\test_leaf_small_statements.py -> build\lib.win-amd64-cpython-313\libcst\_nodes\tests  
      copying libcst\_nodes\tests\test_list.py -> build\lib.win-amd64-cpython-313\libcst\_nodes\tests
      copying libcst\_nodes\tests\test_match.py -> build\lib.win-amd64-cpython-313\libcst\_nodes\tests
      copying libcst\_nodes\tests\test_matrix_multiply.py -> build\lib.win-amd64-cpython-313\libcst\_nodes\tests        
      copying libcst\_nodes\tests\test_module.py -> build\lib.win-amd64-cpython-313\libcst\_nodes\tests
      copying libcst\_nodes\tests\test_namedexpr.py -> build\lib.win-amd64-cpython-313\libcst\_nodes\tests
      copying libcst\_nodes\tests\test_newline.py -> build\lib.win-amd64-cpython-313\libcst\_nodes\tests
      copying libcst\_nodes\tests\test_nonlocal.py -> build\lib.win-amd64-cpython-313\libcst\_nodes\tests
      copying libcst\_nodes\tests\test_number.py -> build\lib.win-amd64-cpython-313\libcst\_nodes\tests
      copying libcst\_nodes\tests\test_raise.py -> build\lib.win-amd64-cpython-313\libcst\_nodes\tests
      copying libcst\_nodes\tests\test_removal_behavior.py -> build\lib.win-amd64-cpython-313\libcst\_nodes\tests       
      copying libcst\_nodes\tests\test_return.py -> build\lib.win-amd64-cpython-313\libcst\_nodes\tests
      copying libcst\_nodes\tests\test_set.py -> build\lib.win-amd64-cpython-313\libcst\_nodes\tests
      copying libcst\_nodes\tests\test_simple_comp.py -> build\lib.win-amd64-cpython-313\libcst\_nodes\tests
      copying libcst\_nodes\tests\test_simple_statement.py -> build\lib.win-amd64-cpython-313\libcst\_nodes\tests       
      copying libcst\_nodes\tests\test_simple_string.py -> build\lib.win-amd64-cpython-313\libcst\_nodes\tests
      copying libcst\_nodes\tests\test_simple_whitespace.py -> build\lib.win-amd64-cpython-313\libcst\_nodes\tests      
      copying libcst\_nodes\tests\test_small_statement.py -> build\lib.win-amd64-cpython-313\libcst\_nodes\tests        
      copying libcst\_nodes\tests\test_subscript.py -> build\lib.win-amd64-cpython-313\libcst\_nodes\tests
      copying libcst\_nodes\tests\test_trailing_whitespace.py -> build\lib.win-amd64-cpython-313\libcst\_nodes\tests    
      copying libcst\_nodes\tests\test_try.py -> build\lib.win-amd64-cpython-313\libcst\_nodes\tests
      copying libcst\_nodes\tests\test_tuple.py -> build\lib.win-amd64-cpython-313\libcst\_nodes\tests
      copying libcst\_nodes\tests\test_type_alias.py -> build\lib.win-amd64-cpython-313\libcst\_nodes\tests
      copying libcst\_nodes\tests\test_unary_op.py -> build\lib.win-amd64-cpython-313\libcst\_nodes\tests
      copying libcst\_nodes\tests\test_while.py -> build\lib.win-amd64-cpython-313\libcst\_nodes\tests
      copying libcst\_nodes\tests\test_with.py -> build\lib.win-amd64-cpython-313\libcst\_nodes\tests
      copying libcst\_nodes\tests\test_yield.py -> build\lib.win-amd64-cpython-313\libcst\_nodes\tests
      copying libcst\_nodes\tests\__init__.py -> build\lib.win-amd64-cpython-313\libcst\_nodes\tests
      creating build\lib.win-amd64-cpython-313\libcst\_parser\conversions
      copying libcst\_parser\conversions\expression.py -> build\lib.win-amd64-cpython-313\libcst\_parser\conversions    
      copying libcst\_parser\conversions\module.py -> build\lib.win-amd64-cpython-313\libcst\_parser\conversions        
      copying libcst\_parser\conversions\params.py -> build\lib.win-amd64-cpython-313\libcst\_parser\conversions        
      copying libcst\_parser\conversions\statement.py -> build\lib.win-amd64-cpython-313\libcst\_parser\conversions     
      copying libcst\_parser\conversions\terminals.py -> build\lib.win-amd64-cpython-313\libcst\_parser\conversions     
      copying libcst\_parser\conversions\__init__.py -> build\lib.win-amd64-cpython-313\libcst\_parser\conversions      
      creating build\lib.win-amd64-cpython-313\libcst\_parser\parso
      copying libcst\_parser\parso\utils.py -> build\lib.win-amd64-cpython-313\libcst\_parser\parso
      copying libcst\_parser\parso\__init__.py -> build\lib.win-amd64-cpython-313\libcst\_parser\parso
      creating build\lib.win-amd64-cpython-313\libcst\_parser\tests
      copying libcst\_parser\tests\test_config.py -> build\lib.win-amd64-cpython-313\libcst\_parser\tests
      copying libcst\_parser\tests\test_detect_config.py -> build\lib.win-amd64-cpython-313\libcst\_parser\tests        
      copying libcst\_parser\tests\test_footer_behavior.py -> build\lib.win-amd64-cpython-313\libcst\_parser\tests      
      copying libcst\_parser\tests\test_node_identity.py -> build\lib.win-amd64-cpython-313\libcst\_parser\tests        
      copying libcst\_parser\tests\test_parse_errors.py -> build\lib.win-amd64-cpython-313\libcst\_parser\tests
      copying libcst\_parser\tests\test_version_compare.py -> build\lib.win-amd64-cpython-313\libcst\_parser\tests
      copying libcst\_parser\tests\test_whitespace_parser.py -> build\lib.win-amd64-cpython-313\libcst\_parser\tests    
      copying libcst\_parser\tests\test_wrapped_tokenize.py -> build\lib.win-amd64-cpython-313\libcst\_parser\tests     
      copying libcst\_parser\tests\__init__.py -> build\lib.win-amd64-cpython-313\libcst\_parser\tests
      creating build\lib.win-amd64-cpython-313\libcst\_parser\types
      copying libcst\_parser\types\config.py -> build\lib.win-amd64-cpython-313\libcst\_parser\types
      copying libcst\_parser\types\conversions.py -> build\lib.win-amd64-cpython-313\libcst\_parser\types
      copying libcst\_parser\types\partials.py -> build\lib.win-amd64-cpython-313\libcst\_parser\types
      copying libcst\_parser\types\production.py -> build\lib.win-amd64-cpython-313\libcst\_parser\types
      copying libcst\_parser\types\py_config.py -> build\lib.win-amd64-cpython-313\libcst\_parser\types
      copying libcst\_parser\types\py_token.py -> build\lib.win-amd64-cpython-313\libcst\_parser\types
      copying libcst\_parser\types\py_whitespace_state.py -> build\lib.win-amd64-cpython-313\libcst\_parser\types       
      copying libcst\_parser\types\token.py -> build\lib.win-amd64-cpython-313\libcst\_parser\types
      copying libcst\_parser\types\whitespace_state.py -> build\lib.win-amd64-cpython-313\libcst\_parser\types
      copying libcst\_parser\types\__init__.py -> build\lib.win-amd64-cpython-313\libcst\_parser\types
      creating build\lib.win-amd64-cpython-313\libcst\_parser\parso\pgen2
      copying libcst\_parser\parso\pgen2\generator.py -> build\lib.win-amd64-cpython-313\libcst\_parser\parso\pgen2     
      copying libcst\_parser\parso\pgen2\grammar_parser.py -> build\lib.win-amd64-cpython-313\libcst\_parser\parso\pgen2      copying libcst\_parser\parso\pgen2\__init__.py -> build\lib.win-amd64-cpython-313\libcst\_parser\parso\pgen2      
      creating build\lib.win-amd64-cpython-313\libcst\_parser\parso\python
      copying libcst\_parser\parso\python\py_token.py -> build\lib.win-amd64-cpython-313\libcst\_parser\parso\python    
      copying libcst\_parser\parso\python\token.py -> build\lib.win-amd64-cpython-313\libcst\_parser\parso\python       
      copying libcst\_parser\parso\python\tokenize.py -> build\lib.win-amd64-cpython-313\libcst\_parser\parso\python    
      copying libcst\_parser\parso\python\__init__.py -> build\lib.win-amd64-cpython-313\libcst\_parser\parso\python    
      creating build\lib.win-amd64-cpython-313\libcst\_parser\parso\tests
      copying libcst\_parser\parso\tests\test_fstring.py -> build\lib.win-amd64-cpython-313\libcst\_parser\parso\tests  
      copying libcst\_parser\parso\tests\test_tokenize.py -> build\lib.win-amd64-cpython-313\libcst\_parser\parso\tests 
      copying libcst\_parser\parso\tests\test_utils.py -> build\lib.win-amd64-cpython-313\libcst\_parser\parso\tests    
      copying libcst\_parser\parso\tests\__init__.py -> build\lib.win-amd64-cpython-313\libcst\_parser\parso\tests      
      creating build\lib.win-amd64-cpython-313\libcst\_parser\types\tests
      copying libcst\_parser\types\tests\test_config.py -> build\lib.win-amd64-cpython-313\libcst\_parser\types\tests   
      copying libcst\_parser\types\tests\__init__.py -> build\lib.win-amd64-cpython-313\libcst\_parser\types\tests      
      running egg_info
      writing libcst.egg-info\PKG-INFO
      writing dependency_links to libcst.egg-info\dependency_links.txt
      writing requirements to libcst.egg-info\requires.txt
      writing top-level names to libcst.egg-info\top_level.txt
      ERROR setuptools_scm._file_finders.git listing git files failed - pretending there aren't any
      reading manifest file 'libcst.egg-info\SOURCES.txt'
      reading manifest template 'MANIFEST.in'
      warning: no previously-included files matching '*' found under directory 'native\target'
      adding license file 'LICENSE'
      writing manifest file 'libcst.egg-info\SOURCES.txt'
      C:\Users\Avasam\AppData\Local\Temp\pip-build-env-3pmjtsds\overlay\Lib\site-packages\setuptools\command\build_py.py:218: _Warning: Package 'libcst.tests.pyre' is absent from the `packages` configuration.
      !!
     
              ********************************************************************************
              ############################
              # Package would be ignored #
              ############################
              Python recognizes 'libcst.tests.pyre' as an importable package[^1],
              but it is absent from setuptools' `packages` configuration.
     
              This leads to an ambiguous overall configuration. If you want to distribute this
              package, please make sure that 'libcst.tests.pyre' is explicitly added
              to the `packages` configuration field.
     
              Alternatively, you can also rely on setuptools' discovery methods
              (for example by using `find_namespace_packages(...)`/`find_namespace:`
              instead of `find_packages(...)`/`find:`).
     
              You can read more about "package discovery" on setuptools documentation page:
     
              - https://setuptools.pypa.io/en/latest/userguide/package_discovery.html
     
              If you don't want 'libcst.tests.pyre' to be distributed and are
              already explicitly excluding 'libcst.tests.pyre' via
              `find_namespace_packages(...)/find_namespace` or `find_packages(...)/find`,
              you can try to use `exclude_package_data`, or `include-package-data=False` in
              combination with a more fine grained `package-data` configuration.
     
              You can read more about "package data files" on setuptools documentation page:
     
              - https://setuptools.pypa.io/en/latest/userguide/datafiles.html
     
     
              [^1]: For Python, any directory (with suitable naming) can be imported,
                    even if it does not contain any `.py` files.
                    On the other hand, currently there is no concept of package data
                    directory, all directories are treated like packages.
              ********************************************************************************
     
      !!
        check.warn(importable)
      copying libcst\py.typed -> build\lib.win-amd64-cpython-313\libcst
      creating build\lib.win-amd64-cpython-313\libcst\tests\pyre
      copying libcst\tests\pyre\.pyre_configuration -> build\lib.win-amd64-cpython-313\libcst\tests\pyre
      copying libcst\tests\pyre\simple_class.json -> build\lib.win-amd64-cpython-313\libcst\tests\pyre
      copying libcst\tests\pyre\simple_class.py -> build\lib.win-amd64-cpython-313\libcst\tests\pyre
      copying libcst\codemod\tests\codemod_formatter_error_input.py.txt -> build\lib.win-amd64-cpython-313\libcst\codemod\tests
      copying libcst\_parser\conversions\README.md -> build\lib.win-amd64-cpython-313\libcst\_parser\conversions        
      running build_ext
      running build_rust
      error: can't find Rust compiler
     
      If you are using an outdated pip version, it is possible a prebuilt wheel is available for this package but pip is not able to install from it. Installing from the wheel would avoid the need for a Rust compiler.
     
      To update pip, run:
     
          pip install --upgrade pip
     
      and then retry package installation.
     
      If you did intend to build this package from source, try installing a Rust compiler from your system package manager and ensure it is on the PATH during installation. Alternatively, rustup (available at https://rustup.rs) is the recommended way to download and update the Rust compiler toolchain.
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for libcst
Failed to build libcst
ERROR: ERROR: Failed to build installable wheels for some pyproject.toml based projects (libcst)
```