### PR TITLE
Mark `OSError.strerror` as sometimes None

### DIFF
--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -1917,7 +1917,7 @@ class StopIteration(Exception):
 
 class OSError(Exception):
     errno: int | None
-    strerror: str
+    strerror: str | None
     # filename, filename2 are actually str | bytes | None
     filename: Any
     filename2: Any


### PR DESCRIPTION
Refs #9864, follows from #12910

Like `OSError.errno`, `strerror` can sometimes be `None`. Usually, both attributes are `None` at the same time.

Since we added `None` to `errno`, it probably makes sense to do the same for `strerror`.