### PR TITLE
make shlex.shlex Iterator

### DIFF
--- a/stdlib/shlex.pyi
+++ b/stdlib/shlex.pyi
@@ -1,6 +1,6 @@
 import sys
 from collections import deque
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
 from io import TextIOWrapper
 from typing import Literal, Protocol, overload, type_check_only
 from typing_extensions import Self, deprecated
@@ -27,7 +27,7 @@ def join(split_command: Iterable[str]) -> str: ...
 def quote(s: str) -> str: ...
 
 # TODO: Make generic over infile once PEP 696 is implemented.
-class shlex(Iterable[str]):
+class shlex(Iterator[str]):
     commenters: str
     wordchars: str
     whitespace: str

--- a/stdlib/shlex.pyi
+++ b/stdlib/shlex.pyi
@@ -27,7 +27,7 @@ def join(split_command: Iterable[str]) -> str: ...
 def quote(s: str) -> str: ...
 
 # TODO: Make generic over infile once PEP 696 is implemented.
-class shlex(Iterator[str]):
+class shlex:
     commenters: str
     wordchars: str
     whitespace: str

--- a/stdlib/shlex.pyi
+++ b/stdlib/shlex.pyi
@@ -1,6 +1,6 @@
 import sys
 from collections import deque
-from collections.abc import Iterable, Iterator
+from collections.abc import Iterable
 from io import TextIOWrapper
 from typing import Literal, Protocol, overload, type_check_only
 from typing_extensions import Self, deprecated


### PR DESCRIPTION
It was changed to Iterable on the basis that `__next__` was abstract: https://github.com/python/typeshed/issues/1476#issuecomment-388663644

But that doesn't seem to be true? Let's see what the test suite says.