### PR TITLE
add socket.__all__

### DIFF
--- a/stdlib/@tests/stubtest_allowlists/linux.txt
+++ b/stdlib/@tests/stubtest_allowlists/linux.txt
@@ -47,3 +47,30 @@ curses.COLORS  # Initialized after start_color
 curses.COLOR_PAIRS  # Initialized after start_color
 curses.COLS  # Initialized only after initscr call
 curses.LINES  # Initialized only after initscr call
+
+# These seem like they should be available on Linux, but they're not
+# in the gitlab pipline for some reason.
+_?socket.IPX_TYPE
+_?socket.RDS_CANCEL_SENT_TO
+_?socket.RDS_CMSG_RDMA_ARGS
+_?socket.RDS_CMSG_RDMA_DEST
+_?socket.RDS_CMSG_RDMA_MAP
+_?socket.RDS_CMSG_RDMA_STATUS
+_?socket.RDS_CONG_MONITOR
+_?socket.RDS_FREE_MR
+_?socket.RDS_GET_MR
+_?socket.RDS_GET_MR_FOR_DEST
+_?socket.RDS_RDMA_DONTWAIT
+_?socket.RDS_RDMA_FENCE
+_?socket.RDS_RDMA_INVALIDATE
+_?socket.RDS_RDMA_NOTIFY_ME
+_?socket.RDS_RDMA_READWRITE
+_?socket.RDS_RDMA_SILENT
+_?socket.RDS_RDMA_USE_ONCE
+_?socket.RDS_RECVERR
+_?socket.SOL_ATALK
+_?socket.SOL_AX25
+_?socket.SOL_HCI
+_?socket.SOL_IPX
+_?socket.SOL_NETROM
+_?socket.SOL_ROSE

--- a/stdlib/@tests/stubtest_allowlists/linux.txt
+++ b/stdlib/@tests/stubtest_allowlists/linux.txt
@@ -2,11 +2,9 @@
 # TODO: Review the following
 # ==========
 
-_socket.*
 _posixsubprocess.cloexec_pipe
 curses.has_key
 selectors.KqueueSelector
-socket.[A-Z0-9_]+
 
 _ctypes.dlclose
 _ctypes.dlopen

--- a/stdlib/@tests/stubtest_allowlists/linux.txt
+++ b/stdlib/@tests/stubtest_allowlists/linux.txt
@@ -49,7 +49,7 @@ curses.COLS  # Initialized only after initscr call
 curses.LINES  # Initialized only after initscr call
 
 # These seem like they should be available on Linux, but they're not
-# in the gitlab pipline for some reason.
+# on GitHub Actions runners for some reason.
 _?socket.IPX_TYPE
 _?socket.RDS_CANCEL_SENT_TO
 _?socket.RDS_CMSG_RDMA_ARGS

--- a/stdlib/_socket.pyi
+++ b/stdlib/_socket.pyi
@@ -87,6 +87,7 @@ if sys.platform != "win32" and sys.platform != "darwin":
     SO_PEERSEC: int
     SO_PRIORITY: int
     SO_PROTOCOL: int
+if sys.platform != "win32" and sys.platform != "darwin" and sys.platform != "linux":
     SO_SETFIB: int
 if sys.platform == "linux" and sys.version_info >= (3, 13):
     SO_BINDTOIFINDEX: int
@@ -101,39 +102,43 @@ MSG_TRUNC: int
 MSG_WAITALL: int
 if sys.platform != "win32":
     MSG_DONTWAIT: int
-    MSG_EOF: int
     MSG_EOR: int
     MSG_NOSIGNAL: int  # Sometimes this exists on darwin, sometimes not
 if sys.platform != "darwin":
-    MSG_BCAST: int
     MSG_ERRQUEUE: int
+if sys.platform == "win32":
+    MSG_BCAST: int
     MSG_MCAST: int
 if sys.platform != "win32" and sys.platform != "darwin":
-    MSG_BTAG: int
+    # MSG_BTAG: int  # Availability?
     MSG_CMSG_CLOEXEC: int
     MSG_CONFIRM: int
-    MSG_ETAG: int
+    # MSG_ETAG: int  # Availability?
     MSG_FASTOPEN: int
     MSG_MORE: int
+if sys.platform != "win32" and sys.platform != "linux":
+    MSG_EOF: int
+if sys.platform != "win32" and sys.platform != "linux" and sys.platform != "darwin":
     MSG_NOTIFICATION: int
 
 SOL_IP: int
 SOL_SOCKET: int
 SOL_TCP: int
 SOL_UDP: int
-if sys.platform != "win32" and sys.platform != "darwin":
-    SOL_ATALK: int
-    SOL_AX25: int
-    SOL_HCI: int
-    SOL_IPX: int
-    SOL_NETROM: int
-    SOL_ROSE: int
+# if sys.platform != "win32" and sys.platform != "darwin":
+#     SOL_ATALK: int  # Availability?
+#     SOL_AX25: int  # Availability?
+#     SOL_HCI: int  # Availability?
+#     SOL_IPX: int  # Availability?
+#     SOL_NETROM: int  # Availability?
+#     SOL_ROSE: int  # Availability?
 
 if sys.platform != "win32":
-    SCM_CREDS: int
     SCM_RIGHTS: int
 if sys.platform != "win32" and sys.platform != "darwin":
     SCM_CREDENTIALS: int
+if sys.platform != "win32" and sys.platform != "linux":
+    SCM_CREDS: int
 
 IPPROTO_ICMP: int
 IPPROTO_IP: int
@@ -145,7 +150,6 @@ IPPROTO_DSTOPTS: int
 IPPROTO_EGP: int
 IPPROTO_ESP: int
 IPPROTO_FRAGMENT: int
-IPPROTO_GGP: int
 IPPROTO_HOPOPTS: int
 IPPROTO_ICMPV6: int
 IPPROTO_IDP: int
@@ -159,7 +163,9 @@ IPPROTO_PIM: int
 IPPROTO_PUP: int
 IPPROTO_ROUTING: int
 IPPROTO_SCTP: int
-if sys.platform != "darwin":
+if sys.platform != "linux":
+    IPPROTO_GGP: int
+if sys.platform == "win32":
     IPPROTO_CBT: int
     IPPROTO_ICLFXBM: int
     IPPROTO_IGP: int
@@ -168,18 +174,19 @@ if sys.platform != "darwin":
     IPPROTO_RDP: int
     IPPROTO_ST: int
 if sys.platform != "win32":
-    IPPROTO_EON: int
     IPPROTO_GRE: int
-    IPPROTO_HELLO: int
-    IPPROTO_IPCOMP: int
     IPPROTO_IPIP: int
     IPPROTO_RSVP: int
     IPPROTO_TP: int
+if sys.platform != "win32" and sys.platform != "linux":
+    IPPROTO_EON: int
+    IPPROTO_HELLO: int
+    IPPROTO_IPCOMP: int
     IPPROTO_XTP: int
-if sys.platform != "win32" and sys.platform != "darwin":
-    IPPROTO_BIP: int
-    IPPROTO_MOBILE: int
-    IPPROTO_VRRP: int
+# if sys.platform != "win32" and sys.platform != "darwin":
+#     IPPROTO_BIP: int   # Availability?
+#     IPPROTO_MOBILE: int  # Availability?
+#     IPPROTO_VRRP: int  # Availability?
 if sys.version_info >= (3, 9) and sys.platform == "linux":
     # Availability: Linux >= 2.6.20, FreeBSD >= 10.1
     IPPROTO_UDPLITE: int
@@ -269,11 +276,12 @@ EAI_SERVICE: int
 EAI_SOCKTYPE: int
 if sys.platform != "win32":
     EAI_ADDRFAMILY: int
+    EAI_OVERFLOW: int
+    EAI_SYSTEM: int
+if sys.platform != "win32" and sys.platform != "linux":
     EAI_BADHINTS: int
     EAI_MAX: int
-    EAI_OVERFLOW: int
     EAI_PROTOCOL: int
-    EAI_SYSTEM: int
 
 AI_ADDRCONFIG: int
 AI_ALL: int
@@ -282,7 +290,7 @@ AI_NUMERICHOST: int
 AI_NUMERICSERV: int
 AI_PASSIVE: int
 AI_V4MAPPED: int
-if sys.platform != "win32":
+if sys.platform != "win32" and sys.platform != "linux":
     AI_DEFAULT: int
     AI_MASK: int
     AI_V4MAPPED_CFG: int
@@ -547,7 +555,8 @@ if sys.platform == "linux":
 if sys.platform != "win32" or sys.version_info >= (3, 9):
     # Documented as only available on BSD, macOS, but empirically sometimes
     # available on Windows
-    AF_LINK: int
+    if sys.platform != "linux":
+        AF_LINK: int
 
 has_ipv6: bool
 
@@ -661,13 +670,14 @@ AF_SNA: int
 
 if sys.platform != "win32":
     AF_ROUTE: int
+
+if sys.platform == "darwin":
     AF_SYSTEM: int
 
 if sys.platform != "darwin":
     AF_IRDA: int
 
 if sys.platform != "win32" and sys.platform != "darwin":
-    AF_AAL5: int
     AF_ASH: int
     AF_ATMPVC: int
     AF_ATMSVC: int
@@ -686,11 +696,11 @@ if sys.platform != "win32" and sys.platform != "darwin":
 
 # Miscellaneous undocumented
 
-if sys.platform != "win32":
+if sys.platform != "win32" and sys.platform != "linux":
     LOCAL_PEERCRED: int
 
-if sys.platform != "win32" and sys.platform != "darwin":
-    IPX_TYPE: int
+# if sys.platform != "win32" and sys.platform != "darwin":
+#     IPX_TYPE: int  # availability?
 
 # ===== Classes =====
 

--- a/stdlib/_socket.pyi
+++ b/stdlib/_socket.pyi
@@ -565,7 +565,7 @@ if sys.platform != "win32" or sys.version_info >= (3, 9):
 
 has_ipv6: bool
 
-if sys.platform != "darwin":
+if sys.platform != "darwin" and sys.platform != "linux":
     if sys.platform != "win32" or sys.version_info >= (3, 9):
         BDADDR_ANY: str
         BDADDR_LOCAL: str
@@ -638,7 +638,7 @@ if sys.platform == "darwin":
     PF_SYSTEM: int
     SYSPROTO_CONTROL: int
 
-if sys.platform != "darwin":
+if sys.platform != "darwin" and sys.platform != "linux":
     if sys.version_info >= (3, 9) or sys.platform != "win32":
         AF_BLUETOOTH: int
 
@@ -648,7 +648,7 @@ if sys.platform != "win32" and sys.platform != "darwin" and sys.platform != "lin
     BTPROTO_HCI: int
     BTPROTO_L2CAP: int
     BTPROTO_SCO: int  # not in FreeBSD
-if sys.platform != "darwin":
+if sys.platform != "darwin" and sys.platform != "linux":
     if sys.version_info >= (3, 9) or sys.platform != "win32":
         BTPROTO_RFCOMM: int
 

--- a/stdlib/_socket.pyi
+++ b/stdlib/_socket.pyi
@@ -88,6 +88,8 @@ if sys.platform != "win32" and sys.platform != "darwin":
     SO_PRIORITY: int
     SO_PROTOCOL: int
     SO_SETFIB: int
+if sys.platform == "linux" and sys.version_info >= (3, 13):
+    SO_BINDTOIFINDEX: int
 
 SOMAXCONN: int
 
@@ -205,8 +207,6 @@ IP_OPTIONS: int
 IP_RECVDSTADDR: int
 if sys.version_info >= (3, 10):
     IP_RECVTOS: int
-elif sys.platform != "win32" and sys.platform != "darwin":
-    IP_RECVTOS: int
 IP_TOS: int
 IP_TTL: int
 if sys.platform != "win32":
@@ -218,6 +218,7 @@ if sys.platform != "win32":
     IP_RETOPTS: int
 if sys.platform != "win32" and sys.platform != "darwin":
     IP_TRANSPARENT: int
+if sys.platform != "win32" and sys.platform != "darwin" and sys.version_info >= (3, 11):
     IP_BIND_ADDRESS_NO_PORT: int
 if sys.version_info >= (3, 12):
     IP_ADD_SOURCE_MEMBERSHIP: int
@@ -293,6 +294,8 @@ NI_NAMEREQD: int
 NI_NOFQDN: int
 NI_NUMERICHOST: int
 NI_NUMERICSERV: int
+if sys.platform == "linux" and sys.version_info >= (3, 13):
+    NI_IDN: int
 
 TCP_FASTOPEN: int
 TCP_KEEPCNT: int
@@ -318,6 +321,27 @@ if sys.platform != "win32" and sys.platform != "darwin":
     TCP_SYNCNT: int
     TCP_USER_TIMEOUT: int
     TCP_WINDOW_CLAMP: int
