### PR TITLE
Avoid using `_typeshed.StrEnum`

### DIFF
--- a/stdlib/_typeshed/__init__.pyi
+++ b/stdlib/_typeshed/__init__.pyi
@@ -352,12 +352,3 @@ class DataclassInstance(Protocol):
 # Anything that can be passed to the int/float constructors
 ConvertibleToInt: TypeAlias = str | ReadableBuffer | SupportsInt | SupportsIndex | SupportsTrunc
 ConvertibleToFloat: TypeAlias = str | ReadableBuffer | SupportsFloat | SupportsIndex
-
-# A few classes updated from Foo(str, Enum) to Foo(StrEnum). This is a convenience so these
-# can be accurate on all python versions without getting too wordy
-if sys.version_info >= (3, 11):
-    from enum import StrEnum as StrEnum
-else:
-    from enum import Enum
-
-    class StrEnum(str, Enum): ...

--- a/stdlib/_typeshed/__init__.pyi
+++ b/stdlib/_typeshed/__init__.pyi
@@ -352,3 +352,12 @@ class DataclassInstance(Protocol):
 # Anything that can be passed to the int/float constructors
 ConvertibleToInt: TypeAlias = str | ReadableBuffer | SupportsInt | SupportsIndex | SupportsTrunc
 ConvertibleToFloat: TypeAlias = str | ReadableBuffer | SupportsFloat | SupportsIndex
+
+# A few classes updated from Foo(str, Enum) to Foo(StrEnum). This is a convenience so these
+# can be accurate on all python versions without getting too wordy
+if sys.version_info >= (3, 11):
+    from enum import StrEnum as StrEnum
+else:
+    from enum import Enum
+
+    class StrEnum(str, Enum): ...

--- a/stdlib/pstats.pyi
+++ b/stdlib/pstats.pyi
@@ -1,10 +1,15 @@
 import sys
-from _typeshed import StrEnum, StrOrBytesPath
+from _typeshed import StrOrBytesPath
 from collections.abc import Iterable
 from cProfile import Profile as _cProfile
 from profile import Profile
 from typing import IO, Any, Literal, overload
 from typing_extensions import Self, TypeAlias
+
+if sys.version_info >= (3, 11):
+    from enum import StrEnum
+else:
+    from enum import Enum
 
 if sys.version_info >= (3, 9):
     __all__ = ["Stats", "SortKey", "FunctionProfile", "StatsProfile"]
@@ -13,16 +18,29 @@ else:
 
 _Selector: TypeAlias = str | float | int
 
-class SortKey(StrEnum):
-    CALLS = "calls"
-    CUMULATIVE = "cumulative"
-    FILENAME = "filename"
-    LINE = "line"
-    NAME = "name"
-    NFL = "nfl"
-    PCALLS = "pcalls"
-    STDNAME = "stdname"
-    TIME = "time"
+if sys.version_info >= (3, 11):
+    class SortKey(StrEnum):
+        CALLS = "calls"
+        CUMULATIVE = "cumulative"
+        FILENAME = "filename"
+        LINE = "line"
+        NAME = "name"
+        NFL = "nfl"
+        PCALLS = "pcalls"
+        STDNAME = "stdname"
+        TIME = "time"
+
+else:
+    class SortKey(str, Enum):
+        CALLS = "calls"
+        CUMULATIVE = "cumulative"
+        FILENAME = "filename"
+        LINE = "line"
+        NAME = "name"
+        NFL = "nfl"
+        PCALLS = "pcalls"
+        STDNAME = "stdname"
+        TIME = "time"
 
 if sys.version_info >= (3, 9):
     from dataclasses import dataclass

--- a/stdlib/tkinter/__init__.pyi
+++ b/stdlib/tkinter/__init__.pyi
@@ -1,12 +1,17 @@
 import _tkinter
 import sys
-from _typeshed import Incomplete, MaybeNone, StrEnum, StrOrBytesPath
+from _typeshed import Incomplete, MaybeNone, StrOrBytesPath
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from tkinter.constants import *
 from tkinter.font import _FontDescription
 from types import TracebackType
 from typing import Any, Generic, Literal, NamedTuple, TypedDict, TypeVar, overload, type_check_only
 from typing_extensions import TypeAlias, TypeVarTuple, Unpack, deprecated
