### PR TITLE
Adds some overloads for the `add_argument` method

### DIFF
--- a/stdlib/argparse.pyi
+++ b/stdlib/argparse.pyi
@@ -161,6 +161,16 @@ class _ActionsContainer:
     def add_argument(
         self,
         *name_or_flags: str,
+        action: Literal["count"],
+        dest: str | None = ...,
+        default: Any = ...,
+        required: bool = ...,
+        help: str | None = ...,
+    ) -> Action: ...
+    @overload
+    def add_argument(
+        self,
+        *name_or_flags: str,
         action: _ActionStr | type[Action] = ...,
         nargs: int | _NArgsStr | _SUPPRESS_T | None = None,
         const: Any = ...,

--- a/stdlib/argparse.pyi
+++ b/stdlib/argparse.pyi
@@ -2,7 +2,7 @@ import sys
 from _typeshed import sentinel
 from collections.abc import Callable, Generator, Iterable, Sequence
 from re import Pattern
-from typing import IO, Any, Final, Generic, NewType, NoReturn, Protocol, TypeVar, overload
+from typing import IO, Any, Final, Generic, Literal, NewType, NoReturn, Protocol, TypeVar, overload
 from typing_extensions import Self, TypeAlias, deprecated
 
 __all__ = [
@@ -83,6 +83,22 @@ class _ActionsContainer:
     def _registry_get(self, registry_name: str, value: Any, default: Any = None) -> Any: ...
     def set_defaults(self, **kwargs: Any) -> None: ...
     def get_default(self, dest: str) -> Any: ...
+    @overload
+    def add_argument(
+        self,
+        *name_or_flags: str,
+        action: Literal["store"],
+        dest: str | None = ...,
+        nargs: int | _NArgsStr | _SUPPRESS_T | None = None,
+        const: Any = ...,
+        default: Any = ...,
+        type: _ActionType = ...,
+        choices: Iterable[_T] | None = ...,
+        required: bool = ...,
+        help: str | None = ...,
+        metavar: str | tuple[str, ...] | None = ...,
+    ) -> _StoreAction: ...
+    @overload
     def add_argument(
         self,
         *name_or_flags: str,

--- a/stdlib/argparse.pyi
+++ b/stdlib/argparse.pyi
@@ -171,6 +171,25 @@ class _ActionsContainer:
     def add_argument(
         self,
         *name_or_flags: str,
+        action: Literal["help"],
+        dest: str | None = ...,
+        default: Any = ...,
+        help: str | None = ...,
+    ) -> Action: ...
+    @overload
+    def add_argument(
+        self,
+        *name_or_flags: str,
+        action: Literal["version"],
+        version: str = ...,
+        dest: str | None = ...,
+        default: Any = ...,
+        help: str | None = ...,
+    ) -> Action: ...
+    @overload
+    def add_argument(
+        self,
+        *name_or_flags: str,
         action: _ActionStr | type[Action] = ...,
         nargs: int | _NArgsStr | _SUPPRESS_T | None = None,
         const: Any = ...,

--- a/stdlib/argparse.pyi
+++ b/stdlib/argparse.pyi
@@ -149,6 +149,18 @@ class _ActionsContainer:
     def add_argument(
         self,
         *name_or_flags: str,
+        action: Literal["append_const"],
+        dest: str | None = ...,
+        const: Any = ...,
+        default: Any = ...,
+        required: bool = ...,
+        help: str | None = ...,
+        metavar: str | tuple[str, ...] | None = ...,
+    ) -> Action: ...
+    @overload
+    def add_argument(
+        self,
+        *name_or_flags: str,
         action: _ActionStr | type[Action] = ...,
         nargs: int | _NArgsStr | _SUPPRESS_T | None = None,
         const: Any = ...,

--- a/stdlib/argparse.pyi
+++ b/stdlib/argparse.pyi
@@ -102,6 +102,18 @@ class _ActionsContainer:
     def add_argument(
         self,
         *name_or_flags: str,
+        action: Literal["store_const"],
+        dest: str | None = ...,
+        const: Any = ...,
+        default: Any = ...,
+        required: bool = ...,
+        help: str | None = ...,
+        metavar: str | tuple[str, ...] | None = ...,
+    ) -> _StoreConstAction: ...
+    @overload
+    def add_argument(
+        self,
+        *name_or_flags: str,
         action: _ActionStr | type[Action] = ...,
         nargs: int | _NArgsStr | _SUPPRESS_T | None = None,
         const: Any = ...,

--- a/stdlib/argparse.pyi
+++ b/stdlib/argparse.pyi
@@ -134,6 +134,21 @@ class _ActionsContainer:
     def add_argument(
         self,
         *name_or_flags: str,
+        action: Literal["append"],
+        dest: str | None = ...,
+        nargs: int | _NArgsStr | _SUPPRESS_T | None = None,
+        const: Any = ...,
+        default: Any = ...,
+        type: _ActionType = ...,
+        choices: Iterable[_T] | None = ...,
+        required: bool = ...,
+        help: str | None = ...,
+        metavar: str | tuple[str, ...] | None = ...,
+    ) -> Action: ...
+    @overload
+    def add_argument(
+        self,
+        *name_or_flags: str,
         action: _ActionStr | type[Action] = ...,
         nargs: int | _NArgsStr | _SUPPRESS_T | None = None,
         const: Any = ...,

--- a/stdlib/argparse.pyi
+++ b/stdlib/argparse.pyi
@@ -114,6 +114,26 @@ class _ActionsContainer:
     def add_argument(
         self,
         *name_or_flags: str,
+        action: Literal["store_true"],
+        dest: str | None = ...,
+        default: bool = False,
+        required: bool = False,
+        help: str | None = None,
+    ) -> _StoreTrueAction: ...
+    @overload
+    def add_argument(
+        self,
+        *name_or_flags: str,
+        action: Literal["store_false"],
+        dest: str | None = ...,
+        default: bool = True,
+        required: bool = False,
+        help: str | None = None,
+    ) -> _StoreFalseAction: ...
+    @overload
+    def add_argument(
+        self,
+        *name_or_flags: str,
         action: _ActionStr | type[Action] = ...,
         nargs: int | _NArgsStr | _SUPPRESS_T | None = None,
         const: Any = ...,


### PR DESCRIPTION
This is to foresee some exceptions like:
```python
TypeError: _StoreAction.__init__() got an unexpected keyword argument 'version'
```
```python
TypeError: _StoreConstAction.__init__() got an unexpected keyword argument 'nargs'
```
```python
TypeError: _StoreConstAction.__init__() got an unexpected keyword argument 'type'
```
```python
TypeError: _StoreTrueAction.__init__() got an unexpected keyword argument 'type'
```
```python
TypeError: _StoreTrueAction.__init__() got an unexpected keyword argument 'choices'
```
```python
TypeError: _CountAction.__init__() got an unexpected keyword argument 'type'
```
```python
TypeError: _CountAction.__init__() got an unexpected keyword argument 'choices'
```