### PR TITLE
Reuse `hashlib._Hash` in `hmac`

### DIFF
--- a/stdlib/hmac.pyi
+++ b/stdlib/hmac.pyi
@@ -1,12 +1,11 @@
 from _typeshed import ReadableBuffer, SizedBuffer
 from collections.abc import Callable
+from hashlib import _Hash as _HashlibHash
 from types import ModuleType
-from typing import Any, AnyStr, overload
+from typing import AnyStr, overload
 from typing_extensions import TypeAlias
 
-# TODO more precise type for object of hashlib
-_Hash: TypeAlias = Any
-_DigestMod: TypeAlias = str | Callable[[], _Hash] | ModuleType
+_DigestMod: TypeAlias = str | Callable[[], _HashlibHash] | ModuleType
 
 trans_5C: bytes
 trans_36: bytes


### PR DESCRIPTION
Attempts to resolve this `# TODO`:
    https://github.com/python/typeshed/blob/03fe755ec11617b7437ddb3f914a9d06a022be1d/stdlib/hmac.pyi#L7-L8

This PR replaces the `_Hash` alias with the existing [`hashlib._Hash`](https://github.com/python/typeshed/blob/03fe755ec11617b7437ddb3f914a9d06a022be1d/stdlib/hashlib.pyi#L51), which seems to work perfectly here (all protocol members are used somewhere in `hmac`, and no expected members are missing).

I couldn't find any documentation about whether importing private protocols from different modules is generally acceptable, but I found an existing instance of this being done in [`tarfile`](https://github.com/python/typeshed/blob/352cfc9773193ac7b3bfc28a190d36ec12be42fa/stdlib/tarfile.pyi#L7), so I'm hoping this pattern is fine here as well.
