### PR TITLE
WTForms: Form errors no longer use `None` as a special key

### DIFF
--- a/stubs/WTForms/wtforms/fields/form.pyi
+++ b/stubs/WTForms/wtforms/fields/form.pyi
@@ -1,8 +1,8 @@
-from collections.abc import Iterator, Sequence
+from collections.abc import Iterator
 from typing import Any, Generic, TypeVar
 
 from wtforms.fields.core import Field, _Widget
-from wtforms.form import BaseForm
+from wtforms.form import BaseForm, _FormErrors
 from wtforms.meta import DefaultMeta, _SupportsGettextAndNgettext
 
 __all__ = ("FormField",)
@@ -37,4 +37,4 @@ class FormField(Field, Generic[_BoundFormT]):
     @property
     def data(self) -> dict[str, Any]: ...
     @property
-    def errors(self) -> dict[str | None, Sequence[str]]: ...  # type: ignore[override]
+    def errors(self) -> _FormErrors: ...  # type: ignore[override]

--- a/stubs/WTForms/wtforms/fields/list.pyi
+++ b/stubs/WTForms/wtforms/fields/list.pyi
@@ -1,4 +1,4 @@
-from collections.abc import Callable, Iterable, Iterator
+from collections.abc import Callable, Iterable, Iterator, Sequence
 from typing import Any, Generic, TypeVar
 
 from wtforms.fields.core import Field, UnboundField, _FormT, _Validator, _Widget
@@ -16,6 +16,11 @@ class FieldList(Field, Generic[_BoundFieldT]):
     last_index: int
     entries: list[_BoundFieldT]
     object_data: Iterable[Any]
+    # NOTE: This depends on the shape of errors of the bound field, which usually should
+    #       be a `Sequence[Sequence[str]]`, but can be `Sequence[_FormErrors]` for `FormField`
+    #       we could model this with a fake descriptor with overloads for `FieldList[FormField]`
+    #       but it might not be worth the hassle, for now we'll just leave it lax
+    errors: Sequence[Any]
     def __init__(
         self: FieldList[_BoundFieldT],  # pyright: ignore[reportInvalidTypeVarUse]  #11780
         # because of our workaround we need to accept Field as well

--- a/stubs/WTForms/wtforms/form.pyi
+++ b/stubs/WTForms/wtforms/form.pyi
@@ -7,7 +7,7 @@ from wtforms.fields.core import Field, UnboundField
 from wtforms.meta import DefaultMeta, _MultiDictLike
 
 _T = TypeVar("_T")
-_FormErrors: TypeAlias = dict[str | None, Sequence[str] | _FormErrors]
+_FormErrors: TypeAlias = dict[str, Sequence[str] | _FormErrors]
 
 # _unbound_fields will always be a list on an instance, but on a
 # class it might be None, if it never has been instantiated, or


### PR DESCRIPTION
This was changed as part of the upgrade to 3.2.0, I also fixed a couple of related issues I missed.