### PR TITLE
Add missing parameter to `email.policy.EmailPolicy.__init__`

### DIFF
--- a/stdlib/email/policy.pyi
+++ b/stdlib/email/policy.pyi
@@ -24,6 +24,8 @@ class EmailPolicy(Policy[_MessageT]):
         raise_on_defect: bool = ...,
         mangle_from_: bool = ...,
         message_factory: None = None,
+        # Added in Python 3.8.20, 3.9.20, 3.10.15, 3.11.10, 3.12.5
+        verify_generated_headers: bool = ...,
         utf8: bool = ...,
         refold_source: str = ...,
         header_factory: Callable[[str, str], str] = ...,
@@ -39,6 +41,8 @@ class EmailPolicy(Policy[_MessageT]):
         raise_on_defect: bool = ...,
         mangle_from_: bool = ...,
         message_factory: _MessageFactory[_MessageT] | None = ...,
+        # Added in Python 3.8.20, 3.9.20, 3.10.15, 3.11.10, 3.12.5
+        verify_generated_headers: bool = ...,
         utf8: bool = ...,
         refold_source: str = ...,
         header_factory: Callable[[str, str], str] = ...,


### PR DESCRIPTION
The parameter `verify_generated_headers` was added to `_PolicyBase.__init__` in #12638, but it wasn't copied to `EmailPolicy.__init__`. This causes the following to fail to type check in mypy despite being valid at runtime:

```python
import email.policy

email.policy.EmailPolicy(verify_generated_headers=False)  # E: Unexpected keyword argument "verify_generated_headers" for "EmailPolicy"
```