### PR TITLE
inheritance for zipimporter

### DIFF
--- a/stdlib/zipimport.pyi
+++ b/stdlib/zipimport.pyi
@@ -5,11 +5,16 @@ from importlib.machinery import ModuleSpec
 from types import CodeType, ModuleType
 from typing_extensions import deprecated
 
+if sys.version_info >= (3, 10):
+    from importlib._bootstrap_external import _LoaderBasics
+else:
+    _LoaderBasics = object
+
 __all__ = ["ZipImportError", "zipimporter"]
 
 class ZipImportError(ImportError): ...
 
-class zipimporter:
+class zipimporter(_LoaderBasics):
     archive: str
     prefix: str
     if sys.version_info >= (3, 11):

--- a/stdlib/zipimport.pyi
+++ b/stdlib/zipimport.pyi
@@ -6,7 +6,7 @@ from types import CodeType, ModuleType
 from typing_extensions import deprecated
 
 if sys.version_info >= (3, 10):
-    from importlib._bootstrap_external import _LoaderBasics
+    from _frozen_importlib_external import _LoaderBasics
 else:
     _LoaderBasics = object
 


### PR DESCRIPTION
While poking around I was reminded of the approach I used in https://github.com/python/typeshed/pull/11127 to handle inheritance that is different depending on the version.

What do people think overall of this versus having two copies of the class in an if/else? This probably gives us a minimum of duplication, and the only downside is redundant inheritances from object. I suppose it's also less clear when reading the stub that the inheritance is conditional, since the condition switch can be in a different part of the file than then actual usage. Using a one-off local name could help with that, `import _LoaderBasics as _LoaderBasics_if_min_310` or something, but that's probably overkill for most situations.