### PR TITLE
WTForms: Fix incorrect `Form` constructor return type for pyright

### DIFF
--- a/stubs/WTForms/@tests/test_cases/check_form.py
+++ b/stubs/WTForms/@tests/test_cases/check_form.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from typing_extensions import assert_type
+
+from wtforms import Form, StringField
+
+
+class MyForm(Form):
+    name = StringField()
+
+
+form = MyForm()
+assert_type(form, MyForm)
+assert_type(form.name, StringField)

--- a/stubs/WTForms/@tests/test_cases/check_form.py
+++ b/stubs/WTForms/@tests/test_cases/check_form.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing_extensions import assert_type
 
 from wtforms import Form, StringField
+from wtforms.fields.core import UnboundField
 
 
 class MyForm(Form):
@@ -12,3 +13,4 @@ class MyForm(Form):
 form = MyForm()
 assert_type(form, MyForm)
 assert_type(form.name, StringField)
+assert_type(MyForm.name, UnboundField[StringField])

--- a/stubs/WTForms/wtforms/form.pyi
+++ b/stubs/WTForms/wtforms/form.pyi
@@ -1,11 +1,12 @@
 from _typeshed import SupportsItems
 from collections.abc import Iterable, Iterator, Mapping, Sequence
-from typing import Any, ClassVar, Protocol, overload
+from typing import Any, ClassVar, Protocol, TypeVar, overload
 from typing_extensions import TypeAlias
 
 from wtforms.fields.core import Field, UnboundField
 from wtforms.meta import DefaultMeta, _MultiDictLike
 
+_T = TypeVar("_T")
 _FormErrors: TypeAlias = dict[str | None, Sequence[str] | _FormErrors]
 
 # _unbound_fields will always be a list on an instance, but on a
@@ -55,7 +56,7 @@ class BaseForm:
 
 class FormMeta(type):
     def __init__(cls, name: str, bases: Sequence[type[object]], attrs: Mapping[str, Any]) -> None: ...
-    def __call__(cls, *args: Any, **kwargs: Any) -> Any: ...
+    def __call__(cls: type[_T], *args: Any, **kwargs: Any) -> _T: ...
     def __setattr__(cls, name: str, value: object) -> None: ...
     def __delattr__(cls, name: str) -> None: ...
 


### PR DESCRIPTION
This fixes https://github.com/pallets-eco/wtforms/issues/848