### PR TITLE
add typing._Final

### DIFF
--- a/stdlib/@tests/stubtest_allowlists/common.txt
+++ b/stdlib/@tests/stubtest_allowlists/common.txt
@@ -462,6 +462,8 @@ typing_extensions\.ParamSpec.*
 typing(_extensions)?\.Generic
 typing\.Protocol
 typing(_extensions)?\._TypedDict
+typing._Final
+typing._Final.__init_subclass__
 
 # Special primitives
 typing_extensions\.Final

--- a/stdlib/typing.pyi
+++ b/stdlib/typing.pyi
@@ -133,6 +133,8 @@ if sys.version_info >= (3, 13):
 
 Any = object()
 
+class _Final: ...
+
 def final(f: _T) -> _T: ...
 @final
 class TypeVar:
@@ -191,7 +193,7 @@ _promote = object()
 
 # N.B. Keep this definition in sync with typing_extensions._SpecialForm
 @final
-class _SpecialForm:
+class _SpecialForm(_Final):
     def __getitem__(self, parameters: Any) -> object: ...
     if sys.version_info >= (3, 10):
         def __or__(self, other: Any) -> _SpecialForm: ...
@@ -973,7 +975,7 @@ class _TypedDict(Mapping[str, object], metaclass=ABCMeta):
         def __ior__(self, value: typing_extensions.Self, /) -> typing_extensions.Self: ...  # type: ignore[misc]
 
 @final
-class ForwardRef:
+class ForwardRef(_Final):
     __forward_arg__: str
     __forward_code__: CodeType
     __forward_evaluated__: bool

--- a/stdlib/typing_extensions.pyi
+++ b/stdlib/typing_extensions.pyi
@@ -190,8 +190,10 @@ _T = typing.TypeVar("_T")
 _F = typing.TypeVar("_F", bound=Callable[..., Any])
 _TC = typing.TypeVar("_TC", bound=type[object])
 
+class _Final: ...  # This should be imported from typing but that breaks pytype
+
 # unfortunately we have to duplicate this class definition from typing.pyi or we break pytype
-class _SpecialForm:
+class _SpecialForm(_Final):
     def __getitem__(self, parameters: Any) -> object: ...
     if sys.version_info >= (3, 10):
         def __or__(self, other: Any) -> _SpecialForm: ...


### PR DESCRIPTION
This is the subset of typing module internal base class inheritance that's stable over all supported versions of python.

This probably isn't worth doing either. But [like the maximalist version of this MR](https://github.com/python/typeshed/pull/13011), I wanted to work out what it would look like, and once I did that I feel like it makes sense to push it up to generate a record of that and let other people see it too. 

I know I've pushed up a bunch of MRs lately which are really scraping the bottom of the barrel, metaphorically speaking, in the name of accurate inheritance. So if it's not too weird, I wanted to say that I hope that it's not too much of a pain for the maintainers here for me to do that. I appreciate the work that you all do and I don't want to be making it harder for you.