### PR TITLE
OSError.errno can be None

### DIFF
--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -1916,7 +1916,7 @@ class StopIteration(Exception):
     value: Any
 
 class OSError(Exception):
-    errno: int
+    errno: int | None
     strerror: str
     # filename, filename2 are actually str | bytes | None
     filename: Any


### PR DESCRIPTION
```
>>> try:
...  raise TimeoutError
... except OSError as e:
...  print(e.errno)
... 
None
```

Code in cpython seems to always throw TimeoutError with no arguments.