### PR TITLE
fix up blake2b/blake2s classes

### DIFF
--- a/stdlib/VERSIONS
+++ b/stdlib/VERSIONS
@@ -22,6 +22,7 @@ __main__: 3.0-
 _ast: 3.0-
 _asyncio: 3.0-
 _bisect: 3.0-
+_blake2: 3.6-
 _bootlocale: 3.4-3.9
 _codecs: 3.0-
 _collections_abc: 3.3-

--- a/stdlib/_blake2.pyi
+++ b/stdlib/_blake2.pyi
@@ -1,0 +1,117 @@
+import sys
+from _typeshed import ReadableBuffer
+from typing import ClassVar, final
+from typing_extensions import Self
+
+BLAKE2B_MAX_DIGEST_SIZE: int = 64
+BLAKE2B_MAX_KEY_SIZE: int = 64
+BLAKE2B_PERSON_SIZE: int = 16
+BLAKE2B_SALT_SIZE: int = 16
+BLAKE2S_MAX_DIGEST_SIZE: int = 32
+BLAKE2S_MAX_KEY_SIZE: int = 32
+BLAKE2S_PERSON_SIZE: int = 8
+BLAKE2S_SALT_SIZE: int = 8
+
+@final
+class blake2b:
+    MAX_DIGEST_SIZE: ClassVar[int] = 64
+    MAX_KEY_SIZE: ClassVar[int] = 64
+    PERSON_SIZE: ClassVar[int] = 16
+    SALT_SIZE: ClassVar[int] = 16
+    block_size: int
+    digest_size: int
+    name: str
+    if sys.version_info >= (3, 9):
+        def __init__(
+            self,
+            data: ReadableBuffer = b"",
+            /,
+            *,
+            digest_size: int = 64,
+            key: ReadableBuffer = b"",
+            salt: ReadableBuffer = b"",
+            person: ReadableBuffer = b"",
+            fanout: int = 1,
+            depth: int = 1,
+            leaf_size: int = 0,
+            node_offset: int = 0,
+            node_depth: int = 0,
+            inner_size: int = 0,
+            last_node: bool = False,
+            usedforsecurity: bool = True,
+        ) -> None: ...
+    else:
+        def __init__(
+            self,
+            data: ReadableBuffer = b"",
+            /,
+            *,
+            digest_size: int = 64,
+            key: ReadableBuffer = b"",
+            salt: ReadableBuffer = b"",
+            person: ReadableBuffer = b"",
+            fanout: int = 1,
+            depth: int = 1,
+            leaf_size: int = 0,
+            node_offset: int = 0,
+            node_depth: int = 0,
+            inner_size: int = 0,
+            last_node: bool = False,
+        ) -> None: ...
+
+    def copy(self) -> Self: ...
+    def digest(self) -> bytes: ...
+    def hexdigest(self) -> str: ...
+    def update(self, data: ReadableBuffer, /) -> None: ...
+
+@final
+class blake2s:
+    MAX_DIGEST_SIZE: ClassVar[int] = 32
+    MAX_KEY_SIZE: ClassVar[int] = 32
+    PERSON_SIZE: ClassVar[int] = 8
+    SALT_SIZE: ClassVar[int] = 8
+    block_size: int
+    digest_size: int
+    name: str
+    if sys.version_info >= (3, 9):
+        def __init__(
+            self,
+            data: ReadableBuffer = b"",
+            /,
+            *,
+            digest_size: int = 32,
+            key: ReadableBuffer = b"",
+            salt: ReadableBuffer = b"",
+            person: ReadableBuffer = b"",
+            fanout: int = 1,
+            depth: int = 1,
+            leaf_size: int = 0,
+            node_offset: int = 0,
+            node_depth: int = 0,
+            inner_size: int = 0,
+            last_node: bool = False,
+            usedforsecurity: bool = True,
+        ) -> None: ...
+    else:
+        def __init__(
+            self,
+            data: ReadableBuffer = b"",
+            /,
+            *,
+            digest_size: int = 32,
+            key: ReadableBuffer = b"",
+            salt: ReadableBuffer = b"",
+            person: ReadableBuffer = b"",
+            fanout: int = 1,
+            depth: int = 1,
+            leaf_size: int = 0,
+            node_offset: int = 0,
+            node_depth: int = 0,
+            inner_size: int = 0,
+            last_node: bool = False,
+        ) -> None: ...
+
+    def copy(self) -> Self: ...
+    def digest(self) -> bytes: ...
+    def hexdigest(self) -> str: ...
+    def update(self, data: ReadableBuffer, /) -> None: ...

--- a/stdlib/hashlib.pyi
+++ b/stdlib/hashlib.pyi
@@ -1,7 +1,8 @@
 import sys
+from _blake2 import blake2b as blake2b, blake2s as blake2s
 from _typeshed import ReadableBuffer
 from collections.abc import Callable, Set as AbstractSet
-from typing import Protocol, final
+from typing import Protocol
 from typing_extensions import Self
 
 if sys.version_info >= (3, 11):
@@ -106,53 +107,6 @@ shake_256 = _VarLenHash
 def scrypt(
     password: ReadableBuffer, *, salt: ReadableBuffer, n: int, r: int, p: int, maxmem: int = 0, dklen: int = 64
 ) -> bytes: ...
-@final
-class _BlakeHash(_Hash):
-    MAX_DIGEST_SIZE: int
-    MAX_KEY_SIZE: int
-    PERSON_SIZE: int
-    SALT_SIZE: int
-
-    if sys.version_info >= (3, 9):
-        def __init__(
-            self,
-            data: ReadableBuffer = ...,
-            /,
-            *,
-            digest_size: int = ...,
-            key: ReadableBuffer = ...,
-            salt: ReadableBuffer = ...,
-            person: ReadableBuffer = ...,
-            fanout: int = ...,
-            depth: int = ...,
-            leaf_size: int = ...,
-            node_offset: int = ...,
-            node_depth: int = ...,
-            inner_size: int = ...,
-            last_node: bool = ...,
-            usedforsecurity: bool = ...,
-        ) -> None: ...
-    else:
-        def __init__(
-            self,
-            data: ReadableBuffer = ...,
-            /,
-            *,
-            digest_size: int = ...,
-            key: ReadableBuffer = ...,
-            salt: ReadableBuffer = ...,
-            person: ReadableBuffer = ...,
-            fanout: int = ...,
-            depth: int = ...,
-            leaf_size: int = ...,
-            node_offset: int = ...,
-            node_depth: int = ...,
-            inner_size: int = ...,
-            last_node: bool = ...,
-        ) -> None: ...
-
-blake2b = _BlakeHash
-blake2s = _BlakeHash
 
 if sys.version_info >= (3, 11):
     class _BytesIOLike(Protocol):


### PR DESCRIPTION
This MR moves hashlib.blake2b and hashlib.blake2s into _blake2 where they live at runtime, makes their inheritance accurate, and fills in all the default values, which are notably the primary difference between the blake2b and blake2s classes.

Let's see if losing the inheritance from hashlib._Hash causes any issues.