### PR TITLE
Use compatible version marker for icalendar

### DIFF
--- a/stubs/icalendar/METADATA.toml
+++ b/stubs/icalendar/METADATA.toml
@@ -1,4 +1,4 @@
-version = "6.0.*"
+version = "~= 6.0.1"
 upstream_repository = "https://github.com/collective/icalendar"
 requires = ["types-python-dateutil", "backports.zoneinfo; python_version<'3.9'"]
 


### PR DESCRIPTION
icalendar 6.0.1 had some API changes, so it's an ideal candidate to check whether this works.