### PR TITLE
Add `win32com.gen_py`

### DIFF
--- a/stubs/pywin32/win32com/__init__.pyi
+++ b/stubs/pywin32/win32com/__init__.pyi
@@ -1,9 +1,9 @@
-from _typeshed import Incomplete
+from collections.abc import MutableSequence
+
+from . import gen_py as gen_py
 
 __gen_path__: str
-__build_path__: Incomplete
+__build_path__: str | None
 
 def SetupEnvironment() -> None: ...
-def __PackageSupportBuildPath__(package_path) -> None: ...
-
-gen_py: Incomplete
+def __PackageSupportBuildPath__(package_path: MutableSequence[str]) -> None: ...


### PR DESCRIPTION
Some information about what this is:

A dynamic package that contains the generated com modules.

stubtest couldn't autodiscover it because it lives in temp directories and is dynamically added to path. (there's an open PR to have it generated in site-packages instead: https://github.com/mhammond/pywin32/pull/1675)