### PR TITLE
Improve path-related type hints for `setuptools.Extension()` and `distutils.CCompiler()`

### DIFF
--- a/stdlib/distutils/ccompiler.pyi
+++ b/stdlib/distutils/ccompiler.pyi
@@ -1,5 +1,5 @@
 from _typeshed import BytesPath, StrPath, Unused
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Sequence
 from distutils.file_util import _BytesPathT, _StrPathT
 from typing import Literal, overload
 from typing_extensions import TypeAlias, TypeVarTuple, Unpack
@@ -63,7 +63,7 @@ class CCompiler:
     def set_executables(self, **args: str) -> None: ...
     def compile(
         self,
-        sources: list[str],
+        sources: Sequence[StrPath],
         output_dir: str | None = None,
         macros: list[_Macro] | None = None,
         include_dirs: list[str] | None = None,

--- a/stubs/setuptools/@tests/test_cases/check_distutils.py
+++ b/stubs/setuptools/@tests/test_cases/check_distutils.py
@@ -1,3 +1,21 @@
+from __future__ import annotations
+
 import distutils.command.sdist
+from _typeshed import StrPath
+from pathlib import Path
+from typing import List
+
+from setuptools._distutils.ccompiler import CCompiler
 
 c = distutils.command.sdist.sdist
+
+# Test CCompiler().compile with varied sources
+
+compiler = CCompiler()
+compiler.compile(sources=["file1.c", "file2.c"])
+
+paths: List[StrPath] = [Path("file1.c"), Path("file2.c")]
+compiler.compile(sources=paths)
+
+mixed: List[StrPath] = [Path("file1.c"), "file2.c"]
+compiler.compile(sources=mixed)

--- a/stubs/setuptools/@tests/test_cases/check_distutils.py
+++ b/stubs/setuptools/@tests/test_cases/check_distutils.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import distutils.command.sdist
 from _typeshed import StrPath
+from os import PathLike
 from pathlib import Path
-from typing import List
 
 from setuptools._distutils.ccompiler import CCompiler
 
@@ -12,10 +12,20 @@ c = distutils.command.sdist.sdist
 # Test CCompiler().compile with varied sources
 
 compiler = CCompiler()
+
+str_list: list[str] = ["file1.c", "file2.c"]
+compiler.compile(sources=str_list)
+
+path_list: list[Path] = [Path("file1.c"), Path("file2.c")]
+compiler.compile(sources=path_list)
+
+pathlike_list: list[PathLike[str]] = [Path("file1.c"), Path("file2.c")]
+compiler.compile(sources=pathlike_list)
+
+strpath_list: list[StrPath] = [Path("file1.c"), "file2.c"]
+compiler.compile(sources=strpath_list)
+
+# Direct literals should also work
 compiler.compile(sources=["file1.c", "file2.c"])
-
-paths: List[StrPath] = [Path("file1.c"), Path("file2.c")]
-compiler.compile(sources=paths)
-
-mixed: List[StrPath] = [Path("file1.c"), "file2.c"]
-compiler.compile(sources=mixed)
+compiler.compile(sources=[Path("file1.c"), Path("file2.c")])
+compiler.compile(sources=[Path("file1.c"), "file2.c"])

--- a/stubs/setuptools/@tests/test_cases/check_extension.py
+++ b/stubs/setuptools/@tests/test_cases/check_extension.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+
+from setuptools import Extension
+
+# Dummy extensions
+ext1 = Extension(name="test1", sources=["file1.c", "file2.c"])  # list of str(s)
+ext2 = Extension(name="test2", sources=[Path("file1.c"), Path("file2.c")])  # list of Path(s)
+ext3 = Extension(name="test3", sources=[Path("file1.c"), "file2.c"])  # mixed str(s) and Path(s)

--- a/stubs/setuptools/@tests/test_cases/check_extension.py
+++ b/stubs/setuptools/@tests/test_cases/check_extension.py
@@ -1,8 +1,15 @@
+from __future__ import annotations
+
+from os import PathLike
 from pathlib import Path
 
 from setuptools import Extension
 
 # Dummy extensions
-ext1 = Extension(name="test1", sources=["file1.c", "file2.c"])  # list of str(s)
-ext2 = Extension(name="test2", sources=[Path("file1.c"), Path("file2.c")])  # list of Path(s)
-ext3 = Extension(name="test3", sources=[Path("file1.c"), "file2.c"])  # mixed str(s) and Path(s)
+ext1 = Extension(name="test1", sources=["file1.c", "file2.c"])  # plain list[str] works
+
+path_sources: list[Path] = [Path("file1.c"), Path("file2.c")]
+ext2 = Extension(name="test2", sources=path_sources)  # list of Path(s)
+
+mixed_sources: list[str | PathLike[str]] = [Path("file1.c"), "file2.c"]  # or list[StrPath]
+ext3 = Extension(name="test3", sources=mixed_sources)  # mixed types

--- a/stubs/setuptools/setuptools/_distutils/ccompiler.pyi
+++ b/stubs/setuptools/setuptools/_distutils/ccompiler.pyi
@@ -1,5 +1,5 @@
 from _typeshed import BytesPath, StrPath, Unused
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Sequence
 from typing import ClassVar, Literal, TypeVar, overload
 from typing_extensions import TypeAlias, TypeVarTuple, Unpack
 
@@ -67,7 +67,7 @@ class CCompiler:
     def set_executables(self, **args: str) -> None: ...
     def compile(
         self,
-        sources: list[str] | list[StrPath],
+        sources: Sequence[StrPath],
         output_dir: str | None = None,
         macros: list[_Macro] | None = None,
         include_dirs: list[str] | None = None,

--- a/stubs/setuptools/setuptools/_distutils/ccompiler.pyi
+++ b/stubs/setuptools/setuptools/_distutils/ccompiler.pyi
@@ -67,7 +67,7 @@ class CCompiler:
     def set_executables(self, **args: str) -> None: ...
     def compile(
         self,
-        sources: list[str],
+        sources: list[str] | list[StrPath],
         output_dir: str | None = None,
         macros: list[_Macro] | None = None,
         include_dirs: list[str] | None = None,

--- a/stubs/setuptools/setuptools/_distutils/extension.pyi
+++ b/stubs/setuptools/setuptools/_distutils/extension.pyi
@@ -2,7 +2,7 @@ from _typeshed import StrPath
 
 class Extension:
     name: str
-    sources: list[StrPath]
+    sources: list[str] | list[StrPath]
     include_dirs: list[str]
     define_macros: list[tuple[str, str | None]]
     undef_macros: list[str]
@@ -20,7 +20,7 @@ class Extension:
     def __init__(
         self,
         name: str,
-        sources: list[StrPath],
+        sources: list[str] | list[StrPath],
         include_dirs: list[str] | None = None,
         define_macros: list[tuple[str, str | None]] | None = None,
         undef_macros: list[str] | None = None,

--- a/stubs/setuptools/setuptools/_distutils/extension.pyi
+++ b/stubs/setuptools/setuptools/_distutils/extension.pyi
@@ -1,9 +1,8 @@
 from _typeshed import StrPath
-from collections.abc import Sequence
 
 class Extension:
     name: str
-    sources: Sequence[StrPath]
+    sources: list[StrPath]
     include_dirs: list[str]
     define_macros: list[tuple[str, str | None]]
     undef_macros: list[str]
@@ -21,7 +20,7 @@ class Extension:
     def __init__(
         self,
         name: str,
-        sources: Sequence[StrPath],
+        sources: list[StrPath],
         include_dirs: list[str] | None = None,
         define_macros: list[tuple[str, str | None]] | None = None,
         undef_macros: list[str] | None = None,

--- a/stubs/setuptools/setuptools/_distutils/extension.pyi
+++ b/stubs/setuptools/setuptools/_distutils/extension.pyi
@@ -4,7 +4,7 @@ from pathlib import Path
 
 class Extension:
     name: str
-    sources: list[str] | list[PathLike[str]] | list[Path] | list[StrPath]
+    sources: list[str] | list[StrPath]
     include_dirs: list[str]
     define_macros: list[tuple[str, str | None]]
     undef_macros: list[str]

--- a/stubs/setuptools/setuptools/_distutils/extension.pyi
+++ b/stubs/setuptools/setuptools/_distutils/extension.pyi
@@ -1,4 +1,6 @@
 from _typeshed import StrPath
+from os import PathLike
+from pathlib import Path
 
 class Extension:
     name: str
@@ -20,7 +22,7 @@ class Extension:
     def __init__(
         self,
         name: str,
-        sources: list[str] | list[StrPath],
+        sources: list[str] | list[PathLike[str]] | list[Path] | list[StrPath],
         include_dirs: list[str] | None = None,
         define_macros: list[tuple[str, str | None]] | None = None,
         undef_macros: list[str] | None = None,

--- a/stubs/setuptools/setuptools/_distutils/extension.pyi
+++ b/stubs/setuptools/setuptools/_distutils/extension.pyi
@@ -1,6 +1,9 @@
+from _typeshed import StrPath
+from collections.abc import Sequence
+
 class Extension:
     name: str
-    sources: list[str]
+    sources: Sequence[StrPath]
     include_dirs: list[str]
     define_macros: list[tuple[str, str | None]]
     undef_macros: list[str]
@@ -18,7 +21,7 @@ class Extension:
     def __init__(
         self,
         name: str,
-        sources: list[str],
+        sources: Sequence[StrPath],
         include_dirs: list[str] | None = None,
         define_macros: list[tuple[str, str | None]] | None = None,
         undef_macros: list[str] | None = None,

--- a/stubs/setuptools/setuptools/_distutils/extension.pyi
+++ b/stubs/setuptools/setuptools/_distutils/extension.pyi
@@ -4,7 +4,7 @@ from pathlib import Path
 
 class Extension:
     name: str
-    sources: list[str] | list[StrPath]
+    sources: list[str] | list[PathLike[str]] | list[Path] | list[StrPath]
     include_dirs: list[str]
     define_macros: list[tuple[str, str | None]]
     undef_macros: list[str]

--- a/stubs/setuptools/setuptools/extension.pyi
+++ b/stubs/setuptools/setuptools/extension.pyi
@@ -1,4 +1,6 @@
 from _typeshed import StrPath
+from os import PathLike
+from pathlib import Path
 
 from ._distutils.extension import Extension as _Extension
 
@@ -9,7 +11,7 @@ class Extension(_Extension):
     def __init__(
         self,
         name: str,
-        sources: list[StrPath],
+        sources: list[str] | list[PathLike[str]] | list[Path] | list[StrPath],
         include_dirs: list[str] | None = None,
         define_macros: list[tuple[str, str | None]] | None = None,
         undef_macros: list[str] | None = None,


### PR DESCRIPTION
## Description

This PR is coming via https://github.com/python/mypy/issues/18107#issuecomment-2459028882 post #12928. I think this should maintain compatibility since Sequence is covariant. In particular, the type annotation of the `sources` parameter in `setuptools.Extension.__init__` has been from `list[StrPath]` to ~~`Sequence[StrPath]`~~ `list[str] | list[StrPath]`. `setuptools.Extension` shouldn't need a mutable sequence.

I also added a few test cases, but this is one of my first pull requests to `typeshed` and towards a typing-related project in general (plus I'm not well-versed with type theory) and I'm unsure if these changes are correct – please feel free to guide me towards making these changes in the correct manner, push changes to my branch directly, or close the PR in case it ends up not being needed. Thank you!

Closes python/mypy#18107

## Additional context

xref: https://github.com/python/mypy/issues/18107, https://github.com/pyodide/pyodide/issues/5160