### PR TITLE
Add `types.ModuleType.__doc__`

### DIFF
--- a/stdlib/types.pyi
+++ b/stdlib/types.pyi
@@ -337,6 +337,13 @@ class ModuleType:
     __package__: str | None
     __path__: MutableSequence[str]
     __spec__: ModuleSpec | None
+    # N.B. Although this is the same type as `builtins.object.__doc__`,
+    # it is deliberately redeclared here. Most symbols declared in the namespace
+    # of `types.ModuleType` are available as "implicit globals" within a module's
+    # namespace, but this is not true for symbols declared in the namespace of `builtins.object`.
+    # Redeclaring `__doc__` here helps some type checkers understand that `__doc__` is available
+    # as an implicit global in all modules, similar to `__name__`, `__file__`, `__spec__`, etc.
+    __doc__: str | None
     def __init__(self, name: str, doc: str | None = ...) -> None: ...
     # __getattr__ doesn't exist at runtime,
     # but having it here in typeshed makes dynamic imports


### PR DESCRIPTION
This would be helpful for red-knot, the work-in-progress type checker we're building at Astral.

To figure out which symbols are available in all modules as ["implicit globals"](https://docs.python.org/3/reference/datamodel.html#modules), red-knot [iterates through the symbols declared in typeshed's stub for `types.ModuleType`](https://github.com/astral-sh/ruff/blob/d2c9f5e43c12fdb8741af535dbf3acb5150ca09c/crates/red_knot_python_semantic/src/types.rs#L91-L124). Currently the only implicit global that is not declared in the stub for `types.ModuleType` is `__doc__`[^1]; this PR adds it to the stub. 

While adding `ModuleType.__doc__` is somewhat "redundant" from a purist view of the stubs (since it's the same type as `object.__doc__`, and `ModuleType` inherits from `object`), it's still accurate. We _could_ special-case `__doc__` in red-knot instead of adding it to the typeshed stubs, but we'd prefer to figure out which attributes exist as implicit globals by inspecting typeshed's stubs and doing the absolute minimum amount of special-casing. This approach means that we'll naturally pick up new implicit globals if they're ever added to the stubs in the future.

[^1]: ...Well. `__annotations__` is also available as an implicit global in some versions of Python:

    ```pycon
    Python 3.13.0 (main, Oct  8 2024, 11:56:29) [Clang 15.0.0 (clang-1500.3.9.4)] on darwin
    Type "help", "copyright", "credits" or "license" for more information.
    >>> __annotations__
    {}
    ```

	But not on others:
	
	```pycon
	Python 3.14.0a1+ (heads/main:91ddde4af0c, Oct 22 2024, 14:16:04) [Clang 15.0.0 (clang-1500.3.9.4)] on darwin
	Type "help", "copyright", "credits" or "license" for more information.
	>>> __annotations__
	Traceback (most recent call last):
	  File "<python-input-0>", line 1, in <module>
	    __annotations__
	NameError: name '__annotations__' is not defined
	```
	
	So it seems like it's probably a bad idea for users to rely on that one being defined as an implicit global. Therefore this PR does not add `ModuleType.__annotations__`, only `ModuleType.__doc__`.