### PR TITLE
add encodings.utf_16 and encodings.utf_32

### DIFF
--- a/stdlib/@tests/stubtest_allowlists/common.txt
+++ b/stdlib/@tests/stubtest_allowlists/common.txt
@@ -72,10 +72,8 @@ encodings.raw_unicode_escape
 encodings.rot_13
 encodings.undefined
 encodings.unicode_escape
-encodings.utf_16
 encodings.utf_16_be
 encodings.utf_16_le
-encodings.utf_32
 encodings.utf_32_be
 encodings.utf_32_le
 encodings.utf_7

--- a/stdlib/encodings/utf_16.pyi
+++ b/stdlib/encodings/utf_16.pyi
@@ -1,0 +1,20 @@
+import codecs
+from _typeshed import ReadableBuffer
+
+encode = codecs.utf_16_encode
+
+def decode(input: ReadableBuffer, errors: str | None = "strict") -> tuple[str, int]: ...
+
+class IncrementalEncoder(codecs.IncrementalEncoder):
+    def encode(self, input: str, final: bool = False) -> bytes: ...
+
+class IncrementalDecoder(codecs.BufferedIncrementalDecoder):
+    def _buffer_decode(self, input: ReadableBuffer, errors: str, final: bool) -> tuple[str, int]: ...
+
+class StreamWriter(codecs.StreamWriter):
+    def encode(self, input: str, errors: str = "strict") -> tuple[bytes, int]: ...
+
+class StreamReader(codecs.StreamReader):
+    def decode(self, input: ReadableBuffer, errors: str = "strict") -> tuple[str, int]: ...
+
+def getregentry() -> codecs.CodecInfo: ...

--- a/stdlib/encodings/utf_32.pyi
+++ b/stdlib/encodings/utf_32.pyi
@@ -1,0 +1,20 @@
+import codecs
+from _typeshed import ReadableBuffer
+
+encode = codecs.utf_32_encode
+
+def decode(input: ReadableBuffer, errors: str | None = "strict") -> tuple[str, int]: ...
+
+class IncrementalEncoder(codecs.IncrementalEncoder):
+    def encode(self, input: str, final: bool = False) -> bytes: ...
+
+class IncrementalDecoder(codecs.BufferedIncrementalDecoder):
+    def _buffer_decode(self, input: ReadableBuffer, errors: str, final: bool) -> tuple[str, int]: ...
+
+class StreamWriter(codecs.StreamWriter):
+    def encode(self, input: str, errors: str = "strict") -> tuple[bytes, int]: ...
+
+class StreamReader(codecs.StreamReader):
+    def decode(self, input: ReadableBuffer, errors: str = "strict") -> tuple[str, int]: ...
+
+def getregentry() -> codecs.CodecInfo: ...


### PR DESCRIPTION
These are similar to the stubs in https://github.com/python/typeshed/pull/13112, but because they're switching endian, they don't just assign the C function to themselves and call it a day.