### PR TITLE
Add `__code__` to `types.MethodType`

### DIFF
--- a/stdlib/types.pyi
+++ b/stdlib/types.pyi
@@ -424,6 +424,8 @@ class MethodType:
     @property
     def __closure__(self) -> tuple[CellType, ...] | None: ...  # inherited from the added function
     @property
+    def __code__(self) -> CodeType: ...  # inherited from the added function
+    @property
     def __defaults__(self) -> tuple[Any, ...] | None: ...  # inherited from the added function
     @property
     def __func__(self) -> Callable[..., Any]: ...


### PR DESCRIPTION
I have no idea if this is even correct. But here's the PR that made me add this: https://github.com/mhammond/pywin32/pull/2385 and here's a short repro:
```py
import types

class A:
    def test(self): ...

print(type(A().test) is types.MethodType)
print(A().test.__code__)
A().test.__code__ = None
```
results in:
```py
True
<code object test at 0x00000236894BB660, file "c:\Users\Avasam\Desktop\import types.py", line 4>
Traceback (most recent call last):
  File "c:\Users\Avasam\Desktop\import types.py", line 8, in <module>
    A().test.__code__ = None
AttributeError: 'method' object has no attribute '__code__'
```
