### PR TITLE
setuptools & distutils: Add more recent MSVCCompiler from _msvccompiler

### DIFF
--- a/stdlib/distutils/_msvccompiler.pyi
+++ b/stdlib/distutils/_msvccompiler.pyi
@@ -1,0 +1,3 @@
+from distutils.ccompiler import CCompiler
+
+class MSVCCompiler(CCompiler): ...

--- a/stdlib/distutils/_msvccompiler.pyi
+++ b/stdlib/distutils/_msvccompiler.pyi
@@ -1,3 +1,12 @@
+from _typeshed import Incomplete
 from distutils.ccompiler import CCompiler
+from typing import ClassVar, Final
 
-class MSVCCompiler(CCompiler): ...
+PLAT_SPEC_TO_RUNTIME: Final[dict[str, str]]
+PLAT_TO_VCVARS: Final[dict[str, str]]
+
+class MSVCCompiler(CCompiler):
+    compiler_type: ClassVar[str]
+    executables: ClassVar[dict[Incomplete, Incomplete]]
+    res_extension: ClassVar[str]
+    initialized: bool

--- a/stdlib/distutils/_msvccompiler.pyi
+++ b/stdlib/distutils/_msvccompiler.pyi
@@ -10,3 +10,4 @@ class MSVCCompiler(CCompiler):
     executables: ClassVar[dict[Incomplete, Incomplete]]
     res_extension: ClassVar[str]
     initialized: bool
+    def initialize(self, plat_name: str | None = None) -> None: ...

--- a/stubs/setuptools/distutils/_msvccompiler.pyi
+++ b/stubs/setuptools/distutils/_msvccompiler.pyi
@@ -1,0 +1,1 @@
+from setuptools._distutils._msvccompiler import *

--- a/stubs/setuptools/setuptools/_distutils/_msvccompiler.pyi
+++ b/stubs/setuptools/setuptools/_distutils/_msvccompiler.pyi
@@ -1,0 +1,3 @@
+from .ccompiler import CCompiler
+
+class MSVCCompiler(CCompiler): ...

--- a/stubs/setuptools/setuptools/_distutils/_msvccompiler.pyi
+++ b/stubs/setuptools/setuptools/_distutils/_msvccompiler.pyi
@@ -1,3 +1,14 @@
+from binascii import Incomplete
+from typing import ClassVar, Final
+
 from .ccompiler import CCompiler
 
-class MSVCCompiler(CCompiler): ...
+PLAT_SPEC_TO_RUNTIME: Final[dict[str, str]]
+
+class MSVCCompiler(CCompiler):
+    compiler_type: ClassVar[str]
+    executables: ClassVar[dict[Incomplete, Incomplete]]
+    res_extension: ClassVar[str]
+    initialized: bool
+    @property
+    def out_extensions(self) -> dict[str, str]: ...

--- a/stubs/setuptools/setuptools/_distutils/_msvccompiler.pyi
+++ b/stubs/setuptools/setuptools/_distutils/_msvccompiler.pyi
@@ -10,5 +10,6 @@ class MSVCCompiler(CCompiler):
     executables: ClassVar[dict[Incomplete, Incomplete]]
     res_extension: ClassVar[str]
     initialized: bool
+    def initialize(self, plat_name: str | None = None) -> None: ...
     @property
     def out_extensions(self) -> dict[str, str]: ...


### PR DESCRIPTION
This is used by pywin32: https://github.com/mhammond/pywin32/blob/5a46a21be0fdf9472f1904c54bd301745cfc482d/setup.py#L48

There doesn't seem to be a good replacement yet and its still actively being used. Here's some other references:
- https://github.com/pypa/setuptools/issues/2806#issuecomment-2415319446
- https://github.com/pypa/setuptools/issues/3933#issuecomment-1563100268
- https://github.com/pypa/setuptools/issues/3329#issuecomment-1201663383
