### PR TITLE
Remove unnecessary environment markers

### DIFF
--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -7,16 +7,14 @@ pytype==2024.10.11; platform_system != "Windows" and python_version >= "3.10" an
 
 # Libraries used by our various scripts.
 aiohttp==3.10.11
-# grpc install only fails on Windows, but let's avoid building sdist on other platforms
-# https://github.com/grpc/grpc/issues/36201
-grpcio-tools; python_version < "3.13" # For grpc_tools.protoc
+grpcio-tools>=1.66.2 # For grpc_tools.protoc
 mypy-protobuf==3.6.0
 packaging==24.1
 pathspec>=0.11.1
 pre-commit
 # Required by create_baseline_stubs.py. Must match .pre-commit-config.yaml.
 ruff==0.7.1
-stubdefaulter==0.1.0; python_version < "3.13" # Requires libcst which doesn't have 3.13 wheels yet and requires a Rust compiler
+stubdefaulter==0.1.0
 termcolor>=2.3
 tomli==2.0.2
 tomlkit==0.13.2


### PR DESCRIPTION
Fixes #13094. `grpc` and `libcst` have both released versions that claim to support Python 3.13 now (though I haven't actually tried to install them locally)