### PR TITLE
[pysftp-types] Logging attribute can be bool or str

### DIFF
--- a/stubs/pysftp/pysftp/__init__.pyi
+++ b/stubs/pysftp/pysftp/__init__.pyi
@@ -25,7 +25,7 @@ from pysftp.helpers import (
 )
 
 class CnOpts:
-    log: bool
+    log: bool | str
     compression: bool
     ciphers: Sequence[str] | None
     hostkeys: paramiko.HostKeys | None
@@ -45,7 +45,7 @@ class Connection:
         port: int = 22,
         private_key_pass: str | None = None,
         ciphers: Sequence[str] | None = None,
-        log: bool = False,
+        log: bool | str = False,
         cnopts: CnOpts | None = None,
         default_path: _Path | None = None,
     ) -> None: ...


### PR DESCRIPTION
According to inline documentation in [pysftp](https://github.com/ryhsiao/pysftp/blob/master/pysftp.py#L137-L144), CnOpts.log is either a bool or string and only meaningful custom values are strings, which are treated as file paths.

Same goes for the constructor parameter `log` on [Connection](https://github.com/ryhsiao/pysftp/blob/master/pysftp.py#L137-L144). Corrected the type here, but it is scheduled for removal in a future version.