+if sys.platform == "linux" and sys.version_info >= (3, 12):
+    TCP_CC_INFO: int
+    TCP_FASTOPEN_CONNECT: int
+    TCP_FASTOPEN_KEY: int
+    TCP_FASTOPEN_NO_COOKIE: int
+    TCP_INQ: int
+    TCP_MD5SIG: int
+    TCP_MD5SIG_EXT: int
+    TCP_QUEUE_SEQ: int
+    TCP_REPAIR: int
+    TCP_REPAIR_OPTIONS: int
+    TCP_REPAIR_QUEUE: int
+    TCP_REPAIR_WINDOW: int
+    TCP_SAVED_SYN: int
+    TCP_SAVE_SYN: int
+    TCP_THIN_DUPACK: int
+    TCP_THIN_LINEAR_TIMEOUTS: int
+    TCP_TIMESTAMP: int
+    TCP_TX_DELAY: int
+    TCP_ULP: int
+    TCP_ZEROCOPY_RECEIVE: int
 
 # --------------------
 # Specifically documented constants
@@ -334,12 +358,13 @@ if sys.platform == "linux":
     CAN_ERR_FLAG: int
     CAN_ERR_MASK: int
     CAN_RAW: int
-    CAN_RAW_ERR_FILTER: int
     CAN_RAW_FILTER: int
     CAN_RAW_LOOPBACK: int
     CAN_RAW_RECV_OWN_MSGS: int
     CAN_RTR_FLAG: int
     CAN_SFF_MASK: int
+    if sys.version_info < (3, 11):
+        CAN_RAW_ERR_FILTER: int
 
 if sys.platform == "linux":
     # Availability: Linux >= 2.6.25

--- a/stdlib/_socket.pyi
+++ b/stdlib/_socket.pyi
@@ -72,7 +72,8 @@ SO_SNDBUF: int
 SO_SNDLOWAT: int
 SO_SNDTIMEO: int
 SO_TYPE: int
-SO_USELOOPBACK: int
+if sys.platform != "linux":
+    SO_USELOOPBACK: int
 if sys.platform == "win32":
     SO_EXCLUSIVEADDRUSE: int
 if sys.platform != "win32":
@@ -154,10 +155,7 @@ IPPROTO_HOPOPTS: int
 IPPROTO_ICMPV6: int
 IPPROTO_IDP: int
 IPPROTO_IGMP: int
-IPPROTO_IPV4: int
 IPPROTO_IPV6: int
-IPPROTO_MAX: int
-IPPROTO_ND: int
 IPPROTO_NONE: int
 IPPROTO_PIM: int
 IPPROTO_PUP: int
@@ -165,6 +163,9 @@ IPPROTO_ROUTING: int
 IPPROTO_SCTP: int
 if sys.platform != "linux":
     IPPROTO_GGP: int
+    IPPROTO_IPV4: int
+    IPPROTO_MAX: int
+    IPPROTO_ND: int
 if sys.platform == "win32":
     IPPROTO_CBT: int
     IPPROTO_ICLFXBM: int
@@ -211,7 +212,8 @@ IP_MULTICAST_IF: int
 IP_MULTICAST_LOOP: int
 IP_MULTICAST_TTL: int
 IP_OPTIONS: int
-IP_RECVDSTADDR: int
+if sys.platform != "linux":
+    IP_RECVDSTADDR: int
 if sys.version_info >= (3, 10):
     IP_RECVTOS: int
 IP_TOS: int
@@ -263,6 +265,9 @@ if sys.platform != "win32":
         IPV6_RECVPATHMTU: int
         IPV6_RECVPKTINFO: int
         IPV6_RTHDRDSTOPTS: int
+
+if sys.platform != "win32" and sys.platform != "linux":
+    if sys.version_info >= (3, 9) or sys.platform != "darwin":
         IPV6_USE_MIN_MTU: int
 
 EAI_AGAIN: int
@@ -470,24 +475,24 @@ if sys.platform == "linux":
     AF_RDS: int
     PF_RDS: int
     SOL_RDS: int
-    RDS_CANCEL_SENT_TO: int
-    RDS_CMSG_RDMA_ARGS: int
-    RDS_CMSG_RDMA_DEST: int
-    RDS_CMSG_RDMA_MAP: int
-    RDS_CMSG_RDMA_STATUS: int
-    RDS_CMSG_RDMA_UPDATE: int
-    RDS_CONG_MONITOR: int
-    RDS_FREE_MR: int
-    RDS_GET_MR: int
-    RDS_GET_MR_FOR_DEST: int
-    RDS_RDMA_DONTWAIT: int
-    RDS_RDMA_FENCE: int
-    RDS_RDMA_INVALIDATE: int
-    RDS_RDMA_NOTIFY_ME: int
-    RDS_RDMA_READWRITE: int
-    RDS_RDMA_SILENT: int
-    RDS_RDMA_USE_ONCE: int
-    RDS_RECVERR: int
+    # RDS_CANCEL_SENT_TO: int  # Availability?
+    # RDS_CMSG_RDMA_ARGS: int  # Availability?
+    # RDS_CMSG_RDMA_DEST: int  # Availability?
+    # RDS_CMSG_RDMA_MAP: int  # Availability?
+    # RDS_CMSG_RDMA_STATUS: int  # Availability?
+    # RDS_CMSG_RDMA_UPDATE: int  # Availability?
+    # RDS_CONG_MONITOR: int  # Availability?
+    # RDS_FREE_MR: int  # Availability?
+    # RDS_GET_MR: int  # Availability?
+    # RDS_GET_MR_FOR_DEST: int  # Availability?
+    # RDS_RDMA_DONTWAIT: int  # Availability?
+    # RDS_RDMA_FENCE: int  # Availability?
+    # RDS_RDMA_INVALIDATE: int  # Availability?
+    # RDS_RDMA_NOTIFY_ME: int  # Availability?
+    # RDS_RDMA_READWRITE: int  # Availability?
+    # RDS_RDMA_SILENT: int  # Availability?
+    # RDS_RDMA_USE_ONCE: int  # Availability?
+    # RDS_RECVERR: int  # Availability?
 
 if sys.platform == "win32":
     SIO_RCVALL: int
@@ -565,7 +570,7 @@ if sys.platform != "darwin":
         BDADDR_ANY: str
         BDADDR_LOCAL: str
 
-if sys.platform != "win32" and sys.platform != "darwin":
+if sys.platform != "win32" and sys.platform != "darwin" and sys.platform != "linux":
     HCI_FILTER: int  # not in NetBSD or DragonFlyBSD
     HCI_TIME_STAMP: int  # not in FreeBSD, NetBSD, or DragonFlyBSD
     HCI_DATA_DIR: int  # not in FreeBSD, NetBSD, or DragonFlyBSD
@@ -614,19 +619,19 @@ if sys.version_info >= (3, 12):
 if sys.platform == "linux":
     # Netlink is defined by Linux
     AF_NETLINK: int
-    NETLINK_ARPD: int
+    # NETLINK_ARPD: int  # Availability?
     NETLINK_CRYPTO: int
     NETLINK_DNRTMSG: int
     NETLINK_FIREWALL: int
     NETLINK_IP6_FW: int
     NETLINK_NFLOG: int
-    NETLINK_ROUTE6: int
+    # NETLINK_ROUTE6: int  # Availability?
     NETLINK_ROUTE: int
-    NETLINK_SKIP: int
-    NETLINK_TAPBASE: int
-    NETLINK_TCPDIAG: int
+    # NETLINK_SKIP: int  # Availability?
+    # NETLINK_TAPBASE: int  # Availability?
+    # NETLINK_TCPDIAG: int  # Availability?
     NETLINK_USERSOCK: int
-    NETLINK_W1: int
+    # NETLINK_W1: int  # Availability?
     NETLINK_XFRM: int
 
 if sys.platform == "darwin":
@@ -637,7 +642,7 @@ if sys.platform != "darwin":
     if sys.version_info >= (3, 9) or sys.platform != "win32":
         AF_BLUETOOTH: int
 
-if sys.platform != "win32" and sys.platform != "darwin":
+if sys.platform != "win32" and sys.platform != "darwin" and sys.platform != "linux":
     # Linux and some BSD support is explicit in the docs
     # Windows and macOS do not support in practice
     BTPROTO_HCI: int

--- a/stdlib/_socket.pyi
+++ b/stdlib/_socket.pyi
@@ -111,28 +111,30 @@ if sys.platform == "win32":
     MSG_BCAST: int
     MSG_MCAST: int
 if sys.platform != "win32" and sys.platform != "darwin":
-    # MSG_BTAG: int  # Availability?
     MSG_CMSG_CLOEXEC: int
     MSG_CONFIRM: int
-    # MSG_ETAG: int  # Availability?
     MSG_FASTOPEN: int
     MSG_MORE: int
 if sys.platform != "win32" and sys.platform != "linux":
     MSG_EOF: int
 if sys.platform != "win32" and sys.platform != "linux" and sys.platform != "darwin":
     MSG_NOTIFICATION: int
+    MSG_BTAG: int  # Not FreeBSD either
+    MSG_ETAG: int  # Not FreeBSD either
 
 SOL_IP: int
 SOL_SOCKET: int
 SOL_TCP: int
 SOL_UDP: int
-# if sys.platform != "win32" and sys.platform != "darwin":
-#     SOL_ATALK: int  # Availability?
-#     SOL_AX25: int  # Availability?
-#     SOL_HCI: int  # Availability?
-#     SOL_IPX: int  # Availability?
-#     SOL_NETROM: int  # Availability?
-#     SOL_ROSE: int  # Availability?
+if sys.platform != "win32" and sys.platform != "darwin":
+    # Defined in socket.h for Linux, but these aren't always present for
+    # some reason.
+    SOL_ATALK: int
+    SOL_AX25: int
+    SOL_HCI: int
+    SOL_IPX: int
+    SOL_NETROM: int
+    SOL_ROSE: int
 
 if sys.platform != "win32":
     SCM_RIGHTS: int
@@ -184,10 +186,10 @@ if sys.platform != "win32" and sys.platform != "linux":
     IPPROTO_HELLO: int
     IPPROTO_IPCOMP: int
     IPPROTO_XTP: int
-# if sys.platform != "win32" and sys.platform != "darwin":
-#     IPPROTO_BIP: int   # Availability?
-#     IPPROTO_MOBILE: int  # Availability?
-#     IPPROTO_VRRP: int  # Availability?
+if sys.platform != "win32" and sys.platform != "darwin" and sys.platform != "linux":
+    IPPROTO_BIP: int  # Not FreeBSD either
+    IPPROTO_MOBILE: int  # Not FreeBSD either
+    IPPROTO_VRRP: int  # Not FreeBSD either
 if sys.version_info >= (3, 9) and sys.platform == "linux":
     # Availability: Linux >= 2.6.20, FreeBSD >= 10.1
     IPPROTO_UDPLITE: int
@@ -475,24 +477,29 @@ if sys.platform == "linux":
     AF_RDS: int
     PF_RDS: int
     SOL_RDS: int
-    # RDS_CANCEL_SENT_TO: int  # Availability?
-    # RDS_CMSG_RDMA_ARGS: int  # Availability?
-    # RDS_CMSG_RDMA_DEST: int  # Availability?
-    # RDS_CMSG_RDMA_MAP: int  # Availability?
-    # RDS_CMSG_RDMA_STATUS: int  # Availability?
-    # RDS_CMSG_RDMA_UPDATE: int  # Availability?
-    # RDS_CONG_MONITOR: int  # Availability?
-    # RDS_FREE_MR: int  # Availability?
-    # RDS_GET_MR: int  # Availability?
-    # RDS_GET_MR_FOR_DEST: int  # Availability?
-    # RDS_RDMA_DONTWAIT: int  # Availability?
-    # RDS_RDMA_FENCE: int  # Availability?
-    # RDS_RDMA_INVALIDATE: int  # Availability?
-    # RDS_RDMA_NOTIFY_ME: int  # Availability?
-    # RDS_RDMA_READWRITE: int  # Availability?
-    # RDS_RDMA_SILENT: int  # Availability?
-    # RDS_RDMA_USE_ONCE: int  # Availability?
-    # RDS_RECVERR: int  # Availability?
+    # These are present in include/linux/rds.h but don't always show up
+    # here.
+    RDS_CANCEL_SENT_TO: int
+    RDS_CMSG_RDMA_ARGS: int
+    RDS_CMSG_RDMA_DEST: int
+    RDS_CMSG_RDMA_MAP: int
+    RDS_CMSG_RDMA_STATUS: int
+    RDS_CONG_MONITOR: int
+    RDS_FREE_MR: int
+    RDS_GET_MR: int
+    RDS_GET_MR_FOR_DEST: int
+    RDS_RDMA_DONTWAIT: int
+    RDS_RDMA_FENCE: int
+    RDS_RDMA_INVALIDATE: int
+    RDS_RDMA_NOTIFY_ME: int
+    RDS_RDMA_READWRITE: int
+    RDS_RDMA_SILENT: int
+    RDS_RDMA_USE_ONCE: int
+    RDS_RECVERR: int
+
+    # This is supported by cpython but doesn't seem to be a real thing.
+    # The closest existing constant in rds.h is RDS_CMSG_CONG_UPDATE
+    # RDS_CMSG_RDMA_UPDATE: int
 
 if sys.platform == "win32":
     SIO_RCVALL: int
@@ -619,20 +626,21 @@ if sys.version_info >= (3, 12):
 if sys.platform == "linux":
     # Netlink is defined by Linux
     AF_NETLINK: int
