### PR TITLE
Add encodings.mbcs and encodings.oem

### DIFF
--- a/stdlib/@tests/stubtest_allowlists/darwin.txt
+++ b/stdlib/@tests/stubtest_allowlists/darwin.txt
@@ -32,6 +32,8 @@ select.POLLMSG   # system dependent
 _winapi
 asyncio.windows_events
 asyncio.windows_utils
+encodings.oem
+encodings.mbcs
 msvcrt
 nt
 winreg

--- a/stdlib/@tests/stubtest_allowlists/linux.txt
+++ b/stdlib/@tests/stubtest_allowlists/linux.txt
@@ -13,6 +13,8 @@ selectors.KqueueSelector
 _winapi
 asyncio.windows_events
 asyncio.windows_utils
+encodings.oem
+encodings.mbcs
 msvcrt
 nt
 winreg

--- a/stdlib/@tests/stubtest_allowlists/win32.txt
+++ b/stdlib/@tests/stubtest_allowlists/win32.txt
@@ -4,8 +4,6 @@ ctypes.GetLastError  # Is actually a pointer
 multiprocessing.reduction.AbstractReducer.DupHandle
 
 # Exists at runtime, but missing from stubs
-encodings.mbcs
-encodings.oem
 _winapi.CreateFileMapping
 _winapi.MapViewOfFile
 _winapi.OpenFileMapping

--- a/stdlib/encodings/mbcs.pyi
+++ b/stdlib/encodings/mbcs.pyi
@@ -11,12 +11,12 @@ if sys.platform == "win32":
         def encode(self, input: str, final: bool = False) -> bytes: ...
 
     class IncrementalDecoder(codecs.BufferedIncrementalDecoder):
-        _buffer_decode = codecs.mbcs_decode  # type: ignore[assignment]
+        _buffer_decode = codecs.mbcs_decode  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
 
     class StreamWriter(codecs.StreamWriter):
-        encode = codecs.mbcs_encode  # type: ignore[assignment]
+        encode = codecs.mbcs_encode  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
 
     class StreamReader(codecs.StreamReader):
-        decode = codecs.mbcs_decode  # type: ignore[assignment]
+        decode = codecs.mbcs_decode  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
 
     def getregentry() -> codecs.CodecInfo: ...

--- a/stdlib/encodings/mbcs.pyi
+++ b/stdlib/encodings/mbcs.pyi
@@ -10,7 +10,8 @@ if sys.platform == "win32":
     class IncrementalEncoder(codecs.IncrementalEncoder):
         def encode(self, input: str, final: bool = False) -> bytes: ...
 
-    class IncrementalDecoder(codecs.BufferedIncrementalDecoder): ...
+    class IncrementalDecoder(codecs.BufferedIncrementalDecoder):
+        _buffer_decode = codecs.mbcs_decode  # type: ignore[assignment]
 
     class StreamWriter(codecs.StreamWriter):
         encode = codecs.mbcs_encode  # type: ignore[assignment]

--- a/stdlib/encodings/mbcs.pyi
+++ b/stdlib/encodings/mbcs.pyi
@@ -13,16 +13,16 @@ if sys.platform == "win32":
     class IncrementalDecoder(codecs.BufferedIncrementalDecoder):
         # At runtime, this is codecs.mbcs_decode
         @staticmethod
-        def _buffer_decode(data: ReadableBuffer, errors: str | None = None, final: bool = False, /) -> tuple[str, int]: ...  # type: ignore[override]
+        def _buffer_decode(data: ReadableBuffer, errors: str | None = None, final: bool = False, /) -> tuple[str, int]: ...
 
     class StreamWriter(codecs.StreamWriter):
         # At runtime, this is codecs.mbcs_encode
         @staticmethod
-        def encode(str: str, errors: str | None = None, /) -> tuple[bytes, int]: ...  # type: ignore[override]
+        def encode(str: str, errors: str | None = None, /) -> tuple[bytes, int]: ...
 
     class StreamReader(codecs.StreamReader):
         # At runtime, this is codecs.mbcs_decode
         @staticmethod
-        def decode(data: ReadableBuffer, errors: str | None = None, final: bool = False, /) -> tuple[str, int]: ...  # type: ignore[override]
+        def decode(data: ReadableBuffer, errors: str | None = None, final: bool = False, /) -> tuple[str, int]: ...
 
     def getregentry() -> codecs.CodecInfo: ...

--- a/stdlib/encodings/mbcs.pyi
+++ b/stdlib/encodings/mbcs.pyi
@@ -13,9 +13,9 @@ if sys.platform == "win32":
     class IncrementalDecoder(codecs.BufferedIncrementalDecoder): ...
 
     class StreamWriter(codecs.StreamWriter):
-        encode = codecs.mbcs_encode
+        encode = codecs.mbcs_encode  # type: ignore[assignment]
 
     class StreamReader(codecs.StreamReader):
-        decode = codecs.mbcs_decode
+        decode = codecs.mbcs_decode  # type: ignore[assignment]
 
     def getregentry() -> codecs.CodecInfo: ...