+
+if sys.version_info >= (3, 11):
+    from enum import StrEnum
+else:
+    from enum import Enum
 
 if sys.version_info >= (3, 9):
     __all__ = [
@@ -196,46 +201,89 @@ if sys.version_info >= (3, 11):
 
     class _VersionInfoType(_VersionInfoTypeBase): ...
 
-class EventType(StrEnum):
-    Activate = "36"
-    ButtonPress = "4"
-    Button = ButtonPress
-    ButtonRelease = "5"
-    Circulate = "26"
-    CirculateRequest = "27"
-    ClientMessage = "33"
-    Colormap = "32"
-    Configure = "22"
-    ConfigureRequest = "23"
-    Create = "16"
-    Deactivate = "37"
-    Destroy = "17"
-    Enter = "7"
-    Expose = "12"
-    FocusIn = "9"
-    FocusOut = "10"
-    GraphicsExpose = "13"
-    Gravity = "24"
-    KeyPress = "2"
-    Key = "2"
-    KeyRelease = "3"
-    Keymap = "11"
-    Leave = "8"
-    Map = "19"
-    MapRequest = "20"
-    Mapping = "34"
-    Motion = "6"
-    MouseWheel = "38"
-    NoExpose = "14"
-    Property = "28"
-    Reparent = "21"
-    ResizeRequest = "25"
-    Selection = "31"
-    SelectionClear = "29"
-    SelectionRequest = "30"
-    Unmap = "18"
-    VirtualEvent = "35"
-    Visibility = "15"
+if sys.version_info >= (3, 11):
+    class EventType(StrEnum):
+        Activate = "36"
+        ButtonPress = "4"
+        Button = ButtonPress
+        ButtonRelease = "5"
+        Circulate = "26"
+        CirculateRequest = "27"
+        ClientMessage = "33"
+        Colormap = "32"
+        Configure = "22"
+        ConfigureRequest = "23"
+        Create = "16"
+        Deactivate = "37"
+        Destroy = "17"
+        Enter = "7"
+        Expose = "12"
+        FocusIn = "9"
+        FocusOut = "10"
+        GraphicsExpose = "13"
+        Gravity = "24"
+        KeyPress = "2"
+        Key = "2"
+        KeyRelease = "3"
+        Keymap = "11"
+        Leave = "8"
+        Map = "19"
+        MapRequest = "20"
+        Mapping = "34"
+        Motion = "6"
+        MouseWheel = "38"
+        NoExpose = "14"
+        Property = "28"
+        Reparent = "21"
+        ResizeRequest = "25"
+        Selection = "31"
+        SelectionClear = "29"
+        SelectionRequest = "30"
+        Unmap = "18"
+        VirtualEvent = "35"
+        Visibility = "15"
+
+else:
+    class EventType(str, Enum):
+        Activate = "36"
+        ButtonPress = "4"
+        Button = ButtonPress
+        ButtonRelease = "5"
+        Circulate = "26"
+        CirculateRequest = "27"
+        ClientMessage = "33"
+        Colormap = "32"
+        Configure = "22"
+        ConfigureRequest = "23"
+        Create = "16"
+        Deactivate = "37"
+        Destroy = "17"
+        Enter = "7"
+        Expose = "12"
+        FocusIn = "9"
+        FocusOut = "10"
+        GraphicsExpose = "13"
+        Gravity = "24"
+        KeyPress = "2"
+        Key = "2"
+        KeyRelease = "3"
+        Keymap = "11"
+        Leave = "8"
+        Map = "19"
+        MapRequest = "20"
+        Mapping = "34"
+        Motion = "6"
+        MouseWheel = "38"
+        NoExpose = "14"
+        Property = "28"
+        Reparent = "21"
+        ResizeRequest = "25"
+        Selection = "31"
+        SelectionClear = "29"
+        SelectionRequest = "30"
+        Unmap = "18"
+        VirtualEvent = "35"
+        Visibility = "15"
 
 _W = TypeVar("_W", bound=Misc)
 # Events considered covariant because you should never assign to event.widget.


### PR DESCRIPTION
This was a perfectly reasonable way to handle StrEnum. That said, there's only two uses of it, and this is just about the only thing currently in the stdlib that benefits from the complicated MRO-with-skips comparison in the original version of @hauntsaninja's inheritance checker from https://github.com/python/typeshed/issues/3968. As I get ready to propose a version of that check for inclusion in stubtest, it'd be nice to drop that part.