### PR TITLE
add async cluster redis stubs

### DIFF
--- a/stubs/redis/redis/asyncio/cluster.pyi
+++ b/stubs/redis/redis/asyncio/cluster.pyi
@@ -1,7 +1,7 @@
 from _typeshed import Incomplete
 from collections.abc import Awaitable, Callable, Mapping
 from types import TracebackType
-from typing import Any, Generic, TypeVar
+from typing import Any, TypeVar
 from typing_extensions import Self
 
 from redis.asyncio.client import ResponseCallbackT
@@ -9,9 +9,7 @@ from redis.asyncio.connection import AbstractConnection, BaseParser, Connection,
 from redis.asyncio.parser import CommandsParser
 from redis.client import AbstractRedis
 from redis.cluster import AbstractRedisCluster, LoadBalancer
-
-# TODO: add  AsyncRedisClusterCommands stubs
-# from redis.commands import AsyncRedisClusterCommands
+from redis.commands.cluster import AsyncRedisClusterCommands
 from redis.commands.core import _StrType
 from redis.credentials import CredentialProvider
 from redis.exceptions import ResponseError
@@ -27,7 +25,7 @@ class ClusterParser(BaseParser):
     async def can_read_destructive(self) -> bool: ...
     async def read_response(self, disable_decoding: bool = False) -> EncodableT | ResponseError | list[EncodableT] | None: ...
 
-class RedisCluster(AbstractRedis, AbstractRedisCluster, Generic[_StrType]):  # TODO: AsyncRedisClusterCommands
+class RedisCluster(AbstractRedis, AbstractRedisCluster, AsyncRedisClusterCommands[_StrType]):
     @classmethod
     def from_url(
         cls,
@@ -203,7 +201,7 @@ class NodesManager:
     async def close(self, attr: str = "nodes_cache") -> None: ...
     def remap_host_port(self, host: str, port: int) -> tuple[str, int]: ...
 
-class ClusterPipeline(AbstractRedis, AbstractRedisCluster, Generic[_StrType]):  # TODO: AsyncRedisClusterCommands
+class ClusterPipeline(AbstractRedis, AbstractRedisCluster, AsyncRedisClusterCommands[_StrType]):
     def __init__(self, client: RedisCluster[_StrType]) -> None: ...
     async def initialize(self) -> Self: ...
     async def __aenter__(self) -> Self: ...

--- a/stubs/redis/redis/commands/cluster.pyi
+++ b/stubs/redis/redis/commands/cluster.pyi
@@ -1,7 +1,23 @@
 from _typeshed import Incomplete
-from typing import NoReturn
+from collections.abc import AsyncIterator
+from typing import Any, NoReturn
 
-from .core import ACLCommands, DataAccessCommands, ManagementCommands, PubSubCommands, _StrType
+from redis.commands.redismodules import RedisModuleCommands
+
+from .core import (
+    ACLCommands,
+    AsyncACLCommands,
+    AsyncDataAccessCommands,
+    AsyncFunctionCommands,
+    AsyncGeoCommands,
+    AsyncManagementCommands,
+    AsyncModuleCommands,
+    AsyncScriptCommands,
+    DataAccessCommands,
+    ManagementCommands,
+    PubSubCommands,
+    _StrType,
+)
 
 class ClusterMultiKeyCommands:
     def mget_nonatomic(self, keys, *args): ...
@@ -29,6 +45,11 @@ class ClusterDataAccessCommands(DataAccessCommands[_StrType]):
         withmatchlen: bool = False,
         **kwargs,
     ): ...
+
+class AsyncClusterDataAccessCommands(ClusterDataAccessCommands[_StrType], AsyncDataAccessCommands[_StrType]):
+    async def scan_iter(
+        self, match: str | bytes | None = None, count: int | None = None, _type: str | None = None, **kwargs
+    ) -> AsyncIterator[_StrType]: ...
 
 class RedisClusterCommands(
     ClusterMultiKeyCommands, ClusterManagementCommands, ACLCommands[_StrType], PubSubCommands, ClusterDataAccessCommands[_StrType]
@@ -58,3 +79,22 @@ class RedisClusterCommands(
     read_from_replicas: bool
     def readonly(self, target_nodes: Incomplete | None = None): ...
     def readwrite(self, target_nodes: Incomplete | None = None): ...
+
+class AsyncClusterMultiKeyCommands(ClusterMultiKeyCommands):
+    async def mget_nonatomic(self, keys, *args) -> list[Any]: ...
+    async def mset_nonatomic(self, mapping): ...
+
+class AsyncClusterManagementCommands(ClusterManagementCommands, AsyncManagementCommands):
+    async def cluster_delslots(self, *slots): ...
+
+class AsyncRedisClusterCommands(
+    AsyncClusterMultiKeyCommands,
+    AsyncClusterManagementCommands,
+    AsyncACLCommands[_StrType],
+    AsyncClusterDataAccessCommands[_StrType],
+    AsyncScriptCommands[_StrType],
+    AsyncFunctionCommands,
+    AsyncGeoCommands,
+    AsyncModuleCommands,
+    RedisModuleCommands,
+): ...


### PR DESCRIPTION
There is an issue of missing stubs for async cluster on Redis:
https://github.com/python/typeshed/issues/12925

On other hand there is a recommendation of remove redis(not before February 2025)
https://github.com/python/typeshed/issues/10592

And a similar draft PR:
https://github.com/python/typeshed/pull/12988/files

The PR that added this TODOs don't left an explanation about:
https://github.com/python/typeshed/pull/9468/files