### PR TITLE
Update `TOMLDecodeError` for Python 3.14

### DIFF
--- a/stdlib/tomllib.pyi
+++ b/stdlib/tomllib.pyi
@@ -1,6 +1,6 @@
+import sys
 from _typeshed import SupportsRead
 from collections.abc import Callable
-import sys
 from typing import Any
 
 __all__ = ("loads", "load", "TOMLDecodeError")
@@ -13,6 +13,7 @@ if sys.version_info >= (3, 14):
         lineno: int
         colno: int
         def __init__(self, msg: str, doc: str, pos: int) -> None: ...
+
 else:
     class TOMLDecodeError(ValueError): ...
 

--- a/stdlib/tomllib.pyi
+++ b/stdlib/tomllib.pyi
@@ -1,10 +1,20 @@
 from _typeshed import SupportsRead
 from collections.abc import Callable
+import sys
 from typing import Any
 
 __all__ = ("loads", "load", "TOMLDecodeError")
 
-class TOMLDecodeError(ValueError): ...
+if sys.version_info >= (3, 14):
+    class TOMLDecodeError(ValueError):
+        msg: str
+        doc: str
+        pos: int
+        lineno: int
+        colno: int
+        def __init__(self, msg: str, doc: str, pos: int) -> None: ...
+else:
+    class TOMLDecodeError(ValueError): ...
 
 def load(fp: SupportsRead[bytes], /, *, parse_float: Callable[[str], Any] = ...) -> dict[str, Any]: ...
 def loads(s: str, /, *, parse_float: Callable[[str], Any] = ...) -> dict[str, Any]: ...


### PR DESCRIPTION
Update `tomllib.TOMLDecodeError` typing to reflect changes in Python 3.14 (https://github.com/python/cpython/pull/126428).

Note that this PR currently hides the old deprecated interface. Not sure if that is what maintainers want.