### PR TITLE
Improve `datetime._IsoCalendarDate`

### DIFF
--- a/stdlib/datetime.pyi
+++ b/stdlib/datetime.pyi
@@ -1,7 +1,7 @@
 import sys
 from abc import abstractmethod
 from time import struct_time
-from typing import ClassVar, Final, NamedTuple, NoReturn, SupportsIndex, final, overload
+from typing import ClassVar, Final, NoReturn, SupportsIndex, final, overload, type_check_only
 from typing_extensions import Self, TypeAlias, deprecated
 
 if sys.version_info >= (3, 11):
@@ -40,10 +40,17 @@ if sys.version_info >= (3, 11):
     UTC: timezone
 
 if sys.version_info >= (3, 9):
-    class _IsoCalendarDate(NamedTuple):
-        year: int
-        week: int
-        weekday: int
+    # This class calls itself datetime.IsoCalendarDate. It's neither
+    # NamedTuple nor structseq.
+    @final
+    @type_check_only
+    class _IsoCalendarDate(tuple[int, int, int]):
+        @property
+        def year(self) -> int: ...
+        @property
+        def week(self) -> int: ...
+        @property
+        def weekday(self) -> int: ...
 
 class date:
     min: ClassVar[date]


### PR DESCRIPTION
Related to https://github.com/python/typeshed/issues/13016

A weird case of named tuple (general category) that isn't NamedTuple or structseq, just a custom implementation of that pattern.