### PR TITLE
[CI] Pin Ubuntu in third party stubtest

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -60,7 +60,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
+        # As of 2024-10-18, ubuntu-latest can refer to different Ubuntu versions,
+        # which causes problems when testing gdb.
+        os: ["ubuntu-24.04", "windows-latest", "macos-latest"]
         shard-index: [0, 1, 2, 3]
       fail-fast: false
     steps:

--- a/.github/workflows/stubtest_third_party.yml
+++ b/.github/workflows/stubtest_third_party.yml
@@ -32,7 +32,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
+        # As of 2024-10-18, ubuntu-latest can refer to different Ubuntu versions,
+        # which causes problems when testing gdb.
+        os: ["ubuntu-24.04", "windows-latest", "macos-latest"]
       fail-fast: false
 
     steps:


### PR DESCRIPTION
This fixes a problem with gdb changing between the Ubuntu versions.