### PR TITLE
remove duplicate allowlist entry

### DIFF
--- a/stdlib/@tests/stubtest_allowlists/py310.txt
+++ b/stdlib/@tests/stubtest_allowlists/py310.txt
@@ -1,6 +1,5 @@
 _collections_abc.AsyncGenerator.athrow  # async at runtime, deliberately not in the stub, see #7491. Pos-only differences also.
 _weakref.ProxyType.__reversed__  # Doesn't really exist
-asyncio.base_events.BaseEventLoop.subprocess_exec # BaseEventLoop adds several parameters and stubtest fails on the difference if we add them
 builtins.float.__setformat__  # Internal method for CPython test suite
 builtins.property.__set_name__  # Doesn't actually exist
 _?bz2.BZ2Decompressor.__init__  # function does not accept parameters but C signature is set


### PR DESCRIPTION
`asyncio.base_events.BaseEventLoop.subprocess_exec` is in both common.txt and py310.txt for some reason