### PR TITLE
Make builtins.type generic

### DIFF
--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -98,7 +98,7 @@ _P = ParamSpec("_P")
 _StartT = TypeVar("_StartT", covariant=True, default=Any)
 _StopT = TypeVar("_StopT", covariant=True, default=Any)
 _StepT = TypeVar("_StepT", covariant=True, default=Any)
-_TypeT = TypeVar('_TypeT', default=Any)
+_TypeT = TypeVar("_TypeT", default=Any)
 
 class object:
     __doc__: str | None

--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -168,7 +168,7 @@ class classmethod(Generic[_T, _P, _R_co]):
         @property
         def __wrapped__(self) -> Callable[Concatenate[type[_T], _P], _R_co]: ...
 
-class type(Generic[_TypeT]):
+class type(Generic[_TypeT_co]):
     # object.__base__ is None. Otherwise, it would be a type.
     @property
     def __base__(self) -> type | None: ...

--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -167,7 +167,7 @@ class classmethod(Generic[_T, _P, _R_co]):
         @property
         def __wrapped__(self) -> Callable[Concatenate[type[_T], _P], _R_co]: ...
 
-class type:
+class type(Generic[_T]):
     # object.__base__ is None. Otherwise, it would be a type.
     @property
     def __base__(self) -> type | None: ...

--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -98,7 +98,7 @@ _P = ParamSpec("_P")
 _StartT = TypeVar("_StartT", covariant=True, default=Any)
 _StopT = TypeVar("_StopT", covariant=True, default=Any)
 _StepT = TypeVar("_StepT", covariant=True, default=Any)
-_TypeT = TypeVar("_TypeT", default=Any)
+_TypeT_co = TypeVar("_TypeT_co", default=Any, covariant=True)
 
 class object:
     __doc__: str | None

--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -98,6 +98,7 @@ _P = ParamSpec("_P")
 _StartT = TypeVar("_StartT", covariant=True, default=Any)
 _StopT = TypeVar("_StopT", covariant=True, default=Any)
 _StepT = TypeVar("_StepT", covariant=True, default=Any)
+_TypeT = TypeVar('_TypeT', default=Any)
 
 class object:
     __doc__: str | None
@@ -167,7 +168,7 @@ class classmethod(Generic[_T, _P, _R_co]):
         @property
         def __wrapped__(self) -> Callable[Concatenate[type[_T], _P], _R_co]: ...
 
-class type(Generic[_T]):
+class type(Generic[_TypeT]):
     # object.__base__ is None. Otherwise, it would be a type.
     @property
     def __base__(self) -> type | None: ...


### PR DESCRIPTION
I'm fairly certain type should be generic. Unless there's some reason it's intentionally not marked as such?