### PR TITLE
remove _posixsubprocess.cloexec_pipe

### DIFF
--- a/stdlib/@tests/stubtest_allowlists/darwin.txt
+++ b/stdlib/@tests/stubtest_allowlists/darwin.txt
@@ -1,4 +1,3 @@
-_posixsubprocess.cloexec_pipe
 curses.has_key
 (os|posix).sched_param  # system dependent. Unclear if macos has it.
 select.KQ_FILTER_NETDEV  # system dependent

--- a/stdlib/@tests/stubtest_allowlists/linux.txt
+++ b/stdlib/@tests/stubtest_allowlists/linux.txt
@@ -2,7 +2,6 @@
 # TODO: Review the following
 # ==========
 
-_posixsubprocess.cloexec_pipe
 curses.has_key
 selectors.KqueueSelector
 

--- a/stdlib/_posixsubprocess.pyi
+++ b/stdlib/_posixsubprocess.pyi
@@ -4,7 +4,6 @@ from collections.abc import Callable, Sequence
 from typing import SupportsIndex
 
 if sys.platform != "win32":
-    def cloexec_pipe() -> tuple[int, int]: ...
     def fork_exec(
         args: Sequence[StrOrBytesPath] | None,
         executable_list: Sequence[bytes],


### PR DESCRIPTION
removed from CPython in 2013...

https://github.com/python/cpython/commit/daf455554bc21b6b5df0a016ab5fa639d36cc595