### PR TITLE
The four protocol-like ABCs outside of collections.abc inherit from ABC directly

### DIFF
--- a/stdlib/contextlib.pyi
+++ b/stdlib/contextlib.pyi
@@ -38,22 +38,22 @@ _P = ParamSpec("_P")
 _ExitFunc: TypeAlias = Callable[[type[BaseException] | None, BaseException | None, TracebackType | None], bool | None]
 _CM_EF = TypeVar("_CM_EF", bound=AbstractContextManager[Any, Any] | _ExitFunc)
 
-# mypy objects to this being both ABC and Protocol.
+# mypy and pyright object to this being both ABC and Protocol.
 # At runtime it inherits from ABC and is not a Protocol, but it is on the
 # allowlist for use as a Protocol.
 @runtime_checkable
-class AbstractContextManager(ABC, Protocol[_T_co, _ExitT_co]):  # type: ignore[misc]
+class AbstractContextManager(ABC, Protocol[_T_co, _ExitT_co]):  # type: ignore[misc]  # pyright: ignore[reportGeneralTypeIssues]
     def __enter__(self) -> _T_co: ...
     @abstractmethod
     def __exit__(
         self, exc_type: type[BaseException] | None, exc_value: BaseException | None, traceback: TracebackType | None, /
     ) -> _ExitT_co: ...
 
-# mypy objects to this being both ABC and Protocol.
+# mypy and pyright object to this being both ABC and Protocol.
 # At runtime it inherits from ABC and is not a Protocol, but it is on the
 # allowlist for use as a Protocol.
 @runtime_checkable
-class AbstractAsyncContextManager(ABC, Protocol[_T_co, _ExitT_co]):  # type: ignore[misc]
+class AbstractAsyncContextManager(ABC, Protocol[_T_co, _ExitT_co]):  # type: ignore[misc]  # pyright: ignore[reportGeneralTypeIssues]
     async def __aenter__(self) -> _T_co: ...
     @abstractmethod
     async def __aexit__(

--- a/stdlib/contextlib.pyi
+++ b/stdlib/contextlib.pyi
@@ -1,7 +1,7 @@
 import abc
 import sys
 from _typeshed import FileDescriptorOrPath, Unused
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable, Generator, Iterator
 from types import TracebackType
 from typing import IO, Any, Generic, Protocol, TypeVar, overload, runtime_checkable
@@ -38,16 +38,22 @@ _P = ParamSpec("_P")
 _ExitFunc: TypeAlias = Callable[[type[BaseException] | None, BaseException | None, TracebackType | None], bool | None]
 _CM_EF = TypeVar("_CM_EF", bound=AbstractContextManager[Any, Any] | _ExitFunc)
 
+# mypy objects to this being both ABC and Protocol.
+# At runtime it inherits from ABC and is not a Protocol, but it is on the
+# allowlist for use as a Protocol.
 @runtime_checkable
-class AbstractContextManager(Protocol[_T_co, _ExitT_co]):
+class AbstractContextManager(ABC, Protocol[_T_co, _ExitT_co]):  # type: ignore[misc]
     def __enter__(self) -> _T_co: ...
     @abstractmethod
     def __exit__(
         self, exc_type: type[BaseException] | None, exc_value: BaseException | None, traceback: TracebackType | None, /
     ) -> _ExitT_co: ...
 
+# mypy objects to this being both ABC and Protocol.
+# At runtime it inherits from ABC and is not a Protocol, but it is on the
+# allowlist for use as a Protocol.
 @runtime_checkable
-class AbstractAsyncContextManager(Protocol[_T_co, _ExitT_co]):
+class AbstractAsyncContextManager(ABC, Protocol[_T_co, _ExitT_co]):  # type: ignore[misc]
     async def __aenter__(self) -> _T_co: ...
     @abstractmethod
     async def __aexit__(

--- a/stdlib/os/__init__.pyi
+++ b/stdlib/os/__init__.pyi
@@ -19,7 +19,7 @@ from _typeshed import (
     WriteableBuffer,
     structseq,
 )
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 from builtins import OSError
 from collections.abc import Callable, Iterable, Iterator, Mapping, MutableMapping, Sequence
 from contextlib import AbstractContextManager
@@ -413,8 +413,11 @@ In the future, this property will contain the last metadata change time."""
     # Attributes documented as sometimes appearing, but deliberately omitted from the stub: `st_creator`, `st_rsize`, `st_type`.
     # See https://github.com/python/typeshed/pull/6560#issuecomment-991253327
 
+# mypy objects to this being both ABC and Protocol.
+# At runtime it inherits from ABC and is not a Protocol, but it will be
+# on the allowlist for use as a Protocol starting in 3.14.
 @runtime_checkable
-class PathLike(Protocol[AnyStr_co]):
+class PathLike(ABC, Protocol[AnyStr_co]):  # type: ignore[misc]
     @abstractmethod
     def __fspath__(self) -> AnyStr_co: ...
 

--- a/stdlib/os/__init__.pyi
+++ b/stdlib/os/__init__.pyi
@@ -413,11 +413,11 @@ In the future, this property will contain the last metadata change time."""
     # Attributes documented as sometimes appearing, but deliberately omitted from the stub: `st_creator`, `st_rsize`, `st_type`.
     # See https://github.com/python/typeshed/pull/6560#issuecomment-991253327
 
-# mypy objects to this being both ABC and Protocol.
+# mypy and pyright object to this being both ABC and Protocol.
 # At runtime it inherits from ABC and is not a Protocol, but it will be
 # on the allowlist for use as a Protocol starting in 3.14.
 @runtime_checkable
-class PathLike(ABC, Protocol[AnyStr_co]):  # type: ignore[misc]
+class PathLike(ABC, Protocol[AnyStr_co]):  # type: ignore[misc]  # pyright: ignore[reportGeneralTypeIssues]
     @abstractmethod
     def __fspath__(self) -> AnyStr_co: ...
 

--- a/stdlib/typing_extensions.pyi
+++ b/stdlib/typing_extensions.pyi
@@ -413,7 +413,7 @@ else:
     # At runtime it inherits from ABC and is not a Protocol, but it is on the
     # allowlist for use as a Protocol.
     @runtime_checkable
-    class Buffer(Protocol, abc.ABC):
+    class Buffer(Protocol, abc.ABC):  # type: ignore[misc]  # pyright: ignore[reportGeneralTypeIssues]
         # Not actually a Protocol at runtime; see
         # https://github.com/python/typeshed/issues/10224 for why we're defining it this way
         def __buffer__(self, flags: int, /) -> memoryview: ...

--- a/stdlib/typing_extensions.pyi
+++ b/stdlib/typing_extensions.pyi
@@ -409,8 +409,11 @@ else:
             def __or__(self, right: Any) -> _SpecialForm: ...
             def __ror__(self, left: Any) -> _SpecialForm: ...
 
+    # mypy and pyright object to this being both ABC and Protocol.
+    # At runtime it inherits from ABC and is not a Protocol, but it is on the
+    # allowlist for use as a Protocol.
     @runtime_checkable
-    class Buffer(Protocol):
+    class Buffer(Protocol, abc.ABC):
         # Not actually a Protocol at runtime; see
         # https://github.com/python/typeshed/issues/10224 for why we're defining it this way
         def __buffer__(self, flags: int, /) -> memoryview: ...


### PR DESCRIPTION
Related to:
https://github.com/python/cpython/pull/126706
https://github.com/python/typeshed/pull/11269

Switching PathLike from abc.ABC to abc.ABCMeta wasn't accepted (reasonably so), so I'm wondering what happens to mypy-primer if we do this.