### PR TITLE
Type __call__ on builtins._NotImplementedType as None.

### DIFF
--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -1284,9 +1284,7 @@ class property:
 
 @final
 class _NotImplementedType(Any):
-    # A little weird, but typing the __call__ as NotImplemented makes the error message
-    # for NotImplemented() much better
-    __call__: NotImplemented  # type: ignore[valid-type]  # pyright: ignore[reportInvalidTypeForm]
+    __call__: None
 
 NotImplemented: _NotImplementedType
 


### PR DESCRIPTION
Currently, this is intentionally incorrectly typed in order to produce a better mypy error message. But pyright (and presumably other type checkers) end up just treating instances of _NotImplementedType as callable.

I'm happy to drop this if it's particularly important that mypy generate a good error message here, but IMO it would be better to change this so that other type checkers can understand that instances of _NotImplementedType aren't callable, at the cost of making the error message a little worse.