### PR TITLE
Protocol inheritance for typing_extensions.SupportsX classes

### DIFF
--- a/stdlib/typing_extensions.pyi
+++ b/stdlib/typing_extensions.pyi
@@ -48,12 +48,6 @@ from typing import (  # noqa: Y022,Y037,Y038,Y039
     Sequence as Sequence,
     Set as Set,
     Sized as Sized,
-    SupportsAbs as SupportsAbs,
-    SupportsBytes as SupportsBytes,
-    SupportsComplex as SupportsComplex,
-    SupportsFloat as SupportsFloat,
-    SupportsInt as SupportsInt,
-    SupportsRound as SupportsRound,
     Text as Text,
     TextIO as TextIO,
     Tuple as Tuple,
@@ -189,6 +183,7 @@ __all__ = [
 _T = typing.TypeVar("_T")
 _F = typing.TypeVar("_F", bound=Callable[..., Any])
 _TC = typing.TypeVar("_TC", bound=type[object])
+_T_co = typing.TypeVar("_T_co", covariant=True)  # Any type covariant containers.
 
 # unfortunately we have to duplicate this class definition from typing.pyi or we break pytype
 class _SpecialForm:
@@ -281,11 +276,6 @@ def get_origin(tp: Any) -> Any | None: ...
 
 Annotated: _SpecialForm
 _AnnotatedAlias: Any  # undocumented
-
-@runtime_checkable
-class SupportsIndex(Protocol, metaclass=abc.ABCMeta):
-    @abc.abstractmethod
-    def __index__(self) -> int: ...
 
 # New and changed things in 3.10
 if sys.version_info >= (3, 10):
@@ -383,7 +373,17 @@ else:
 if sys.version_info >= (3, 12):
     from collections.abc import Buffer as Buffer
     from types import get_original_bases as get_original_bases
-    from typing import TypeAliasType as TypeAliasType, override as override
+    from typing import (
+        SupportsAbs as SupportsAbs,
+        SupportsBytes as SupportsBytes,
+        SupportsComplex as SupportsComplex,
+        SupportsFloat as SupportsFloat,
+        SupportsIndex as SupportsIndex,
+        SupportsInt as SupportsInt,
+        SupportsRound as SupportsRound,
+        TypeAliasType as TypeAliasType,
+        override as override,
+    )
 else:
     def override(arg: _F, /) -> _F: ...
     def get_original_bases(cls: type, /) -> tuple[Any, ...]: ...
@@ -414,6 +414,45 @@ else:
         # Not actually a Protocol at runtime; see
         # https://github.com/python/typeshed/issues/10224 for why we're defining it this way
         def __buffer__(self, flags: int, /) -> memoryview: ...
+
+    @runtime_checkable
+    class SupportsInt(Protocol, metaclass=abc.ABCMeta):
+        @abc.abstractmethod
+        def __int__(self) -> int: ...
+
+    @runtime_checkable
+    class SupportsFloat(Protocol, metaclass=abc.ABCMeta):
+        @abc.abstractmethod
+        def __float__(self) -> float: ...
+
+    @runtime_checkable
+    class SupportsComplex(Protocol, metaclass=abc.ABCMeta):
+        @abc.abstractmethod
+        def __complex__(self) -> complex: ...
+
+    @runtime_checkable
+    class SupportsBytes(Protocol, metaclass=abc.ABCMeta):
+        @abc.abstractmethod
+        def __bytes__(self) -> bytes: ...
+
+    @runtime_checkable
+    class SupportsIndex(Protocol, metaclass=abc.ABCMeta):
+        @abc.abstractmethod
+        def __index__(self) -> int: ...
+
+    @runtime_checkable
+    class SupportsAbs(Protocol[_T_co]):
+        @abc.abstractmethod
+        def __abs__(self) -> _T_co: ...
+
+    @runtime_checkable
+    class SupportsRound(Protocol[_T_co]):
+        @overload
+        @abc.abstractmethod
+        def __round__(self) -> int: ...
+        @overload
+        @abc.abstractmethod
+        def __round__(self, ndigits: int, /) -> _T_co: ...
 
 if sys.version_info >= (3, 13):
     from types import CapsuleType as CapsuleType


### PR DESCRIPTION
I had MR up before that was similar to this one, and it wasn't accepted. I wanted to take another run at it,
because I don't think I justified it properly. The thing that this fixes is sorting out whether these classes
inherit from `typing.Protocol` or `typing_extenstions.Protocol`.