### PR TITLE
Update `logging.config.fileConfig` to accept any `Mapping` for defaults

### DIFF
--- a/stdlib/logging/config.pyi
+++ b/stdlib/logging/config.pyi
@@ -1,6 +1,6 @@
 import sys
 from _typeshed import StrOrBytesPath
-from collections.abc import Callable, Hashable, Iterable, Sequence
+from collections.abc import Callable, Hashable, Iterable, Mapping, Sequence
 from configparser import RawConfigParser
 from re import Pattern
 from threading import Thread
@@ -63,7 +63,7 @@ def dictConfig(config: _DictConfigArgs | dict[str, Any]) -> None: ...
 if sys.version_info >= (3, 10):
     def fileConfig(
         fname: StrOrBytesPath | IO[str] | RawConfigParser,
-        defaults: dict[str, str] | None = None,
+        defaults: Mapping[str, str] | None = None,
         disable_existing_loggers: bool = True,
         encoding: str | None = None,
     ) -> None: ...
@@ -71,7 +71,7 @@ if sys.version_info >= (3, 10):
 else:
     def fileConfig(
         fname: StrOrBytesPath | IO[str] | RawConfigParser,
-        defaults: dict[str, str] | None = None,
+        defaults: Mapping[str, str] | None = None,
         disable_existing_loggers: bool = True,
     ) -> None: ...
 


### PR DESCRIPTION
Internally, `defaults` gets passed to `configparser.ConfigParser` ([here](https://github.com/python/cpython/blob/85036c8d612007356d2118eb25b460505078b023/Lib/logging/config.py#L74)), which accepts any `Mapping` (not just `dict`).