### PR TITLE
add `xml.__all__`

### DIFF
--- a/stdlib/@tests/stubtest_allowlists/common.txt
+++ b/stdlib/@tests/stubtest_allowlists/common.txt
@@ -591,8 +591,10 @@ email.mime
 email.parser
 email.quoprimime
 email.utils
+xml.__all__
 xml.dom
 xml.etree
+xml.parsers
 xml.sax
 
 # Missing aliases to existing methods that not many people seem to use.

--- a/stdlib/xml/__init__.pyi
+++ b/stdlib/xml/__init__.pyi
@@ -1,1 +1,3 @@
-from xml import parsers as parsers
+# At runtime, listing submodules in __all__ without them being imported is
+# valid, and causes them to be included in a star import. See #6523
+__all__ = ["dom", "parsers", "sax", "etree"]  # noqa: F822  # pyright: ignore[reportUnsupportedDunderAll]


### PR DESCRIPTION
Here's `xml.__all__`, handled the same way as `email.__all__` in https://github.com/python/typeshed/pull/13047.

I waffled on what to do about the existing import of `xml.parsers`. It's not imported at runtime, so in the end I took it out to be consistent.