### PR TITLE
`curses._ncurses_version` updates

### DIFF
--- a/stdlib/_curses.pyi
+++ b/stdlib/_curses.pyi
@@ -1,6 +1,7 @@
 import sys
 from _typeshed import ReadOnlyBuffer, SupportsRead
-from typing import IO, Any, NamedTuple, final, overload
+from curses import _ncurses_version
+from typing import IO, Any, final, overload
 from typing_extensions import TypeAlias
 
 # NOTE: This module is ordinarily only available on Unix, but the windows-curses
@@ -548,10 +549,5 @@ class window:  # undocumented
     def vline(self, ch: _ChType, n: int) -> None: ...
     @overload
     def vline(self, y: int, x: int, ch: _ChType, n: int) -> None: ...
-
-class _ncurses_version(NamedTuple):
-    major: int
-    minor: int
-    patch: int
 
 ncurses_version: _ncurses_version

--- a/stdlib/curses/__init__.pyi
+++ b/stdlib/curses/__init__.pyi
@@ -33,6 +33,9 @@ _CursesWindow = window
 @final
 @type_check_only
 class _ncurses_version(structseq[int], tuple[int, int, int]):
-    major: int
-    minor: int
-    patch: int
+    @property
+    def major(self) -> int: ...
+    @property
+    def minor(self) -> int: ...
+    @property
+    def patch(self) -> int: ...

--- a/stdlib/curses/__init__.pyi
+++ b/stdlib/curses/__init__.pyi
@@ -1,5 +1,6 @@
 from _curses import *
 from _curses import window as window
+from _typeshed import structseq
 from collections.abc import Callable
 from typing import TypeVar, final, type_check_only
 from typing_extensions import Concatenate, ParamSpec

--- a/stdlib/curses/__init__.pyi
+++ b/stdlib/curses/__init__.pyi
@@ -1,7 +1,7 @@
 from _curses import *
 from _curses import window as window
 from collections.abc import Callable
-from typing import TypeVar
+from typing import TypeVar, final, type_check_only
 from typing_extensions import Concatenate, ParamSpec
 
 # NOTE: The _curses module is ordinarily only available on Unix, but the
@@ -25,3 +25,13 @@ def wrapper(func: Callable[Concatenate[window, _P], _T], /, *arg: _P.args, **kwd
 # it was mapped to the name 'window' in 3.8.
 # Kept here as a legacy alias in case any third-party code is relying on it.
 _CursesWindow = window
+
+# At runtime this class is unexposed and calls itself curses.ncurses_version.
+# That name would conflict with the actual curses.ncurses_version, which is
+# an instance of this class.
+@final
+@type_check_only
+class _ncurses_version(structseq[int], tuple[int, int, int]):
+    major: int
+    minor: int
+    patch: int

--- a/stdlib/curses/__init__.pyi
+++ b/stdlib/curses/__init__.pyi
@@ -1,8 +1,9 @@
+import sys
 from _curses import *
 from _curses import window as window
 from _typeshed import structseq
 from collections.abc import Callable
-from typing import TypeVar, final, type_check_only
+from typing import Final, TypeVar, final, type_check_only
 from typing_extensions import Concatenate, ParamSpec
 
 # NOTE: The _curses module is ordinarily only available on Unix, but the
@@ -33,6 +34,9 @@ _CursesWindow = window
 @final
 @type_check_only
 class _ncurses_version(structseq[int], tuple[int, int, int]):
+    if sys.version_info >= (3, 10):
+        __match_args__: Final = ("major", "minor", "patch")
+
     @property
     def major(self) -> int: ...
     @property


### PR DESCRIPTION
related to https://github.com/python/typeshed/issues/13016

To get access to the type:

```python
import curses
type(curses.ncurses_version)
```
