### PR TITLE
remove duplicate allowlist entry

### DIFF
--- a/stdlib/@tests/stubtest_allowlists/py313.txt
+++ b/stdlib/@tests/stubtest_allowlists/py313.txt
@@ -22,7 +22,6 @@ tkinter.Misc.tk_busy_current
 tkinter.Misc.tk_busy_forget
 tkinter.Misc.tk_busy_hold
 tkinter.Misc.tk_busy_status
-tkinter.Text.count
 tkinter.Wm.wm_attributes
 
 # ======================================


### PR DESCRIPTION
`tkinter.Text.count` is in both common.txt and py313.txt

