### PR TITLE
Remove redundant inheritances from `Iterator`

### DIFF
--- a/stdlib/csv.pyi
+++ b/stdlib/csv.pyi
@@ -24,7 +24,7 @@ if sys.version_info >= (3, 12):
     from _csv import QUOTE_NOTNULL as QUOTE_NOTNULL, QUOTE_STRINGS as QUOTE_STRINGS
 
 from _typeshed import SupportsWrite
-from collections.abc import Collection, Iterable, Iterator, Mapping, Sequence
+from collections.abc import Collection, Iterable, Mapping, Sequence
 from typing import Any, Generic, Literal, TypeVar, overload
 from typing_extensions import Self
 
@@ -66,7 +66,7 @@ class excel(Dialect): ...
 class excel_tab(excel): ...
 class unix_dialect(Dialect): ...
 
-class DictReader(Iterator[dict[_T | Any, str | Any]], Generic[_T]):
+class DictReader(Generic[_T]):
     fieldnames: Sequence[_T] | None
     restkey: _T | None
     restval: str | Any | None

--- a/stdlib/fileinput.pyi
+++ b/stdlib/fileinput.pyi
@@ -1,8 +1,8 @@
 import sys
 from _typeshed import AnyStr_co, StrOrBytesPath
-from collections.abc import Callable, Iterable, Iterator
+from collections.abc import Callable, Iterable
 from types import TracebackType
-from typing import IO, Any, AnyStr, Literal, Protocol, overload
+from typing import IO, Any, AnyStr, Generic, Literal, Protocol, overload
 from typing_extensions import Self, TypeAlias
 
 if sys.version_info >= (3, 9):
@@ -107,7 +107,7 @@ def fileno() -> int: ...
 def isfirstline() -> bool: ...
 def isstdin() -> bool: ...
 
-class FileInput(Iterator[AnyStr]):
+class FileInput(Generic[AnyStr]):
     if sys.version_info >= (3, 10):
         # encoding and errors are added
         @overload

--- a/stdlib/multiprocessing/pool.pyi
+++ b/stdlib/multiprocessing/pool.pyi
@@ -1,5 +1,5 @@
 import sys
-from collections.abc import Callable, Iterable, Iterator, Mapping
+from collections.abc import Callable, Iterable, Mapping
 from types import TracebackType
 from typing import Any, Final, Generic, TypeVar
 from typing_extensions import Self
@@ -36,7 +36,7 @@ class MapResult(ApplyResult[list[_T]]):
         error_callback: Callable[[BaseException], object] | None,
     ) -> None: ...
 
-class IMapIterator(Iterator[_T]):
+class IMapIterator(Generic[_T]):
     def __init__(self, pool: Pool) -> None: ...
     def __iter__(self) -> Self: ...
     def next(self, timeout: float | None = None) -> _T: ...


### PR DESCRIPTION
I'm at about 90% confidence on this one, so I'm looking forward to the mypy-primer results for validation.