-    # NETLINK_ARPD: int  # Availability?
     NETLINK_CRYPTO: int
     NETLINK_DNRTMSG: int
     NETLINK_FIREWALL: int
     NETLINK_IP6_FW: int
     NETLINK_NFLOG: int
-    # NETLINK_ROUTE6: int  # Availability?
     NETLINK_ROUTE: int
-    # NETLINK_SKIP: int  # Availability?
-    # NETLINK_TAPBASE: int  # Availability?
-    # NETLINK_TCPDIAG: int  # Availability?
     NETLINK_USERSOCK: int
-    # NETLINK_W1: int  # Availability?
     NETLINK_XFRM: int
+    # Technically still supported by cpython
+    # NETLINK_ARPD: int  # linux 2.0 to 2.6.12 (EOL August 2005)
+    # NETLINK_ROUTE6: int  # linux 2.2 to 2.6.12 (EOL August 2005)
+    # NETLINK_SKIP: int  # linux 2.0 to 2.6.12 (EOL August 2005)
+    # NETLINK_TAPBASE: int  # linux 2.2 to 2.6.12 (EOL August 2005)
+    # NETLINK_TCPDIAG: int  # linux 2.6.0 to 2.6.13 (EOL December 2005)
+    # NETLINK_W1: int  # linux 2.6.13 to 2.6.17 (EOL October 2006)
 
 if sys.platform == "darwin":
     PF_SYSTEM: int
@@ -704,8 +712,10 @@ if sys.platform != "win32" and sys.platform != "darwin":
 if sys.platform != "win32" and sys.platform != "linux":
     LOCAL_PEERCRED: int
 
-# if sys.platform != "win32" and sys.platform != "darwin":
-#     IPX_TYPE: int  # availability?
+if sys.platform != "win32" and sys.platform != "darwin":
+    # Defined in linux socket.h, but this isn't always present for
+    # some reason.
+    IPX_TYPE: int
 
 # ===== Classes =====
 

--- a/stdlib/socket.pyi
+++ b/stdlib/socket.pyi
@@ -139,6 +139,184 @@ from io import BufferedReader, BufferedRWPair, BufferedWriter, IOBase, RawIOBase
 from typing import Any, Literal, Protocol, SupportsIndex, overload
 from typing_extensions import Self
 
+__all__ = [
+    "fromfd",
+    "getfqdn",
+    "create_connection",
+    "create_server",
+    "has_dualstack_ipv6",
+    "AddressFamily",
+    "SocketKind",
+    "AF_APPLETALK",
+    "AF_DECnet",
+    "AF_INET",
+    "AF_INET6",
+    "AF_IPX",
+    "AF_LINK",
+    "AF_ROUTE",
+    "AF_SNA",
+    "AF_SYSTEM",
+    "AF_UNIX",
+    "AF_UNSPEC",
+    "AI_ADDRCONFIG",
+    "AI_ALL",
+    "AI_CANONNAME",
+    "AI_DEFAULT",
+    "AI_MASK",
+    "AI_NUMERICHOST",
+    "AI_NUMERICSERV",
+    "AI_PASSIVE",
+    "AI_V4MAPPED",
+    "AI_V4MAPPED_CFG",
+    "CAPI",
+    "EAI_AGAIN",
+    "EAI_BADFLAGS",
+    "EAI_FAIL",
+    "EAI_FAMILY",
+    "EAI_MEMORY",
+    "EAI_NODATA",
+    "EAI_NONAME",
+    "EAI_SERVICE",
+    "EAI_SOCKTYPE",
+    "INADDR_ALLHOSTS_GROUP",
+    "INADDR_ANY",
+    "INADDR_BROADCAST",
+    "INADDR_LOOPBACK",
+    "INADDR_MAX_LOCAL_GROUP",
+    "INADDR_NONE",
+    "INADDR_UNSPEC_GROUP",
+    "IPPORT_RESERVED",
+    "IPPORT_USERRESERVED",
+    "IPPROTO_AH",
+    "IPPROTO_DSTOPTS",
+    "IPPROTO_EGP",
+    "IPPROTO_ESP",
+    "IPPROTO_FRAGMENT",
+    "IPPROTO_GGP",
+    "IPPROTO_HOPOPTS",
+    "IPPROTO_ICMP",
+    "IPPROTO_ICMPV6",
+    "IPPROTO_IDP",
+    "IPPROTO_IGMP",
+    "IPPROTO_IP",
+    "IPPROTO_IPV4",
+    "IPPROTO_IPV6",
+    "IPPROTO_MAX",
+    "IPPROTO_ND",
+    "IPPROTO_NONE",
+    "IPPROTO_PIM",
+    "IPPROTO_PUP",
+    "IPPROTO_RAW",
+    "IPPROTO_ROUTING",
+    "IPPROTO_SCTP",
+    "IPPROTO_TCP",
+    "IPPROTO_UDP",
+    "IPV6_CHECKSUM",
+    "IPV6_JOIN_GROUP",
+    "IPV6_LEAVE_GROUP",
+    "IPV6_MULTICAST_HOPS",
+    "IPV6_MULTICAST_IF",
+    "IPV6_MULTICAST_LOOP",
+    "IPV6_RECVTCLASS",
+    "IPV6_TCLASS",
+    "IPV6_UNICAST_HOPS",
+    "IPV6_V6ONLY",
+    "IP_ADD_MEMBERSHIP",
+    "IP_DROP_MEMBERSHIP",
+    "IP_HDRINCL",
+    "IP_MULTICAST_IF",
+    "IP_MULTICAST_LOOP",
+    "IP_MULTICAST_TTL",
+    "IP_OPTIONS",
+    "IP_RECVDSTADDR",
+    "IP_TOS",
+    "IP_TTL",
+    "MSG_CTRUNC",
+    "MSG_DONTROUTE",
+    "MSG_DONTWAIT",
+    "MSG_EOF",
+    "MSG_EOR",
+    "MSG_NOSIGNAL",
+    "MSG_OOB",
+    "MSG_PEEK",
+    "MSG_TRUNC",
+    "MSG_WAITALL",
+    "NI_DGRAM",
+    "NI_MAXHOST",
+    "NI_MAXSERV",
+    "NI_NAMEREQD",
+    "NI_NOFQDN",
+    "NI_NUMERICHOST",
+    "NI_NUMERICSERV",
+    "SHUT_RD",
+    "SHUT_RDWR",
+    "SHUT_WR",
+    "SOCK_DGRAM",
+    "SOCK_RAW",
+    "SOCK_RDM",
+    "SOCK_SEQPACKET",
+    "SOCK_STREAM",
+    "SOL_IP",
+    "SOL_SOCKET",
+    "SOL_TCP",
+    "SOL_UDP",
+    "SOMAXCONN",
+    "SO_ACCEPTCONN",
+    "SO_BROADCAST",
+    "SO_DEBUG",
+    "SO_DONTROUTE",
+    "SO_ERROR",
+    "SO_KEEPALIVE",
+    "SO_LINGER",
+    "SO_OOBINLINE",
+    "SO_RCVBUF",
+    "SO_RCVLOWAT",
+    "SO_RCVTIMEO",
+    "SO_REUSEADDR",
+    "SO_SNDBUF",
+    "SO_SNDLOWAT",
+    "SO_SNDTIMEO",
+    "SO_TYPE",
+    "SO_USELOOPBACK",
+    "SocketType",
+    "TCP_FASTOPEN",
+    "TCP_KEEPCNT",
+    "TCP_KEEPINTVL",
+    "TCP_MAXSEG",
+    "TCP_NODELAY",
+    "close",
+    "dup",
+    "error",
+    "gaierror",
+    "getaddrinfo",
+    "getdefaulttimeout",
+    "gethostbyaddr",
+    "gethostbyname",
+    "gethostbyname_ex",
+    "gethostname",
+    "getnameinfo",
+    "getprotobyname",
+    "getservbyname",
+    "getservbyport",
+    "has_ipv6",
+    "herror",
+    "htonl",
+    "htons",
+    "if_indextoname",
+    "if_nameindex",
+    "if_nametoindex",
+    "inet_aton",
+    "inet_ntoa",
+    "inet_ntop",
+    "inet_pton",
+    "ntohl",
+    "ntohs",
+    "setdefaulttimeout",
+    "socket",
+    "socketpair",
+    "timeout",
+]
+
 if sys.platform == "win32":
     from _socket import (
         RCVALL_MAX as RCVALL_MAX,
@@ -151,6 +329,18 @@ if sys.platform == "win32":
         SO_EXCLUSIVEADDRUSE as SO_EXCLUSIVEADDRUSE,
     )
 
+    __all__ += [
+        "RCVALL_MAX",
+        "RCVALL_OFF",
+        "RCVALL_ON",
+        "RCVALL_SOCKETLEVELONLY",
+        "SIO_KEEPALIVE_VALS",
+        "SIO_LOOPBACK_FAST_PATH",
+        "SIO_RCVALL",
+        "SO_EXCLUSIVEADDRUSE",
+        "fromshare",
+    ]
+
 if sys.platform != "darwin" or sys.version_info >= (3, 9):
     from _socket import (
         IPV6_DONTFRAG as IPV6_DONTFRAG,
@@ -161,8 +351,12 @@ if sys.platform != "darwin" or sys.version_info >= (3, 9):
         IPV6_RTHDR as IPV6_RTHDR,
     )
 
+    __all__ += ["IPV6_DONTFRAG", "IPV6_HOPLIMIT", "IPV6_HOPOPTS", "IPV6_PKTINFO", "IPV6_RECVRTHDR", "IPV6_RTHDR"]
+
 if sys.platform == "darwin":
     from _socket import PF_SYSTEM as PF_SYSTEM, SYSPROTO_CONTROL as SYSPROTO_CONTROL
+
+    __all__ += ["PF_SYSTEM", "SYSPROTO_CONTROL"]
 
 if sys.platform != "darwin":
     from _socket import (
@@ -176,10 +370,25 @@ if sys.platform != "darwin":
         TCP_KEEPIDLE as TCP_KEEPIDLE,
     )
 
+    __all__ += [
+        "IPPROTO_CBT",
+        "IPPROTO_ICLFXBM",
+        "IPPROTO_IGP",
+        "IPPROTO_L2TP",
+        "IPPROTO_PGM",
+        "IPPROTO_RDP",
+        "IPPROTO_ST",
+        "TCP_KEEPIDLE",
+    ]
+
 if sys.version_info >= (3, 10):
     from _socket import IP_RECVTOS as IP_RECVTOS
+
+    __all__ += ["IP_RECVTOS"]
 elif sys.platform != "win32" and sys.platform != "darwin":
     from _socket import IP_RECVTOS as IP_RECVTOS
+
+    __all__ += ["IP_RECVTOS"]
 
 if sys.platform != "win32" and sys.platform != "darwin":
     from _socket import (
@@ -217,6 +426,41 @@ if sys.platform != "win32" and sys.platform != "darwin":
         TCP_WINDOW_CLAMP as TCP_WINDOW_CLAMP,
     )
 
+    __all__ += [
+        "IP_BIND_ADDRESS_NO_PORT",
+        "IP_TRANSPARENT",
+        "IPPROTO_BIP",
+        "IPPROTO_MOBILE",
+        "IPPROTO_VRRP",
+        "IPX_TYPE",
+        "SCM_CREDENTIALS",
+        "SO_BINDTODEVICE",
+        "SO_DOMAIN",
+        "SO_MARK",
+        "SO_PASSCRED",
+        "SO_PASSSEC",
+        "SO_PEERCRED",
+        "SO_PEERSEC",
+        "SO_PRIORITY",
+        "SO_PROTOCOL",
+        "SO_SETFIB",
+        "SOL_ATALK",
+        "SOL_AX25",
+        "SOL_HCI",
+        "SOL_IPX",
+        "SOL_NETROM",
+        "SOL_ROSE",
+        "TCP_CONGESTION",
+        "TCP_CORK",
+        "TCP_DEFER_ACCEPT",
+        "TCP_INFO",
+        "TCP_LINGER2",
+        "TCP_QUICKACK",
+        "TCP_SYNCNT",
+        "TCP_USER_TIMEOUT",
+        "TCP_WINDOW_CLAMP",
+    ]
+
 if sys.platform != "win32":
     from _socket import (
         CMSG_LEN as CMSG_LEN,
@@ -250,6 +494,38 @@ if sys.platform != "win32":
         sethostname as sethostname,
     )
 
+    __all__ += [
+        "CMSG_LEN",
+        "CMSG_SPACE",
+        "EAI_ADDRFAMILY",
+        "EAI_BADHINTS",
+        "EAI_MAX",
+        "EAI_OVERFLOW",
+        "EAI_PROTOCOL",
+        "EAI_SYSTEM",
+        "IP_DEFAULT_MULTICAST_LOOP",
+        "IP_DEFAULT_MULTICAST_TTL",
+        "IP_MAX_MEMBERSHIPS",
+        "IP_RECVOPTS",
+        "IP_RECVRETOPTS",
+        "IP_RETOPTS",
+        "IPPROTO_EON",
+        "IPPROTO_GRE",
+        "IPPROTO_HELLO",
+        "IPPROTO_IPCOMP",
+        "IPPROTO_IPIP",
+        "IPPROTO_RSVP",
+        "IPPROTO_TP",
+        "IPPROTO_XTP",
+        "IPV6_RTHDR_TYPE_0",
+        "LOCAL_PEERCRED",
+        "SCM_CREDS",
+        "SCM_RIGHTS",
+        "SO_REUSEPORT",
+        "TCP_NOTSENT_LOWAT",
+        "sethostname",
+    ]
+
     if sys.platform != "darwin" or sys.version_info >= (3, 9):
         from _socket import (
             IPV6_DSTOPTS as IPV6_DSTOPTS,
@@ -264,15 +540,34 @@ if sys.platform != "win32":
             IPV6_USE_MIN_MTU as IPV6_USE_MIN_MTU,
         )
 
