### PR TITLE
Improve Typing for `threading.Thread`

### DIFF
--- a/stdlib/@tests/test_cases/check_threading.py
+++ b/stdlib/@tests/test_cases/check_threading.py
@@ -22,6 +22,9 @@ def my_func(a: int, b: int) -> int: ...
 def no_arguements() -> None: ...
 
 
+def key_word_only_arguments(*, a: int, b: int) -> int: ...
+
+
 # Fine
 threading.Thread(target=my_func, args=(1, 1)).start()
 # Incorrect
@@ -36,3 +39,8 @@ threading.Thread(None, my_func, None, (), {"a": 1, "b": 1}).start()
 
 # With no arguments, the type errors should go away.
 threading.Thread(target=no_arguements).start()
+
+# With key-word only arguments, we should get an error trying to pass in args.
+threading.Thread(target=key_word_only_arguments, args=(1, 1)).start()  # type: ignore
+# We should not get an error when passing in kwargs.
+threading.Thread(target=key_word_only_arguments, kwargs={"a": 1, "b": 1}).start()

--- a/stdlib/@tests/test_cases/check_threading.py
+++ b/stdlib/@tests/test_cases/check_threading.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import _threading_local
 import threading
+from typing import Any
 
 loc = threading.local()
 loc.foo = 42
@@ -12,3 +13,26 @@ del loc.baz
 l2 = _threading_local.local()
 l2.asdfasdf = 56
 del l2.asdfasdf
+
+
+# Type-checking when we don't have key-word only arguments.
+def my_func(a: int, b: int) -> int: ...
+
+
+def no_arguements() -> None: ...
+
+
+# Fine
+threading.Thread(target=my_func, args=(1, 1)).start()
+# Incorrect
+threading.Thread(target=my_func, args=(1, "test")).start()  # type: ignore
+# Incorrect # of arguments
+threading.Thread(target=my_func, args=(1, 1, 1)).start()  # type: ignore
+
+# When providing kwargs, the type errors should go away.
+threading.Thread(target=my_func, kwargs={"a": 1, "b": 1}).start()
+threading.Thread(None, my_func, None, (), {"a": 1, "b": 1}).start()
+
+
+# With no arguments, the type errors should go away.
+threading.Thread(target=no_arguements).start()

--- a/stdlib/threading.pyi
+++ b/stdlib/threading.pyi
@@ -8,7 +8,7 @@ from typing import Any, TypeVar, final, overload
 from typing_extensions import TypeVarTuple, Unpack
 
 _T = TypeVar("_T")
-_Ts = TypeVarTuple("_Ts", default=Unpack[tuple[Any, ...]])
+_Ts = TypeVarTuple("_Ts")
 
 __all__ = [
     "get_ident",
@@ -81,6 +81,7 @@ class Thread:
         group: None = None,
         target: Callable[[Unpack[_Ts]], object] | None = None,
         name: str | None = None,
+        args: tuple[Unpack[_Ts]] = (),  # type: ignore[arg-type] - MyPy false positive
         *,
         daemon: bool | None = None,
     ) -> None: ...

--- a/stdlib/threading.pyi
+++ b/stdlib/threading.pyi
@@ -82,7 +82,7 @@ class Thread:
         target: Callable[[Unpack[_Ts]], object] | None = None,
         name: str | None = None,
         # MyPy false positive
-        args: tuple[Unpack[_Ts]] = (),  # type: ignore[arg-type]
+        args: tuple[Unpack[_Ts]] = (),  # type: ignore
         *,
         daemon: bool | None = None,
     ) -> None: ...

--- a/stdlib/threading.pyi
+++ b/stdlib/threading.pyi
@@ -4,8 +4,8 @@ from _thread import _excepthook, _ExceptHookArgs, get_native_id as get_native_id
 from _typeshed import ProfileFunction, TraceFunction
 from collections.abc import Callable, Iterable, Mapping
 from types import TracebackType
-from typing import Any, TypeVar, Unpack, final, overload
-from typing_extensions import TypeVarTuple
+from typing import Any, TypeVar, final, overload
+from typing_extensions import TypeVarTuple, Unpack
 
 _T = TypeVar("_T")
 _Ts = TypeVarTuple("_Ts")

