### PR TITLE
Add type signatures to `lru_cache` using overloads (not ready to merge)

### DIFF
--- a/stdlib/functools.pyi
+++ b/stdlib/functools.pyi
@@ -2,7 +2,7 @@ import sys
 import types
 from _typeshed import SupportsAllComparisons, SupportsItems
 from collections.abc import Callable, Hashable, Iterable, Sequence, Sized
-from typing import Any, Generic, Literal, NamedTuple, TypedDict, TypeVar, final, overload, Protocol
+from typing import Any, Generic, Literal, NamedTuple, Protocol, TypedDict, TypeVar, final, overload
 from typing_extensions import ParamSpec, Self, TypeAlias
 
 if sys.version_info >= (3, 9):
@@ -72,38 +72,15 @@ class _lru_cache_wrapper(Generic[_C]):
     __wrapped__: _C
 
     @overload
-    def __call__(
-        _self: _CacheMethod[_T, _P, _R],
-        *args: _P.args,
-        **kwargs: _P.kwargs
-    ) -> _R: ...
+    def __call__(_self: _CacheMethod[_T, _P, _R], *args: _P.args, **kwargs: _P.kwargs) -> _R: ...
     @overload
-    def __call__(
-        _self: _CacheMethod[_T, _P, _R],
-        self: _T,
-        *args: _P.args,
-        **kwargs: _P.kwargs
-    ) -> _R: ...
+    def __call__(_self: _CacheMethod[_T, _P, _R], self: _T, *args: _P.args, **kwargs: _P.kwargs) -> _R: ...
     @overload
-    def __call__(
-        _self: _CacheClassmethod[_T, _P, _R],
-        *args: _P.args,
-        **kwargs: _P.kwargs
-    ) -> _R: ...
+    def __call__(_self: _CacheClassmethod[_T, _P, _R], *args: _P.args, **kwargs: _P.kwargs) -> _R: ...
     @overload
-    def __call__(
-        _self: _CacheClassmethod[_T, _P, _R],
-        cls: type[_T],
-        *args: _P.args,
-        **kwargs: _P.kwargs
-    ) -> _R: ...
+    def __call__(_self: _CacheClassmethod[_T, _P, _R], cls: type[_T], *args: _P.args, **kwargs: _P.kwargs) -> _R: ...
     @overload
-    def __call__(
-        _self: _CacheFn[_P, _R],
-        *args: _P.args,
-        **kwargs: _P.kwargs
-    ) -> _R: ...
-
+    def __call__(_self: _CacheFn[_P, _R], *args: _P.args, **kwargs: _P.kwargs) -> _R: ...
     def cache_info(self) -> _CacheInfo: ...
     def cache_clear(self) -> None: ...
     if sys.version_info >= (3, 9):


### PR DESCRIPTION
Undecided if this is a good way to go, but marked as for review to see what others say. I've added some notes on output of `mypy_primer` at the end, there are a couple of unexpected errors but mostly good.

Change `lru_cache` callable signature to use `ParamSpec`. This has previously been tried unsuccessfully (#11662) due to compatibility with the `classmethod` decorator. I've attempted to solve that compatibility by using overloads that do/don't include the necessary `cls` and `self` parameter when it appearrs that a method/classmethod is being cached.

This removes the `Hashable` constraint on parameters.

Instead, this uses the function signatures (almost) correctly (methods and class methods have 2 overloads, one with and without `cls` and `self`, but I think this would be less error prone than currently, could possibly be refined).

As a trivial example, the below type checks correctly
```python
from functools import cache
@cache
def foo(arg: str):
    ...
foo(1) # correctly raises type error
foo("1")
foo.cache_clear()
```
There is a more comprehensive example that I've been using to test in #12952 which (with 2 minor exceptions) type checks perfectly.