### PR TITLE
Revert "`memoryview`: remove inheritance from `Sequence`"

### DIFF
--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -834,7 +834,7 @@ _IntegerFormats: TypeAlias = Literal[
 ]
 
 @final
-class memoryview(Generic[_I]):
+class memoryview(Sequence[_I]):
     @property
     def format(self) -> str: ...
     @property


### PR DESCRIPTION
Reverts python/typeshed#12781

Although it does not implement the full Sequence API at runtime, memoryview is in fact a subclass of Sequence at runtime (through ABC registration). I will work soon on changes in CPython to remedy the discrepancy, but that doesn't solve the problem on existing versions of Python.

I'd prefer to revert to the previous behavior where memoryview is a subclass of Sequence, for a few reasons:

- It's been like this for a long time and hasn't led to a lot of issues. Both options introduce potential problems; it's better to stick with the existing solution in case people are relying on it in their code already.
- Removing the inheritance makes it so the behavior of `isinstance(..., Sequence)` becomes inconsistent between type checkers and the runtime. That's confusing and can lead to soundness issues.
- I don't find the arguments in https://github.com/python/typeshed/pull/12781#issuecomment-2407802965 convincing. The missing methods are relatively rarely used, note core parts of the Sequence API. Sequence may not appear in the MRO of `memoryview`, but that's hos we handle ABC inheritance throughout typeshed. There wasn't fallout in mypy-primer, but most typechecked code isn't in mypy-primer. Inheritance from ABCs can lead to metaclass problems in type checkers, but removing the ABC from a single builtin class hardly fixes that problem.