### PR TITLE
Quality of life for running stubtest against 3.14 builds

### DIFF
--- a/stdlib/@tests/stubtest_allowlists/common.txt
+++ b/stdlib/@tests/stubtest_allowlists/common.txt
@@ -151,7 +151,7 @@ wave.Wave_write.initfp
 socket.AF_DECnet
 
 # sys attributes that are not always defined
-sys.gettotalrefcount  # Available on python debug builds
+(sys.gettotalrefcount)?  # Available on python debug builds
 sys.last_traceback
 sys.last_type
 sys.last_value
@@ -222,13 +222,6 @@ _frozen_importlib_external.FileLoader.load_module
 _pydecimal.*  # See comments in file
 argparse.ArgumentParser.__init__  # stubtest doesn't recognise the runtime default (a class) as being compatible with a callback protocol (the stub annotation)
 argparse.Namespace.__getattr__  # The whole point of this class is its attributes are dynamic
-
-# runtime is *args, **kwargs due to a wrapper, but we have more accurate signatures in the stubs
-ast.Bytes.__new__
-ast.Ellipsis.__new__
-ast.NameConstant.__new__
-ast.Num.__new__
-ast.Str.__new__
 
 ast.NodeVisitor.visit_\w+  # Methods are discovered dynamically, see #3796
 asyncio.proactor_events.BaseProactorEventLoop.sock_recv # nbytes parameter has different name 'n' in implementation
@@ -417,7 +410,6 @@ typing(_extensions)?\.Generator
 typing(_extensions)?\.Coroutine
 typing(_extensions)?\.Collection
 typing(_extensions)?\.Container
-typing\.ByteString
 typing(_extensions)?\.Awaitable
 typing(_extensions)?\.AbstractSet
 
@@ -428,11 +420,6 @@ _collections_abc.Callable
 _typeshed.*  # Utility types for typeshed, doesn't exist at runtime
 typing._SpecialForm.__call__
 typing._SpecialForm.__init__
-
-# Pretend typing.ByteString is a Union, to better match its documented semantics.
-# As a side effect, this changes the definition of collections.abc.ByteString, which is okay,
-# because it's not an ABC that makes any sense and was deprecated in 3.12
-_collections_abc.ByteString
 
 # These are abstract properties at runtime,
 # but marking them as such in the stub breaks half the the typed-Python ecosystem (see #8726)

--- a/stdlib/@tests/stubtest_allowlists/py310.txt
+++ b/stdlib/@tests/stubtest_allowlists/py310.txt
@@ -261,3 +261,18 @@ tkinter.EventType.__new__
 ctypes._endian.DEFAULT_MODE
 ctypes._endian.RTLD_GLOBAL
 ctypes._endian.RTLD_LOCAL
+
+# runtime is *args, **kwargs due to a wrapper, but we have more accurate signatures in the stubs
+ast.Bytes.__new__
+ast.Ellipsis.__new__
+ast.NameConstant.__new__
+ast.Num.__new__
+ast.Str.__new__
+
+# Special primitives
+typing\.ByteString
+
+# Pretend typing.ByteString is a Union, to better match its documented semantics.
+# As a side effect, this changes the definition of collections.abc.ByteString, which is okay,
+# because it's not an ABC that makes any sense and was deprecated in 3.12
+_collections_abc.ByteString

--- a/stdlib/@tests/stubtest_allowlists/py311.txt
+++ b/stdlib/@tests/stubtest_allowlists/py311.txt
@@ -220,3 +220,18 @@ pkgutil.ImpLoader\..*
 ctypes._endian.DEFAULT_MODE
 ctypes._endian.RTLD_GLOBAL
 ctypes._endian.RTLD_LOCAL
+
+# runtime is *args, **kwargs due to a wrapper, but we have more accurate signatures in the stubs
+ast.Bytes.__new__
+ast.Ellipsis.__new__
+ast.NameConstant.__new__
+ast.Num.__new__
+ast.Str.__new__
+
+# Special primitives
+typing\.ByteString
+
+# Pretend typing.ByteString is a Union, to better match its documented semantics.
+# As a side effect, this changes the definition of collections.abc.ByteString, which is okay,
+# because it's not an ABC that makes any sense and was deprecated in 3.12
+_collections_abc.ByteString