--- a/stdlib/encodings/mbcs.pyi
+++ b/stdlib/encodings/mbcs.pyi
@@ -11,12 +11,18 @@ if sys.platform == "win32":
         def encode(self, input: str, final: bool = False) -> bytes: ...
 
     class IncrementalDecoder(codecs.BufferedIncrementalDecoder):
-        _buffer_decode = codecs.mbcs_decode  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+        # At runtime, this is codecs.mbcs_decode
+        @staticmethod
+        def _buffer_decode(data: ReadableBuffer, errors: str | None = None, final: bool = False, /) -> tuple[str, int]: ...  # type: ignore[override]
 
     class StreamWriter(codecs.StreamWriter):
-        encode = codecs.mbcs_encode  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+        # At runtime, this is codecs.mbcs_encode
+        @staticmethod
+        def encode(str: str, errors: str | None = None, /) -> tuple[bytes, int]: ...  # type: ignore[override]
 
     class StreamReader(codecs.StreamReader):
-        decode = codecs.mbcs_decode  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+        # At runtime, this is codecs.mbcs_decode
+        @staticmethod
+        def decode(data: ReadableBuffer, errors: str | None = None, final: bool = False, /) -> tuple[str, int]: ...  # type: ignore[override]
 
     def getregentry() -> codecs.CodecInfo: ...

--- a/stdlib/encodings/mbcs.pyi
+++ b/stdlib/encodings/mbcs.pyi
@@ -3,9 +3,7 @@ import sys
 from _typeshed import ReadableBuffer
 
 if sys.platform == "win32":
-    from codecs import mbcs_decode, mbcs_encode
-
-    encode = mbcs_encode
+    encode = codecs.mbcs_encode
 
     def decode(input: ReadableBuffer, errors: str | None = "strict") -> tuple[str, int]: ...
 
@@ -15,9 +13,9 @@ if sys.platform == "win32":
     class IncrementalDecoder(codecs.BufferedIncrementalDecoder): ...
 
     class StreamWriter(codecs.StreamWriter):
-        encode = mbcs_encode
+        encode = codecs.mbcs_encode
 
     class StreamReader(codecs.StreamReader):
-        decode = mbcs_decode
+        decode = codecs.mbcs_decode
 
     def getregentry() -> codecs.CodecInfo: ...

--- a/stdlib/encodings/mbcs.pyi
+++ b/stdlib/encodings/mbcs.pyi
@@ -1,0 +1,23 @@
+import codecs
+import sys
+from _typeshed import ReadableBuffer
+
+if sys.platform == "win32":
+    from codecs import mbcs_decode, mbcs_encode
+
+    encode = mbcs_encode
+
+    def decode(input: ReadableBuffer, errors: str | None = "strict") -> tuple[str, int]: ...
+
+    class IncrementalEncoder(codecs.IncrementalEncoder):
+        def encode(self, input: str, final: bool = False) -> bytes: ...
+
+    class IncrementalDecoder(codecs.BufferedIncrementalDecoder): ...
+
+    class StreamWriter(codecs.StreamWriter):
+        encode = mbcs_encode
+
+    class StreamReader(codecs.StreamReader):
+        decode = mbcs_decode
+
+    def getregentry() -> codecs.CodecInfo: ...

--- a/stdlib/encodings/oem.pyi
+++ b/stdlib/encodings/oem.pyi
@@ -13,9 +13,9 @@ if sys.platform == "win32":
     class IncrementalDecoder(codecs.BufferedIncrementalDecoder): ...
 
     class StreamWriter(codecs.StreamWriter):
-        encode = codecs.oem_encode
+        encode = codecs.oem_encode  # type: ignore[assignment]
 
     class StreamReader(codecs.StreamReader):
-        decode = codecs.oem_decode
+        decode = codecs.oem_decode  # type: ignore[assignment]
 
     def getregentry() -> codecs.CodecInfo: ...

--- a/stdlib/encodings/oem.pyi
+++ b/stdlib/encodings/oem.pyi
@@ -11,12 +11,12 @@ if sys.platform == "win32":
         def encode(self, input: str, final: bool = False) -> bytes: ...
 
     class IncrementalDecoder(codecs.BufferedIncrementalDecoder):
-        _buffer_decode = codecs.oem_decode  # type: ignore[assignment]
+        _buffer_decode = codecs.oem_decode  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
 
     class StreamWriter(codecs.StreamWriter):
-        encode = codecs.oem_encode  # type: ignore[assignment]
+        encode = codecs.oem_encode  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
 
     class StreamReader(codecs.StreamReader):
-        decode = codecs.oem_decode  # type: ignore[assignment]
+        decode = codecs.oem_decode  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]]
 
     def getregentry() -> codecs.CodecInfo: ...