--- a/stdlib/threading.pyi
+++ b/stdlib/threading.pyi
@@ -81,7 +81,8 @@ class Thread:
         group: None = None,
         target: Callable[[Unpack[_Ts]], object] | None = None,
         name: str | None = None,
-        args: tuple[Unpack[_Ts]] = (),  # type: ignore[arg-type] - MyPy false positive
+        # MyPy false positive
+        args: tuple[Unpack[_Ts]] = (),  # type: ignore[arg-type]
         *,
         daemon: bool | None = None,
     ) -> None: ...

--- a/stdlib/threading.pyi
+++ b/stdlib/threading.pyi
@@ -8,7 +8,7 @@ from typing import Any, TypeVar, final, overload
 from typing_extensions import TypeVarTuple, Unpack
 
 _T = TypeVar("_T")
-_Ts = TypeVarTuple("_Ts", default=Unpack[tuple[()]])
+_Ts = TypeVarTuple("_Ts", default=Unpack[tuple[Any, ...]])
 
 __all__ = [
     "get_ident",
@@ -81,7 +81,6 @@ class Thread:
         group: None = None,
         target: Callable[[Unpack[_Ts]], object] | None = None,
         name: str | None = None,
-        args: tuple[Unpack[_Ts]] = (),
         *,
         daemon: bool | None = None,
     ) -> None: ...

--- a/stdlib/threading.pyi
+++ b/stdlib/threading.pyi
@@ -4,9 +4,11 @@ from _thread import _excepthook, _ExceptHookArgs, get_native_id as get_native_id
 from _typeshed import ProfileFunction, TraceFunction
 from collections.abc import Callable, Iterable, Mapping
 from types import TracebackType
-from typing import Any, TypeVar, final
+from typing import Any, TypeVar, Unpack, final, overload
+from typing_extensions import TypeVarTuple
 
 _T = TypeVar("_T")
+_Ts = TypeVarTuple("_Ts")
 
 __all__ = [
     "get_ident",
@@ -73,14 +75,36 @@ class Thread:
     @property
     def ident(self) -> int | None: ...
     daemon: bool
+    @overload
+    def __init__(
+        self,
+        group: None = None,
+        target: Callable[[Unpack[_Ts]], object] | None = None,
+        name: str | None = None,
+        args: tuple[Unpack[_Ts]] = (),
+        *,
+        daemon: bool | None = None,
+    ) -> None: ...
+    @overload
+    def __init__(
+        self,
+        group: None,
+        target: Callable[..., object] | None,
+        name: str | None,
+        args: Iterable[Any],
+        kwargs: Mapping[str, Any],
+        *,
+        daemon: bool | None = None,
+    ) -> None: ...
+    @overload
     def __init__(
         self,
         group: None = None,
         target: Callable[..., object] | None = None,
         name: str | None = None,
         args: Iterable[Any] = (),
-        kwargs: Mapping[str, Any] | None = None,
         *,
+        kwargs: Mapping[str, Any],
         daemon: bool | None = None,
     ) -> None: ...
     def start(self) -> None: ...

--- a/stdlib/threading.pyi
+++ b/stdlib/threading.pyi
@@ -8,7 +8,7 @@ from typing import Any, TypeVar, final, overload
 from typing_extensions import TypeVarTuple, Unpack
 
 _T = TypeVar("_T")
-_Ts = TypeVarTuple("_Ts")
+_Ts = TypeVarTuple("_Ts", default=Unpack[tuple[()]])
 
 __all__ = [
     "get_ident",


### PR DESCRIPTION
This PR makes it so that if you pass a Callable, while passing in args, but not kwargs, that type-checking is done on the arguments. Take this simple example, which would normally lead to a false negative:

```python
def my_func(a: int, b: int) -> int: ...

threading.Thread(target=my_func, args=(1, "test")).start() 
```

Which now would get cause by a type-checker. If kwargs are provided, we skip type-checking of the args as in that case there's no mechanism for verifying they are correct.

The only limitation here is that now if you're providing `args`, it must be a tuple, I don't see that as a major downside to ensure that we have type-checking on the these arguments. Additionally `Iterable` is a bit more flexible than what the docstring says (`list` or `tuple`) already.