+        __all__ += [
+            "IPV6_DSTOPTS",
+            "IPV6_NEXTHOP",
+            "IPV6_PATHMTU",
+            "IPV6_RECVDSTOPTS",
+            "IPV6_RECVHOPLIMIT",
+            "IPV6_RECVHOPOPTS",
+            "IPV6_RECVPATHMTU",
+            "IPV6_RECVPKTINFO",
+            "IPV6_RTHDRDSTOPTS",
+            "IPV6_USE_MIN_MTU",
+        ]
+
 if sys.platform != "darwin":
     if sys.platform != "win32" or sys.version_info >= (3, 9):
         from _socket import BDADDR_ANY as BDADDR_ANY, BDADDR_LOCAL as BDADDR_LOCAL, BTPROTO_RFCOMM as BTPROTO_RFCOMM
 
+        __all__ += ["BDADDR_ANY", "BDADDR_LOCAL", "BTPROTO_RFCOMM"]
+
 if sys.platform == "darwin" and sys.version_info >= (3, 10):
     from _socket import TCP_KEEPALIVE as TCP_KEEPALIVE
 
+    __all__ += ["TCP_KEEPALIVE"]
+
 if sys.platform == "darwin" and sys.version_info >= (3, 11):
     from _socket import TCP_CONNECTION_INFO as TCP_CONNECTION_INFO
+
+    __all__ += ["TCP_CONNECTION_INFO"]
 
 if sys.platform == "linux":
     from _socket import (
@@ -404,6 +699,135 @@ if sys.platform == "linux":
         VMADDR_PORT_ANY as VMADDR_PORT_ANY,
     )
 
+    __all__ += [
+        "ALG_OP_DECRYPT",
+        "ALG_OP_ENCRYPT",
+        "ALG_OP_SIGN",
+        "ALG_OP_VERIFY",
+        "ALG_SET_AEAD_ASSOCLEN",
+        "ALG_SET_AEAD_AUTHSIZE",
+        "ALG_SET_IV",
+        "ALG_SET_KEY",
+        "ALG_SET_OP",
+        "ALG_SET_PUBKEY",
+        "CAN_BCM",
+        "CAN_BCM_CAN_FD_FRAME",
+        "CAN_BCM_RX_ANNOUNCE_RESUME",
+        "CAN_BCM_RX_CHANGED",
+        "CAN_BCM_RX_CHECK_DLC",
+        "CAN_BCM_RX_DELETE",
+        "CAN_BCM_RX_FILTER_ID",
+        "CAN_BCM_RX_NO_AUTOTIMER",
+        "CAN_BCM_RX_READ",
+        "CAN_BCM_RX_RTR_FRAME",
+        "CAN_BCM_RX_SETUP",
+        "CAN_BCM_RX_STATUS",
+        "CAN_BCM_RX_TIMEOUT",
+        "CAN_BCM_SETTIMER",
+        "CAN_BCM_STARTTIMER",
+        "CAN_BCM_TX_ANNOUNCE",
+        "CAN_BCM_TX_COUNTEVT",
+        "CAN_BCM_TX_CP_CAN_ID",
+        "CAN_BCM_TX_DELETE",
+        "CAN_BCM_TX_EXPIRED",
+        "CAN_BCM_TX_READ",
+        "CAN_BCM_TX_RESET_MULTI_IDX",
+        "CAN_BCM_TX_SEND",
+        "CAN_BCM_TX_SETUP",
+        "CAN_BCM_TX_STATUS",
+        "CAN_EFF_FLAG",
+        "CAN_EFF_MASK",
+        "CAN_ERR_FLAG",
+        "CAN_ERR_MASK",
+        "CAN_ISOTP",
+        "CAN_RAW",
+        "CAN_RAW_ERR_FILTER",
+        "CAN_RAW_FD_FRAMES",
+        "CAN_RAW_FILTER",
+        "CAN_RAW_LOOPBACK",
+        "CAN_RAW_RECV_OWN_MSGS",
+        "CAN_RTR_FLAG",
+        "CAN_SFF_MASK",
+        "IOCTL_VM_SOCKETS_GET_LOCAL_CID",
+        "NETLINK_ARPD",
+        "NETLINK_CRYPTO",
+        "NETLINK_DNRTMSG",
+        "NETLINK_FIREWALL",
+        "NETLINK_IP6_FW",
+        "NETLINK_NFLOG",
+        "NETLINK_ROUTE",
+        "NETLINK_ROUTE6",
+        "NETLINK_SKIP",
+        "NETLINK_TAPBASE",
+        "NETLINK_TCPDIAG",
+        "NETLINK_USERSOCK",
+        "NETLINK_W1",
+        "NETLINK_XFRM",
+        "PACKET_BROADCAST",
+        "PACKET_FASTROUTE",
+        "PACKET_HOST",
+        "PACKET_LOOPBACK",
+        "PACKET_MULTICAST",
+        "PACKET_OTHERHOST",
+        "PACKET_OUTGOING",
+        "PF_CAN",
+        "PF_PACKET",
+        "PF_RDS",
+        "RDS_CANCEL_SENT_TO",
+        "RDS_CMSG_RDMA_ARGS",
+        "RDS_CMSG_RDMA_DEST",
+        "RDS_CMSG_RDMA_MAP",
+        "RDS_CMSG_RDMA_STATUS",
+        "RDS_CMSG_RDMA_UPDATE",
+        "RDS_CONG_MONITOR",
+        "RDS_FREE_MR",
+        "RDS_GET_MR",
+        "RDS_GET_MR_FOR_DEST",
+        "RDS_RDMA_DONTWAIT",
+        "RDS_RDMA_FENCE",
+        "RDS_RDMA_INVALIDATE",
+        "RDS_RDMA_NOTIFY_ME",
+        "RDS_RDMA_READWRITE",
+        "RDS_RDMA_SILENT",
+        "RDS_RDMA_USE_ONCE",
+        "RDS_RECVERR",
+        "SO_VM_SOCKETS_BUFFER_MAX_SIZE",
+        "SO_VM_SOCKETS_BUFFER_MIN_SIZE",
+        "SO_VM_SOCKETS_BUFFER_SIZE",
+        "SOL_ALG",
+        "SOL_CAN_BASE",
+        "SOL_CAN_RAW",
+        "SOL_RDS",
+        "SOL_TIPC",
+        "TIPC_ADDR_ID",
+        "TIPC_ADDR_NAME",
+        "TIPC_ADDR_NAMESEQ",
+        "TIPC_CFG_SRV",
+        "TIPC_CLUSTER_SCOPE",
+        "TIPC_CONN_TIMEOUT",
+        "TIPC_CRITICAL_IMPORTANCE",
+        "TIPC_DEST_DROPPABLE",
+        "TIPC_HIGH_IMPORTANCE",
+        "TIPC_IMPORTANCE",
+        "TIPC_LOW_IMPORTANCE",
+        "TIPC_MEDIUM_IMPORTANCE",
+        "TIPC_NODE_SCOPE",
+        "TIPC_PUBLISHED",
+        "TIPC_SRC_DROPPABLE",
+        "TIPC_SUB_CANCEL",
+        "TIPC_SUB_PORTS",
+        "TIPC_SUB_SERVICE",
+        "TIPC_SUBSCR_TIMEOUT",
+        "TIPC_TOP_SRV",
+        "TIPC_WAIT_FOREVER",
+        "TIPC_WITHDRAWN",
+        "TIPC_ZONE_SCOPE",
+        "VM_SOCKETS_INVALID_VERSION",
+        "VMADDR_CID_ANY",
+        "VMADDR_CID_HOST",
+        "VMADDR_PORT_ANY",
+    ]
+
 if sys.platform == "linux" and sys.version_info >= (3, 9):
     from _socket import (
         CAN_J1939 as CAN_J1939,
@@ -434,10 +858,44 @@ if sys.platform == "linux" and sys.version_info >= (3, 9):
         UDPLITE_RECV_CSCOV as UDPLITE_RECV_CSCOV,
         UDPLITE_SEND_CSCOV as UDPLITE_SEND_CSCOV,
     )
+
+    __all__ = [
+        "CAN_J1939",
+        "CAN_RAW_JOIN_FILTERS",
+        "J1939_EE_INFO_NONE",
+        "J1939_EE_INFO_TX_ABORT",
+        "J1939_FILTER_MAX",
+        "J1939_IDLE_ADDR",
+        "J1939_MAX_UNICAST_ADDR",
+        "J1939_NLA_BYTES_ACKED",
+        "J1939_NLA_PAD",
+        "J1939_NO_ADDR",
+        "J1939_NO_NAME",
+        "J1939_NO_PGN",
+        "J1939_PGN_ADDRESS_CLAIMED",
+        "J1939_PGN_ADDRESS_COMMANDED",
+        "J1939_PGN_MAX",
+        "J1939_PGN_PDU1_MAX",
+        "J1939_PGN_REQUEST",
+        "SCM_J1939_DEST_ADDR",
+        "SCM_J1939_DEST_NAME",
+        "SCM_J1939_ERRQUEUE",
+        "SCM_J1939_PRIO",
+        "SO_J1939_ERRQUEUE",
+        "SO_J1939_FILTER",
+        "SO_J1939_PROMISC",
+        "SO_J1939_SEND_PRIO",
+        "UDPLITE_RECV_CSCOV",
+        "UDPLITE_SEND_CSCOV",
+    ]
 if sys.platform == "linux" and sys.version_info >= (3, 10):
     from _socket import IPPROTO_MPTCP as IPPROTO_MPTCP
+
+    __all__ += ["IPPROTO_MPTCP"]
 if sys.platform == "linux" and sys.version_info >= (3, 11):
     from _socket import SO_INCOMING_CPU as SO_INCOMING_CPU
+
+    __all__ += ["SO_INCOMING_CPU"]
 
 if sys.version_info >= (3, 12):
     from _socket import (
@@ -447,6 +905,8 @@ if sys.version_info >= (3, 12):
         IP_PKTINFO as IP_PKTINFO,
         IP_UNBLOCK_SOURCE as IP_UNBLOCK_SOURCE,
     )
+
+    __all__ += ["IP_ADD_SOURCE_MEMBERSHIP", "IP_BLOCK_SOURCE", "IP_DROP_SOURCE_MEMBERSHIP", "IP_PKTINFO", "IP_UNBLOCK_SOURCE"]
 
     if sys.platform == "win32":
         from _socket import (
@@ -462,6 +922,20 @@ if sys.version_info >= (3, 12):
             HVSOCKET_CONNECT_TIMEOUT_MAX as HVSOCKET_CONNECT_TIMEOUT_MAX,
             HVSOCKET_CONNECTED_SUSPEND as HVSOCKET_CONNECTED_SUSPEND,
         )
+
+        __all__ += [
+            "HV_GUID_BROADCAST",
+            "HV_GUID_CHILDREN",
+            "HV_GUID_LOOPBACK",
+            "HV_GUID_PARENT",
+            "HV_GUID_WILDCARD",
+            "HV_GUID_ZERO",
+            "HV_PROTOCOL_RAW",
+            "HVSOCKET_ADDRESS_FLAG_PASSTHRU",
+            "HVSOCKET_CONNECT_TIMEOUT",
+            "HVSOCKET_CONNECT_TIMEOUT_MAX",
+            "HVSOCKET_CONNECTED_SUSPEND",
+        ]
     else:
         from _socket import (
             ETHERTYPE_ARP as ETHERTYPE_ARP,
@@ -470,12 +944,21 @@ if sys.version_info >= (3, 12):
             ETHERTYPE_VLAN as ETHERTYPE_VLAN,
         )
 
+        __all__ += ["ETHERTYPE_ARP", "ETHERTYPE_IP", "ETHERTYPE_IPV6", "ETHERTYPE_VLAN"]
+
     if sys.platform == "linux":
         from _socket import ETH_P_ALL as ETH_P_ALL
+
+        __all__ += ["ETH_P_ALL"]
 
     if sys.platform != "linux" and sys.platform != "win32" and sys.platform != "darwin":
         # FreeBSD >= 14.0
         from _socket import PF_DIVERT as PF_DIVERT
+
+        __all__ += ["PF_DIVERT"]
+
+if sys.platform != "win32" and sys.version_info >= (3, 9):
+    __all__ += ["send_fds", "recv_fds"]
 
 # Re-exported from errno
 EBADF: int
@@ -701,6 +1184,7 @@ if sys.platform != "win32":
 
 if sys.platform == "win32":
     errorTab: dict[int, str]  # undocumented
