### PR TITLE
Add deprecation annotation for `zipimport.zipimporter.load_module`

### DIFF
--- a/stdlib/zipimport.pyi
+++ b/stdlib/zipimport.pyi
@@ -3,6 +3,7 @@ from _typeshed import StrOrBytesPath
 from importlib.abc import ResourceReader
 from importlib.machinery import ModuleSpec
 from types import CodeType, ModuleType
+from typing_extensions import deprecated
 
 __all__ = ["ZipImportError", "zipimporter"]
 
@@ -26,6 +27,7 @@ class zipimporter:
     def get_resource_reader(self, fullname: str) -> ResourceReader | None: ...  # undocumented
     def get_source(self, fullname: str) -> str | None: ...
     def is_package(self, fullname: str) -> bool: ...
+    @deprecated("Deprecated since 3.10; use exec_module() instead")
     def load_module(self, fullname: str) -> ModuleType: ...
     if sys.version_info >= (3, 10):
         def exec_module(self, module: ModuleType) -> None: ...


### PR DESCRIPTION
This has been [deprecated since 3.10](https://docs.python.org/3/library/zipimport.html#zipimport.zipimporter.load_module), and I'm quite sure that it's been causing problems for the `exec_module` migration. See my comment [here](https://github.com/python/cpython/issues/125746#issuecomment-2425030377).