### PR TITLE
Update pytype to 2024.10.11

### DIFF
--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -3,7 +3,7 @@
 mypy==1.11.2
 pyright==1.1.383
 # pytype can be installed on Windows, but requires building wheels, let's not do that on the CI
-pytype==2024.9.13; platform_system != "Windows" and python_version < "3.13"
+pytype==2024.10.11; platform_system != "Windows" and python_version < "3.13"
 
 # Libraries used by our various scripts.
 aiohttp==3.10.9

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -3,7 +3,7 @@
 mypy==1.11.2
 pyright==1.1.383
 # pytype can be installed on Windows, but requires building wheels, let's not do that on the CI
-pytype==2024.10.11; platform_system != "Windows" and python_version < "3.13"
+pytype==2024.10.11; platform_system != "Windows" and python_version >= "3.10" and python_version < "3.13"
 
 # Libraries used by our various scripts.
 aiohttp==3.10.9


### PR DESCRIPTION
pytype 2024.10.11 fixes an issue around ParamSpec and circular imports.

pytype 2024.10.11 also drops support for Python 3.8 and 3.9. To account for that, this PR adds a python_version restriction to requirements-tests.txt.

I tested this version with https://github.com/python/typeshed/pull/12745 and confirmed that it fixes the issue.