### PR TITLE
Remove unused allowlist entry

### DIFF
--- a/stdlib/@tests/stubtest_allowlists/common.txt
+++ b/stdlib/@tests/stubtest_allowlists/common.txt
@@ -63,7 +63,6 @@ encodings.ascii
 encodings.base64_codec
 encodings.bz2_codec
 encodings.charmap
-encodings\.cp\d+
 encodings.hex_codec
 encodings.idna
 encodings.latin_1


### PR DESCRIPTION
Fixes stubtest failures on main. I assume there was a merge race or something between two PRs that meant that the entry is now unused? Not sure.