### PR TITLE
Bump WTForms to ~= 3.2.1

### DIFF
--- a/stubs/WTForms/METADATA.toml
+++ b/stubs/WTForms/METADATA.toml
@@ -1,3 +1,3 @@
-version = "3.2.*"
+version = "~= 3.2.1"
 upstream_repository = "https://github.com/pallets-eco/wtforms"
 requires = ["MarkupSafe"]

--- a/stubs/WTForms/wtforms/__init__.pyi
+++ b/stubs/WTForms/wtforms/__init__.pyi
@@ -4,6 +4,7 @@ from wtforms import validators as validators, widgets as widgets
 from wtforms.fields.choices import (
     RadioField as RadioField,
     SelectField as SelectField,
+    SelectFieldBase as SelectFieldBase,
     SelectMultipleField as SelectMultipleField,
 )
 from wtforms.fields.core import Field as Field, Flags as Flags, Label as Label
@@ -49,6 +50,7 @@ __all__ = [
     "Form",
     "ValidationError",
     "SelectField",
+    "SelectFieldBase",
     "SelectMultipleField",
     "RadioField",
     "Field",

--- a/stubs/WTForms/wtforms/fields/__init__.pyi
+++ b/stubs/WTForms/wtforms/fields/__init__.pyi
@@ -1,6 +1,7 @@
 from wtforms.fields.choices import (
     RadioField as RadioField,
     SelectField as SelectField,
+    SelectFieldBase as SelectFieldBase,
     SelectMultipleField as SelectMultipleField,
 )
 from wtforms.fields.core import Field as Field, Flags as Flags, Label as Label
@@ -43,6 +44,7 @@ __all__ = [
     "Flags",
     "Label",
     "SelectField",
+    "SelectFieldBase",
     "SelectMultipleField",
     "RadioField",
     "DateTimeField",


### PR DESCRIPTION
If we wanted to be extra nice we could manually run stub_uploader once before merging or wait until tomorrow to merge this, so we have correct stubs for both 3.2.0 and 3.2.1+.

I don't really think it matters though considering how close together these releases were.