+    __all__ += ["errorTab"]
 
 class _SendableFile(Protocol):
     def read(self, size: int, /) -> bytes: ...
@@ -718,7 +1202,7 @@ class socket(_socket.socket):
     ) -> None: ...
     def __enter__(self) -> Self: ...
     def __exit__(self, *args: Unused) -> None: ...
-    def dup(self) -> Self: ...  # noqa: F811
+    def dup(self) -> Self: ...
     def accept(self) -> tuple[socket, _RetAddress]: ...
     # Note that the makefile's documented windows-specific behavior is not represented
     # mode strings with duplicates are intentionally excluded

--- a/stdlib/socket.pyi
+++ b/stdlib/socket.pyi
@@ -28,7 +28,6 @@ from _socket import (
     IP_MULTICAST_LOOP as IP_MULTICAST_LOOP,
     IP_MULTICAST_TTL as IP_MULTICAST_TTL,
     IP_OPTIONS as IP_OPTIONS,
-    IP_RECVDSTADDR as IP_RECVDSTADDR,
     IP_TOS as IP_TOS,
     IP_TTL as IP_TTL,
     IPPORT_RESERVED as IPPORT_RESERVED,
@@ -44,10 +43,7 @@ from _socket import (
     IPPROTO_IDP as IPPROTO_IDP,
     IPPROTO_IGMP as IPPROTO_IGMP,
     IPPROTO_IP as IPPROTO_IP,
-    IPPROTO_IPV4 as IPPROTO_IPV4,
     IPPROTO_IPV6 as IPPROTO_IPV6,
-    IPPROTO_MAX as IPPROTO_MAX,
-    IPPROTO_ND as IPPROTO_ND,
     IPPROTO_NONE as IPPROTO_NONE,
     IPPROTO_PIM as IPPROTO_PIM,
     IPPROTO_PUP as IPPROTO_PUP,
@@ -92,7 +88,6 @@ from _socket import (
     SO_SNDLOWAT as SO_SNDLOWAT,
     SO_SNDTIMEO as SO_SNDTIMEO,
     SO_TYPE as SO_TYPE,
-    SO_USELOOPBACK as SO_USELOOPBACK,
     SOL_IP as SOL_IP,
     SOL_SOCKET as SOL_SOCKET,
     SOL_TCP as SOL_TCP,
@@ -190,10 +185,7 @@ __all__ = [
     "IPPROTO_IDP",
     "IPPROTO_IGMP",
     "IPPROTO_IP",
-    "IPPROTO_IPV4",
     "IPPROTO_IPV6",
-    "IPPROTO_MAX",
-    "IPPROTO_ND",
     "IPPROTO_NONE",
     "IPPROTO_PIM",
     "IPPROTO_PUP",
@@ -219,7 +211,6 @@ __all__ = [
     "IP_MULTICAST_LOOP",
     "IP_MULTICAST_TTL",
     "IP_OPTIONS",
-    "IP_RECVDSTADDR",
     "IP_TOS",
     "IP_TTL",
     "MSG_CTRUNC",
@@ -264,7 +255,6 @@ __all__ = [
     "SO_SNDLOWAT",
     "SO_SNDTIMEO",
     "SO_TYPE",
-    "SO_USELOOPBACK",
     "SocketType",
     "TCP_FASTOPEN",
     "TCP_KEEPCNT",
@@ -506,7 +496,6 @@ if sys.platform != "win32":
             IPV6_RECVPATHMTU as IPV6_RECVPATHMTU,
             IPV6_RECVPKTINFO as IPV6_RECVPKTINFO,
             IPV6_RTHDRDSTOPTS as IPV6_RTHDRDSTOPTS,
-            IPV6_USE_MIN_MTU as IPV6_USE_MIN_MTU,
         )
 
         __all__ += [
@@ -519,7 +508,6 @@ if sys.platform != "win32":
             "IPV6_RECVPATHMTU",
             "IPV6_RECVPKTINFO",
             "IPV6_RTHDRDSTOPTS",
-            "IPV6_USE_MIN_MTU",
         ]
 
 if sys.platform != "darwin":
@@ -588,19 +576,13 @@ if sys.platform == "linux":
         CAN_RTR_FLAG as CAN_RTR_FLAG,
         CAN_SFF_MASK as CAN_SFF_MASK,
         IOCTL_VM_SOCKETS_GET_LOCAL_CID as IOCTL_VM_SOCKETS_GET_LOCAL_CID,
-        NETLINK_ARPD as NETLINK_ARPD,
         NETLINK_CRYPTO as NETLINK_CRYPTO,
         NETLINK_DNRTMSG as NETLINK_DNRTMSG,
         NETLINK_FIREWALL as NETLINK_FIREWALL,
         NETLINK_IP6_FW as NETLINK_IP6_FW,
         NETLINK_NFLOG as NETLINK_NFLOG,
         NETLINK_ROUTE as NETLINK_ROUTE,
-        NETLINK_ROUTE6 as NETLINK_ROUTE6,
-        NETLINK_SKIP as NETLINK_SKIP,
-        NETLINK_TAPBASE as NETLINK_TAPBASE,
-        NETLINK_TCPDIAG as NETLINK_TCPDIAG,
         NETLINK_USERSOCK as NETLINK_USERSOCK,
-        NETLINK_W1 as NETLINK_W1,
         NETLINK_XFRM as NETLINK_XFRM,
         PACKET_BROADCAST as PACKET_BROADCAST,
         PACKET_FASTROUTE as PACKET_FASTROUTE,
@@ -612,24 +594,6 @@ if sys.platform == "linux":
         PF_CAN as PF_CAN,
         PF_PACKET as PF_PACKET,
         PF_RDS as PF_RDS,
-        RDS_CANCEL_SENT_TO as RDS_CANCEL_SENT_TO,
-        RDS_CMSG_RDMA_ARGS as RDS_CMSG_RDMA_ARGS,
-        RDS_CMSG_RDMA_DEST as RDS_CMSG_RDMA_DEST,
-        RDS_CMSG_RDMA_MAP as RDS_CMSG_RDMA_MAP,
-        RDS_CMSG_RDMA_STATUS as RDS_CMSG_RDMA_STATUS,
-        RDS_CMSG_RDMA_UPDATE as RDS_CMSG_RDMA_UPDATE,
-        RDS_CONG_MONITOR as RDS_CONG_MONITOR,
-        RDS_FREE_MR as RDS_FREE_MR,
-        RDS_GET_MR as RDS_GET_MR,
-        RDS_GET_MR_FOR_DEST as RDS_GET_MR_FOR_DEST,
-        RDS_RDMA_DONTWAIT as RDS_RDMA_DONTWAIT,
-        RDS_RDMA_FENCE as RDS_RDMA_FENCE,
-        RDS_RDMA_INVALIDATE as RDS_RDMA_INVALIDATE,
-        RDS_RDMA_NOTIFY_ME as RDS_RDMA_NOTIFY_ME,
-        RDS_RDMA_READWRITE as RDS_RDMA_READWRITE,
-        RDS_RDMA_SILENT as RDS_RDMA_SILENT,
-        RDS_RDMA_USE_ONCE as RDS_RDMA_USE_ONCE,
-        RDS_RECVERR as RDS_RECVERR,
         SO_VM_SOCKETS_BUFFER_MAX_SIZE as SO_VM_SOCKETS_BUFFER_MAX_SIZE,
         SO_VM_SOCKETS_BUFFER_MIN_SIZE as SO_VM_SOCKETS_BUFFER_MIN_SIZE,
         SO_VM_SOCKETS_BUFFER_SIZE as SO_VM_SOCKETS_BUFFER_SIZE,
@@ -716,19 +680,13 @@ if sys.platform == "linux":
         "CAN_RTR_FLAG",
         "CAN_SFF_MASK",
         "IOCTL_VM_SOCKETS_GET_LOCAL_CID",
-        "NETLINK_ARPD",
         "NETLINK_CRYPTO",
         "NETLINK_DNRTMSG",
         "NETLINK_FIREWALL",
         "NETLINK_IP6_FW",
         "NETLINK_NFLOG",
         "NETLINK_ROUTE",
-        "NETLINK_ROUTE6",
-        "NETLINK_SKIP",
-        "NETLINK_TAPBASE",
-        "NETLINK_TCPDIAG",
         "NETLINK_USERSOCK",
-        "NETLINK_W1",
         "NETLINK_XFRM",
         "PACKET_BROADCAST",
         "PACKET_FASTROUTE",
@@ -740,24 +698,6 @@ if sys.platform == "linux":
         "PF_CAN",
         "PF_PACKET",
         "PF_RDS",
-        "RDS_CANCEL_SENT_TO",
-        "RDS_CMSG_RDMA_ARGS",
-        "RDS_CMSG_RDMA_DEST",
-        "RDS_CMSG_RDMA_MAP",
-        "RDS_CMSG_RDMA_STATUS",
-        "RDS_CMSG_RDMA_UPDATE",
-        "RDS_CONG_MONITOR",
-        "RDS_FREE_MR",
-        "RDS_GET_MR",
-        "RDS_GET_MR_FOR_DEST",
-        "RDS_RDMA_DONTWAIT",
-        "RDS_RDMA_FENCE",
-        "RDS_RDMA_INVALIDATE",
-        "RDS_RDMA_NOTIFY_ME",
-        "RDS_RDMA_READWRITE",
-        "RDS_RDMA_SILENT",
-        "RDS_RDMA_USE_ONCE",
-        "RDS_RECVERR",
         "SO_VM_SOCKETS_BUFFER_MAX_SIZE",
         "SO_VM_SOCKETS_BUFFER_MIN_SIZE",
         "SO_VM_SOCKETS_BUFFER_SIZE",
@@ -1032,15 +972,27 @@ if sys.platform != "win32" and sys.platform != "linux":
         "AI_V4MAPPED_CFG",
         "MSG_EOF",
     ]
+    if sys.platform != "darwin" or sys.version_info >= (3, 9):
+        from _socket import IPV6_USE_MIN_MTU as IPV6_USE_MIN_MTU
+
+        __all__ += ["IPV6_USE_MIN_MTU"]
+
 if sys.platform != "win32" and sys.platform != "darwin" and sys.platform != "linux":
     from _socket import SO_SETFIB as SO_SETFIB
 
     __all__ += ["SO_SETFIB", "MSG_NOTIFICATION"]
 
 if sys.platform != "linux":
-    from _socket import IPPROTO_GGP as IPPROTO_GGP
+    from _socket import (
+        IP_RECVDSTADDR as IP_RECVDSTADDR,
+        IPPROTO_GGP as IPPROTO_GGP,
+        IPPROTO_IPV4 as IPPROTO_IPV4,
+        IPPROTO_MAX as IPPROTO_MAX,
+        IPPROTO_ND as IPPROTO_ND,
+        SO_USELOOPBACK as SO_USELOOPBACK,
+    )
 
-    __all__ += ["IPPROTO_GGP"]
+    __all__ += ["IPPROTO_GGP", "IPPROTO_IPV4", "IPPROTO_MAX", "IPPROTO_ND", "IP_RECVDSTADDR", "SO_USELOOPBACK"]
 
 # Re-exported from errno
 EBADF: int

--- a/stdlib/socket.pyi
+++ b/stdlib/socket.pyi
@@ -1054,7 +1054,7 @@ class AddressFamily(IntEnum):
     if sys.platform != "win32" or sys.version_info >= (3, 9):
         if sys.platform != "linux":
             AF_LINK = 33
-        if sys.platform != "darwin":
+        if sys.platform != "darwin" and sys.platform != "linux":
             AF_BLUETOOTH = 32
     if sys.platform == "win32" and sys.version_info >= (3, 12):
         AF_HYPERV = 34
@@ -1110,7 +1110,7 @@ if sys.platform == "linux":
 if sys.platform != "win32" or sys.version_info >= (3, 9):
     if sys.platform != "linux":
         AF_LINK = AddressFamily.AF_LINK
-    if sys.platform != "darwin":
+    if sys.platform != "darwin" and sys.platform != "linux":
         AF_BLUETOOTH = AddressFamily.AF_BLUETOOTH
 
 if sys.platform == "win32" and sys.version_info >= (3, 12):

--- a/stdlib/socket.pyi
+++ b/stdlib/socket.pyi
@@ -379,14 +379,9 @@ if sys.version_info >= (3, 10):
     from _socket import IP_RECVTOS as IP_RECVTOS
 
     __all__ += ["IP_RECVTOS"]
-elif sys.platform != "win32" and sys.platform != "darwin":
-    from _socket import IP_RECVTOS as IP_RECVTOS
-
-    __all__ += ["IP_RECVTOS"]
 
 if sys.platform != "win32" and sys.platform != "darwin":
     from _socket import (
-        IP_BIND_ADDRESS_NO_PORT as IP_BIND_ADDRESS_NO_PORT,
         IP_TRANSPARENT as IP_TRANSPARENT,
         IPPROTO_BIP as IPPROTO_BIP,
         IPPROTO_MOBILE as IPPROTO_MOBILE,
@@ -421,7 +416,6 @@ if sys.platform != "win32" and sys.platform != "darwin":
     )
 
     __all__ += [
-        "IP_BIND_ADDRESS_NO_PORT",
         "IP_TRANSPARENT",
         "IPPROTO_BIP",
         "IPPROTO_MOBILE",
@@ -474,6 +468,11 @@ if sys.platform != "win32" and sys.platform != "darwin":
         "MSG_FASTOPEN",
         "MSG_MORE",
     ]
+
+if sys.platform != "win32" and sys.platform != "darwin" and sys.version_info >= (3, 11):
+    from _socket import IP_BIND_ADDRESS_NO_PORT as IP_BIND_ADDRESS_NO_PORT
+
+    __all__ += ["IP_BIND_ADDRESS_NO_PORT"]
 
 if sys.platform != "win32":
     from _socket import (
@@ -636,7 +635,6 @@ if sys.platform == "linux":
         CAN_ERR_MASK as CAN_ERR_MASK,
         CAN_ISOTP as CAN_ISOTP,
         CAN_RAW as CAN_RAW,
-        CAN_RAW_ERR_FILTER as CAN_RAW_ERR_FILTER,
         CAN_RAW_FD_FRAMES as CAN_RAW_FD_FRAMES,
         CAN_RAW_FILTER as CAN_RAW_FILTER,
         CAN_RAW_LOOPBACK as CAN_RAW_LOOPBACK,
@@ -765,7 +763,6 @@ if sys.platform == "linux":
         "CAN_ERR_MASK",
         "CAN_ISOTP",
         "CAN_RAW",
-        "CAN_RAW_ERR_FILTER",
         "CAN_RAW_FD_FRAMES",
         "CAN_RAW_FILTER",
         "CAN_RAW_LOOPBACK",
@@ -862,6 +859,11 @@ if sys.platform == "linux":
         "SOCK_NONBLOCK",
     ]
 
+    if sys.version_info < (3, 11):
+        from _socket import CAN_RAW_ERR_FILTER as CAN_RAW_ERR_FILTER
+
+        __all__ += ["CAN_RAW_ERR_FILTER"]
+
 if sys.platform == "linux" and sys.version_info >= (3, 9):
     from _socket import (
         CAN_J1939 as CAN_J1939,
@@ -932,6 +934,57 @@ if sys.platform == "linux" and sys.version_info >= (3, 11):
     from _socket import SO_INCOMING_CPU as SO_INCOMING_CPU
 
     __all__ += ["SO_INCOMING_CPU"]
+if sys.platform == "linux" and sys.version_info >= (3, 12):
+    from _socket import (
+        TCP_CC_INFO as TCP_CC_INFO,
+        TCP_FASTOPEN_CONNECT as TCP_FASTOPEN_CONNECT,
+        TCP_FASTOPEN_KEY as TCP_FASTOPEN_KEY,
+        TCP_FASTOPEN_NO_COOKIE as TCP_FASTOPEN_NO_COOKIE,
+        TCP_INQ as TCP_INQ,
+        TCP_MD5SIG as TCP_MD5SIG,
+        TCP_MD5SIG_EXT as TCP_MD5SIG_EXT,
+        TCP_QUEUE_SEQ as TCP_QUEUE_SEQ,
+        TCP_REPAIR as TCP_REPAIR,
+        TCP_REPAIR_OPTIONS as TCP_REPAIR_OPTIONS,
+        TCP_REPAIR_QUEUE as TCP_REPAIR_QUEUE,
+        TCP_REPAIR_WINDOW as TCP_REPAIR_WINDOW,
+        TCP_SAVE_SYN as TCP_SAVE_SYN,
+        TCP_SAVED_SYN as TCP_SAVED_SYN,
+        TCP_THIN_DUPACK as TCP_THIN_DUPACK,
+        TCP_THIN_LINEAR_TIMEOUTS as TCP_THIN_LINEAR_TIMEOUTS,
+        TCP_TIMESTAMP as TCP_TIMESTAMP,
+        TCP_TX_DELAY as TCP_TX_DELAY,
+        TCP_ULP as TCP_ULP,
+        TCP_ZEROCOPY_RECEIVE as TCP_ZEROCOPY_RECEIVE,
+    )
+
+    __all__ += [
+        "TCP_CC_INFO",
+        "TCP_FASTOPEN_CONNECT",
+        "TCP_FASTOPEN_KEY",
+        "TCP_FASTOPEN_NO_COOKIE",
+        "TCP_INQ",
+        "TCP_MD5SIG",
+        "TCP_MD5SIG_EXT",
+        "TCP_QUEUE_SEQ",
+        "TCP_REPAIR",
+        "TCP_REPAIR_OPTIONS",
+        "TCP_REPAIR_QUEUE",
+        "TCP_REPAIR_WINDOW",
+        "TCP_SAVED_SYN",
+        "TCP_SAVE_SYN",
+        "TCP_THIN_DUPACK",
+        "TCP_THIN_LINEAR_TIMEOUTS",
+        "TCP_TIMESTAMP",
+        "TCP_TX_DELAY",
+        "TCP_ULP",
+        "TCP_ZEROCOPY_RECEIVE",
+    ]
+
+if sys.platform == "linux" and sys.version_info >= (3, 13):
+    from _socket import NI_IDN as NI_IDN, SO_BINDTOIFINDEX as SO_BINDTOIFINDEX
+
+    __all__ += ["NI_IDN", "SO_BINDTOIFINDEX"]
 
 if sys.version_info >= (3, 12):
     from _socket import (

--- a/stdlib/socket.pyi
+++ b/stdlib/socket.pyi
@@ -365,6 +365,7 @@ if sys.version_info >= (3, 10):
 if sys.platform != "win32" and sys.platform != "darwin":
     from _socket import (
         IP_TRANSPARENT as IP_TRANSPARENT,
+        IPX_TYPE as IPX_TYPE,
         SCM_CREDENTIALS as SCM_CREDENTIALS,
         SO_BINDTODEVICE as SO_BINDTODEVICE,
         SO_DOMAIN as SO_DOMAIN,
@@ -375,6 +376,12 @@ if sys.platform != "win32" and sys.platform != "darwin":
         SO_PEERSEC as SO_PEERSEC,
         SO_PRIORITY as SO_PRIORITY,
         SO_PROTOCOL as SO_PROTOCOL,
+        SOL_ATALK as SOL_ATALK,
+        SOL_AX25 as SOL_AX25,
+        SOL_HCI as SOL_HCI,
+        SOL_IPX as SOL_IPX,
+        SOL_NETROM as SOL_NETROM,
+        SOL_ROSE as SOL_ROSE,
         TCP_CONGESTION as TCP_CONGESTION,
         TCP_CORK as TCP_CORK,
         TCP_DEFER_ACCEPT as TCP_DEFER_ACCEPT,
@@ -594,6 +601,23 @@ if sys.platform == "linux":
         PF_CAN as PF_CAN,
         PF_PACKET as PF_PACKET,
         PF_RDS as PF_RDS,
+        RDS_CANCEL_SENT_TO as RDS_CANCEL_SENT_TO,
+        RDS_CMSG_RDMA_ARGS as RDS_CMSG_RDMA_ARGS,
+        RDS_CMSG_RDMA_DEST as RDS_CMSG_RDMA_DEST,
+        RDS_CMSG_RDMA_MAP as RDS_CMSG_RDMA_MAP,
+        RDS_CMSG_RDMA_STATUS as RDS_CMSG_RDMA_STATUS,
+        RDS_CONG_MONITOR as RDS_CONG_MONITOR,
+        RDS_FREE_MR as RDS_FREE_MR,
+        RDS_GET_MR as RDS_GET_MR,
+        RDS_GET_MR_FOR_DEST as RDS_GET_MR_FOR_DEST,
+        RDS_RDMA_DONTWAIT as RDS_RDMA_DONTWAIT,
+        RDS_RDMA_FENCE as RDS_RDMA_FENCE,
+        RDS_RDMA_INVALIDATE as RDS_RDMA_INVALIDATE,
+        RDS_RDMA_NOTIFY_ME as RDS_RDMA_NOTIFY_ME,
+        RDS_RDMA_READWRITE as RDS_RDMA_READWRITE,
+        RDS_RDMA_SILENT as RDS_RDMA_SILENT,
+        RDS_RDMA_USE_ONCE as RDS_RDMA_USE_ONCE,
+        RDS_RECVERR as RDS_RECVERR,
         SO_VM_SOCKETS_BUFFER_MAX_SIZE as SO_VM_SOCKETS_BUFFER_MAX_SIZE,
         SO_VM_SOCKETS_BUFFER_MIN_SIZE as SO_VM_SOCKETS_BUFFER_MIN_SIZE,
         SO_VM_SOCKETS_BUFFER_SIZE as SO_VM_SOCKETS_BUFFER_SIZE,
@@ -978,9 +1002,16 @@ if sys.platform != "win32" and sys.platform != "linux":
         __all__ += ["IPV6_USE_MIN_MTU"]
 
 if sys.platform != "win32" and sys.platform != "darwin" and sys.platform != "linux":
-    from _socket import SO_SETFIB as SO_SETFIB
+    from _socket import (
+        IPPROTO_BIP as IPPROTO_BIP,
+        IPPROTO_MOBILE as IPPROTO_MOBILE,
+        IPPROTO_VRRP as IPPROTO_VRRP,
+        MSG_BTAG as MSG_BTAG,
+        MSG_ETAG as MSG_ETAG,
+        SO_SETFIB as SO_SETFIB,
+    )
 
-    __all__ += ["SO_SETFIB", "MSG_NOTIFICATION"]
+    __all__ += ["SO_SETFIB", "MSG_BTAG", "MSG_ETAG", "IPPROTO_BIP", "IPPROTO_MOBILE", "IPPROTO_VRRP", "MSG_NOTIFICATION"]
 
 if sys.platform != "linux":
     from _socket import (

--- a/stdlib/socket.pyi
+++ b/stdlib/socket.pyi
@@ -866,6 +866,7 @@ if sys.platform == "linux" and sys.version_info >= (3, 9):
     from _socket import (
         CAN_J1939 as CAN_J1939,
         CAN_RAW_JOIN_FILTERS as CAN_RAW_JOIN_FILTERS,
+        IPPROTO_UDPLITE as IPPROTO_UDPLITE,
         J1939_EE_INFO_NONE as J1939_EE_INFO_NONE,
         J1939_EE_INFO_TX_ABORT as J1939_EE_INFO_TX_ABORT,
         J1939_FILTER_MAX as J1939_FILTER_MAX,
@@ -896,6 +897,7 @@ if sys.platform == "linux" and sys.version_info >= (3, 9):
     __all__ = [
         "CAN_J1939",
         "CAN_RAW_JOIN_FILTERS",
+        "IPPROTO_UDPLITE",
         "J1939_EE_INFO_NONE",
         "J1939_EE_INFO_TX_ABORT",
         "J1939_FILTER_MAX",

--- a/stdlib/socket.pyi
+++ b/stdlib/socket.pyi
@@ -38,7 +38,6 @@ from _socket import (
     IPPROTO_EGP as IPPROTO_EGP,
     IPPROTO_ESP as IPPROTO_ESP,
     IPPROTO_FRAGMENT as IPPROTO_FRAGMENT,
-    IPPROTO_GGP as IPPROTO_GGP,
     IPPROTO_HOPOPTS as IPPROTO_HOPOPTS,
     IPPROTO_ICMP as IPPROTO_ICMP,
     IPPROTO_ICMPV6 as IPPROTO_ICMPV6,
@@ -185,7 +184,6 @@ __all__ = [
     "IPPROTO_EGP",
     "IPPROTO_ESP",
     "IPPROTO_FRAGMENT",
-    "IPPROTO_GGP",
     "IPPROTO_HOPOPTS",
     "IPPROTO_ICMP",
     "IPPROTO_ICMPV6",
@@ -308,6 +306,13 @@ __all__ = [
 
 if sys.platform == "win32":
     from _socket import (
+        IPPROTO_CBT as IPPROTO_CBT,
+        IPPROTO_ICLFXBM as IPPROTO_ICLFXBM,
+        IPPROTO_IGP as IPPROTO_IGP,
+        IPPROTO_L2TP as IPPROTO_L2TP,
+        IPPROTO_PGM as IPPROTO_PGM,
+        IPPROTO_RDP as IPPROTO_RDP,
+        IPPROTO_ST as IPPROTO_ST,
         RCVALL_MAX as RCVALL_MAX,
         RCVALL_OFF as RCVALL_OFF,
         RCVALL_ON as RCVALL_ON,
@@ -319,6 +324,13 @@ if sys.platform == "win32":
     )
 
     __all__ += [
+        "IPPROTO_CBT",
+        "IPPROTO_ICLFXBM",
+        "IPPROTO_IGP",
+        "IPPROTO_L2TP",
+        "IPPROTO_PGM",
+        "IPPROTO_RDP",
+        "IPPROTO_ST",
         "RCVALL_MAX",
         "RCVALL_OFF",
         "RCVALL_ON",
@@ -329,6 +341,8 @@ if sys.platform == "win32":
         "SO_EXCLUSIVEADDRUSE",
         "fromshare",
         "errorTab",
+        "MSG_BCAST",
+        "MSG_MCAST",
     ]
 
 if sys.platform != "darwin" or sys.version_info >= (3, 9):
@@ -346,34 +360,12 @@ if sys.platform != "darwin" or sys.version_info >= (3, 9):
 if sys.platform == "darwin":
     from _socket import PF_SYSTEM as PF_SYSTEM, SYSPROTO_CONTROL as SYSPROTO_CONTROL
 
-    __all__ += ["PF_SYSTEM", "SYSPROTO_CONTROL"]
+    __all__ += ["PF_SYSTEM", "SYSPROTO_CONTROL", "AF_SYSTEM"]
 
 if sys.platform != "darwin":
-    from _socket import (
-        IPPROTO_CBT as IPPROTO_CBT,
-        IPPROTO_ICLFXBM as IPPROTO_ICLFXBM,
-        IPPROTO_IGP as IPPROTO_IGP,
-        IPPROTO_L2TP as IPPROTO_L2TP,
-        IPPROTO_PGM as IPPROTO_PGM,
-        IPPROTO_RDP as IPPROTO_RDP,
-        IPPROTO_ST as IPPROTO_ST,
-        TCP_KEEPIDLE as TCP_KEEPIDLE,
-    )
+    from _socket import TCP_KEEPIDLE as TCP_KEEPIDLE
 
-    __all__ += [
-        "IPPROTO_CBT",
-        "IPPROTO_ICLFXBM",
-        "IPPROTO_IGP",
-        "IPPROTO_L2TP",
-        "IPPROTO_PGM",
-        "IPPROTO_RDP",
-        "IPPROTO_ST",
-        "TCP_KEEPIDLE",
-        "AF_IRDA",
-        "MSG_ERRQUEUE",
-        "MSG_BCAST",
-        "MSG_MCAST",
-    ]
+    __all__ += ["TCP_KEEPIDLE", "AF_IRDA", "MSG_ERRQUEUE"]
 
 if sys.version_info >= (3, 10):
     from _socket import IP_RECVTOS as IP_RECVTOS
@@ -383,10 +375,6 @@ if sys.version_info >= (3, 10):
 if sys.platform != "win32" and sys.platform != "darwin":
     from _socket import (
         IP_TRANSPARENT as IP_TRANSPARENT,
-        IPPROTO_BIP as IPPROTO_BIP,
-        IPPROTO_MOBILE as IPPROTO_MOBILE,
-        IPPROTO_VRRP as IPPROTO_VRRP,
-        IPX_TYPE as IPX_TYPE,
         SCM_CREDENTIALS as SCM_CREDENTIALS,
         SO_BINDTODEVICE as SO_BINDTODEVICE,
         SO_DOMAIN as SO_DOMAIN,
@@ -397,13 +385,6 @@ if sys.platform != "win32" and sys.platform != "darwin":
         SO_PEERSEC as SO_PEERSEC,
         SO_PRIORITY as SO_PRIORITY,
         SO_PROTOCOL as SO_PROTOCOL,
-        SO_SETFIB as SO_SETFIB,
-        SOL_ATALK as SOL_ATALK,
-        SOL_AX25 as SOL_AX25,
-        SOL_HCI as SOL_HCI,
-        SOL_IPX as SOL_IPX,
-        SOL_NETROM as SOL_NETROM,
-        SOL_ROSE as SOL_ROSE,
         TCP_CONGESTION as TCP_CONGESTION,
         TCP_CORK as TCP_CORK,
         TCP_DEFER_ACCEPT as TCP_DEFER_ACCEPT,
@@ -417,10 +398,6 @@ if sys.platform != "win32" and sys.platform != "darwin":
 
     __all__ += [
         "IP_TRANSPARENT",
-        "IPPROTO_BIP",
-        "IPPROTO_MOBILE",
-        "IPPROTO_VRRP",
-        "IPX_TYPE",
         "SCM_CREDENTIALS",
         "SO_BINDTODEVICE",
         "SO_DOMAIN",
@@ -431,13 +408,6 @@ if sys.platform != "win32" and sys.platform != "darwin":
         "SO_PEERSEC",
         "SO_PRIORITY",
         "SO_PROTOCOL",
-        "SO_SETFIB",
-        "SOL_ATALK",
-        "SOL_AX25",
-        "SOL_HCI",
-        "SOL_IPX",
-        "SOL_NETROM",
-        "SOL_ROSE",
         "TCP_CONGESTION",
         "TCP_CORK",
         "TCP_DEFER_ACCEPT",
@@ -447,7 +417,6 @@ if sys.platform != "win32" and sys.platform != "darwin":
         "TCP_SYNCNT",
         "TCP_USER_TIMEOUT",
         "TCP_WINDOW_CLAMP",
-        "AF_AAL5",
         "AF_ASH",
         "AF_ATMPVC",
         "AF_ATMSVC",
@@ -479,10 +448,7 @@ if sys.platform != "win32":
         CMSG_LEN as CMSG_LEN,
         CMSG_SPACE as CMSG_SPACE,
         EAI_ADDRFAMILY as EAI_ADDRFAMILY,
-        EAI_BADHINTS as EAI_BADHINTS,
-        EAI_MAX as EAI_MAX,
         EAI_OVERFLOW as EAI_OVERFLOW,
-        EAI_PROTOCOL as EAI_PROTOCOL,
         EAI_SYSTEM as EAI_SYSTEM,
         IP_DEFAULT_MULTICAST_LOOP as IP_DEFAULT_MULTICAST_LOOP,
         IP_DEFAULT_MULTICAST_TTL as IP_DEFAULT_MULTICAST_TTL,
@@ -490,17 +456,11 @@ if sys.platform != "win32":
         IP_RECVOPTS as IP_RECVOPTS,
         IP_RECVRETOPTS as IP_RECVRETOPTS,
         IP_RETOPTS as IP_RETOPTS,
-        IPPROTO_EON as IPPROTO_EON,
         IPPROTO_GRE as IPPROTO_GRE,
-        IPPROTO_HELLO as IPPROTO_HELLO,
-        IPPROTO_IPCOMP as IPPROTO_IPCOMP,
         IPPROTO_IPIP as IPPROTO_IPIP,
         IPPROTO_RSVP as IPPROTO_RSVP,
         IPPROTO_TP as IPPROTO_TP,
-        IPPROTO_XTP as IPPROTO_XTP,
         IPV6_RTHDR_TYPE_0 as IPV6_RTHDR_TYPE_0,
-        LOCAL_PEERCRED as LOCAL_PEERCRED,
-        SCM_CREDS as SCM_CREDS,
         SCM_RIGHTS as SCM_RIGHTS,
         SO_REUSEPORT as SO_REUSEPORT,
         TCP_NOTSENT_LOWAT as TCP_NOTSENT_LOWAT,
@@ -511,7 +471,6 @@ if sys.platform != "win32":
         "CMSG_LEN",
         "CMSG_SPACE",
         "EAI_ADDRFAMILY",
-        "EAI_BADHINTS",
         "EAI_MAX",
         "EAI_OVERFLOW",
         "EAI_PROTOCOL",
@@ -524,27 +483,19 @@ if sys.platform != "win32":
         "IP_RETOPTS",
         "IPPROTO_EON",
         "IPPROTO_GRE",
-        "IPPROTO_HELLO",
-        "IPPROTO_IPCOMP",
         "IPPROTO_IPIP",
         "IPPROTO_RSVP",
         "IPPROTO_TP",
         "IPPROTO_XTP",
         "IPV6_RTHDR_TYPE_0",
         "LOCAL_PEERCRED",
-        "SCM_CREDS",
         "SCM_RIGHTS",
         "SO_REUSEPORT",
         "TCP_NOTSENT_LOWAT",
         "sethostname",
         "AF_ROUTE",
-        "AF_SYSTEM",
         "AF_UNIX",
-        "AI_DEFAULT",
-        "AI_MASK",
-        "AI_V4MAPPED_CFG",
         "MSG_DONTWAIT",
-        "MSG_EOF",
         "MSG_EOR",
         "MSG_NOSIGNAL",
     ]
@@ -1057,6 +1008,44 @@ if sys.platform != "win32" or sys.version_info >= (3, 9):
 if sys.platform == "win32" and sys.version_info >= (3, 12):
     __all__ += ["AF_HYPERV"]
 
+if sys.platform != "win32" and sys.platform != "linux":
+    from _socket import (
+        EAI_BADHINTS as EAI_BADHINTS,
+        EAI_MAX as EAI_MAX,
+        EAI_PROTOCOL as EAI_PROTOCOL,
+        IPPROTO_EON as IPPROTO_EON,
+        IPPROTO_HELLO as IPPROTO_HELLO,
+        IPPROTO_IPCOMP as IPPROTO_IPCOMP,
+        IPPROTO_XTP as IPPROTO_XTP,
+        LOCAL_PEERCRED as LOCAL_PEERCRED,
+        SCM_CREDS as SCM_CREDS,
+    )
+
+    __all__ += [
+        "EAI_BADHINTS",
+        "EAI_MAX",
+        "EAI_PROTOCOL",
+        "IPPROTO_EON",
+        "IPPROTO_HELLO",
+        "IPPROTO_IPCOMP",
+        "IPPROTO_XTP",
+        "LOCAL_PEERCRED",
+        "SCM_CREDS",
+        "AI_DEFAULT",
+        "AI_MASK",
+        "AI_V4MAPPED_CFG",
+        "MSG_EOF",
+    ]
+if sys.platform != "win32" and sys.platform != "darwin" and sys.platform != "linux":
+    from _socket import SO_SETFIB as SO_SETFIB
+
+    __all__ += ["SO_SETFIB", "MSG_NOTIFICATION"]
+
+if sys.platform != "linux":
+    from _socket import IPPROTO_GGP as IPPROTO_GGP
+
+    __all__ += ["IPPROTO_GGP"]
+
 # Re-exported from errno
 EBADF: int
 EAGAIN: int
@@ -1086,10 +1075,10 @@ class AddressFamily(IntEnum):
         AF_IRDA = 23
     if sys.platform != "win32":
         AF_ROUTE = 16
-        AF_SYSTEM = 32
         AF_UNIX = 1
+    if sys.platform == "darwin":
+        AF_SYSTEM = 32
     if sys.platform != "win32" and sys.platform != "darwin":
-        AF_AAL5 = ...
         AF_ASH = 18
         AF_ATMPVC = 8
         AF_ATMSVC = 20
@@ -1115,7 +1104,8 @@ class AddressFamily(IntEnum):
         AF_VSOCK = 40
         AF_QIPCRTR = 42
     if sys.platform != "win32" or sys.version_info >= (3, 9):
-        AF_LINK = 33
+        if sys.platform != "linux":
+            AF_LINK = 33
         if sys.platform != "darwin":
             AF_BLUETOOTH = 32
     if sys.platform == "win32" and sys.version_info >= (3, 12):
@@ -1137,11 +1127,12 @@ if sys.platform != "darwin":
 
 if sys.platform != "win32":
     AF_ROUTE = AddressFamily.AF_ROUTE
-    AF_SYSTEM = AddressFamily.AF_SYSTEM
     AF_UNIX = AddressFamily.AF_UNIX
 
+if sys.platform == "darwin":
+    AF_SYSTEM = AddressFamily.AF_SYSTEM
+
 if sys.platform != "win32" and sys.platform != "darwin":
-    AF_AAL5 = AddressFamily.AF_AAL5
     AF_ASH = AddressFamily.AF_ASH
     AF_ATMPVC = AddressFamily.AF_ATMPVC
     AF_ATMSVC = AddressFamily.AF_ATMSVC
@@ -1169,7 +1160,8 @@ if sys.platform == "linux":
     AF_QIPCRTR = AddressFamily.AF_QIPCRTR
 
 if sys.platform != "win32" or sys.version_info >= (3, 9):
-    AF_LINK = AddressFamily.AF_LINK
+    if sys.platform != "linux":
+        AF_LINK = AddressFamily.AF_LINK
     if sys.platform != "darwin":
         AF_BLUETOOTH = AddressFamily.AF_BLUETOOTH
 
@@ -1205,26 +1197,28 @@ class MsgFlag(IntFlag):
     MSG_PEEK = 2
     MSG_TRUNC = 32
     MSG_WAITALL = 256
-
-    if sys.platform != "darwin":
+    if sys.platform == "win32":
         MSG_BCAST = 1024
         MSG_MCAST = 2048
+
+    if sys.platform != "darwin":
         MSG_ERRQUEUE = 8192
 
     if sys.platform != "win32" and sys.platform != "darwin":
-        MSG_BTAG = ...
         MSG_CMSG_CLOEXEC = 1073741821
         MSG_CONFIRM = 2048
-        MSG_ETAG = ...
         MSG_FASTOPEN = 536870912
         MSG_MORE = 32768
-        MSG_NOTIFICATION = ...
+
+    if sys.platform != "win32" and sys.platform != "darwin" and sys.platform != "linux":
+        MSG_NOTIFICATION = 8192
 
     if sys.platform != "win32":
         MSG_DONTWAIT = 64
-        MSG_EOF = 256
         MSG_EOR = 128
         MSG_NOSIGNAL = 16384  # sometimes this exists on darwin, sometimes not
+    if sys.platform != "win32" and sys.platform != "linux":
+        MSG_EOF = 256
 
 MSG_CTRUNC = MsgFlag.MSG_CTRUNC
 MSG_DONTROUTE = MsgFlag.MSG_DONTROUTE
@@ -1233,25 +1227,30 @@ MSG_PEEK = MsgFlag.MSG_PEEK
 MSG_TRUNC = MsgFlag.MSG_TRUNC
 MSG_WAITALL = MsgFlag.MSG_WAITALL
 
-if sys.platform != "darwin":
+if sys.platform == "win32":
     MSG_BCAST = MsgFlag.MSG_BCAST
     MSG_MCAST = MsgFlag.MSG_MCAST
+
+if sys.platform != "darwin":
     MSG_ERRQUEUE = MsgFlag.MSG_ERRQUEUE
 
 if sys.platform != "win32":
     MSG_DONTWAIT = MsgFlag.MSG_DONTWAIT
-    MSG_EOF = MsgFlag.MSG_EOF
     MSG_EOR = MsgFlag.MSG_EOR
     MSG_NOSIGNAL = MsgFlag.MSG_NOSIGNAL  # Sometimes this exists on darwin, sometimes not
 
 if sys.platform != "win32" and sys.platform != "darwin":
-    MSG_BTAG = MsgFlag.MSG_BTAG
     MSG_CMSG_CLOEXEC = MsgFlag.MSG_CMSG_CLOEXEC
     MSG_CONFIRM = MsgFlag.MSG_CONFIRM
     MSG_ETAG = MsgFlag.MSG_ETAG
     MSG_FASTOPEN = MsgFlag.MSG_FASTOPEN
     MSG_MORE = MsgFlag.MSG_MORE
+
+if sys.platform != "win32" and sys.platform != "darwin" and sys.platform != "linux":
     MSG_NOTIFICATION = MsgFlag.MSG_NOTIFICATION
+
+if sys.platform != "win32" and sys.platform != "linux":
+    MSG_EOF = MsgFlag.MSG_EOF
 
 class AddressInfo(IntFlag):
     AI_ADDRCONFIG = 32
@@ -1261,7 +1260,7 @@ class AddressInfo(IntFlag):
     AI_NUMERICSERV = 1024
     AI_PASSIVE = 1
     AI_V4MAPPED = 8
-    if sys.platform != "win32":
+    if sys.platform != "win32" and sys.platform != "linux":
         AI_DEFAULT = 1536
         AI_MASK = 5127
         AI_V4MAPPED_CFG = 512
@@ -1274,7 +1273,7 @@ AI_NUMERICSERV = AddressInfo.AI_NUMERICSERV
 AI_PASSIVE = AddressInfo.AI_PASSIVE
 AI_V4MAPPED = AddressInfo.AI_V4MAPPED
 
-if sys.platform != "win32":
+if sys.platform != "win32" and sys.platform != "linux":
     AI_DEFAULT = AddressInfo.AI_DEFAULT
     AI_MASK = AddressInfo.AI_MASK
     AI_V4MAPPED_CFG = AddressInfo.AI_V4MAPPED_CFG

--- a/stdlib/socket.pyi
+++ b/stdlib/socket.pyi
@@ -370,6 +370,9 @@ if sys.platform != "darwin":
         "IPPROTO_ST",
         "TCP_KEEPIDLE",
         "AF_IRDA",
+        "MSG_ERRQUEUE",
+        "MSG_BCAST",
+        "MSG_MCAST",
     ]
 
 if sys.version_info >= (3, 10):
@@ -466,6 +469,10 @@ if sys.platform != "win32" and sys.platform != "darwin":
         "AF_SECURITY",
         "AF_WANPIPE",
         "AF_X25",
+        "MSG_CMSG_CLOEXEC",
+        "MSG_CONFIRM",
+        "MSG_FASTOPEN",
+        "MSG_MORE",
     ]
 
 if sys.platform != "win32":
@@ -851,6 +858,8 @@ if sys.platform == "linux":
         "AF_NETLINK",
         "AF_VSOCK",
         "AF_QIPCRTR",
+        "SOCK_CLOEXEC",
+        "SOCK_NONBLOCK",
     ]
 
 if sys.platform == "linux" and sys.version_info >= (3, 9):

--- a/stdlib/socket.pyi
+++ b/stdlib/socket.pyi
@@ -471,9 +471,7 @@ if sys.platform != "win32":
         "CMSG_LEN",
         "CMSG_SPACE",
         "EAI_ADDRFAMILY",
-        "EAI_MAX",
         "EAI_OVERFLOW",
-        "EAI_PROTOCOL",
         "EAI_SYSTEM",
         "IP_DEFAULT_MULTICAST_LOOP",
         "IP_DEFAULT_MULTICAST_TTL",
@@ -481,14 +479,11 @@ if sys.platform != "win32":
         "IP_RECVOPTS",
         "IP_RECVRETOPTS",
         "IP_RETOPTS",
-        "IPPROTO_EON",
         "IPPROTO_GRE",
         "IPPROTO_IPIP",
         "IPPROTO_RSVP",
         "IPPROTO_TP",
-        "IPPROTO_XTP",
         "IPV6_RTHDR_TYPE_0",
-        "LOCAL_PEERCRED",
         "SCM_RIGHTS",
         "SO_REUSEPORT",
         "TCP_NOTSENT_LOWAT",
@@ -1001,7 +996,8 @@ if sys.platform != "win32" and sys.version_info >= (3, 9):
     __all__ += ["send_fds", "recv_fds"]
 
 if sys.platform != "win32" or sys.version_info >= (3, 9):
-    __all__ += ["AF_LINK"]
+    if sys.platform != "linux":
+        __all__ += ["AF_LINK"]
     if sys.platform != "darwin":
         __all__ += ["AF_BLUETOOTH"]
 
@@ -1242,7 +1238,6 @@ if sys.platform != "win32":
 if sys.platform != "win32" and sys.platform != "darwin":
     MSG_CMSG_CLOEXEC = MsgFlag.MSG_CMSG_CLOEXEC
     MSG_CONFIRM = MsgFlag.MSG_CONFIRM
-    MSG_ETAG = MsgFlag.MSG_ETAG
     MSG_FASTOPEN = MsgFlag.MSG_FASTOPEN
     MSG_MORE = MsgFlag.MSG_MORE
 

--- a/stdlib/socket.pyi
+++ b/stdlib/socket.pyi
@@ -510,7 +510,7 @@ if sys.platform != "win32":
             "IPV6_RTHDRDSTOPTS",
         ]
 
-if sys.platform != "darwin":
+if sys.platform != "darwin" and sys.platform != "linux":
     if sys.platform != "win32" or sys.version_info >= (3, 9):
         from _socket import BDADDR_ANY as BDADDR_ANY, BDADDR_LOCAL as BDADDR_LOCAL, BTPROTO_RFCOMM as BTPROTO_RFCOMM
 
@@ -938,7 +938,7 @@ if sys.platform != "win32" and sys.version_info >= (3, 9):
 if sys.platform != "win32" or sys.version_info >= (3, 9):
     if sys.platform != "linux":
         __all__ += ["AF_LINK"]
-    if sys.platform != "darwin":
+    if sys.platform != "darwin" and sys.platform != "linux":
         __all__ += ["AF_BLUETOOTH"]
 
 if sys.platform == "win32" and sys.version_info >= (3, 12):

--- a/stdlib/socket.pyi
+++ b/stdlib/socket.pyi
@@ -782,7 +782,7 @@ if sys.platform == "linux" and sys.version_info >= (3, 9):
         UDPLITE_SEND_CSCOV as UDPLITE_SEND_CSCOV,
     )
 
-    __all__ = [
+    __all__ += [
         "CAN_J1939",
         "CAN_RAW_JOIN_FILTERS",
         "IPPROTO_UDPLITE",

--- a/stdlib/socket.pyi
+++ b/stdlib/socket.pyi
@@ -152,22 +152,15 @@ __all__ = [
     "AF_INET",
     "AF_INET6",
     "AF_IPX",
-    "AF_LINK",
-    "AF_ROUTE",
     "AF_SNA",
-    "AF_SYSTEM",
-    "AF_UNIX",
     "AF_UNSPEC",
     "AI_ADDRCONFIG",
     "AI_ALL",
     "AI_CANONNAME",
-    "AI_DEFAULT",
-    "AI_MASK",
     "AI_NUMERICHOST",
     "AI_NUMERICSERV",
     "AI_PASSIVE",
     "AI_V4MAPPED",
-    "AI_V4MAPPED_CFG",
     "CAPI",
     "EAI_AGAIN",
     "EAI_BADFLAGS",
@@ -233,10 +226,6 @@ __all__ = [
     "IP_TTL",
     "MSG_CTRUNC",
     "MSG_DONTROUTE",
-    "MSG_DONTWAIT",
-    "MSG_EOF",
-    "MSG_EOR",
-    "MSG_NOSIGNAL",
     "MSG_OOB",
     "MSG_PEEK",
     "MSG_TRUNC",
@@ -339,6 +328,7 @@ if sys.platform == "win32":
         "SIO_RCVALL",
         "SO_EXCLUSIVEADDRUSE",
         "fromshare",
+        "errorTab",
     ]
 
 if sys.platform != "darwin" or sys.version_info >= (3, 9):
@@ -379,6 +369,7 @@ if sys.platform != "darwin":
         "IPPROTO_RDP",
         "IPPROTO_ST",
         "TCP_KEEPIDLE",
+        "AF_IRDA",
     ]
 
 if sys.version_info >= (3, 10):
@@ -459,6 +450,22 @@ if sys.platform != "win32" and sys.platform != "darwin":
         "TCP_SYNCNT",
         "TCP_USER_TIMEOUT",
         "TCP_WINDOW_CLAMP",
+        "AF_AAL5",
+        "AF_ASH",
+        "AF_ATMPVC",
+        "AF_ATMSVC",
+        "AF_AX25",
+        "AF_BRIDGE",
+        "AF_ECONET",
+        "AF_KEY",
+        "AF_LLC",
+        "AF_NETBEUI",
+        "AF_NETROM",
+        "AF_PPPOX",
+        "AF_ROSE",
+        "AF_SECURITY",
+        "AF_WANPIPE",
+        "AF_X25",
     ]
 
 if sys.platform != "win32":
@@ -524,6 +531,16 @@ if sys.platform != "win32":
         "SO_REUSEPORT",
         "TCP_NOTSENT_LOWAT",
         "sethostname",
+        "AF_ROUTE",
+        "AF_SYSTEM",
+        "AF_UNIX",
+        "AI_DEFAULT",
+        "AI_MASK",
+        "AI_V4MAPPED_CFG",
+        "MSG_DONTWAIT",
+        "MSG_EOF",
+        "MSG_EOR",
+        "MSG_NOSIGNAL",
     ]
 
     if sys.platform != "darwin" or sys.version_info >= (3, 9):
@@ -826,6 +843,14 @@ if sys.platform == "linux":
         "VMADDR_CID_ANY",
         "VMADDR_CID_HOST",
         "VMADDR_PORT_ANY",
+        "AF_CAN",
+        "AF_PACKET",
+        "AF_RDS",
+        "AF_TIPC",
+        "AF_ALG",
+        "AF_NETLINK",
+        "AF_VSOCK",
+        "AF_QIPCRTR",
     ]
 
 if sys.platform == "linux" and sys.version_info >= (3, 9):
@@ -955,10 +980,18 @@ if sys.version_info >= (3, 12):
         # FreeBSD >= 14.0
         from _socket import PF_DIVERT as PF_DIVERT
 
-        __all__ += ["PF_DIVERT"]
+        __all__ += ["PF_DIVERT", "AF_DIVERT"]
 
 if sys.platform != "win32" and sys.version_info >= (3, 9):
     __all__ += ["send_fds", "recv_fds"]
+
+if sys.platform != "win32" or sys.version_info >= (3, 9):
+    __all__ += ["AF_LINK"]
+    if sys.platform != "darwin":
+        __all__ += ["AF_BLUETOOTH"]
+
+if sys.platform == "win32" and sys.version_info >= (3, 12):
+    __all__ += ["AF_HYPERV"]
 
 # Re-exported from errno
 EBADF: int
@@ -1184,7 +1217,6 @@ if sys.platform != "win32":
 
 if sys.platform == "win32":
     errorTab: dict[int, str]  # undocumented
-    __all__ += ["errorTab"]
 
 class _SendableFile(Protocol):
     def read(self, size: int, /) -> bytes: ...


### PR DESCRIPTION
I didn't realize there were so many errors being hidden for linux in here when I started. I only have access to MacOS and FreeBSD locally, so I just took the linux pipeline results at mostly face value. In working through all the things that don't exist in the Linux pipeline, I tested against my BSD machine to sort out what was for example, `platform = "win32"` versus `platform != "darwin" and platform != "linux"` or `platform = "darwin" versus "platform != "win32" and platform != "linux"`, etc.

 When it didn't seem like any system that had a thing, I commented it out in `_socket` and removed it from `socket`. I expect many of these exist on some linux system somewhere - there's a lot of variance in that space. It seemed like leaving them as a comment in _socket was a good placeholder for now.