### PR TITLE
`check_distutils` test: Make the file path of missing setuptools distutils files more obvious

### DIFF
--- a/tests/check_typeshed_structure.py
+++ b/tests/check_typeshed_structure.py
@@ -93,11 +93,13 @@ def check_distutils() -> None:
     def all_relative_paths_in_directory(path: Path) -> set[Path]:
         return {pyi.relative_to(path) for pyi in path.rglob("*.pyi")}
 
-    all_setuptools_files = all_relative_paths_in_directory(STUBS_PATH / "setuptools" / "setuptools" / "_distutils")
-    all_distutils_files = all_relative_paths_in_directory(STUBS_PATH / "setuptools" / "distutils")
+    setuptools_path = STUBS_PATH / "setuptools" / "setuptools" / "_distutils"
+    distutils_path = STUBS_PATH / "setuptools" / "distutils"
+    all_setuptools_files = all_relative_paths_in_directory(setuptools_path)
+    all_distutils_files = all_relative_paths_in_directory(distutils_path)
     assert all_setuptools_files and all_distutils_files, "Looks like this test might be out of date!"
     extra_files = all_setuptools_files - all_distutils_files
-    joined = "\n".join(f"  * {f}" for f in extra_files)
+    joined = "\n".join(f"  * {distutils_path / f}" for f in extra_files)
     assert not extra_files, f"Files missing from distutils:\n{joined}"
 
 


### PR DESCRIPTION
In https://github.com/python/typeshed/pull/13036 I got really confused as to what the error was trying to tell me, since I didn't add any file that didn't exist in distutils. I had to start digging in the test's code to see that it was checking a different folder than I expected.

![image](https://github.com/user-attachments/assets/15169460-17ab-44ee-a4e3-fce0fd481f69)

Before:
![image](https://github.com/user-attachments/assets/cebccd50-d6fb-470e-86d0-0e1f6b54f7c9)

After:
![image](https://github.com/user-attachments/assets/e3409ad1-f8e0-47f9-8ab9-b42a444adcbd)

(unrelated but 3.13 errors are indeed looking nice)