### PR TITLE
Add undocumented `quopri` symbols

### DIFF
--- a/stdlib/quopri.pyi
+++ b/stdlib/quopri.pyi
@@ -1,7 +1,12 @@
 from _typeshed import ReadableBuffer, SupportsNoArgReadline, SupportsRead, SupportsWrite
-from typing import Protocol
+from typing import Final, Protocol
 
 __all__ = ["encode", "decode", "encodestring", "decodestring"]
+
+ESCAPE: Final = b"="  # undocumented
+MAXLINESIZE: Final = 76  # undocumented
+HEX: Final = b"0123456789ABCDEF"  # undocumented
+EMPTYSTRING: Final = b""  # undocumented
 
 class _Input(SupportsRead[bytes], SupportsNoArgReadline[bytes], Protocol): ...
 
@@ -9,3 +14,8 @@ def encode(input: _Input, output: SupportsWrite[bytes], quotetabs: int, header: 
 def encodestring(s: ReadableBuffer, quotetabs: bool = False, header: bool = False) -> bytes: ...
 def decode(input: _Input, output: SupportsWrite[bytes], header: bool = False) -> None: ...
 def decodestring(s: str | ReadableBuffer, header: bool = False) -> bytes: ...
+def needsquoting(c: bytes, quotetabs: bool, header: bool) -> bool: ...  # undocumented
+def quote(c: bytes) -> bytes: ...  # undocumented
+def ishex(c: bytes) -> bool: ...  # undocumented
+def unhex(s: bytes) -> int: ...  # undocumented
+def main() -> None: ...  # undocumented


### PR DESCRIPTION
Adds some undocumented `quopri` symbols.

All of these symbols exist in all supported Python versions.