### PR TITLE
correct inheritance for io.StringIO

### DIFF
--- a/stdlib/_io.pyi
+++ b/stdlib/_io.pyi
@@ -173,13 +173,15 @@ class TextIOWrapper(TextIOBase, _TextIOBase, TextIO, Generic[_BufferT_co]):  # t
     # operations.
     def seek(self, cookie: int, whence: int = 0, /) -> int: ...
 
-class StringIO(TextIOWrapper, TextIOBase, _TextIOBase):  # type: ignore[misc]  # incompatible definitions of write in the base classes
+class StringIO(TextIOBase, _TextIOBase):  # type: ignore[misc]  # incompatible definitions of write in the base classes
     def __init__(self, initial_value: str | None = ..., newline: str | None = ...) -> None: ...
     # StringIO does not contain a "name" field. This workaround is necessary
     # to allow StringIO sub-classes to add this field, as it is defined
     # as a read-only property on IO[].
     name: Any
     def getvalue(self) -> str: ...
+    @property
+    def line_buffering(self) -> bool: ...
 
 class IncrementalNewlineDecoder:
     def __init__(self, decoder: codecs.IncrementalDecoder | None, translate: bool, errors: str = ...) -> None: ...

--- a/stdlib/_io.pyi
+++ b/stdlib/_io.pyi
@@ -173,7 +173,7 @@ class TextIOWrapper(TextIOBase, _TextIOBase, TextIO, Generic[_BufferT_co]):  # t
     # operations.
     def seek(self, cookie: int, whence: int = 0, /) -> int: ...
 
-class StringIO(TextIOBase, _TextIOBase):  # type: ignore[misc]  # incompatible definitions of write in the base classes
+class StringIO(TextIOBase, _TextIOBase, TextIO):  # type: ignore[misc]  # incompatible definitions of write in the base classes
     def __init__(self, initial_value: str | None = ..., newline: str | None = ...) -> None: ...
     # StringIO does not contain a "name" field. This workaround is necessary
     # to allow StringIO sub-classes to add this field, as it is defined


### PR DESCRIPTION
does not inherit from TextIOWrapper at runtime.

As in https://github.com/python/typeshed/pull/12883 , I expect that missing TextIO as a base will cause trouble but this first commit is missing it just to double check.