### PR TITLE
csv.Dialect doesn't actually subclass _csv.Dialect

### DIFF
--- a/stdlib/_csv.pyi
+++ b/stdlib/_csv.pyi
@@ -1,3 +1,4 @@
+import csv
 import sys
 from _typeshed import SupportsWrite
 from collections.abc import Iterable, Iterator
@@ -20,7 +21,7 @@ _QuotingType: TypeAlias = int
 
 class Error(Exception): ...
 
-_DialectLike: TypeAlias = str | Dialect | type[Dialect]
+_DialectLike: TypeAlias = str | Dialect | csv.Dialect | type[Dialect | csv.Dialect]
 
 class Dialect:
     delimiter: str

--- a/stdlib/csv.pyi
+++ b/stdlib/csv.pyi
@@ -4,7 +4,6 @@ from _csv import (
     QUOTE_MINIMAL as QUOTE_MINIMAL,
     QUOTE_NONE as QUOTE_NONE,
     QUOTE_NONNUMERIC as QUOTE_NONNUMERIC,
-    Dialect as _Dialect,
     Error as Error,
     __version__ as __version__,
     _DialectLike,
@@ -59,7 +58,15 @@ if sys.version_info < (3, 13):
 
 _T = TypeVar("_T")
 
-class Dialect(_Dialect):
+class Dialect:
+    delimiter: str
+    quotechar: str | None
+    escapechar: str | None
+    doublequote: bool
+    skipinitialspace: bool
+    lineterminator: str
+    quoting: _QuotingType
+    strict: bool
     def __init__(self) -> None: ...
 
 class excel(Dialect): ...


### PR DESCRIPTION
It does a weird wrapping thing instead:
https://github.com/python/cpython/blob/2a5cdb251674ce8d9a824c102f7cd846d944cfa4/Lib/csv.py#L114

related to https://github.com/python/typeshed/issues/3968