### PR TITLE
mark _codecs.EncodingMap as final

### DIFF
--- a/stdlib/_codecs.pyi
+++ b/stdlib/_codecs.pyi
@@ -2,14 +2,16 @@ import codecs
 import sys
 from _typeshed import ReadableBuffer
 from collections.abc import Callable
-from typing import Literal, overload
+from typing import Literal, final, overload, type_check_only
 from typing_extensions import TypeAlias
 
 # This type is not exposed; it is defined in unicodeobject.c
-class _EncodingMap:
+@final
+@type_check_only
+class EncodingMap:
     def size(self) -> int: ...
 
-_CharMap: TypeAlias = dict[int, int] | _EncodingMap
+_CharMap: TypeAlias = dict[int, int] | EncodingMap
 _Handler: TypeAlias = Callable[[UnicodeError], tuple[str | bytes, int]]
 _SearchFunction: TypeAlias = Callable[[str], codecs.CodecInfo | None]
 

--- a/stdlib/_codecs.pyi
+++ b/stdlib/_codecs.pyi
@@ -6,12 +6,13 @@ from typing import Literal, final, overload, type_check_only
 from typing_extensions import TypeAlias
 
 # This type is not exposed; it is defined in unicodeobject.c
+# At runtime it calls itself builtins.EncodingMap
 @final
 @type_check_only
-class EncodingMap:
+class _EncodingMap:
     def size(self) -> int: ...
 
-_CharMap: TypeAlias = dict[int, int] | EncodingMap
+_CharMap: TypeAlias = dict[int, int] | _EncodingMap
 _Handler: TypeAlias = Callable[[UnicodeError], tuple[str | bytes, int]]
 _SearchFunction: TypeAlias = Callable[[str], codecs.CodecInfo | None]
 


### PR DESCRIPTION
Related to https://github.com/python/typeshed/issues/13016

The runtime name doesn't have the underscore prefix, and I believe it isn't necessary if type_check_only is used, so I updated that as well.