--- a/stdlib/@tests/stubtest_allowlists/py312.txt
+++ b/stdlib/@tests/stubtest_allowlists/py312.txt
@@ -206,3 +206,18 @@ ctypes._endian.SIZEOF_TIME_T
 
 # Incompatible changes introduced in Python 3.12.5
 concurrent.futures.__all__
+
+# runtime is *args, **kwargs due to a wrapper, but we have more accurate signatures in the stubs
+ast.Bytes.__new__
+ast.Ellipsis.__new__
+ast.NameConstant.__new__
+ast.Num.__new__
+ast.Str.__new__
+
+# Special primitives
+typing\.ByteString
+
+# Pretend typing.ByteString is a Union, to better match its documented semantics.
+# As a side effect, this changes the definition of collections.abc.ByteString, which is okay,
+# because it's not an ABC that makes any sense and was deprecated in 3.12
+_collections_abc.ByteString

--- a/stdlib/@tests/stubtest_allowlists/py313.txt
+++ b/stdlib/@tests/stubtest_allowlists/py313.txt
@@ -180,3 +180,18 @@ codecs.xmlcharrefreplace_errors
 
 # To match `dict`, we lie about the runtime, but use overloads to match the correct behavior
 types.MappingProxyType.get
+
+# runtime is *args, **kwargs due to a wrapper, but we have more accurate signatures in the stubs
+ast.Bytes.__new__
+ast.Ellipsis.__new__
+ast.NameConstant.__new__
+ast.Num.__new__
+ast.Str.__new__
+
+# Special primitives
+typing\.ByteString
+
+# Pretend typing.ByteString is a Union, to better match its documented semantics.
+# As a side effect, this changes the definition of collections.abc.ByteString, which is okay,
+# because it's not an ABC that makes any sense and was deprecated in 3.12
+_collections_abc.ByteString

--- a/stdlib/@tests/stubtest_allowlists/py38.txt
+++ b/stdlib/@tests/stubtest_allowlists/py38.txt
@@ -270,3 +270,18 @@ multiprocessing.managers.DictProxy.copy
 multiprocessing.managers.DictProxy.items
 multiprocessing.managers.DictProxy.keys
 multiprocessing.managers.DictProxy.values
+
+# runtime is *args, **kwargs due to a wrapper, but we have more accurate signatures in the stubs
+ast.Bytes.__new__
+ast.Ellipsis.__new__
+ast.NameConstant.__new__
+ast.Num.__new__
+ast.Str.__new__
+
+# Special primitives
+typing\.ByteString
+
+# Pretend typing.ByteString is a Union, to better match its documented semantics.
+# As a side effect, this changes the definition of collections.abc.ByteString, which is okay,
+# because it's not an ABC that makes any sense and was deprecated in 3.12
+_collections_abc.ByteString

--- a/stdlib/@tests/stubtest_allowlists/py39.txt
+++ b/stdlib/@tests/stubtest_allowlists/py39.txt
@@ -238,3 +238,18 @@ _ssl.RAND_egd
 ctypes._endian.DEFAULT_MODE
 ctypes._endian.RTLD_GLOBAL
 ctypes._endian.RTLD_LOCAL
+
+# runtime is *args, **kwargs due to a wrapper, but we have more accurate signatures in the stubs
+ast.Bytes.__new__
+ast.Ellipsis.__new__
+ast.NameConstant.__new__
+ast.Num.__new__
+ast.Str.__new__
+
+# Special primitives
+typing\.ByteString
+
+# Pretend typing.ByteString is a Union, to better match its documented semantics.
+# As a side effect, this changes the definition of collections.abc.ByteString, which is okay,
+# because it's not an ABC that makes any sense and was deprecated in 3.12
+_collections_abc.ByteString

--- a/stdlib/ast.pyi
+++ b/stdlib/ast.pyi
@@ -170,7 +170,7 @@ class FunctionDef(stmt):
         ) -> None: ...
 
     if sys.version_info >= (3, 14):