--- a/stdlib/encodings/oem.pyi
+++ b/stdlib/encodings/oem.pyi
@@ -1,0 +1,23 @@
+import codecs
+import sys
+from _typeshed import ReadableBuffer
+
+if sys.platform == "win32":
+    from codecs import oem_decode, oem_encode
+
+    encode = oem_encode
+
+    def decode(input: ReadableBuffer, errors: str | None = "strict") -> tuple[str, int]: ...
+
+    class IncrementalEncoder(codecs.IncrementalEncoder):
+        def encode(self, input: str, final: bool = False) -> bytes: ...
+
+    class IncrementalDecoder(codecs.BufferedIncrementalDecoder): ...
+
+    class StreamWriter(codecs.StreamWriter):
+        encode = oem_encode
+
+    class StreamReader(codecs.StreamReader):
+        decode = oem_decode
+
+    def getregentry() -> codecs.CodecInfo: ...

--- a/stdlib/encodings/oem.pyi
+++ b/stdlib/encodings/oem.pyi
@@ -3,9 +3,7 @@ import sys
 from _typeshed import ReadableBuffer
 
 if sys.platform == "win32":
-    from codecs import oem_decode, oem_encode
-
-    encode = oem_encode
+    encode = codecs.oem_encode
 
     def decode(input: ReadableBuffer, errors: str | None = "strict") -> tuple[str, int]: ...
 
@@ -15,9 +13,9 @@ if sys.platform == "win32":
     class IncrementalDecoder(codecs.BufferedIncrementalDecoder): ...
 
     class StreamWriter(codecs.StreamWriter):
-        encode = oem_encode
+        encode = codecs.oem_encode
 
     class StreamReader(codecs.StreamReader):
-        decode = oem_decode
+        decode = codecs.oem_decode
 
     def getregentry() -> codecs.CodecInfo: ...

--- a/stdlib/encodings/oem.pyi
+++ b/stdlib/encodings/oem.pyi
@@ -13,16 +13,16 @@ if sys.platform == "win32":
     class IncrementalDecoder(codecs.BufferedIncrementalDecoder):
         # At runtime, this is codecs.oem_decode
         @staticmethod
-        def _buffer_decode(data: ReadableBuffer, errors: str | None = None, final: bool = False, /) -> tuple[str, int]: ...  # type: ignore[override]
+        def _buffer_decode(data: ReadableBuffer, errors: str | None = None, final: bool = False, /) -> tuple[str, int]: ...
 
     class StreamWriter(codecs.StreamWriter):
         # At runtime, this is codecs.oem_encode
         @staticmethod
-        def encode(str: str, errors: str | None = None, /) -> tuple[bytes, int]: ...  # type: ignore[override]
+        def encode(str: str, errors: str | None = None, /) -> tuple[bytes, int]: ...
 
     class StreamReader(codecs.StreamReader):
         # At runtime, this is codecs.oem_decode
         @staticmethod
-        def decode(data: ReadableBuffer, errors: str | None = None, final: bool = False, /) -> tuple[str, int]: ...  # type: ignore[override]
+        def decode(data: ReadableBuffer, errors: str | None = None, final: bool = False, /) -> tuple[str, int]: ...
 
     def getregentry() -> codecs.CodecInfo: ...

--- a/stdlib/encodings/oem.pyi
+++ b/stdlib/encodings/oem.pyi
@@ -10,7 +10,8 @@ if sys.platform == "win32":
     class IncrementalEncoder(codecs.IncrementalEncoder):
         def encode(self, input: str, final: bool = False) -> bytes: ...
 
-    class IncrementalDecoder(codecs.BufferedIncrementalDecoder): ...
+    class IncrementalDecoder(codecs.BufferedIncrementalDecoder):
+        _buffer_decode = codecs.oem_decode  # type: ignore[assignment]
 
     class StreamWriter(codecs.StreamWriter):
         encode = codecs.oem_encode  # type: ignore[assignment]

--- a/stdlib/encodings/oem.pyi
+++ b/stdlib/encodings/oem.pyi
@@ -11,12 +11,18 @@ if sys.platform == "win32":
         def encode(self, input: str, final: bool = False) -> bytes: ...
 
     class IncrementalDecoder(codecs.BufferedIncrementalDecoder):
-        _buffer_decode = codecs.oem_decode  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+        # At runtime, this is codecs.oem_decode
+        @staticmethod
+        def _buffer_decode(data: ReadableBuffer, errors: str | None = None, final: bool = False, /) -> tuple[str, int]: ...  # type: ignore[override]
 
     class StreamWriter(codecs.StreamWriter):
-        encode = codecs.oem_encode  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+        # At runtime, this is codecs.oem_encode
+        @staticmethod
+        def encode(str: str, errors: str | None = None, /) -> tuple[bytes, int]: ...  # type: ignore[override]
 
     class StreamReader(codecs.StreamReader):
-        decode = codecs.oem_decode  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]]
+        # At runtime, this is codecs.oem_decode
+        @staticmethod
+        def decode(data: ReadableBuffer, errors: str | None = None, final: bool = False, /) -> tuple[str, int]: ...  # type: ignore[override]
 
     def getregentry() -> codecs.CodecInfo: ...


### PR DESCRIPTION
Two windows-only submodules. The stubs differ only by the functions imported from codecs.