### PR TITLE
move dict_keys, dict_items, and dict_values to builtins

### DIFF
--- a/stdlib/_collections_abc.pyi
+++ b/stdlib/_collections_abc.pyi
@@ -1,6 +1,6 @@
 import sys
 from abc import abstractmethod
-from types import MappingProxyType
+from builtins import dict_items as _dict_items, dict_keys as _dict_keys, dict_values as _dict_values
 from typing import (  # noqa: Y022,Y038
     AbstractSet as Set,
     AsyncGenerator as AsyncGenerator,
@@ -12,7 +12,6 @@ from typing import (  # noqa: Y022,Y038
     Container as Container,
     Coroutine as Coroutine,
     Generator as Generator,
-    Generic,
     Hashable as Hashable,
     ItemsView as ItemsView,
     Iterable as Iterable,
@@ -27,9 +26,7 @@ from typing import (  # noqa: Y022,Y038
     Reversible as Reversible,
     Sequence as Sequence,
     Sized as Sized,
-    TypeVar,
     ValuesView as ValuesView,
-    final,
     runtime_checkable,
 )
 
@@ -67,35 +64,12 @@ if sys.version_info < (3, 14):
 if sys.version_info >= (3, 12):
     __all__ += ["Buffer"]
 
-_KT_co = TypeVar("_KT_co", covariant=True)  # Key type covariant containers.
-_VT_co = TypeVar("_VT_co", covariant=True)  # Value type covariant containers.
-
-@final
-class dict_keys(KeysView[_KT_co], Generic[_KT_co, _VT_co]):  # undocumented
-    def __eq__(self, value: object, /) -> bool: ...
-    if sys.version_info >= (3, 13):
-        def isdisjoint(self, other: Iterable[_KT_co], /) -> bool: ...
-    if sys.version_info >= (3, 10):
-        @property
-        def mapping(self) -> MappingProxyType[_KT_co, _VT_co]: ...
-
-@final
-class dict_values(ValuesView[_VT_co], Generic[_KT_co, _VT_co]):  # undocumented
-    if sys.version_info >= (3, 10):
-        @property
-        def mapping(self) -> MappingProxyType[_KT_co, _VT_co]: ...
-
-@final
-class dict_items(ItemsView[_KT_co, _VT_co]):  # undocumented
-    def __eq__(self, value: object, /) -> bool: ...
-    if sys.version_info >= (3, 13):
-        def isdisjoint(self, other: Iterable[tuple[_KT_co, _VT_co]], /) -> bool: ...
-    if sys.version_info >= (3, 10):
-        @property
-        def mapping(self) -> MappingProxyType[_KT_co, _VT_co]: ...
-
 if sys.version_info >= (3, 12):
     @runtime_checkable
     class Buffer(Protocol):
         @abstractmethod
         def __buffer__(self, flags: int, /) -> memoryview: ...
+
+dict_keys = _dict_keys  # undocumented
+dict_items = _dict_items  # undocumented
+dict_values = _dict_values  # undocumented

--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -3,7 +3,6 @@ import _ast
 import _typeshed
 import sys
 import types
-from _collections_abc import dict_items, dict_keys, dict_values
 from _typeshed import (
     AnyStr_co,
     ConvertibleToFloat,
@@ -31,9 +30,21 @@ from _typeshed import (
     SupportsRichComparisonT,
     SupportsWrite,
 )
-from collections.abc import Awaitable, Callable, Iterable, Iterator, MutableSet, Reversible, Set as AbstractSet, Sized
+from collections.abc import (
+    Awaitable,
+    Callable,
+    ItemsView,
+    Iterable,
+    Iterator,
+    KeysView,
+    MutableSet,
+    Reversible,
+    Set as AbstractSet,
+    Sized,
+    ValuesView,
+)
 from io import BufferedRandom, BufferedReader, BufferedWriter, FileIO, TextIOWrapper
-from types import CellType, CodeType, TracebackType
+from types import CellType, CodeType, MappingProxyType, TracebackType
 
 # mypy crashes if any of {ByteString, Sequence, MutableSequence, Mapping, MutableMapping}
 # are imported from collections.abc in builtins.pyi
@@ -84,6 +95,8 @@ _T_contra = TypeVar("_T_contra", contravariant=True)
 _R_co = TypeVar("_R_co", covariant=True)
 _KT = TypeVar("_KT")
 _VT = TypeVar("_VT")
+_KT_co = TypeVar("_KT_co", covariant=True)  # Key type covariant containers.
+_VT_co = TypeVar("_VT_co", covariant=True)  # Value type covariant containers.
 _S = TypeVar("_S")
 _T1 = TypeVar("_T1")
 _T2 = TypeVar("_T2")
@@ -1075,6 +1088,33 @@ class list(MutableSequence[_T]):
     def __eq__(self, value: object, /) -> bool: ...
     if sys.version_info >= (3, 9):
         def __class_getitem__(cls, item: Any, /) -> GenericAlias: ...
+
+@final
+@type_check_only
+class dict_keys(KeysView[_KT_co], Generic[_KT_co, _VT_co]):
+    def __eq__(self, value: object, /) -> bool: ...
+    if sys.version_info >= (3, 13):
+        def isdisjoint(self, other: Iterable[_KT_co], /) -> bool: ...
+    if sys.version_info >= (3, 10):
+        @property
+        def mapping(self) -> MappingProxyType[_KT_co, _VT_co]: ...
+
+@final
+@type_check_only
+class dict_values(ValuesView[_VT_co], Generic[_KT_co, _VT_co]):
+    if sys.version_info >= (3, 10):
+        @property
+        def mapping(self) -> MappingProxyType[_KT_co, _VT_co]: ...
+
+@final
+@type_check_only
+class dict_items(ItemsView[_KT_co, _VT_co]):
+    def __eq__(self, value: object, /) -> bool: ...
+    if sys.version_info >= (3, 13):
+        def isdisjoint(self, other: Iterable[tuple[_KT_co, _VT_co]], /) -> bool: ...
+    if sys.version_info >= (3, 10):
+        @property
+        def mapping(self) -> MappingProxyType[_KT_co, _VT_co]: ...
 
 class dict(MutableMapping[_KT, _VT]):
     # __init__ should be kept roughly in line with `collections.UserDict.__init__`, which has similar semantics

--- a/stdlib/collections/__init__.pyi
+++ b/stdlib/collections/__init__.pyi
@@ -1,6 +1,6 @@
 import sys
-from _collections_abc import dict_items, dict_keys, dict_values
 from _typeshed import SupportsItems, SupportsKeysAndGetItem, SupportsRichComparison, SupportsRichComparisonT
+from builtins import dict_items, dict_keys, dict_values
 from typing import Any, Generic, NoReturn, SupportsIndex, TypeVar, final, overload
 from typing_extensions import Self
 
@@ -340,19 +340,20 @@ class _OrderedDictValuesView(ValuesView[_VT_co]):
     def __reversed__(self) -> Iterator[_VT_co]: ...
 
 # The C implementations of the "views" classes
-# (At runtime, these are called `odict_keys`, `odict_items` and `odict_values`,
-# but they are not exposed anywhere)
 # pyright doesn't have a specific error code for subclassing error!
 @final
-class _odict_keys(dict_keys[_KT_co, _VT_co]):  # type: ignore[misc]  # pyright: ignore[reportGeneralTypeIssues]
+@type_check_only
+class odict_keys(dict_keys[_KT_co, _VT_co]):  # type: ignore[misc]  # pyright: ignore[reportGeneralTypeIssues]
     def __reversed__(self) -> Iterator[_KT_co]: ...
 
 @final
-class _odict_items(dict_items[_KT_co, _VT_co]):  # type: ignore[misc]  # pyright: ignore[reportGeneralTypeIssues]
+@type_check_only
+class odict_items(dict_items[_KT_co, _VT_co]):  # type: ignore[misc]  # pyright: ignore[reportGeneralTypeIssues]
     def __reversed__(self) -> Iterator[tuple[_KT_co, _VT_co]]: ...
 
 @final
-class _odict_values(dict_values[_KT_co, _VT_co]):  # type: ignore[misc]  # pyright: ignore[reportGeneralTypeIssues]
+@type_check_only
+class odict_values(dict_values[_KT_co, _VT_co]):  # type: ignore[misc]  # pyright: ignore[reportGeneralTypeIssues]
     def __reversed__(self) -> Iterator[_VT_co]: ...
 
 class OrderedDict(dict[_KT, _VT]):
@@ -360,9 +361,9 @@ class OrderedDict(dict[_KT, _VT]):
     def move_to_end(self, key: _KT, last: bool = True) -> None: ...
     def copy(self) -> Self: ...
     def __reversed__(self) -> Iterator[_KT]: ...
-    def keys(self) -> _odict_keys[_KT, _VT]: ...
-    def items(self) -> _odict_items[_KT, _VT]: ...
-    def values(self) -> _odict_values[_KT, _VT]: ...
+    def keys(self) -> odict_keys[_KT, _VT]: ...
+    def items(self) -> odict_items[_KT, _VT]: ...
+    def values(self) -> odict_values[_KT, _VT]: ...
     # The signature of OrderedDict.fromkeys should be kept in line with `dict.fromkeys`, modulo positional-only differences.
     # Like dict.fromkeys, its true signature is not expressible in the current type system.
     # See #3800 & https://github.com/python/typing/issues/548#issuecomment-683336963.

--- a/stdlib/collections/__init__.pyi
+++ b/stdlib/collections/__init__.pyi
@@ -1,7 +1,7 @@
 import sys
 from _typeshed import SupportsItems, SupportsKeysAndGetItem, SupportsRichComparison, SupportsRichComparisonT
 from builtins import dict_items, dict_keys, dict_values
-from typing import Any, Generic, NoReturn, SupportsIndex, TypeVar, final, overload
+from typing import Any, Generic, NoReturn, SupportsIndex, TypeVar, final, overload, type_check_only
 from typing_extensions import Self
 
 if sys.version_info >= (3, 9):

--- a/stdlib/importlib/metadata/__init__.pyi
+++ b/stdlib/importlib/metadata/__init__.pyi
@@ -2,8 +2,8 @@ import abc
 import pathlib
 import sys
 import types
-from _collections_abc import dict_keys, dict_values
 from _typeshed import StrPath
+from builtins import dict_keys, dict_values
 from collections.abc import Iterable, Iterator, Mapping
 from email.message import Message
 from importlib.abc import MetaPathFinder

--- a/stdlib/symtable.pyi
+++ b/stdlib/symtable.pyi
@@ -1,5 +1,5 @@
 import sys
-from _collections_abc import dict_keys
+from builtins import dict_keys
 from collections.abc import Sequence
 from typing import Any
 from typing_extensions import deprecated

--- a/stdlib/typing.pyi
+++ b/stdlib/typing.pyi
@@ -5,9 +5,9 @@
 import collections  # noqa: F401  # pyright: ignore[reportUnusedImport]
 import sys
 import typing_extensions
-from _collections_abc import dict_items, dict_keys, dict_values
 from _typeshed import IdentityFunction, ReadableBuffer, SupportsKeysAndGetItem
 from abc import ABCMeta, abstractmethod
+from builtins import dict_items, dict_keys, dict_values
 from re import Match as Match, Pattern as Pattern
 from types import (
     BuiltinFunctionType,

--- a/stdlib/typing_extensions.pyi
+++ b/stdlib/typing_extensions.pyi
@@ -1,8 +1,8 @@
 import abc
 import sys
 import typing
-from _collections_abc import dict_items, dict_keys, dict_values
 from _typeshed import IdentityFunction
+from builtins import dict_items, dict_keys, dict_values
 from contextlib import AbstractAsyncContextManager as AsyncContextManager, AbstractContextManager as ContextManager
 from typing import (  # noqa: Y022,Y037,Y038,Y039
     IO as IO,

--- a/stdlib/xml/etree/ElementTree.pyi
+++ b/stdlib/xml/etree/ElementTree.pyi
@@ -1,6 +1,6 @@
 import sys
-from _collections_abc import dict_keys
 from _typeshed import FileDescriptorOrPath, ReadableBuffer, SupportsRead, SupportsWrite
+from builtins import dict_keys
 from collections.abc import Callable, Generator, ItemsView, Iterable, Iterator, Mapping, Sequence
 from typing import Any, Final, Literal, SupportsIndex, TypeVar, overload
 from typing_extensions import TypeAlias, TypeGuard, deprecated

--- a/stubs/icalendar/icalendar/parser.pyi
+++ b/stubs/icalendar/icalendar/parser.pyi
@@ -1,5 +1,5 @@
-from _collections_abc import dict_keys
 from _typeshed import Incomplete
+from builtins import dict_keys
 from collections.abc import Iterable
 from re import Pattern
 from typing import AnyStr, Final, overload

--- a/stubs/ldap3/ldap3/core/connection.pyi
+++ b/stubs/ldap3/ldap3/core/connection.pyi
@@ -1,5 +1,6 @@
-from _collections_abc import Generator, dict_keys
+from _collections_abc import Generator
 from _typeshed import Incomplete, ReadableBuffer
+from builtins import dict_keys
 from types import TracebackType
 from typing import Literal
 from typing_extensions import Self, TypeAlias

--- a/stubs/mypy-extensions/mypy_extensions.pyi
+++ b/stubs/mypy-extensions/mypy_extensions.pyi
@@ -1,7 +1,7 @@
 import abc
 import sys
-from _collections_abc import dict_items, dict_keys, dict_values
 from _typeshed import IdentityFunction, Unused
+from builtins import dict_items, dict_keys, dict_values
 from collections.abc import Mapping
 from typing import Any, ClassVar, Generic, TypeVar, overload, type_check_only
 from typing_extensions import Never, Self


### PR DESCRIPTION
these types call themselves `builtins.*` which is probably correct, even if they're not exposed there. Maybe this is a problematic idea? I'm curious to see what mypy-primer thinks.

Within _collections_abc.pyi, using `dict_keys = _dict_keys` instead of `import dict_keys as dict_keys` is to work around the fact that `builtins.dict_keys` is marked as type_check_only.