### PR TITLE
Fix callback parameter type in `ssl.SSLContext.set_psk_server_callback`

### DIFF
--- a/stdlib/_ssl.pyi
+++ b/stdlib/_ssl.pyi
@@ -105,7 +105,7 @@ class _SSLContext:
     if sys.version_info >= (3, 13):
         def set_psk_client_callback(self, callback: Callable[[str | None], tuple[str | None, bytes]] | None) -> None: ...
         def set_psk_server_callback(
-            self, callback: Callable[[str | None], tuple[str | None, bytes]] | None, identity_hint: str | None = None
+            self, callback: Callable[[str | None], bytes] | None, identity_hint: str | None = None
         ) -> None: ...
 
 @final


### PR DESCRIPTION
Fixes #12931

For reference ([docs](https://docs.python.org/3/library/ssl.html#ssl.SSLContext.set_psk_server_callback)): 
> The parameter callback is a callable object with the signature: `def callback(identity: str | None) -> bytes`.