-        def __replace__(
+        def __replace__(  # type: ignore[override]
             self,
             *,
             name: _Identifier = ...,
@@ -246,7 +246,7 @@ class AsyncFunctionDef(stmt):
         ) -> None: ...
 
     if sys.version_info >= (3, 14):
-        def __replace__(
+        def __replace__(  # type: ignore[override]
             self,
             *,
             name: _Identifier = ...,
@@ -304,7 +304,7 @@ class ClassDef(stmt):
         ) -> None: ...
 
     if sys.version_info >= (3, 14):
-        def __replace__(
+        def __replace__(  # type: ignore[override]
             self,
             *,
             name: _Identifier,
@@ -546,7 +546,7 @@ class While(stmt):
         def __init__(self, test: expr, body: list[stmt], orelse: list[stmt], **kwargs: Unpack[_Attributes]) -> None: ...
 
     if sys.version_info >= (3, 14):
-        def __replace__(self, *, test: expr, body: list[stmt], orelse: list[stmt], **kwargs: Unpack[_Attributes]) -> Self: ...
+        def __replace__(self, *, test: expr, body: list[stmt], orelse: list[stmt], **kwargs: Unpack[_Attributes]) -> Self: ...  # type: ignore[override]
 
 class If(stmt):
     if sys.version_info >= (3, 10):
@@ -731,7 +731,7 @@ class Assert(stmt):
     def __init__(self, test: expr, msg: expr | None = None, **kwargs: Unpack[_Attributes]) -> None: ...
 
     if sys.version_info >= (3, 14):
-        def __replace__(self, *, test: expr, msg: expr | None, **kwargs: Unpack[_Attributes]) -> Self: ...
+        def __replace__(self, *, test: expr, msg: expr | None, **kwargs: Unpack[_Attributes]) -> Self: ...  # type: ignore[override]
 
 class Import(stmt):
     if sys.version_info >= (3, 10):
@@ -781,7 +781,7 @@ class Global(stmt):
         def __init__(self, names: list[_Identifier], **kwargs: Unpack[_Attributes]) -> None: ...
 
     if sys.version_info >= (3, 14):
-        def __replace__(self, *, names: list[_Identifier], **kwargs: Unpack[_Attributes]) -> Self: ...
+        def __replace__(self, *, names: list[_Identifier], **kwargs: Unpack[_Attributes]) -> Self: ...  # type: ignore[override]
 
 class Nonlocal(stmt):
     if sys.version_info >= (3, 10):
@@ -1290,7 +1290,7 @@ class ExceptHandler(excepthandler):
         ) -> None: ...
 
     if sys.version_info >= (3, 14):
-        def __replace__(
+        def __replace__(  # type: ignore[override]
             self,
             *,
             type: expr | None = ...,

--- a/stdlib/asyncio/events.pyi
+++ b/stdlib/asyncio/events.pyi
@@ -20,7 +20,9 @@ from .futures import Future
 from .protocols import BaseProtocol
 from .tasks import Task
 from .transports import BaseTransport, DatagramTransport, ReadTransport, SubprocessTransport, Transport, WriteTransport
-from .unix_events import AbstractChildWatcher
+
+if sys.version_info < (3, 14):
+    from .unix_events import AbstractChildWatcher
 
 if sys.version_info >= (3, 14):
     __all__ = (

--- a/stdlib/sqlite3/__init__.pyi
+++ b/stdlib/sqlite3/__init__.pyi
@@ -60,7 +60,6 @@ from sqlite3.dbapi2 import (
     sqlite_version as sqlite_version,
     sqlite_version_info as sqlite_version_info,
     threadsafety as threadsafety,
-    version_info as version_info,
 )
 from types import TracebackType
 from typing import Any, Literal, Protocol, SupportsIndex, TypeVar, final, overload, type_check_only
@@ -205,6 +204,9 @@ if sys.version_info >= (3, 11):
         SQLITE_WARNING as SQLITE_WARNING,
         SQLITE_WARNING_AUTOINDEX as SQLITE_WARNING_AUTOINDEX,
     )
+
+if sys.version_info < (3, 14):
+    from sqlite3.dbapi2 import version_info as version_info
 
 if sys.version_info < (3, 12):
     from sqlite3.dbapi2 import enable_shared_cache as enable_shared_cache, version as version


### PR DESCRIPTION
Given that we're not even in the feature freeze period yet, I figure that it's probably not worth committing a 3.14 allowlist yet? If other people feel differently I don't mind pushing one up.

That said, we do have 3.14 things in typeshed already, and this MR allows stubtest to run cleanly when paired with a local 3.14 allowlist.