### PR TITLE
fix for `webbrowser.MacOSX.__init__`

### DIFF
--- a/stdlib/@tests/stubtest_allowlists/darwin-py310.txt
+++ b/stdlib/@tests/stubtest_allowlists/darwin-py310.txt
@@ -1,5 +1,3 @@
-webbrowser.MacOSX.__init__
-
 # Doesn't exist on macos:
 spwd
 _msi

--- a/stdlib/@tests/stubtest_allowlists/darwin-py311.txt
+++ b/stdlib/@tests/stubtest_allowlists/darwin-py311.txt
@@ -1,5 +1,3 @@
-webbrowser.MacOSX.__init__
-
 # Doesn't exist on macos:
 spwd
 _msi

--- a/stdlib/@tests/stubtest_allowlists/darwin-py312.txt
+++ b/stdlib/@tests/stubtest_allowlists/darwin-py312.txt
@@ -1,5 +1,3 @@
-webbrowser.MacOSX.__init__
-
 # Doesn't exist on macos:
 spwd
 _msi

--- a/stdlib/@tests/stubtest_allowlists/darwin-py38.txt
+++ b/stdlib/@tests/stubtest_allowlists/darwin-py38.txt
@@ -1,5 +1,3 @@
-webbrowser.MacOSX.__init__
-
 # Doesn't exist on macos:
 spwd
 _msi

--- a/stdlib/@tests/stubtest_allowlists/darwin-py39.txt
+++ b/stdlib/@tests/stubtest_allowlists/darwin-py39.txt
@@ -1,5 +1,3 @@
-webbrowser.MacOSX.__init__
-
 # Doesn't exist on macos:
 spwd
 _msi

--- a/stdlib/webbrowser.pyi
+++ b/stdlib/webbrowser.pyi
@@ -66,6 +66,7 @@ if sys.platform == "darwin":
     if sys.version_info < (3, 13):
         @deprecated("Deprecated in 3.11, to be removed in 3.13.")
         class MacOSX(BaseBrowser):
+            def __init__(self, name: str) -> None: ...
             def open(self, url: str, new: int = 0, autoraise: bool = True) -> bool: ...
 
     class MacOSXOSAScript(BaseBrowser):  # In runtime this class does not have `name` and `basename`


### PR DESCRIPTION
It's deprecated, but it's also an easy fix