### PR TITLE
Allowlist `six.create_bound_method.__code__` (Fix daily test failure)

### DIFF
--- a/stubs/six/@tests/stubtest_allowlist.txt
+++ b/stubs/six/@tests/stubtest_allowlist.txt
@@ -4,6 +4,7 @@ six.BytesIO.seek
 six.StringIO.seek
 six.StringIO.truncate
 six.create_bound_method.__closure__
+six.create_bound_method.__code__
 six.create_bound_method.__defaults__
 six.moves.*
 


### PR DESCRIPTION
Follow-up to #12749

Fixes #12758