### PR TITLE
Add `install_data` in `distutils-stubs` from `setuptools`

### DIFF
--- a/stubs/setuptools/distutils/__init__.pyi
+++ b/stubs/setuptools/distutils/__init__.pyi
@@ -1,0 +1,3 @@
+from typing import Final
+
+__version__: Final[str]

--- a/stubs/setuptools/distutils/command/install_data.pyi
+++ b/stubs/setuptools/distutils/command/install_data.pyi
@@ -1,0 +1,1 @@
+from setuptools._distutils.command.install_data import *

--- a/stubs/setuptools/setuptools/_distutils/__init__.pyi
+++ b/stubs/setuptools/setuptools/_distutils/__init__.pyi
@@ -1,0 +1,3 @@
+from typing import Final
+
+__version__: Final[str]

--- a/stubs/setuptools/setuptools/_distutils/command/install_data.pyi
+++ b/stubs/setuptools/setuptools/_distutils/command/install_data.pyi
@@ -1,0 +1,19 @@
+from _typeshed import Incomplete
+
+from ..cmd import Command
+
+class install_data(Command):
+    description: str
+    user_options: Incomplete
+    boolean_options: Incomplete
+    install_dir: Incomplete
+    outfiles: Incomplete
+    root: Incomplete
+    force: bool
+    data_files: Incomplete
+    warn_dir: bool
+    def initialize_options(self) -> None: ...
+    def finalize_options(self) -> None: ...
+    def run(self) -> None: ...
+    def get_inputs(self): ...
+    def get_outputs(self): ...


### PR DESCRIPTION
Similarly to https://github.com/python/typeshed/pull/12887 Should fix an import/Any subclassing issue in pywin32 that is inconsistent before/after Python 3.12
https://github.com/mhammond/pywin32/actions/runs/11487030970/job/31970658450?pr=2418#step:5:13

Autogenerated by stubgen then fixed manually.