### PR TITLE
sort allowlists by version more consistently

### DIFF
--- a/stdlib/@tests/stubtest_allowlists/darwin-py310.txt
+++ b/stdlib/@tests/stubtest_allowlists/darwin-py310.txt
@@ -1,11 +1,6 @@
-# Doesn't exist on macos:
-spwd
-_msi
-msilib(.[a-z]+)?
-ossaudiodev
-
-# Added in Python 3.10.12
-tarfile.TarInfo.replace
+# ===========
+# 3.9 to 3.11
+# ===========
 
 # Added in Python 3.10.15
 email._header_value_parser.NLSET
@@ -13,3 +8,22 @@ email._header_value_parser.SPECIALSNL
 email.errors.HeaderWriteError
 email.utils.getaddresses
 email.utils.parseaddr
+
+
+# =======
+# <= 3.10
+# =======
+
+# Added in Python 3.10.12
+tarfile.TarInfo.replace
+
+
+# =============================================================
+# Allowlist entries that cannot or should not be fixed; <= 3.12
+# =============================================================
+
+# Doesn't exist on macos:
+_msi
+msilib(.[a-z]+)?
+ossaudiodev
+spwd

--- a/stdlib/@tests/stubtest_allowlists/darwin-py311.txt
+++ b/stdlib/@tests/stubtest_allowlists/darwin-py311.txt
@@ -1,13 +1,16 @@
-# Doesn't exist on macos:
-spwd
-_msi
-msilib(.[a-z]+)?
-ossaudiodev
+# ============
+# 3.11 to 3.12
+# ============
 
 # Not present on all MacOS versions
 fcntl.F_OFD_GETLK
 fcntl.F_OFD_SETLK
 fcntl.F_OFD_SETLKW
+
+
+# ===========
+# 3.9 to 3.11
+# ===========
 
 # Incompatible changes introduced in Python 3.11.10
 # (Remove once 3.11.10 becomes available for MacOS)
@@ -16,3 +19,14 @@ email._header_value_parser.SPECIALSNL
 email.errors.HeaderWriteError
 email.utils.getaddresses
 email.utils.parseaddr
+
+
+# =============================================================
+# Allowlist entries that cannot or should not be fixed; <= 3.12
+# =============================================================
+
+# Doesn't exist on macos:
+_msi
+msilib(.[a-z]+)?
+ossaudiodev
+spwd

--- a/stdlib/@tests/stubtest_allowlists/darwin-py312.txt
+++ b/stdlib/@tests/stubtest_allowlists/darwin-py312.txt
@@ -1,10 +1,19 @@
-# Doesn't exist on macos:
-spwd
-_msi
-msilib(.[a-z]+)?
-ossaudiodev
+# ============
+# 3.11 to 3.12
+# ============
 
 # Not present on all MacOS versions
 fcntl.F_OFD_GETLK
 fcntl.F_OFD_SETLK
 fcntl.F_OFD_SETLKW
+
+
+# =============================================================
+# Allowlist entries that cannot or should not be fixed; <= 3.12
+# =============================================================
+
+# Doesn't exist on macos:
+_msi
+msilib(.[a-z]+)?
+ossaudiodev
+spwd

--- a/stdlib/@tests/stubtest_allowlists/darwin-py313.txt
+++ b/stdlib/@tests/stubtest_allowlists/darwin-py313.txt
@@ -1,10 +1,11 @@
-# new in py313
-posixpath.splitroot
+# =======
+# >= 3.13
+# =======
 
 # Depends on HAVE_NCURSESW and how we install CPython,
 # should be removed when 3.13 will be officially released:
 _?curses.unget_wch
 _?curses.window.get_wch
 
-# Exists locally on MacOS but not on GitHub
-(mmap.MAP_32BIT)?
+(mmap.MAP_32BIT)?  # Exists locally on MacOS but not on GitHub
+posixpath.splitroot

--- a/stdlib/@tests/stubtest_allowlists/darwin-py38.txt
+++ b/stdlib/@tests/stubtest_allowlists/darwin-py38.txt
@@ -1,12 +1,26 @@
-# Doesn't exist on macos:
-spwd
-_msi
-msilib(.[a-z]+)?
-ossaudiodev
+# ======
+# <= 3.9
+# ======
 
 # Added in Python 3.8.14
 sys.set_int_max_str_digits
 sys.get_int_max_str_digits
 
+
+# =======
+# <= 3.10
+# =======
+
 # Added in Python 3.8.17
 tarfile.TarInfo.replace
+
+
+# =============================================================
+# Allowlist entries that cannot or should not be fixed; <= 3.12
+# =============================================================
+
+# Doesn't exist on macos:
+_msi
+msilib(.[a-z]+)?
+ossaudiodev
+spwd

--- a/stdlib/@tests/stubtest_allowlists/darwin-py39.txt
+++ b/stdlib/@tests/stubtest_allowlists/darwin-py39.txt
@@ -1,15 +1,6 @@
-# Doesn't exist on macos:
-spwd
-_msi
-msilib(.[a-z]+)?
-ossaudiodev
-
-# Added in Python 3.9.14
-sys.set_int_max_str_digits
-sys.get_int_max_str_digits
-
-# Added in Python 3.9.17
-tarfile.TarInfo.replace
+# ===========
+# 3.9 to 3.11
+# ===========
 
 # Added in Python 3.9.20
 email._header_value_parser.NLSET
@@ -17,3 +8,31 @@ email._header_value_parser.SPECIALSNL
 email.errors.HeaderWriteError
 email.utils.getaddresses
 email.utils.parseaddr
+
+
+# ======
+# <= 3.9
+# ======
+
+# Added in Python 3.9.14
+sys.set_int_max_str_digits
+sys.get_int_max_str_digits
+
+
+# =======
+# <= 3.10
+# =======
+
+# Added in Python 3.9.17
+tarfile.TarInfo.replace
+
+
+# =============================================================
+# Allowlist entries that cannot or should not be fixed; <= 3.12
+# =============================================================
+
+# Doesn't exist on macos:
+_msi
+msilib(.[a-z]+)?
+ossaudiodev
+spwd

--- a/stdlib/@tests/stubtest_allowlists/linux-py310.txt
+++ b/stdlib/@tests/stubtest_allowlists/linux-py310.txt
@@ -1,3 +1,7 @@
+# =============================================================
+# Allowlist entries that cannot or should not be fixed; <= 3.12
+# =============================================================
+
 # doesn't exist on linux
 _msi
 msilib(.[a-z]+)?

--- a/stdlib/@tests/stubtest_allowlists/linux-py311.txt
+++ b/stdlib/@tests/stubtest_allowlists/linux-py311.txt
@@ -1,3 +1,7 @@
+# =============================================================
+# Allowlist entries that cannot or should not be fixed; <= 3.12
+# =============================================================
+
 # doesn't exist on linux
 _msi
 msilib(.[a-z]+)?

--- a/stdlib/@tests/stubtest_allowlists/linux-py312.txt
+++ b/stdlib/@tests/stubtest_allowlists/linux-py312.txt
@@ -1,11 +1,20 @@
+# =======
+# >= 3.12
+# =======
+
+# These seem like they should be available on Linux, but they're not
+# on GitHub Actions runners for some reason.
+os.CLONE_NEWTIME
+posix.CLONE_NEWTIME
+
+
+# =============================================================
+# Allowlist entries that cannot or should not be fixed; <= 3.12
+# =============================================================
+
 # doesn't exist on linux
 _msi
 msilib(.[a-z]+)?
 
 # doesn't exist in all installations
 (nis)?
-
-# These seem like they should be available on Linux, but they're not
-# on GitHub Actions runners for some reason.
-os.CLONE_NEWTIME
-posix.CLONE_NEWTIME

--- a/stdlib/@tests/stubtest_allowlists/linux-py313.txt
+++ b/stdlib/@tests/stubtest_allowlists/linux-py313.txt
@@ -1,5 +1,14 @@
+# =======
+# >= 3.13
+# =======
+
 # TODO: triage these (new in py313)
 posixpath.splitroot
+
+
+# =======
+# >= 3.12
+# =======
 
 # These seem like they should be available on Linux, but they're not
 # on GitHub Actions runners for some reason.

--- a/stdlib/@tests/stubtest_allowlists/linux-py38.txt
+++ b/stdlib/@tests/stubtest_allowlists/linux-py38.txt
@@ -1,6 +1,15 @@
+# ======
+# <= 3.9
+# ======
+
 # `eventmask` argument exists at runtime, but is not correctly recognized
 # while being inspected by stubtest. Fixed in Python 3.10.
 select.epoll.register
+
+
+# =============================================================
+# Allowlist entries that cannot or should not be fixed; <= 3.12
+# =============================================================
 
 # doesn't exist on linux
 _msi

--- a/stdlib/@tests/stubtest_allowlists/linux-py39.txt
+++ b/stdlib/@tests/stubtest_allowlists/linux-py39.txt
@@ -1,6 +1,15 @@
+# ======
+# <= 3.9
+# ======
+
 # `eventmask` argument exists at runtime, but is not correctly recognized
 # while being inspected by stubtest. Fixed in Python 3.10.
 select.epoll.register
+
+
+# =============================================================
+# Allowlist entries that cannot or should not be fixed; <= 3.12
+# =============================================================
 
 # doesn't exist on linux
 _msi

--- a/stdlib/@tests/stubtest_allowlists/py310.txt
+++ b/stdlib/@tests/stubtest_allowlists/py310.txt
@@ -92,13 +92,6 @@ builtins.float.__setformat__  # Internal method for CPython test suite
 typing._SpecialForm.__mro_entries__  # Exists at runtime, but missing from stubs
 
 
-# ===========
-# 3.9 to 3.12
-# ===========
-
-tkinter.tix.[A-Z_]+
-
-
 # =======
 # <= 3.10
 # =======
@@ -149,6 +142,7 @@ lib2to3.pytree.BasePattern.__new__
 lib2to3.pytree.BasePattern.type
 lib2to3.pytree.NegatedPattern.match
 lib2to3.pytree.NegatedPattern.match_seq
+tkinter.tix.[A-Z_]+
 tkinter.tix.CObjView
 tkinter.tix.DialogShell
 tkinter.tix.ExFileSelectDialog

--- a/stdlib/@tests/stubtest_allowlists/py310.txt
+++ b/stdlib/@tests/stubtest_allowlists/py310.txt
@@ -1,19 +1,145 @@
-_collections_abc.AsyncGenerator.athrow  # async at runtime, deliberately not in the stub, see #7491. Pos-only differences also.
-_weakref.ProxyType.__reversed__  # Doesn't really exist
-builtins.float.__setformat__  # Internal method for CPython test suite
-builtins.property.__set_name__  # Doesn't actually exist
-_?bz2.BZ2Decompressor.__init__  # function does not accept parameters but C signature is set
-collections\.UserList\.index  # ignoring pos-or-keyword parameter
-configparser.ParsingError.filename
-contextlib.AbstractAsyncContextManager.__class_getitem__
-contextlib.AbstractContextManager.__class_getitem__
-email.contentmanager.typ
-enum.Enum._generate_next_value_
-functools._lru_cache_wrapper.cache_parameters  # Cannot be detected statically
-gettext.install
-gettext.translation
+# =========================
+# New errors in Python 3.10
+# =========================
+
+
+# =======
+# >= 3.10
+# =======
+
+builtins.ellipsis  # type is not exposed anywhere
 importlib._abc.Loader.exec_module  # See Lib/importlib/_abc.py. Might be defined for backwards compatibility
+
+# positional-only complaints caused by differences between typing aliases and the "real" classes in the stdlib
+_collections_abc.Coroutine.send
+_collections_abc.Coroutine.throw
+_collections_abc.Generator.send
+_collections_abc.Generator.throw
+
+# These are not positional-only at runtime, but we treat them as positional-only to match dict.
+_collections_abc.MutableMapping.pop
+_collections_abc.MutableMapping.setdefault
+
+# These three have a pos-or-keyword first parameter at runtime, but deliberately have a pos-only first parameter in the stub. #6812
+posixpath.join
+ntpath.join
+os.path.join
+
+types.DynamicClassAttribute..*  # In the stub we pretend it's an alias for property, but it has positional-only differences
+
+# typing.IO uses positional-or-keyword arguments, but in the stubs we prefer
+# to mark these as positional-only for compatibility with existing sub-classes.
+typing(_extensions)?\.BinaryIO\.write
+typing(_extensions)?\.IO\.read
+typing(_extensions)?\.IO\.readline
+typing(_extensions)?\.IO\.readlines
+typing(_extensions)?\.IO\.seek
+typing(_extensions)?\.IO\.truncate
+typing(_extensions)?\.IO\.write
+typing(_extensions)?\.IO\.writelines
+
+
+# =========
+# 3.10 only
+# =========
+
+# The "loop" argument exists at runtime, but raises TypeError if you try to provide any value for it
+asyncio.BoundedSemaphore.__init__
+asyncio.Condition.__init__
+asyncio.Event.__init__
+asyncio.Lock.__init__
+asyncio.Queue.__init__
+asyncio.Semaphore.__init__
+asyncio.locks.BoundedSemaphore.__init__
+asyncio.locks.Condition.__init__
+asyncio.locks.Event.__init__
+asyncio.locks.Lock.__init__
+asyncio.locks.Semaphore.__init__
+asyncio.queues.Queue.__init__
+
+bdb.Breakpoint.clearBreakpoints  # Exists at runtime, but missing from stubs
+
+
+# ============
+# 3.10 to 3.11
+# ============
+
+importlib.metadata._meta.SimplePath.__truediv__  # Runtime definition of protocol is incorrect
+
+
+# ===================================
+# Pre-existing errors from Python 3.9
+# ===================================
+
+
+# ======
+# >= 3.9
+# ======
+
+# Exists at runtime, but missing from stubs
+_collections_abc.AsyncIterable.__class_getitem__
+_collections_abc.Awaitable.__class_getitem__
+_collections_abc.Container.__class_getitem__
+_collections_abc.Iterable.__class_getitem__
+_collections_abc.MappingView.__class_getitem__
+
+
+# ===========
+# 3.9 to 3.10
+# ===========
+
+builtins.float.__setformat__  # Internal method for CPython test suite
+typing._SpecialForm.__mro_entries__  # Exists at runtime, but missing from stubs
+
+
+# ===========
+# 3.9 to 3.12
+# ===========
+
+tkinter.tix.[A-Z_]+
+
+
+# =======
+# <= 3.10
+# =======
+
+email.contentmanager.typ
+gettext.install  # codeset default value is ['unspecified'] so can't be specified
+gettext.translation  # codeset default value is ['unspecified'] so can't be specified
+inspect.Signature.from_builtin  # Removed in 3.11, can add if someone needs this
+inspect.Signature.from_function  # Removed in 3.11, can add if someone needs this
+
+# SpooledTemporaryFile implements IO except these methods before Python 3.11
+# See also https://github.com/python/typeshed/pull/2452#issuecomment-420657918
+tempfile.SpooledTemporaryFile.__next__
+tempfile.SpooledTemporaryFile.readable
+tempfile.SpooledTemporaryFile.seekable
+tempfile.SpooledTemporaryFile.writable
+
+tkinter.Tk.split  # Exists at runtime, but missing from stubs
+
+
+# =======
+# <= 3.11
+# =======
+
+_?bz2.BZ2Decompressor.__init__  # function does not accept parameters but C signature is set
+configparser.ParsingError.filename
+enum.Enum._generate_next_value_
 importlib.abc.Finder.find_module
+xml.etree.ElementTree.Element.__bool__  # Doesn't really exist; see comments in stub
+xml.etree.cElementTree.Element.__bool__  # Doesn't really exist; see comments in stub
+
+
+# =======
+# <= 3.12
+# =======
+
+# Exists at runtime, but missing from stubs
+lib2to3.btm_utils
+lib2to3.fixer_util
+lib2to3.patcomp
+lib2to3.pgen2.grammar.Grammar.loads
 lib2to3.pygram.pattern_symbols
 lib2to3.pygram.python_symbols
 lib2to3.pytree.Base.__new__
@@ -23,11 +149,6 @@ lib2to3.pytree.BasePattern.__new__
 lib2to3.pytree.BasePattern.type
 lib2to3.pytree.NegatedPattern.match
 lib2to3.pytree.NegatedPattern.match_seq
-lib2to3.pgen2.grammar.Grammar.loads
-tkinter.Tk.split
-tkinter.tix.[A-Z_]+
-tkinter.tix.TclVersion
-tkinter.tix.TkVersion
 tkinter.tix.CObjView
 tkinter.tix.DialogShell
 tkinter.tix.ExFileSelectDialog
@@ -44,129 +165,82 @@ tkinter.tix.ScrolledTList
 tkinter.tix.ScrolledText
 tkinter.tix.ScrolledWindow
 tkinter.tix.Shell
-types.GenericAlias.__getattr__
-types.GenericAlias.__mro_entries__
-types.GenericAlias.__call__  # Would be complicated to fix properly, Any could silence problems. #6392
-typing._SpecialForm.__mro_entries__
-weakref.ProxyType.__reversed__  # Doesn't really exist
-builtins.ellipsis  # type is not exposed anywhere
+tkinter.tix.TclVersion
+tkinter.tix.TkVersion
 
-xml.etree.ElementTree.Element.__bool__  # Doesn't really exist; see comments in stub
-xml.etree.cElementTree.Element.__bool__  # Doesn't really exist; see comments in stub
 
-# Runtime definition of protocol is incorrect
-importlib.metadata._meta.SimplePath.__truediv__
-importlib.metadata._meta.SimplePath.joinpath
-
-# Modules that exist at runtime, but shouldn't be added to typeshed
-ctypes.test
-ctypes\.test\..+
-lib2to3.tests
-lib2to3\.tests\..+
-sqlite3.test
-sqlite3\.test\..+
-tkinter.test
-tkinter\.test\..+
-unittest.test
-unittest\.test\..+
-
-# Exist at runtime for internal reasons, no need to put them in the stub
-typing_extensions\.TypeAliasType\.__call__
-typing_extensions\.TypeAliasType\.__init_subclass__
-# We call them read-only properties, runtime implementation is slightly different
-typing_extensions\.TypeAliasType\.__(parameters|type_params|name|module|value)__
-
-# Runtime has *args, **kwargs, but will error if any are supplied
-unittest.TestCase.__init_subclass__
-unittest.case.TestCase.__init_subclass__
-
-# SpooledTemporaryFile implements IO except these methods before Python 3.11
-# See also https://github.com/python/typeshed/pull/2452#issuecomment-420657918
-tempfile.SpooledTemporaryFile.__next__
-tempfile.SpooledTemporaryFile.readable
-tempfile.SpooledTemporaryFile.seekable
-tempfile.SpooledTemporaryFile.writable
-
-# The "loop" argument exists at runtime,
-# but raises TypeError if you try to provide any value for it
-asyncio.BoundedSemaphore.__init__
-asyncio.Condition.__init__
-asyncio.Event.__init__
-asyncio.Lock.__init__
-asyncio.Queue.__init__
-asyncio.Semaphore.__init__
-asyncio.locks.BoundedSemaphore.__init__
-asyncio.locks.Semaphore.__init__
-asyncio.locks.Condition.__init__
-asyncio.locks.Event.__init__
-asyncio.locks.Lock.__init__
-asyncio.locks.Semaphore.__init__
-asyncio.queues.Queue.__init__
-
-# Exists at runtime, but missing from stubs
-_collections_abc.AsyncIterable.__class_getitem__
-_collections_abc.Awaitable.__class_getitem__
-_collections_abc.Container.__class_getitem__
-_collections_abc.Iterable.__class_getitem__
-_collections_abc.MappingView.__class_getitem__
-bdb.Breakpoint.clearBreakpoints
-inspect.Signature.from_builtin  # Removed in 3.11, can add if someone needs this
-inspect.Signature.from_function  # Removed in 3.11, can add if someone needs this
-lib2to3.btm_utils
-lib2to3.fixer_util
-lib2to3.patcomp
-
-# ==========
-# Related to positional-only arguments
-# ==========
-
-# These are not positional-only at runtime, but we treat them
-# as positional-only to match dict.
-_collections_abc.MutableMapping.pop
-_collections_abc.MutableMapping.setdefault
-
-# typing.IO uses positional-or-keyword arguments, but in the stubs we prefer
-# to mark these as positional-only for compatibility with existing sub-classes.
-typing(_extensions)?\.BinaryIO\.write
-typing(_extensions)?\.IO\.read
-typing(_extensions)?\.IO\.readline
-typing(_extensions)?\.IO\.readlines
-typing(_extensions)?\.IO\.seek
-typing(_extensions)?\.IO\.truncate
-typing(_extensions)?\.IO\.write
-typing(_extensions)?\.IO\.writelines
-
-# positional-only complaints caused by differences between typing aliases and the "real" classes in the stdlib
-_collections_abc.Coroutine.send
-_collections_abc.Coroutine.throw
-_collections_abc.Generator.send
-_collections_abc.Generator.throw
-
-# typing.SupportsRound.__round__  # pos-or-kw at runtime, but we pretend it's pos-only in the stub so that e.g. float.__round__ satisfies the interface
-types.DynamicClassAttribute..*  # In the stub we pretend it's an alias for property, but it has positional-only differences
-
-# These three have a pos-or-keyword first parameter at runtime, but deliberately have a pos-only first parameter in the stub. #6812
-posixpath.join
-ntpath.join
-os.path.join
-
-# ==========
-# Allowlist entries that cannot or should not be fixed
-# ==========
-
-# Factory function at runtime
-# but that wouldn't let us use it in type hints
-threading.Lock
-multiprocessing.dummy.Lock
+# =============================================================
+# Allowlist entries that cannot or should not be fixed; >= 3.10
+# =============================================================
 
 # Runtime AST node runtime constructor behaviour is too loose.
 # For static typing, the loose behaviour is undesirable (https://github.com/python/typeshed/issues/8378).
 # For the runtime, the loose behaviour is deprecated in Python 3.13 (https://github.com/python/cpython/issues/105858)
 _?ast.pattern.__init__
 
-# more precise signature in the stubs than at runtime
-multiprocessing.managers.DictProxy.clear
-multiprocessing.managers.DictProxy.popitem
+_collections_abc.AsyncGenerator.athrow  # async at runtime, deliberately not in the stub, see #7491. Pos-only differences also.
+builtins.property.__set_name__  # Doesn't actually exist
+collections\.UserList\.index  # ignoring pos-or-keyword parameter
+dataclasses.KW_ONLY  # white lies around defaults
+importlib.metadata._meta.SimplePath.joinpath  # Runtime definition of protocol is incorrect
+unittest.TestCase.__init_subclass__  # Runtime has *args, **kwargs, but will error if any are supplied
+unittest.case.TestCase.__init_subclass__  # Runtime has *args, **kwargs, but will error if any are supplied
+
+
+# ============================================================
+# Allowlist entries that cannot or should not be fixed; >= 3.9
+# ============================================================
+
+_ast.ImportFrom.level  # None on the class, but never None on instances
+_weakref.ProxyType.__reversed__  # Doesn't really exist
+ast.ImportFrom.level  # None on the class, but never None on instances
+ast.ExtSlice.__new__  # C signature is broader than what is actually accepted
+ast.Index.__new__  # C signature is broader than what is actually accepted
+
+# Treated an alias of a typing class in the stubs,
+# they are generic to type checkers anyway.
+contextlib.AbstractAsyncContextManager.__class_getitem__
+contextlib.AbstractContextManager.__class_getitem__
+
+functools._lru_cache_wrapper.cache_parameters  # Cannot be detected statically
+importlib.abc.Traversable.open  # Problematic protocol signature at runtime, see source code comments.
+os.PathLike.__class_getitem__  # PathLike is a protocol; we don't expect all PathLike classes to implement class_getitem
+types.GenericAlias.__call__  # Would be complicated to fix properly, Any could silence problems. #6392
+types.GenericAlias.__getattr__
+types.GenericAlias.__mro_entries__
+typing\.NamedTuple  # Super-special typing primitive
+weakref.ProxyType.__reversed__  # Doesn't really exist
+
+
+# ===============================================================
+# Allowlist entries that cannot or should not be fixed; 3.10 only
+# ===============================================================
+
+importlib.abc.Traversable.joinpath  # Problematic protocol signatures at runtime, see source code comments.
+
+
+# ==================================================================
+# Allowlist entries that cannot or should not be fixed; 3.10 to 3.11
+# ==================================================================
+
+# Deprecation wrapper classes; their methods are just pass-through, so we can ignore them.
+importlib.metadata.DeprecatedList.reverse
+importlib.metadata.DeprecatedList.sort
+
+# We pretend it's a read-only property for forward compatibility with 3.12
+typing.ParamSpec(Args|Kwargs).__origin__
+
+
+# =================================================================
+# Allowlist entries that cannot or should not be fixed; 3.9 to 3.12
+# =================================================================
+
+typing\.Annotated  # Super-special typing primitive
+
+
+# =============================================================
+# Allowlist entries that cannot or should not be fixed; <= 3.10
+# =============================================================
 
 # Side effects from module initialization
 _compat_pickle.excname
@@ -179,10 +253,52 @@ json.encoder.i
 lib2to3.pgen2.grammar.line
 lib2to3.pgen2.grammar.name
 lib2to3.pgen2.grammar.op
-poplib.POP3_SSL.stls  # bad declaration of inherited function. See poplib.pyi
+
+pstats.SortKey.__new__  # Derives from (str, Enum)
 pydoc.Helper.symbol  # Loop variable in class https://github.com/python/typeshed/issues/6401#issuecomment-981178522
 pydoc.Helper.symbols_  # Loop variable in class https://github.com/python/typeshed/issues/6401#issuecomment-981178522
 pydoc.Helper.topic  # Loop variable in class https://github.com/python/typeshed/issues/6401#issuecomment-981178522
+sqlite3.test  # Modules that exist at runtime, but shouldn't be added to typeshed
+sqlite3\.test\..+  # Modules that exist at runtime, but shouldn't be added to typeshed
+tkinter.EventType.__new__  # Derives from (str, Enum)
+types.CodeType.replace  # stubtest thinks default values are None but None doesn't work at runtime
+
+
+# =============================================================
+# Allowlist entries that cannot or should not be fixed; <= 3.11
+# =============================================================
+
+.*.__buffer__  # We lie about the existence of these methods
+.*.__release_buffer__  # We lie about the existence of these methods
+asynchat.async_chat.encoding  # Removed in 3.12
+asynchat.async_chat.use_encoding  # Removed in 3.12
+asynchat.find_prefix_at_end  # Removed in 3.12
+asyncore.dispatcher.addr  # Removed in 3.12
+asyncore.dispatcher.handle_accepted  # Removed in 3.12
+ctypes.test  # Modules that exist at runtime, but shouldn't be added to typeshed
+ctypes\.test\..+  # Modules that exist at runtime, but shouldn't be added to typeshed
+distutils\..*  # Removed in 3.12
+lib2to3.tests  # Modules that exist at runtime, but shouldn't be added to typeshed
+lib2to3\.tests\..+  # Modules that exist at runtime, but shouldn't be added to typeshed
+pkgutil.ImpImporter\..*  # Removed in 3.12
+pkgutil.ImpLoader\..*  # Removed in 3.12
+poplib.POP3_SSL.stls  # bad declaration of inherited function. See poplib.pyi
+tkinter.test  # Modules that exist at runtime, but shouldn't be added to typeshed
+tkinter\.test\..+  # Modules that exist at runtime, but shouldn't be added to typeshed
+
+# Exist at runtime for internal reasons, no need to put them in the stub
+typing_extensions\.TypeAliasType\.__call__
+typing_extensions\.TypeAliasType\.__init_subclass__
+# We call them read-only properties, runtime implementation is slightly different
+typing_extensions\.TypeAliasType\.__(parameters|type_params|name|module|value)__
+
+unittest.test  # Modules that exist at runtime, but shouldn't be added to typeshed
+unittest\.test\..+  # Modules that exist at runtime, but shouldn't be added to typeshed
+
+
+# =============================================================
+# Allowlist entries that cannot or should not be fixed; <= 3.12
+# =============================================================
 
 # Undocumented implementation details
 cgi.FieldStorage.bufsize
@@ -194,34 +310,11 @@ cgi.FieldStorage.read_multi
 cgi.FieldStorage.read_single
 cgi.FieldStorage.read_urlencoded
 cgi.FieldStorage.skip_lines
-pipes.Template.makepipeline
-pipes.Template.open_r
-pipes.Template.open_w
-sunau.Au_read.initfp
-sunau.Au_write.initfp
-typing_extensions\.Annotated
 
-# C signature is broader than what is actually accepted
-ast.ExtSlice.__new__
-ast.Index.__new__
-
-os.PathLike.__class_getitem__  # PathLike is a protocol; we don't expect all PathLike classes to implement class_getitem
-_ast.ImportFrom.level  # None on the class, but never None on instances
-ast.ImportFrom.level  # None on the class, but never None on instances
-
-# White lies around defaults
-dataclasses.KW_ONLY
-
-# We pretend it's a read-only property for forward compatibility with 3.12
-typing.ParamSpec(Args|Kwargs).__origin__
-
-# Problematic protocol signatures at runtime, see source code comments.
-importlib.abc.Traversable.joinpath
-importlib.abc.Traversable.open
-
-# Deprecation wrapper classes; their methods are just pass-through, so we can ignore them.
-importlib.metadata.DeprecatedList.reverse
-importlib.metadata.DeprecatedList.sort
+ctypes._endian.DEFAULT_MODE  # Incorrectly star import.
+ctypes._endian.RTLD_GLOBAL  # Incorrectly star import.
+ctypes._endian.RTLD_LOCAL  # Incorrectly star import.
+multiprocessing.dummy.Lock  # Factory function at runtime, but that wouldn't let us use it in type hints
 
 # These multiprocessing proxy methods have *args, **kwargs signatures at runtime,
 # But have more precise (accurate) signatures in the stub
@@ -232,32 +325,17 @@ multiprocessing.managers.DictProxy.items
 multiprocessing.managers.DictProxy.keys
 multiprocessing.managers.DictProxy.values
 
-# Super-special typing primitives
-typing\.NamedTuple
-typing\.Annotated
+# Runtime signature is incorrect (https://github.com/python/cpython/issues/93021)
+multiprocessing.managers.DictProxy.clear
+multiprocessing.managers.DictProxy.popitem
 
-# We lie about the existence of these methods
-.*.__buffer__
-.*.__release_buffer__
+# Undocumented implementation details
+pipes.Template.makepipeline
+pipes.Template.open_r
+pipes.Template.open_w
+sunau.Au_read.initfp
+sunau.Au_write.initfp
 
-# Removed in 3.12
-distutils\..*
-asyncore.dispatcher.addr
-asyncore.dispatcher.handle_accepted
-asynchat.async_chat.encoding
-asynchat.async_chat.use_encoding
-asynchat.find_prefix_at_end
-pkgutil.ImpImporter\..*
-pkgutil.ImpLoader\..*
-
-types.CodeType.replace  # stubtest thinks default values are None but None doesn't work at runtime
-types.SimpleNamespace.__init__ # class doesn't accept positional arguments but has default C signature
-
-# These enums derive from (str, Enum)
-pstats.SortKey.__new__
-tkinter.EventType.__new__
-
-# Incorrectly star import.
-ctypes._endian.DEFAULT_MODE
-ctypes._endian.RTLD_GLOBAL
-ctypes._endian.RTLD_LOCAL
+threading.Lock  # Factory function at runtime, but that wouldn't let us use it in type hints
+types.SimpleNamespace.__init__  # class doesn't accept positional arguments but has default C signature
+typing_extensions\.Annotated  # Undocumented implementation details

--- a/stdlib/@tests/stubtest_allowlists/py311.txt
+++ b/stdlib/@tests/stubtest_allowlists/py311.txt
@@ -79,13 +79,6 @@ _collections_abc.MappingView.__class_getitem__
 importlib.metadata._meta.SimplePath.__truediv__  # Runtime definition of protocol is incorrect
 
 
-# ===========
-# 3.9 to 3.12
-# ===========
-
-tkinter.tix.[A-Z_]+
-
-
 # =======
 # <= 3.11
 # =======
@@ -116,6 +109,7 @@ lib2to3.pytree.BasePattern.__new__
 lib2to3.pytree.BasePattern.type
 lib2to3.pytree.NegatedPattern.match
 lib2to3.pytree.NegatedPattern.match_seq
+tkinter.tix.[A-Z_]+
 tkinter.tix.CObjView
 tkinter.tix.DialogShell
 tkinter.tix.ExFileSelectDialog

--- a/stdlib/@tests/stubtest_allowlists/py311.txt
+++ b/stdlib/@tests/stubtest_allowlists/py311.txt
@@ -1,17 +1,112 @@
+# =========================
+# New errors in Python 3.11
+# =========================
+
+
+# =======
+# >= 3.11
+# =======
+
+enum.Enum.__init__
+typing.NewType.__mro_entries__
+
+
+# =========
+# 3.11 only
+# =========
+
+# Not strictly speaking a staticmethod on 3.11, but it acts like one:
+enum.StrEnum._generate_next_value_
+
+
+# ====================================
+# Pre-existing errors from Python 3.10
+# ====================================
+
+
+# =======
+# >= 3.10
+# =======
+
+builtins.ellipsis  # type is not exposed anywhere
+importlib._abc.Loader.exec_module  # See Lib/importlib/_abc.py. Might be defined for backwards compatibility
+
+# positional-only complaints caused by differences between typing aliases and the "real" classes in the stdlib
+_collections_abc.Coroutine.send
+_collections_abc.Coroutine.throw
+_collections_abc.Generator.send
+_collections_abc.Generator.throw
+
+# These are not positional-only at runtime, but we treat them as positional-only to match dict.
+_collections_abc.MutableMapping.pop
+_collections_abc.MutableMapping.setdefault
+
+# These three have a pos-or-keyword first parameter at runtime, but deliberately have a pos-only first parameter in the stub. #6812
+posixpath.join
+ntpath.join
+os.path.join
+
+types.DynamicClassAttribute..*  # In the stub we pretend it's an alias for property, but it has positional-only differences
+
+# typing.IO uses positional-or-keyword arguments, but in the stubs we prefer
+# to mark these as positional-only for compatibility with existing sub-classes.
+typing(_extensions)?\.BinaryIO\.write
+typing(_extensions)?\.IO\.read
+typing(_extensions)?\.IO\.readline
+typing(_extensions)?\.IO\.readlines
+typing(_extensions)?\.IO\.seek
+typing(_extensions)?\.IO\.truncate
+typing(_extensions)?\.IO\.write
+typing(_extensions)?\.IO\.writelines
+
+
+# ======
+# >= 3.9
+# ======
+
+# Exists at runtime, but missing from stubs
 _collections_abc.AsyncIterable.__class_getitem__
 _collections_abc.Awaitable.__class_getitem__
 _collections_abc.Container.__class_getitem__
 _collections_abc.Iterable.__class_getitem__
 _collections_abc.MappingView.__class_getitem__
+
+
+# ============
+# 3.10 to 3.11
+# ============
+
+importlib.metadata._meta.SimplePath.__truediv__  # Runtime definition of protocol is incorrect
+
+
+# ===========
+# 3.9 to 3.12
+# ===========
+
+tkinter.tix.[A-Z_]+
+
+
+# =======
+# <= 3.11
+# =======
+
 _?bz2.BZ2Decompressor.__init__  # function does not accept parameters but C signature is set
 configparser.ParsingError.filename
-collections\.UserList\.index  # ignoring pos-or-keyword parameter
-enum.Enum.__init__
 enum.Enum._generate_next_value_
-# Not strictly speaking a staticmethod on 3.11, but it acts like one:
-enum.StrEnum._generate_next_value_
-importlib._abc.Loader.exec_module  # See Lib/importlib/_abc.py. Might be defined for backwards compatibility
 importlib.abc.Finder.find_module
+xml.etree.ElementTree.Element.__bool__  # Doesn't really exist; see comments in stub
+xml.etree.cElementTree.Element.__bool__  # Doesn't really exist; see comments in stub
+
+
+# =======
+# <= 3.12
+# =======
+
+# Exists at runtime, but missing from stubs
+lib2to3.btm_utils
+lib2to3.fixer_util
+lib2to3.patcomp
+lib2to3.pgen2.grammar.Grammar.loads
 lib2to3.pygram.pattern_symbols
 lib2to3.pygram.python_symbols
 lib2to3.pytree.Base.__new__
@@ -21,13 +116,6 @@ lib2to3.pytree.BasePattern.__new__
 lib2to3.pytree.BasePattern.type
 lib2to3.pytree.NegatedPattern.match
 lib2to3.pytree.NegatedPattern.match_seq
-lib2to3.btm_utils
-lib2to3.fixer_util
-lib2to3.patcomp
-lib2to3.pgen2.grammar.Grammar.loads
-tkinter.tix.[A-Z_]+
-tkinter.tix.TclVersion
-tkinter.tix.TkVersion
 tkinter.tix.CObjView
 tkinter.tix.DialogShell
 tkinter.tix.ExFileSelectDialog
@@ -44,103 +132,137 @@ tkinter.tix.ScrolledTList
 tkinter.tix.ScrolledText
 tkinter.tix.ScrolledWindow
 tkinter.tix.Shell
-typing.NewType.__mro_entries__
-builtins.ellipsis  # type is not exposed anywhere
+tkinter.tix.TclVersion
+tkinter.tix.TkVersion
 
-xml.etree.ElementTree.Element.__bool__  # Doesn't really exist; see comments in stub
-xml.etree.cElementTree.Element.__bool__  # Doesn't really exist; see comments in stub
 
-# Runtime definition of protocol is incorrect
-importlib.metadata._meta.SimplePath.__truediv__
-importlib.metadata._meta.SimplePath.joinpath
+# =============================================================
+# Allowlist entries that cannot or should not be fixed; >= 3.11
+# =============================================================
 
-# Modules that exist at runtime, but shouldn't be added to typeshed
-ctypes.test
-ctypes\.test\..+
-lib2to3.tests
-lib2to3\.tests\..+
-tkinter.test
-tkinter\.test\..+
-unittest.test
-unittest\.test\..+
+argparse._MutuallyExclusiveGroup.add_mutually_exclusive_group  # deprecated, forwards arguments to super
+enum.auto.__init__  # The stub for enum.auto is nothing like the implementation
+enum.auto.value  # The stub for enum.auto is nothing like the implementation
+http.HTTPMethod.description  # mutable instance attribute at runtime but we pretend it's a property
+importlib.resources.abc.Traversable.open  # Problematic protocol signature at runtime, see source code comments.
+inspect._ParameterKind.description  # Still exists, but stubtest can't see it
+typing\._SpecialForm.*  # Super-special typing primitive
+typing\.LiteralString  # Super-special typing primitive
 
-# ==========
-# Related to positional-only arguments
-# ==========
 
-# These are not positional-only at runtime, but we treat them
-# as positional-only to match dict.
-_collections_abc.MutableMapping.pop
-_collections_abc.MutableMapping.setdefault
-
-# typing.IO uses positional-or-keyword arguments, but in the stubs we prefer
-# to mark these as positional-only for compatibility with existing sub-classes.
-typing(_extensions)?\.BinaryIO\.write
-typing(_extensions)?\.IO\.read
-typing(_extensions)?\.IO\.readline
-typing(_extensions)?\.IO\.readlines
-typing(_extensions)?\.IO\.seek
-typing(_extensions)?\.IO\.truncate
-typing(_extensions)?\.IO\.write
-typing(_extensions)?\.IO\.writelines
-
-# positional-only complaints caused by differences between typing aliases and the "real" classes in the stdlib
-_collections_abc.Coroutine.send
-_collections_abc.Coroutine.throw
-_collections_abc.Generator.send
-_collections_abc.Generator.throw
-
-# typing.SupportsRound.__round__  # pos-or-kw at runtime, but we pretend it's pos-only in the stub so that e.g. float.__round__ satisfies the interface
-types.DynamicClassAttribute..*  # In the stub we pretend it's an alias for property, but it has positional-only differences
-
-# These three have a pos-or-keyword first parameter at runtime, but deliberately have a pos-only first parameter in the stub. #6812
-posixpath.join
-ntpath.join
-os.path.join
-
-# ==========
-# Allowlist entries that cannot or should not be fixed
-# ==========
-
-configparser.LegacyInterpolation.__init__  # runtime is *args, **kwargs, but it's just a passthrough
-
-# Factory function at runtime
-# but that wouldn't let us use it in type hints
-threading.Lock
-multiprocessing.dummy.Lock
-
-# more precise signature in the stubs than at runtime
-multiprocessing.managers.DictProxy.clear
-multiprocessing.managers.DictProxy.popitem
+# =============================================================
+# Allowlist entries that cannot or should not be fixed; >= 3.10
+# =============================================================
 
 # Runtime AST node runtime constructor behaviour is too loose.
 # For static typing, the loose behaviour is undesirable (https://github.com/python/typeshed/issues/8378).
 # For the runtime, the loose behaviour is deprecated in Python 3.13 (https://github.com/python/cpython/issues/105858)
 _?ast.pattern.__init__
 
-_ast.ImportFrom.level  # None on the class, but never None on instances
 _collections_abc.AsyncGenerator.athrow  # async at runtime, deliberately not in the stub, see #7491. Pos-only differences also.
+builtins.property.__set_name__  # Doesn't actually exist
+collections\.UserList\.index  # ignoring pos-or-keyword parameter
+dataclasses.KW_ONLY  # white lies around defaults
+importlib.metadata._meta.SimplePath.joinpath  # Runtime definition of protocol is incorrect
+unittest.TestCase.__init_subclass__  # Runtime has *args, **kwargs, but will error if any are supplied
+unittest.case.TestCase.__init_subclass__  # Runtime has *args, **kwargs, but will error if any are supplied
+
+
+# ============================================================
+# Allowlist entries that cannot or should not be fixed; >= 3.9
+# ============================================================
+
+_ast.ImportFrom.level  # None on the class, but never None on instances
 _weakref.ProxyType.__reversed__  # Doesn't really exist
 ast.ImportFrom.level  # None on the class, but never None on instances
-argparse._MutuallyExclusiveGroup.add_mutually_exclusive_group  # deprecated, forwards arguments to super
-builtins.property.__set_name__  # Doesn't actually exist
-dataclasses.KW_ONLY  # white lies around defaults
-enum.auto.__init__  # The stub for enum.auto is nothing like the implementation
-enum.auto.value  # The stub for enum.auto is nothing like the implementation
+ast.ExtSlice.__new__  # C signature is broader than what is actually accepted
+ast.Index.__new__  # C signature is broader than what is actually accepted
+
+# Treated an alias of a typing class in the stubs,
+# they are generic to type checkers anyway.
+contextlib.AbstractAsyncContextManager.__class_getitem__
+contextlib.AbstractContextManager.__class_getitem__
+
 functools._lru_cache_wrapper.cache_parameters  # Cannot be detected statically
-http.HTTPMethod.description  # mutable instance attribute at runtime but we pretend it's a property
-inspect._ParameterKind.description  # Still exists, but stubtest can't see it
+importlib.abc.Traversable.open  # Problematic protocol signature at runtime, see source code comments.
 os.PathLike.__class_getitem__  # PathLike is a protocol; we don't expect all PathLike classes to implement class_getitem
-poplib.POP3_SSL.stls  # bad declaration of inherited function. See poplib.pyi
 types.GenericAlias.__call__  # Would be complicated to fix properly, Any could silence problems. #6392
-types.SimpleNamespace.__init__ # class doesn't accept positional arguments but has default C signature
 types.GenericAlias.__getattr__
 types.GenericAlias.__mro_entries__
+typing\.NamedTuple  # Super-special typing primitive
 weakref.ProxyType.__reversed__  # Doesn't really exist
 
-# C signature is broader than what is actually accepted
-ast.ExtSlice.__new__
-ast.Index.__new__
+
+# ===============================================================
+# Allowlist entries that cannot or should not be fixed; 3.11 only
+# ===============================================================
+
+# We pretend it's a read-only property for forward compatibility with 3.12
+typing\.TypeVar\.__.*__
+typing\.ParamSpec\.__.*__
+
+
+# ==================================================================
+# Allowlist entries that cannot or should not be fixed; 3.11 to 3.12
+# ==================================================================
+
+configparser.LegacyInterpolation.__init__  # runtime is *args, **kwargs, but it's just a passthrough
+
+
+# ==================================================================
+# Allowlist entries that cannot or should not be fixed; 3.10 to 3.11
+# ==================================================================
+
+# Deprecation wrapper classes; their methods are just pass-through, so we can ignore them.
+importlib.metadata.DeprecatedList.reverse
+importlib.metadata.DeprecatedList.sort
+
+# We pretend it's a read-only property for forward compatibility with 3.12
+typing.ParamSpec(Args|Kwargs).__origin__
+
+
+# =================================================================
+# Allowlist entries that cannot or should not be fixed; 3.9 to 3.12
+# =================================================================
+
+typing\.Annotated  # Super-special typing primitive
+
+
+# =============================================================
+# Allowlist entries that cannot or should not be fixed; <= 3.11
+# =============================================================
+
+.*.__buffer__  # We lie about the existence of these methods
+.*.__release_buffer__  # We lie about the existence of these methods
+asynchat.async_chat.encoding  # Removed in 3.12
+asynchat.async_chat.use_encoding  # Removed in 3.12
+asynchat.find_prefix_at_end  # Removed in 3.12
+asyncore.dispatcher.addr  # Removed in 3.12
+asyncore.dispatcher.handle_accepted  # Removed in 3.12
+ctypes.test  # Modules that exist at runtime, but shouldn't be added to typeshed
+ctypes\.test\..+  # Modules that exist at runtime, but shouldn't be added to typeshed
+distutils\..*  # Removed in 3.12
+lib2to3.tests  # Modules that exist at runtime, but shouldn't be added to typeshed
+lib2to3\.tests\..+  # Modules that exist at runtime, but shouldn't be added to typeshed
+pkgutil.ImpImporter\..*  # Removed in 3.12
+pkgutil.ImpLoader\..*  # Removed in 3.12
+poplib.POP3_SSL.stls  # bad declaration of inherited function. See poplib.pyi
+tkinter.test  # Modules that exist at runtime, but shouldn't be added to typeshed
+tkinter\.test\..+  # Modules that exist at runtime, but shouldn't be added to typeshed
+
+# Exist at runtime for internal reasons, no need to put them in the stub
+typing_extensions\.TypeAliasType\.__call__
+typing_extensions\.TypeAliasType\.__init_subclass__
+# We call them read-only properties, runtime implementation is slightly different
+typing_extensions\.TypeAliasType\.__(parameters|type_params|name|module|value)__
+
+unittest.test  # Modules that exist at runtime, but shouldn't be added to typeshed
+unittest\.test\..+  # Modules that exist at runtime, but shouldn't be added to typeshed
+
+
+# =============================================================
+# Allowlist entries that cannot or should not be fixed; <= 3.12
+# =============================================================
 
 # Undocumented implementation details
 cgi.FieldStorage.bufsize
@@ -152,29 +274,11 @@ cgi.FieldStorage.read_multi
 cgi.FieldStorage.read_single
 cgi.FieldStorage.read_urlencoded
 cgi.FieldStorage.skip_lines
-pipes.Template.makepipeline
-pipes.Template.open_r
-pipes.Template.open_w
-sunau.Au_read.initfp
-sunau.Au_write.initfp
-typing_extensions\.Annotated
 
-# Treated an alias of a typing class in the stubs,
-# they are generic to type checkers anyway.
-contextlib.AbstractAsyncContextManager.__class_getitem__
-contextlib.AbstractContextManager.__class_getitem__
-
-# Runtime has *args, **kwargs, but will error if any are supplied
-unittest.TestCase.__init_subclass__
-unittest.case.TestCase.__init_subclass__
-
-# Problematic protocol signature at runtime, see source code comments.
-importlib.abc.Traversable.open
-importlib.resources.abc.Traversable.open
-
-# Deprecation wrapper classes; their methods are just pass-through, so we can ignore them.
-importlib.metadata.DeprecatedList.reverse
-importlib.metadata.DeprecatedList.sort
+ctypes._endian.DEFAULT_MODE  # Incorrectly star import.
+ctypes._endian.RTLD_GLOBAL  # Incorrectly star import.
+ctypes._endian.RTLD_LOCAL  # Incorrectly star import.
+multiprocessing.dummy.Lock  # Factory function at runtime, but that wouldn't let us use it in type hints
 
 # These multiprocessing proxy methods have *args, **kwargs signatures at runtime,
 # But have more precise (accurate) signatures in the stub
@@ -185,38 +289,17 @@ multiprocessing.managers.DictProxy.items
 multiprocessing.managers.DictProxy.keys
 multiprocessing.managers.DictProxy.values
 
-# Super-special typing primitives
-typing\._SpecialForm.*
-typing\.NamedTuple
-typing\.LiteralString
-typing\.Annotated
+# Runtime signature is incorrect (https://github.com/python/cpython/issues/93021)
+multiprocessing.managers.DictProxy.clear
+multiprocessing.managers.DictProxy.popitem
 
-# We pretend it's a read-only property for forward compatibility with 3.12
-typing.ParamSpec(Args|Kwargs).__origin__
-typing\.TypeVar\.__.*__
-typing\.ParamSpec\.__.*__
+# Undocumented implementation details
+pipes.Template.makepipeline
+pipes.Template.open_r
+pipes.Template.open_w
+sunau.Au_read.initfp
+sunau.Au_write.initfp
 
-# Exist at runtime for internal reasons, no need to put them in the stub
-typing_extensions\.TypeAliasType\.__call__
-typing_extensions\.TypeAliasType\.__init_subclass__
-# We call them read-only properties, runtime implementation is slightly different
-typing_extensions\.TypeAliasType\.__(parameters|type_params|name|module|value)__
-
-# We lie about the existence of these methods
-.*.__buffer__
-.*.__release_buffer__
-
-# Removed in 3.12
-distutils\..*
-asyncore.dispatcher.addr
-asyncore.dispatcher.handle_accepted
-asynchat.async_chat.encoding
-asynchat.async_chat.use_encoding
-asynchat.find_prefix_at_end
-pkgutil.ImpImporter\..*
-pkgutil.ImpLoader\..*
-
-# Incorrectly star import.
-ctypes._endian.DEFAULT_MODE
-ctypes._endian.RTLD_GLOBAL
-ctypes._endian.RTLD_LOCAL
+threading.Lock  # Factory function at runtime, but that wouldn't let us use it in type hints
+types.SimpleNamespace.__init__  # class doesn't accept positional arguments but has default C signature
+typing_extensions\.Annotated  # Undocumented implementation details

--- a/stdlib/@tests/stubtest_allowlists/py312.txt
+++ b/stdlib/@tests/stubtest_allowlists/py312.txt
@@ -72,13 +72,6 @@ _collections_abc.Iterable.__class_getitem__
 _collections_abc.MappingView.__class_getitem__
 
 
-# ===========
-# 3.9 to 3.12
-# ===========
-
-tkinter.tix.[A-Z_]+
-
-
 # =======
 # <= 3.12
 # =======
@@ -97,6 +90,7 @@ lib2to3.pytree.BasePattern.__new__
 lib2to3.pytree.BasePattern.type
 lib2to3.pytree.NegatedPattern.match
 lib2to3.pytree.NegatedPattern.match_seq
+tkinter.tix.[A-Z_]+
 tkinter.tix.CObjView
 tkinter.tix.DialogShell
 tkinter.tix.ExFileSelectDialog

--- a/stdlib/@tests/stubtest_allowlists/py312.txt
+++ b/stdlib/@tests/stubtest_allowlists/py312.txt
@@ -1,14 +1,93 @@
-# Modules that exist at runtime, but are missing from typeshed
-zipfile._path.glob
+# =========================
+# New errors in Python 3.12
+# =========================
 
-# Errors that also existed on Python 3.11
+
+# =======
+# >= 3.12
+# =======
+
+zipfile._path.glob  # Modules that exist at runtime, but are missing from typeshed
+zoneinfo.ZoneInfo.from_file  # Pos-only parameters had different "names" in different Python versions
+
+
+# ====================================
+# Pre-existing errors from Python 3.11
+# ====================================
+
+
+# =======
+# >= 3.11
+# =======
+
+enum.Enum.__init__
+typing.NewType.__mro_entries__
+
+
+# =======
+# >= 3.10
+# =======
+
+builtins.ellipsis  # type is not exposed anywhere
+importlib._abc.Loader.exec_module  # See Lib/importlib/_abc.py. Might be defined for backwards compatibility
+
+# positional-only complaints caused by differences between typing aliases and the "real" classes in the stdlib
+_collections_abc.Coroutine.send
+_collections_abc.Coroutine.throw
+_collections_abc.Generator.send
+_collections_abc.Generator.throw
+
+# These are not positional-only at runtime, but we treat them as positional-only to match dict.
+_collections_abc.MutableMapping.pop
+_collections_abc.MutableMapping.setdefault
+
+# These three have a pos-or-keyword first parameter at runtime, but deliberately have a pos-only first parameter in the stub. #6812
+posixpath.join
+ntpath.join
+os.path.join
+
+types.DynamicClassAttribute..*  # In the stub we pretend it's an alias for property, but it has positional-only differences
+
+# typing.IO uses positional-or-keyword arguments, but in the stubs we prefer
+# to mark these as positional-only for compatibility with existing sub-classes.
+typing(_extensions)?\.BinaryIO\.write
+typing(_extensions)?\.IO\.read
+typing(_extensions)?\.IO\.readline
+typing(_extensions)?\.IO\.readlines
+typing(_extensions)?\.IO\.seek
+typing(_extensions)?\.IO\.truncate
+typing(_extensions)?\.IO\.write
+typing(_extensions)?\.IO\.writelines
+
+
+# ======
+# >= 3.9
+# ======
+
+# Exists at runtime, but missing from stubs
 _collections_abc.AsyncIterable.__class_getitem__
 _collections_abc.Awaitable.__class_getitem__
 _collections_abc.Container.__class_getitem__
 _collections_abc.Iterable.__class_getitem__
 _collections_abc.MappingView.__class_getitem__
-enum.Enum.__init__
-importlib._abc.Loader.exec_module  # See Lib/importlib/_abc.py. Might be defined for backwards compatibility
+
+
+# ===========
+# 3.9 to 3.12
+# ===========
+
+tkinter.tix.[A-Z_]+
+
+
+# =======
+# <= 3.12
+# =======
+
+# Exists at runtime, but missing from stubs
+lib2to3.btm_utils
+lib2to3.fixer_util
+lib2to3.patcomp
+lib2to3.pgen2.grammar.Grammar.loads
 lib2to3.pygram.pattern_symbols
 lib2to3.pygram.python_symbols
 lib2to3.pytree.Base.__new__
@@ -18,13 +97,6 @@ lib2to3.pytree.BasePattern.__new__
 lib2to3.pytree.BasePattern.type
 lib2to3.pytree.NegatedPattern.match
 lib2to3.pytree.NegatedPattern.match_seq
-lib2to3.btm_utils
-lib2to3.fixer_util
-lib2to3.patcomp
-lib2to3.pgen2.grammar.Grammar.loads
-tkinter.tix.[A-Z_]+
-tkinter.tix.TclVersion
-tkinter.tix.TkVersion
 tkinter.tix.CObjView
 tkinter.tix.DialogShell
 tkinter.tix.ExFileSelectDialog
@@ -41,60 +113,126 @@ tkinter.tix.ScrolledTList
 tkinter.tix.ScrolledText
 tkinter.tix.ScrolledWindow
 tkinter.tix.Shell
-typing.NewType.__mro_entries__
-builtins.ellipsis  # type is not exposed anywhere
+tkinter.tix.TclVersion
+tkinter.tix.TkVersion
 
-# ==========
-# Related to positional-only arguments
-# ==========
 
-# These are not positional-only at runtime, but we treat them
-# as positional-only to match dict.
-_collections_abc.MutableMapping.pop
-_collections_abc.MutableMapping.setdefault
+# =============================================================
+# Allowlist entries that cannot or should not be fixed; >= 3.12
+# =============================================================
 
-# typing.IO uses positional-or-keyword arguments, but in the stubs we prefer
-# to mark these as positional-only for compatibility with existing sub-classes.
-typing(_extensions)?\.BinaryIO\.write
-typing(_extensions)?\.IO\.read
-typing(_extensions)?\.IO\.readline
-typing(_extensions)?\.IO\.readlines
-typing(_extensions)?\.IO\.seek
-typing(_extensions)?\.IO\.truncate
-typing(_extensions)?\.IO\.write
-typing(_extensions)?\.IO\.writelines
+# Runtime AST node runtime constructor behaviour is too loose.
+# For static typing, the loose behaviour is undesirable (https://github.com/python/typeshed/issues/8378).
+# For the runtime, the loose behaviour is deprecated in Python 3.13 (https://github.com/python/cpython/issues/105858)
+_?ast.type_param.__init__
 
-# positional-only complaints caused by differences between typing aliases and the "real" classes in the stdlib
-_collections_abc.Coroutine.send
-_collections_abc.Coroutine.throw
-_collections_abc.Generator.send
-_collections_abc.Generator.throw
+# Deprecation wrapper classes; their methods are just pass-through, so we can ignore them.
+importlib.metadata.DeprecatedNonAbstract.__new__
 
-# typing.SupportsRound.__round__  # pos-or-kw at runtime, but we pretend it's pos-only in the stub so that e.g. float.__round__ satisfies the interface
-types.DynamicClassAttribute..*  # In the stub we pretend it's an alias for property, but it has positional-only differences
+# Deprecated argument is supported at runtime by renaming it through a decorator.
+importlib.resources._common.files
+importlib.resources.files
 
-# These three have a pos-or-keyword first parameter at runtime, but deliberately have a pos-only first parameter in the stub. #6812
-posixpath.join
-ntpath.join
-os.path.join
+sys._monitoring  # Doesn't really exist. See comments in the stub.
+sys.last_exc  # not always defined
 
-# Pos-only parameters had different "names" in different Python versions:
-zoneinfo.ZoneInfo.from_file
+# These only exist to give a better error message if you try to subclass an instance
+typing.ParamSpec.__mro_entries__
+typing.ParamSpecArgs.__mro_entries__
+typing.ParamSpecKwargs.__mro_entries__
+typing.TypeVar.__mro_entries__
+typing.TypeVarTuple.__mro_entries__
 
-# ==========
-# Allowlist entries that cannot or should not be fixed
-# ==========
+# TODO: mypy should infer that this attribute is inherited from builtins.type;
+# why doesn't it infer this?
+typing.SupportsAbs.__type_params__
+typing.SupportsRound.__type_params__
+typing_extensions.SupportsAbs.__type_params__
+typing_extensions.SupportsRound.__type_params__
+
+
+# =============================================================
+# Allowlist entries that cannot or should not be fixed; >= 3.11
+# =============================================================
+
+argparse._MutuallyExclusiveGroup.add_mutually_exclusive_group  # deprecated, forwards arguments to super
+enum.auto.__init__  # The stub for enum.auto is nothing like the implementation
+enum.auto.value  # The stub for enum.auto is nothing like the implementation
+http.HTTPMethod.description  # mutable instance attribute at runtime but we pretend it's a property
+importlib.resources.abc.Traversable.open  # Problematic protocol signature at runtime, see source code comments.
+inspect._ParameterKind.description  # Still exists, but stubtest can't see it
+typing\._SpecialForm.*  # Super-special typing primitive
+typing\.LiteralString  # Super-special typing primitive
+
+
+# =============================================================
+# Allowlist entries that cannot or should not be fixed; >= 3.10
+# =============================================================
+
+# Runtime AST node runtime constructor behaviour is too loose.
+# For static typing, the loose behaviour is undesirable (https://github.com/python/typeshed/issues/8378).
+# For the runtime, the loose behaviour is deprecated in Python 3.13 (https://github.com/python/cpython/issues/105858)
+_?ast.pattern.__init__
+
+_collections_abc.AsyncGenerator.athrow  # async at runtime, deliberately not in the stub, see #7491. Pos-only differences also.
+builtins.property.__set_name__  # Doesn't actually exist
+collections\.UserList\.index  # ignoring pos-or-keyword parameter
+dataclasses.KW_ONLY  # white lies around defaults
+importlib.metadata._meta.SimplePath.joinpath  # Runtime definition of protocol is incorrect
+unittest.TestCase.__init_subclass__  # Runtime has *args, **kwargs, but will error if any are supplied
+unittest.case.TestCase.__init_subclass__  # Runtime has *args, **kwargs, but will error if any are supplied
+
+
+# ============================================================
+# Allowlist entries that cannot or should not be fixed; >= 3.9
+# ============================================================
+
+_ast.ImportFrom.level  # None on the class, but never None on instances
+_weakref.ProxyType.__reversed__  # Doesn't really exist
+ast.ImportFrom.level  # None on the class, but never None on instances
+ast.ExtSlice.__new__  # C signature is broader than what is actually accepted
+ast.Index.__new__  # C signature is broader than what is actually accepted
+
+# Treated an alias of a typing class in the stubs,
+# they are generic to type checkers anyway.
+contextlib.AbstractAsyncContextManager.__class_getitem__
+contextlib.AbstractContextManager.__class_getitem__
+
+functools._lru_cache_wrapper.cache_parameters  # Cannot be detected statically
+importlib.abc.Traversable.open  # Problematic protocol signature at runtime, see source code comments.
+os.PathLike.__class_getitem__  # PathLike is a protocol; we don't expect all PathLike classes to implement class_getitem
+types.GenericAlias.__call__  # Would be complicated to fix properly, Any could silence problems. #6392
+types.GenericAlias.__getattr__
+types.GenericAlias.__mro_entries__
+typing\.NamedTuple  # Super-special typing primitive
+weakref.ProxyType.__reversed__  # Doesn't really exist
+
+
+# ===============================================================
+# Allowlist entries that cannot or should not be fixed; 3.12 only
+# ===============================================================
+
+concurrent.futures.__all__  # Incompatible changes introduced in Python 3.12.5
+ctypes._endian.SIZEOF_TIME_T  # Incorrectly star import.
+
+
+# ==================================================================
+# Allowlist entries that cannot or should not be fixed; 3.11 to 3.12
+# ==================================================================
 
 configparser.LegacyInterpolation.__init__  # runtime is *args, **kwargs, but it's just a passthrough
 
-# Factory function at runtime
-# but that wouldn't let us use it in type hints
-threading.Lock
-multiprocessing.dummy.Lock
 
-# more precise signature in the stubs than at runtime
-multiprocessing.managers.DictProxy.clear
-multiprocessing.managers.DictProxy.popitem
+# =================================================================
+# Allowlist entries that cannot or should not be fixed; 3.9 to 3.12
+# =================================================================
+
+typing\.Annotated  # Super-special typing primitive
+
+
+# =============================================================
+# Allowlist entries that cannot or should not be fixed; <= 3.12
+# =============================================================
 
 # Undocumented implementation details
 cgi.FieldStorage.bufsize
@@ -106,65 +244,11 @@ cgi.FieldStorage.read_multi
 cgi.FieldStorage.read_single
 cgi.FieldStorage.read_urlencoded
 cgi.FieldStorage.skip_lines
-pipes.Template.makepipeline
-pipes.Template.open_r
-pipes.Template.open_w
-sunau.Au_read.initfp
-sunau.Au_write.initfp
-typing_extensions\.Annotated
 
-# Runtime AST node runtime constructor behaviour is too loose.
-# For static typing, the loose behaviour is undesirable (https://github.com/python/typeshed/issues/8378).
-# For the runtime, the loose behaviour is deprecated in Python 3.13 (https://github.com/python/cpython/issues/105858)
-_?ast.pattern.__init__
-_?ast.type_param.__init__
-
-_ast.ImportFrom.level  # None on the class, but never None on instances
-_collections_abc.AsyncGenerator.athrow  # async at runtime, deliberately not in the stub, see #7491. Pos-only differences also.
-_weakref.ProxyType.__reversed__  # Doesn't really exist
-argparse._MutuallyExclusiveGroup.add_mutually_exclusive_group  # deprecated, forwards arguments to super
-ast.ImportFrom.level  # None on the class, but never None on instances
-builtins.property.__set_name__  # Doesn't actually exist
-collections\.UserList\.index  # ignoring pos-or-keyword parameter
-dataclasses.KW_ONLY  # white lies around defaults
-enum.auto.__init__  # The stub for enum.auto is nothing like the implementation
-enum.auto.value  # The stub for enum.auto is nothing like the implementation
-functools._lru_cache_wrapper.cache_parameters  # Cannot be detected statically
-http.HTTPMethod.description  # mutable instance attribute at runtime but we pretend it's a property
-inspect._ParameterKind.description  # Still exists, but stubtest can't see it
-os.PathLike.__class_getitem__  # PathLike is a protocol; we don't expect all PathLike classes to implement class_getitem
-types.GenericAlias.__call__  # Would be complicated to fix properly, Any could silence problems. #6392
-types.GenericAlias.__getattr__
-types.GenericAlias.__mro_entries__
-sys._monitoring  # Doesn't really exist. See comments in the stub.
-weakref.ProxyType.__reversed__  # Doesn't really exist
-importlib.metadata._meta.SimplePath.joinpath  # Incorrect runtime definition
-
-# sys attributes that are not always defined
-sys.last_exc
-
-# C signature is broader than what is actually accepted
-ast.ExtSlice.__new__
-ast.Index.__new__
-
-# Treated an alias of a typing class in the stubs,
-# they are generic to type checkers anyway.
-contextlib.AbstractAsyncContextManager.__class_getitem__
-contextlib.AbstractContextManager.__class_getitem__
-
-# Runtime has *args, **kwargs, but will error if any are supplied
-unittest.TestCase.__init_subclass__
-unittest.case.TestCase.__init_subclass__
-
-# Deprecated argument is supported at runtime by renaming it through a decorator.
-importlib.resources._common.files
-importlib.resources.files
-# Problematic protocol signature at runtime, see source code comments.
-importlib.abc.Traversable.open
-importlib.resources.abc.Traversable.open
-
-# Deprecation wrapper classes; their methods are just pass-through, so we can ignore them.
-importlib.metadata.DeprecatedNonAbstract.__new__
+ctypes._endian.DEFAULT_MODE  # Incorrectly star import.
+ctypes._endian.RTLD_GLOBAL  # Incorrectly star import.
+ctypes._endian.RTLD_LOCAL  # Incorrectly star import.
+multiprocessing.dummy.Lock  # Factory function at runtime, but that wouldn't let us use it in type hints
 
 # These multiprocessing proxy methods have *args, **kwargs signatures at runtime,
 # But have more precise (accurate) signatures in the stub
@@ -175,34 +259,17 @@ multiprocessing.managers.DictProxy.items
 multiprocessing.managers.DictProxy.keys
 multiprocessing.managers.DictProxy.values
 
-# Super-special typing primitives
-typing\._SpecialForm.*
-typing\.NamedTuple
-typing\.LiteralString
-typing\.Annotated
+# Runtime signature is incorrect (https://github.com/python/cpython/issues/93021)
+multiprocessing.managers.DictProxy.clear
+multiprocessing.managers.DictProxy.popitem
 
-# These only exist to give a better error message if you try to subclass an instance
-typing.ParamSpec.__mro_entries__
-typing.ParamSpecArgs.__mro_entries__
-typing.ParamSpecKwargs.__mro_entries__
-typing.TypeVar.__mro_entries__
-typing.TypeVarTuple.__mro_entries__
+# Undocumented implementation details
+pipes.Template.makepipeline
+pipes.Template.open_r
+pipes.Template.open_w
+sunau.Au_read.initfp
+sunau.Au_write.initfp
 
-# class doesn't accept positional arguments but has default C signature
-types.SimpleNamespace.__init__
-
-# TODO: mypy should infer that this attribute is inherited from builtins.type;
-# why doesn't it infer this?
-typing.SupportsAbs.__type_params__
-typing.SupportsRound.__type_params__
-typing_extensions.SupportsAbs.__type_params__
-typing_extensions.SupportsRound.__type_params__
-
-# Incorrectly star import.
-ctypes._endian.DEFAULT_MODE
-ctypes._endian.RTLD_GLOBAL
-ctypes._endian.RTLD_LOCAL
-ctypes._endian.SIZEOF_TIME_T
-
-# Incompatible changes introduced in Python 3.12.5
-concurrent.futures.__all__
+threading.Lock  # Factory function at runtime, but that wouldn't let us use it in type hints
+types.SimpleNamespace.__init__  # class doesn't accept positional arguments but has default C signature
+typing_extensions\.Annotated  # Undocumented implementation details

--- a/stdlib/@tests/stubtest_allowlists/py313.txt
+++ b/stdlib/@tests/stubtest_allowlists/py313.txt
@@ -2,6 +2,11 @@
 # New errors in Python 3.13
 # =========================
 
+
+# =======
+# >= 3.13
+# =======
+
 # TODO: triage these new errors
 _tkinter.create
 os.path.splitroot
@@ -24,32 +29,51 @@ tkinter.Misc.tk_busy_hold
 tkinter.Misc.tk_busy_status
 tkinter.Wm.wm_attributes
 
-# ======================================
-# Pre-existing errors from Python <=3.12
-# ======================================
 
-# Modules that exist at runtime, but are missing from typeshed
-zipfile._path.glob
+# ====================================
+# Pre-existing errors from Python 3.12
+# ====================================
 
-# Errors that also existed on Python 3.11
-_collections_abc.AsyncIterable.__class_getitem__
-_collections_abc.Awaitable.__class_getitem__
-_collections_abc.Container.__class_getitem__
-_collections_abc.Iterable.__class_getitem__
-_collections_abc.MappingView.__class_getitem__
+
+# =======
+# >= 3.12
+# =======
+
+zipfile._path.glob  # Modules that exist at runtime, but are missing from typeshed
+zoneinfo.ZoneInfo.from_file  # Pos-only parameters had different "names" in different Python versions
+
+
+# =======
+# >= 3.11
+# =======
+
 enum.Enum.__init__
-importlib._abc.Loader.exec_module  # See Lib/importlib/_abc.py. Might be defined for backwards compatibility
 typing.NewType.__mro_entries__
+
+
+# =======
+# >= 3.10
+# =======
+
 builtins.ellipsis  # type is not exposed anywhere
+importlib._abc.Loader.exec_module  # See Lib/importlib/_abc.py. Might be defined for backwards compatibility
 
-# ==========
-# Related to positional-only arguments
-# ==========
+# positional-only complaints caused by differences between typing aliases and the "real" classes in the stdlib
+_collections_abc.Coroutine.send
+_collections_abc.Coroutine.throw
+_collections_abc.Generator.send
+_collections_abc.Generator.throw
 
-# These are not positional-only at runtime, but we treat them
-# as positional-only to match dict.
+# These are not positional-only at runtime, but we treat them as positional-only to match dict.
 _collections_abc.MutableMapping.pop
 _collections_abc.MutableMapping.setdefault
+
+# These three have a pos-or-keyword first parameter at runtime, but deliberately have a pos-only first parameter in the stub. #6812
+posixpath.join
+ntpath.join
+os.path.join
+
+types.DynamicClassAttribute..*  # In the stub we pretend it's an alias for property, but it has positional-only differences
 
 # typing.IO uses positional-or-keyword arguments, but in the stubs we prefer
 # to mark these as positional-only for compatibility with existing sub-classes.
@@ -62,82 +86,30 @@ typing(_extensions)?\.IO\.truncate
 typing(_extensions)?\.IO\.write
 typing(_extensions)?\.IO\.writelines
 
-# positional-only complaints caused by differences between typing aliases and the "real" classes in the stdlib
-_collections_abc.Coroutine.send
-_collections_abc.Coroutine.throw
-_collections_abc.Generator.send
-_collections_abc.Generator.throw
 
-# typing.SupportsRound.__round__  # pos-or-kw at runtime, but we pretend it's pos-only in the stub so that e.g. float.__round__ satisfies the interface
-types.DynamicClassAttribute..*  # In the stub we pretend it's an alias for property, but it has positional-only differences
+# ======
+# >= 3.9
+# ======
 
-# These three have a pos-or-keyword first parameter at runtime, but deliberately have a pos-only first parameter in the stub. #6812
-posixpath.join
-ntpath.join
-os.path.join
+# Exists at runtime, but missing from stubs
+_collections_abc.AsyncIterable.__class_getitem__
+_collections_abc.Awaitable.__class_getitem__
+_collections_abc.Container.__class_getitem__
+_collections_abc.Iterable.__class_getitem__
+_collections_abc.MappingView.__class_getitem__
 
-# Pos-only parameters had different "names" in different Python versions:
-zoneinfo.ZoneInfo.from_file
 
-# ==========
-# Allowlist entries that cannot or should not be fixed
-# ==========
+# =============================================================
+# Allowlist entries that cannot or should not be fixed; >= 3.13
+# =============================================================
 
-# The internal implementation of the REPL on py313+; not for public consumption
-_pyrepl\..+
-
-# Runtime AST node runtime constructor behaviour is too loose.
-# For static typing, the loose behaviour is undesirable (https://github.com/python/typeshed/issues/8378).
-# For the runtime, the loose behaviour is deprecated in Python 3.13 (https://github.com/python/cpython/issues/105858)
-_?ast.pattern.__init__
-_?ast.type_param.__init__
-
-_ast.ImportFrom.level  # None on the class, but never None on instances
-_collections_abc.AsyncGenerator.athrow  # async at runtime, deliberately not in the stub, see #7491. Pos-only differences also.
-_weakref.ProxyType.__reversed__  # Doesn't really exist
-argparse._MutuallyExclusiveGroup.add_mutually_exclusive_group  # deprecated, forwards arguments to super
-ast.ImportFrom.level  # None on the class, but never None on instances
-builtins.property.__set_name__  # Doesn't actually exist
-collections\.UserList\.index  # ignoring pos-or-keyword parameter
-dataclasses.KW_ONLY  # white lies around defaults
-enum.auto.__init__  # The stub for enum.auto is nothing like the implementation
-enum.auto.value  # The stub for enum.auto is nothing like the implementation
-functools._lru_cache_wrapper.cache_parameters  # Cannot be detected statically
-http.HTTPMethod.description  # mutable instance attribute at runtime but we pretend it's a property
-inspect._ParameterKind.description  # Still exists, but stubtest can't see it
-os.PathLike.__class_getitem__  # PathLike is a protocol; we don't expect all PathLike classes to implement class_getitem
-types.GenericAlias.__call__  # Would be complicated to fix properly, Any could silence problems. #6392
-types.GenericAlias.__getattr__
-types.GenericAlias.__mro_entries__
-sys._monitoring  # Doesn't really exist. See comments in the stub.
-weakref.ProxyType.__reversed__  # Doesn't really exist
-importlib.metadata._meta.SimplePath.joinpath  # Incorrect runtime definition
-
-# sys attributes that are not always defined
-sys.last_exc
-
-# C signature is broader than what is actually accepted
-ast.ExtSlice.__new__
-ast.Index.__new__
-
-# Treated an alias of a typing class in the stubs,
-# they are generic to type checkers anyway.
-contextlib.AbstractAsyncContextManager.__class_getitem__
-contextlib.AbstractContextManager.__class_getitem__
-
-# Runtime has *args, **kwargs, but will error if any are supplied
-unittest.TestCase.__init_subclass__
-unittest.case.TestCase.__init_subclass__
-
-# Deprecated argument is supported at runtime by renaming it through a decorator.
-importlib.resources._common.files
-importlib.resources.files
-# Problematic protocol signature at runtime, see source code comments.
-importlib.abc.Traversable.open
-importlib.resources.abc.Traversable.open
-
-# Deprecation wrapper classes; their methods are just pass-through, so we can ignore them.
-importlib.metadata.DeprecatedNonAbstract.__new__
+_pyrepl\..+  # The internal implementation of the REPL on py313+; not for public consumption
+codecs.backslashreplace_errors  # Runtime incorrectly has `self`
+codecs.ignore_errors  # Runtime incorrectly has `self`
+codecs.namereplace_errors  # Runtime incorrectly has `self`
+codecs.replace_errors  # Runtime incorrectly has `self`
+codecs.strict_errors  # Runtime incorrectly has `self`
+codecs.xmlcharrefreplace_errors  # Runtime incorrectly has `self`
 
 # These multiprocessing proxy methods have *args, **kwargs signatures at runtime,
 # But have more precise (accurate) signatures in the stub
@@ -150,11 +122,30 @@ multiprocessing.managers._BaseDictProxy.keys
 multiprocessing.managers._BaseDictProxy.popitem
 multiprocessing.managers._BaseDictProxy.values
 
-# Super-special typing primitives
-typing\._SpecialForm.*
-typing\.NamedTuple
-typing\.LiteralString
-typing_extensions.Protocol
+# To match `dict`, we lie about the runtime, but use overloads to match the correct behavior
+types.MappingProxyType.get
+
+typing_extensions.Protocol  # Super-special typing primitive
+
+
+# =============================================================
+# Allowlist entries that cannot or should not be fixed; >= 3.12
+# =============================================================
+
+# Runtime AST node runtime constructor behaviour is too loose.
+# For static typing, the loose behaviour is undesirable (https://github.com/python/typeshed/issues/8378).
+# For the runtime, the loose behaviour is deprecated in Python 3.13 (https://github.com/python/cpython/issues/105858)
+_?ast.type_param.__init__
+
+# Deprecation wrapper classes; their methods are just pass-through, so we can ignore them.
+importlib.metadata.DeprecatedNonAbstract.__new__
+
+# Deprecated argument is supported at runtime by renaming it through a decorator.
+importlib.resources._common.files
+importlib.resources.files
+
+sys._monitoring  # Doesn't really exist. See comments in the stub.
+sys.last_exc  # not always defined
 
 # These only exist to give a better error message if you try to subclass an instance
 typing.ParamSpec.__mro_entries__
@@ -170,13 +161,59 @@ typing.SupportsRound.__type_params__
 typing_extensions.SupportsAbs.__type_params__
 typing_extensions.SupportsRound.__type_params__
 
-# Runtime incorrectly has `self`
-codecs.backslashreplace_errors
-codecs.ignore_errors
-codecs.namereplace_errors
-codecs.replace_errors
-codecs.strict_errors
-codecs.xmlcharrefreplace_errors
 
-# To match `dict`, we lie about the runtime, but use overloads to match the correct behavior
-types.MappingProxyType.get
+# =============================================================
+# Allowlist entries that cannot or should not be fixed; >= 3.11
+# =============================================================
+
+argparse._MutuallyExclusiveGroup.add_mutually_exclusive_group  # deprecated, forwards arguments to super
+enum.auto.__init__  # The stub for enum.auto is nothing like the implementation
+enum.auto.value  # The stub for enum.auto is nothing like the implementation
+http.HTTPMethod.description  # mutable instance attribute at runtime but we pretend it's a property
+importlib.resources.abc.Traversable.open  # Problematic protocol signature at runtime, see source code comments.
+inspect._ParameterKind.description  # Still exists, but stubtest can't see it
+typing\._SpecialForm.*  # Super-special typing primitive
+typing\.LiteralString  # Super-special typing primitive
+
+
+# =============================================================
+# Allowlist entries that cannot or should not be fixed; >= 3.10
+# =============================================================
+
+# Runtime AST node runtime constructor behaviour is too loose.
+# For static typing, the loose behaviour is undesirable (https://github.com/python/typeshed/issues/8378).
+# For the runtime, the loose behaviour is deprecated in Python 3.13 (https://github.com/python/cpython/issues/105858)
+_?ast.pattern.__init__
+
+_collections_abc.AsyncGenerator.athrow  # async at runtime, deliberately not in the stub, see #7491. Pos-only differences also.
+builtins.property.__set_name__  # Doesn't actually exist
+collections\.UserList\.index  # ignoring pos-or-keyword parameter
+dataclasses.KW_ONLY  # white lies around defaults
+importlib.metadata._meta.SimplePath.joinpath  # Runtime definition of protocol is incorrect
+unittest.TestCase.__init_subclass__  # Runtime has *args, **kwargs, but will error if any are supplied
+unittest.case.TestCase.__init_subclass__  # Runtime has *args, **kwargs, but will error if any are supplied
+
+
+# ============================================================
+# Allowlist entries that cannot or should not be fixed; >= 3.9
+# ============================================================
+
+_ast.ImportFrom.level  # None on the class, but never None on instances
+_weakref.ProxyType.__reversed__  # Doesn't really exist
+ast.ImportFrom.level  # None on the class, but never None on instances
+ast.ExtSlice.__new__  # C signature is broader than what is actually accepted
+ast.Index.__new__  # C signature is broader than what is actually accepted
+
+# Treated an alias of a typing class in the stubs,
+# they are generic to type checkers anyway.
+contextlib.AbstractAsyncContextManager.__class_getitem__
+contextlib.AbstractContextManager.__class_getitem__
+
+functools._lru_cache_wrapper.cache_parameters  # Cannot be detected statically
+importlib.abc.Traversable.open  # Problematic protocol signature at runtime, see source code comments.
+os.PathLike.__class_getitem__  # PathLike is a protocol; we don't expect all PathLike classes to implement class_getitem
+types.GenericAlias.__call__  # Would be complicated to fix properly, Any could silence problems. #6392
+types.GenericAlias.__getattr__
+types.GenericAlias.__mro_entries__
+typing\.NamedTuple  # Super-special typing primitive
+weakref.ProxyType.__reversed__  # Doesn't really exist

--- a/stdlib/@tests/stubtest_allowlists/py38.txt
+++ b/stdlib/@tests/stubtest_allowlists/py38.txt
@@ -1,3 +1,7 @@
+# ======
+# <= 3.8
+# ======
+
 _dummy_threading.Condition.acquire
 _dummy_threading.Condition.release
 _dummy_threading.Event.isSet
@@ -8,66 +12,16 @@ _dummy_threading.Thread.native_id
 _dummy_threading._DummyThread.__init__
 _dummy_threading._RLock.__enter__
 _dummy_threading.local.__new__
+asyncio.WriteTransport.get_write_buffer_limits  # Documented. Exists in subclasses, but not in WriteTransport itself
 asyncio.locks._ContextManagerMixin.__enter__  # Always raises; deliberately omitted from the stub
 asyncio.locks._ContextManagerMixin.__exit__  # Always raises; deliberately omitted from the stub
 asyncio.transports.WriteTransport.get_write_buffer_limits  # Documented. Exists in subclasses, but not in WriteTransport itself
-asyncio.WriteTransport.get_write_buffer_limits  # Documented. Exists in subclasses, but not in WriteTransport itself
 builtins.float.__set_format__  # Internal method for CPython test suite
-builtins.input  # Incorrect default value in text signature, fixed in 3.10
-_?bz2.BZ2Decompressor.__init__  # function does not accept parameters but C signature is set
-collections.AsyncGenerator.asend  # async at runtime, deliberately not in the stub, see #7491. Pos-only differences also.
-collections.AsyncGenerator.__anext__  # async at runtime, deliberately not in the stub, see #7491
-collections.AsyncGenerator.aclose  # async at runtime, deliberately not in the stub, see #7491
-collections.AsyncIterator.__anext__  # async at runtime, deliberately not in the stub, see #7491
-collections.AsyncGenerator.ag_await
-collections.AsyncGenerator.ag_code
-collections.AsyncGenerator.ag_frame
-collections.AsyncGenerator.ag_running
-collections.ByteString  # see comments in py3_common.txt
-collections.Callable
-collections.Mapping.__reversed__  # Set to None at runtime for a better error message
-configparser.ParsingError.filename
 dummy_threading.Condition.acquire
 dummy_threading.Condition.release
 dummy_threading.Event.isSet
 dummy_threading.Thread.native_id
 dummy_threading.local.__new__
-email.contentmanager.typ
-enum.Enum._generate_next_value_
-gettext.install  # codeset default value is ['unspecified'] so can't be specified
-gettext.translation  # codeset default value is ['unspecified'] so can't be specified
-importlib.abc.Finder.find_module
-inspect.Signature.from_builtin  # Removed in 3.11, can add if someone needs this
-inspect.Signature.from_function  # Removed in 3.11, can add if someone needs this
-lib2to3.pygram.pattern_symbols
-lib2to3.pygram.python_symbols
-lib2to3.pytree.Base.__new__
-lib2to3.pytree.Base.children
-lib2to3.pytree.Base.type
-lib2to3.pytree.BasePattern.__new__
-lib2to3.pytree.BasePattern.type
-lib2to3.pytree.NegatedPattern.match
-lib2to3.pytree.NegatedPattern.match_seq
-lib2to3.pgen2.grammar.Grammar.loads
-tkinter.tix.[A-Z_]+
-tkinter.tix.TclVersion
-tkinter.tix.TkVersion
-tkinter.tix.CObjView
-tkinter.tix.DialogShell
-tkinter.tix.ExFileSelectDialog
-tkinter.tix.FileSelectDialog
-tkinter.tix.FileTypeList
-tkinter.tix.Grid
-tkinter.tix.NoteBookFrame
-tkinter.tix.OptionName
-tkinter.tix.ResizeHandle
-tkinter.tix.ScrolledGrid
-tkinter.tix.ScrolledHList
-tkinter.tix.ScrolledListBox
-tkinter.tix.ScrolledTList
-tkinter.tix.ScrolledText
-tkinter.tix.ScrolledWindow
-tkinter.tix.Shell
 typing.NamedTuple.__new__
 typing.NamedTuple._asdict
 typing.NamedTuple._make
@@ -75,38 +29,8 @@ typing.NamedTuple._replace
 typing._SpecialForm.__new__
 xml.etree.ElementTree.TreeBuilder.start  # Discrepancy between Python and C modules, fixed in bpo-39495
 xml.etree.cElementTree.TreeBuilder.start  # bpo-39495
-xxsubtype  # module missing from the stubs
-
-xml.etree.ElementTree.Element.__bool__  # Doesn't really exist; see comments in stub
-xml.etree.cElementTree.Element.__bool__  # Doesn't really exist; see comments in stub
-
-# Exist at runtime for internal reasons, no need to put them in the stub
-typing_extensions\.TypeAliasType\.__call__
-typing_extensions\.TypeAliasType\.__init_subclass__
-# We call them read-only properties, runtime implementation is slightly different
-typing_extensions\.TypeAliasType\.__(parameters|type_params|name|module|value)__
-
-collections.Coroutine.cr_await
-collections.Coroutine.cr_code
-collections.Coroutine.cr_frame
-collections.Coroutine.cr_running
-collections.Generator.gi_code
-collections.Generator.gi_frame
-collections.Generator.gi_running
-collections.Generator.gi_yieldfrom
-collections.Mapping.get  # Adding None to the Union messed up mypy
-collections.Sequence.index  # Supporting None in end is not mandatory
-
-# SpooledTemporaryFile implements IO except these methods before Python 3.11
-# See also https://github.com/python/typeshed/pull/2452#issuecomment-420657918
-tempfile.SpooledTemporaryFile.__next__
-tempfile.SpooledTemporaryFile.readable
-tempfile.SpooledTemporaryFile.seekable
-tempfile.SpooledTemporaryFile.writable
-
-# Default values given in the stub are a white lie, see #9637
-tkinter.Tcl
-tkinter.Tk.__init__
+tkinter.Tcl  # Default values given in the stub are a white lie, see #9637
+tkinter.Tk.__init__  # Default values given in the stub are a white lie, see #9637
 
 # Exists at runtime, but missing from stubs
 _?contextvars.ContextVar.__class_getitem__
@@ -117,7 +41,6 @@ html.parser.HTMLParser.unescape
 plistlib.Data.asBase64
 plistlib.Data.fromBase64
 tempfile.SpooledTemporaryFile.softspace
-tkinter.Tk.split
 tkinter.commondialog.[A-Z_]+
 tkinter.commondialog.TclVersion
 tkinter.commondialog.TkVersion
@@ -135,120 +58,110 @@ tkinter.filedialog.TkVersion
 tkinter.filedialog.wantobjects
 tkinter.simpledialog.wantobjects
 tkinter.tix.wantobjects
+
+
+# ======
+# <= 3.9
+# ======
+
+builtins.input  # Incorrect default value in text signature, fixed in 3.10
+collections.AsyncGenerator.__anext__  # async at runtime, deliberately not in the stub, see #7491
+collections.AsyncGenerator.aclose  # async at runtime, deliberately not in the stub, see #7491
+collections.AsyncGenerator.ag_await
+collections.AsyncGenerator.ag_code
+collections.AsyncGenerator.ag_frame
+collections.AsyncGenerator.ag_running
+collections.AsyncGenerator.asend  # async at runtime, deliberately not in the stub, see #7491. Pos-only differences also.
+collections.AsyncIterator.__anext__  # async at runtime, deliberately not in the stub, see #7491
+collections.ByteString  # see comments in py3_common.txt
+collections.Callable
+collections.Coroutine.cr_await
+collections.Coroutine.cr_code
+collections.Coroutine.cr_frame
+collections.Coroutine.cr_running
+collections.Generator.gi_code
+collections.Generator.gi_frame
+collections.Generator.gi_running
+collections.Generator.gi_yieldfrom
+collections.Mapping.__reversed__  # Set to None at runtime for a better error message
+collections.Mapping.get  # Adding None to the Union messed up mypy
+collections.Sequence.index  # Supporting None in end is not mandatory
+xxsubtype  # module missing from the stubs
+
+
+# =======
+# <= 3.10
+# =======
+
+email.contentmanager.typ
+gettext.install  # codeset default value is ['unspecified'] so can't be specified
+gettext.translation  # codeset default value is ['unspecified'] so can't be specified
+inspect.Signature.from_builtin  # Removed in 3.11, can add if someone needs this
+inspect.Signature.from_function  # Removed in 3.11, can add if someone needs this
+
+# SpooledTemporaryFile implements IO except these methods before Python 3.11
+# See also https://github.com/python/typeshed/pull/2452#issuecomment-420657918
+tempfile.SpooledTemporaryFile.__next__
+tempfile.SpooledTemporaryFile.readable
+tempfile.SpooledTemporaryFile.seekable
+tempfile.SpooledTemporaryFile.writable
+
+tkinter.Tk.split  # Exists at runtime, but missing from stubs
+
+
+# =======
+# <= 3.11
+# =======
+
+_?bz2.BZ2Decompressor.__init__  # function does not accept parameters but C signature is set
+configparser.ParsingError.filename
+enum.Enum._generate_next_value_
+importlib.abc.Finder.find_module
+xml.etree.ElementTree.Element.__bool__  # Doesn't really exist; see comments in stub
+xml.etree.cElementTree.Element.__bool__  # Doesn't really exist; see comments in stub
+
+
+# =======
+# <= 3.12
+# =======
+
+# Exists at runtime, but missing from stubs
 lib2to3.btm_utils
 lib2to3.fixer_util
 lib2to3.patcomp
+lib2to3.pgen2.grammar.Grammar.loads
+lib2to3.pygram.pattern_symbols
+lib2to3.pygram.python_symbols
+lib2to3.pytree.Base.__new__
+lib2to3.pytree.Base.children
+lib2to3.pytree.Base.type
+lib2to3.pytree.BasePattern.__new__
+lib2to3.pytree.BasePattern.type
+lib2to3.pytree.NegatedPattern.match
+lib2to3.pytree.NegatedPattern.match_seq
+tkinter.tix.CObjView
+tkinter.tix.DialogShell
+tkinter.tix.ExFileSelectDialog
+tkinter.tix.FileSelectDialog
+tkinter.tix.FileTypeList
+tkinter.tix.Grid
+tkinter.tix.NoteBookFrame
+tkinter.tix.OptionName
+tkinter.tix.ResizeHandle
+tkinter.tix.ScrolledGrid
+tkinter.tix.ScrolledHList
+tkinter.tix.ScrolledListBox
+tkinter.tix.ScrolledTList
+tkinter.tix.ScrolledText
+tkinter.tix.ScrolledWindow
+tkinter.tix.Shell
+tkinter.tix.TclVersion
+tkinter.tix.TkVersion
 
-# ==========
-# Allowlist entries that cannot or should not be fixed
-# ==========
 
-# Factory function at runtime
-# but that wouldn't let us use it in type hints
-threading.Lock
-multiprocessing.dummy.Lock
-
-# Side effects from module initialization
-_compat_pickle.excname
-email.contentmanager.maintype
-email.contentmanager.subtype
-inspect.k
-inspect.mod_dict
-inspect.v
-json.encoder.i
-lib2to3.pgen2.grammar.line
-lib2to3.pgen2.grammar.name
-lib2to3.pgen2.grammar.op
-poplib.POP3_SSL.stls  # bad declaration of inherited function. See poplib.pyi
-pydoc.Helper.symbol  # Loop variable in class https://github.com/python/typeshed/issues/6401#issuecomment-981178522
-pydoc.Helper.symbols_  # Loop variable in class https://github.com/python/typeshed/issues/6401#issuecomment-981178522
-pydoc.Helper.topic  # Loop variable in class https://github.com/python/typeshed/issues/6401#issuecomment-981178522
-
-# Undocumented implementation details
-cgi.FieldStorage.bufsize
-cgi.FieldStorage.read_binary
-cgi.FieldStorage.read_lines
-cgi.FieldStorage.read_lines_to_eof
-cgi.FieldStorage.read_lines_to_outerboundary
-cgi.FieldStorage.read_multi
-cgi.FieldStorage.read_single
-cgi.FieldStorage.read_urlencoded
-cgi.FieldStorage.skip_lines
-pipes.Template.makepipeline
-pipes.Template.open_r
-pipes.Template.open_w
-sunau.Au_read.initfp
-sunau.Au_write.initfp
-typing_extensions\.Annotated
-
-# Adding these reflected dunders to `typing.AbstractSet` causes a large number of false-positives. See #7414.
-collections.Set.__rand__
-collections.Set.__ror__
-collections.Set.__rsub__
-collections.Set.__rxor__
-
-builtins.memoryview.__iter__  # C type that implements __getitem__
-builtins.memoryview.cast  # inspect.signature is incorrect about shape being kw-only
-
-# Runtime signature is incorrect (https://github.com/python/cpython/issues/93021)
-builtins.classmethod.__get__
-builtins.property.__get__
-builtins.staticmethod.__get__
-types.FunctionType.__get__
-types.LambdaType.__get__
-types.ClassMethodDescriptorType.__get__
-types.GetSetDescriptorType.__get__
-types.MemberDescriptorType.__get__
-types.MethodDescriptorType.__get__
-types.WrapperDescriptorType.__get__
-types.SimpleNamespace.__init__  # class doesn't accept positional arguments but has default C signature
-multiprocessing.managers.DictProxy.clear
-multiprocessing.managers.DictProxy.popitem
-
-# We lie about the existence of these methods
-.*.__buffer__
-.*.__release_buffer__
-
-# A property at runtime that works like a method.
-zipfile.Path.open
-
-# Removed in 3.12
-distutils\..*
-asyncore.dispatcher.addr
-asyncore.dispatcher.handle_accepted
-asynchat.async_chat.encoding
-asynchat.async_chat.use_encoding
-asynchat.find_prefix_at_end
-pkgutil.ImpImporter\..*
-pkgutil.ImpLoader\..*
-
-types.CodeType.replace  # stubtest thinks default values are None but None doesn't work at runtime
-
-# Modules that exist at runtime, but shouldn't be added to typeshed
-ctypes.test
-ctypes\.test\..+
-lib2to3.tests
-lib2to3\.tests\..+
-sqlite3.test
-sqlite3\.test\..+
-test
-tkinter.test
-tkinter\.test\..+
-unittest.test
-unittest\.test\..+
-
-# These enums derive from (str, Enum)
-pstats.SortKey.__new__
-tkinter.EventType.__new__
-
-# Items that depend on the existence and flags of SSL
-ssl.RAND_egd
-_ssl.RAND_egd
-
-# Incorrectly star import.
-ctypes._endian.DEFAULT_MODE
-ctypes._endian.RTLD_GLOBAL
-ctypes._endian.RTLD_LOCAL
+# ============================================================
+# Allowlist entries that cannot or should not be fixed; <= 3.8
+# ============================================================
 
 # Incompatible changes introduced in Python 3.8.20
 # (Remove once 3.8.20 becomes available for GitHub Actions)
@@ -262,6 +175,117 @@ email.utils.parseaddr
 hashlib.sha3_\d+  # Class in 3.8, can't be subclassed at runtime, built-in function 3.9+
 hashlib.shake_\d+  # Class in 3.8, can't be subclassed at runtime, built-in function 3.9+
 
+zipfile.Path.open  # A property at runtime that works like a method.
+
+
+# ============================================================
+# Allowlist entries that cannot or should not be fixed; <= 3.9
+# ============================================================
+
+_ssl.RAND_egd  # Depends on the existence and flags of SSL
+builtins.classmethod.__get__  # Runtime signature is incorrect (https://github.com/python/cpython/issues/93021)
+builtins.property.__get__  # Runtime signature is incorrect (https://github.com/python/cpython/issues/93021)
+builtins.staticmethod.__get__  # Runtime signature is incorrect (https://github.com/python/cpython/issues/93021)
+builtins.memoryview.__iter__  # C type that implements __getitem__
+builtins.memoryview.cast  # inspect.signature is incorrect about shape being kw-only
+
+# Adding these reflected dunders to `typing.AbstractSet` causes a large number of false-positives. See #7414.
+collections.Set.__rand__
+collections.Set.__ror__
+collections.Set.__rsub__
+collections.Set.__rxor__
+
+ssl.RAND_egd  # Depends on the existence and flags of SSL
+test  # Modules that exist at runtime, but shouldn't be added to typeshed
+
+# Runtime signature is incorrect (https://github.com/python/cpython/issues/93021)
+types.ClassMethodDescriptorType.__get__
+types.FunctionType.__get__
+types.GetSetDescriptorType.__get__
+types.LambdaType.__get__
+types.MemberDescriptorType.__get__
+types.MethodDescriptorType.__get__
+types.WrapperDescriptorType.__get__
+
+
+# =============================================================
+# Allowlist entries that cannot or should not be fixed; <= 3.10
+# =============================================================
+
+# Side effects from module initialization
+_compat_pickle.excname
+email.contentmanager.maintype
+email.contentmanager.subtype
+inspect.k
+inspect.mod_dict
+inspect.v
+json.encoder.i
+lib2to3.pgen2.grammar.line
+lib2to3.pgen2.grammar.name
+lib2to3.pgen2.grammar.op
+
+pstats.SortKey.__new__  # Derives from (str, Enum)
+pydoc.Helper.symbol  # Loop variable in class https://github.com/python/typeshed/issues/6401#issuecomment-981178522
+pydoc.Helper.symbols_  # Loop variable in class https://github.com/python/typeshed/issues/6401#issuecomment-981178522
+pydoc.Helper.topic  # Loop variable in class https://github.com/python/typeshed/issues/6401#issuecomment-981178522
+sqlite3.test  # Modules that exist at runtime, but shouldn't be added to typeshed
+sqlite3\.test\..+  # Modules that exist at runtime, but shouldn't be added to typeshed
+tkinter.EventType.__new__  # Derives from (str, Enum)
+types.CodeType.replace  # stubtest thinks default values are None but None doesn't work at runtime
+
+
+# =============================================================
+# Allowlist entries that cannot or should not be fixed; <= 3.11
+# =============================================================
+
+.*.__buffer__  # We lie about the existence of these methods
+.*.__release_buffer__  # We lie about the existence of these methods
+asynchat.async_chat.encoding  # Removed in 3.12
+asynchat.async_chat.use_encoding  # Removed in 3.12
+asynchat.find_prefix_at_end  # Removed in 3.12
+asyncore.dispatcher.addr  # Removed in 3.12
+asyncore.dispatcher.handle_accepted  # Removed in 3.12
+ctypes.test  # Modules that exist at runtime, but shouldn't be added to typeshed
+ctypes\.test\..+  # Modules that exist at runtime, but shouldn't be added to typeshed
+distutils\..*  # Removed in 3.12
+lib2to3.tests  # Modules that exist at runtime, but shouldn't be added to typeshed
+lib2to3\.tests\..+  # Modules that exist at runtime, but shouldn't be added to typeshed
+pkgutil.ImpImporter\..*  # Removed in 3.12
+pkgutil.ImpLoader\..*  # Removed in 3.12
+poplib.POP3_SSL.stls  # bad declaration of inherited function. See poplib.pyi
+tkinter.test  # Modules that exist at runtime, but shouldn't be added to typeshed
+tkinter\.test\..+  # Modules that exist at runtime, but shouldn't be added to typeshed
+
+# Exist at runtime for internal reasons, no need to put them in the stub
+typing_extensions\.TypeAliasType\.__call__
+typing_extensions\.TypeAliasType\.__init_subclass__
+# We call them read-only properties, runtime implementation is slightly different
+typing_extensions\.TypeAliasType\.__(parameters|type_params|name|module|value)__
+
+unittest.test  # Modules that exist at runtime, but shouldn't be added to typeshed
+unittest\.test\..+  # Modules that exist at runtime, but shouldn't be added to typeshed
+
+
+# =============================================================
+# Allowlist entries that cannot or should not be fixed; <= 3.12
+# =============================================================
+
+# Undocumented implementation details
+cgi.FieldStorage.bufsize
+cgi.FieldStorage.read_binary
+cgi.FieldStorage.read_lines
+cgi.FieldStorage.read_lines_to_eof
+cgi.FieldStorage.read_lines_to_outerboundary
+cgi.FieldStorage.read_multi
+cgi.FieldStorage.read_single
+cgi.FieldStorage.read_urlencoded
+cgi.FieldStorage.skip_lines
+
+ctypes._endian.DEFAULT_MODE  # Incorrectly star import.
+ctypes._endian.RTLD_GLOBAL  # Incorrectly star import.
+ctypes._endian.RTLD_LOCAL  # Incorrectly star import.
+multiprocessing.dummy.Lock  # Factory function at runtime, but that wouldn't let us use it in type hints
+
 # These multiprocessing proxy methods have *args, **kwargs signatures at runtime,
 # But have more precise (accurate) signatures in the stub
 multiprocessing.managers.DictProxy.__iter__
@@ -270,3 +294,18 @@ multiprocessing.managers.DictProxy.copy
 multiprocessing.managers.DictProxy.items
 multiprocessing.managers.DictProxy.keys
 multiprocessing.managers.DictProxy.values
+
+# Runtime signature is incorrect (https://github.com/python/cpython/issues/93021)
+multiprocessing.managers.DictProxy.clear
+multiprocessing.managers.DictProxy.popitem
+
+# Undocumented implementation details
+pipes.Template.makepipeline
+pipes.Template.open_r
+pipes.Template.open_w
+sunau.Au_read.initfp
+sunau.Au_write.initfp
+
+threading.Lock  # Factory function at runtime, but that wouldn't let us use it in type hints
+types.SimpleNamespace.__init__  # class doesn't accept positional arguments but has default C signature
+typing_extensions\.Annotated  # Undocumented implementation details

--- a/stdlib/@tests/stubtest_allowlists/py38.txt
+++ b/stdlib/@tests/stubtest_allowlists/py38.txt
@@ -139,6 +139,7 @@ lib2to3.pytree.BasePattern.__new__
 lib2to3.pytree.BasePattern.type
 lib2to3.pytree.NegatedPattern.match
 lib2to3.pytree.NegatedPattern.match_seq
+tkinter.tix.[A-Z_]+
 tkinter.tix.CObjView
 tkinter.tix.DialogShell
 tkinter.tix.ExFileSelectDialog

--- a/stdlib/@tests/stubtest_allowlists/py39.txt
+++ b/stdlib/@tests/stubtest_allowlists/py39.txt
@@ -1,31 +1,125 @@
-_weakref.ProxyType.__reversed__  # Doesn't really exist
-ast.ExtSlice.__new__
-ast.Index.__new__
+# ========================
+# New errors in Python 3.9
+# ========================
+
+
+# ======
+# >= 3.9
+# ======
+
+# Exists at runtime, but missing from stubs
+_collections_abc.AsyncIterable.__class_getitem__
+_collections_abc.Awaitable.__class_getitem__
+_collections_abc.Container.__class_getitem__
+_collections_abc.Iterable.__class_getitem__
+_collections_abc.MappingView.__class_getitem__
+
+
+# ========
+# 3.9 only
+# ========
+
+# Exists at runtime, but missing from stubs
+collections.AsyncIterable.__class_getitem__
+collections.Awaitable.__class_getitem__
+collections.Container.__class_getitem__
+collections.Iterable.__class_getitem__
+collections.MappingView.__class_getitem__
+hmac.HMAC.digest_cons
+hmac.HMAC.inner
+hmac.HMAC.outer
+
+
+# ===========
+# 3.9 to 3.10
+# ===========
+
 builtins.float.__setformat__  # Internal method for CPython test suite
+typing._SpecialForm.__mro_entries__  # Exists at runtime, but missing from stubs
+
+
+# ===========
+# 3.9 to 3.12
+# ===========
+
+tkinter.tix.[A-Z_]+
+
+
+# ===================================
+# Pre-existing errors from Python 3.8
+# ===================================
+
+
+# ======
+# <= 3.9
+# ======
+
 builtins.input  # Incorrect default value in text signature, fixed in 3.10
-_?bz2.BZ2Decompressor.__init__  # function does not accept parameters but C signature is set
-collections.AsyncGenerator.asend  # async at runtime, deliberately not in the stub, see #7491. Pos-only differences also.
 collections.AsyncGenerator.__anext__  # async at runtime, deliberately not in the stub, see #7491
 collections.AsyncGenerator.aclose  # async at runtime, deliberately not in the stub, see #7491
-collections.AsyncIterator.__anext__  # async at runtime, deliberately not in the stub, see #7491
 collections.AsyncGenerator.ag_await
 collections.AsyncGenerator.ag_code
 collections.AsyncGenerator.ag_frame
 collections.AsyncGenerator.ag_running
+collections.AsyncGenerator.asend  # async at runtime, deliberately not in the stub, see #7491. Pos-only differences also.
+collections.AsyncIterator.__anext__  # async at runtime, deliberately not in the stub, see #7491
 collections.ByteString  # see comments in py3_common.txt
 collections.Callable
+collections.Coroutine.cr_await
+collections.Coroutine.cr_code
+collections.Coroutine.cr_frame
+collections.Coroutine.cr_running
+collections.Generator.gi_code
+collections.Generator.gi_frame
+collections.Generator.gi_running
+collections.Generator.gi_yieldfrom
 collections.Mapping.__reversed__  # Set to None at runtime for a better error message
-configparser.ParsingError.filename
-contextlib.AbstractAsyncContextManager.__class_getitem__
-contextlib.AbstractContextManager.__class_getitem__
+collections.Mapping.get  # Adding None to the Union messed up mypy
+collections.Sequence.index  # Supporting None in end is not mandatory
+xxsubtype  # module missing from the stubs
+
+
+# =======
+# <= 3.10
+# =======
+
 email.contentmanager.typ
-enum.Enum._generate_next_value_
-functools._lru_cache_wrapper.cache_parameters  # Cannot be detected statically
-gettext.install
-gettext.translation
-importlib.abc.Finder.find_module
+gettext.install  # codeset default value is ['unspecified'] so can't be specified
+gettext.translation  # codeset default value is ['unspecified'] so can't be specified
 inspect.Signature.from_builtin  # Removed in 3.11, can add if someone needs this
 inspect.Signature.from_function  # Removed in 3.11, can add if someone needs this
+
+# SpooledTemporaryFile implements IO except these methods before Python 3.11
+# See also https://github.com/python/typeshed/pull/2452#issuecomment-420657918
+tempfile.SpooledTemporaryFile.__next__
+tempfile.SpooledTemporaryFile.readable
+tempfile.SpooledTemporaryFile.seekable
+tempfile.SpooledTemporaryFile.writable
+
+tkinter.Tk.split  # Exists at runtime, but missing from stubs
+
+
+# =======
+# <= 3.11
+# =======
+
+_?bz2.BZ2Decompressor.__init__  # function does not accept parameters but C signature is set
+configparser.ParsingError.filename
+enum.Enum._generate_next_value_
+importlib.abc.Finder.find_module
+xml.etree.ElementTree.Element.__bool__  # Doesn't really exist; see comments in stub
+xml.etree.cElementTree.Element.__bool__  # Doesn't really exist; see comments in stub
+
+
+# =======
+# <= 3.12
+# =======
+
+# Exists at runtime, but missing from stubs
+lib2to3.btm_utils
+lib2to3.fixer_util
+lib2to3.patcomp
+lib2to3.pgen2.grammar.Grammar.loads
 lib2to3.pygram.pattern_symbols
 lib2to3.pygram.python_symbols
 lib2to3.pytree.Base.__new__
@@ -35,11 +129,6 @@ lib2to3.pytree.BasePattern.__new__
 lib2to3.pytree.BasePattern.type
 lib2to3.pytree.NegatedPattern.match
 lib2to3.pytree.NegatedPattern.match_seq
-lib2to3.pgen2.grammar.Grammar.loads
-tkinter.Tk.split
-tkinter.tix.[A-Z_]+
-tkinter.tix.TclVersion
-tkinter.tix.TkVersion
 tkinter.tix.CObjView
 tkinter.tix.DialogShell
 tkinter.tix.ExFileSelectDialog
@@ -56,79 +145,83 @@ tkinter.tix.ScrolledTList
 tkinter.tix.ScrolledText
 tkinter.tix.ScrolledWindow
 tkinter.tix.Shell
-types.GenericAlias.__getattr__
+tkinter.tix.TclVersion
+tkinter.tix.TkVersion
+
+
+# ============================================================
+# Allowlist entries that cannot or should not be fixed; >= 3.9
+# ============================================================
+
+_ast.ImportFrom.level  # None on the class, but never None on instances
+_weakref.ProxyType.__reversed__  # Doesn't really exist
+ast.ImportFrom.level  # None on the class, but never None on instances
+ast.ExtSlice.__new__  # C signature is broader than what is actually accepted
+ast.Index.__new__  # C signature is broader than what is actually accepted
+
+# Treated an alias of a typing class in the stubs,
+# they are generic to type checkers anyway.
+contextlib.AbstractAsyncContextManager.__class_getitem__
+contextlib.AbstractContextManager.__class_getitem__
+
+functools._lru_cache_wrapper.cache_parameters  # Cannot be detected statically
+importlib.abc.Traversable.open  # Problematic protocol signature at runtime, see source code comments.
+os.PathLike.__class_getitem__  # PathLike is a protocol; we don't expect all PathLike classes to implement class_getitem
 types.GenericAlias.__call__  # Would be complicated to fix properly, Any could silence problems. #6392
-weakref.ProxyType.__reversed__  # Doesn't really exist
-xxsubtype  # module missing from the stubs
-
-xml.etree.ElementTree.Element.__bool__  # Doesn't really exist; see comments in stub
-xml.etree.cElementTree.Element.__bool__  # Doesn't really exist; see comments in stub
-
-# Exist at runtime for internal reasons, no need to put them in the stub
-typing_extensions\.TypeAliasType\.__call__
-typing_extensions\.TypeAliasType\.__init_subclass__
-# We call them read-only properties, runtime implementation is slightly different
-typing_extensions\.TypeAliasType\.__(parameters|type_params|name|module|value)__
-
-collections.Coroutine.cr_await
-collections.Coroutine.cr_code
-collections.Coroutine.cr_frame
-collections.Coroutine.cr_running
-collections.Generator.gi_code
-collections.Generator.gi_frame
-collections.Generator.gi_running
-collections.Generator.gi_yieldfrom
-collections.Mapping.get  # Adding None to the Union messed up mypy
-collections.Sequence.index  # Supporting None in end is not mandatory
-
-# Modules that exist at runtime, but shouldn't be added to typeshed
-ctypes.test
-ctypes\.test\..+
-lib2to3.tests
-lib2to3\.tests\..+
-sqlite3.test
-sqlite3\.test\..+
-test
-tkinter.test
-tkinter\.test\..+
-unittest.test
-unittest\.test\..+
-
-# Exists at runtime, but missing from stubs
-_collections_abc.AsyncIterable.__class_getitem__
-_collections_abc.Awaitable.__class_getitem__
-_collections_abc.Container.__class_getitem__
-_collections_abc.Iterable.__class_getitem__
-_collections_abc.MappingView.__class_getitem__
-collections.AsyncIterable.__class_getitem__
-collections.Awaitable.__class_getitem__
-collections.Container.__class_getitem__
-collections.Iterable.__class_getitem__
-collections.MappingView.__class_getitem__
-hmac.HMAC.digest_cons
-hmac.HMAC.inner
-hmac.HMAC.outer
+types.GenericAlias.__getattr__
 types.GenericAlias.__mro_entries__
-typing._SpecialForm.__mro_entries__
-lib2to3.btm_utils
-lib2to3.fixer_util
-lib2to3.patcomp
+typing\.NamedTuple  # Super-special typing primitive
+weakref.ProxyType.__reversed__  # Doesn't really exist
 
-# SpooledTemporaryFile implements IO except these methods before Python 3.11
-# See also https://github.com/python/typeshed/pull/2452#issuecomment-420657918
-tempfile.SpooledTemporaryFile.__next__
-tempfile.SpooledTemporaryFile.readable
-tempfile.SpooledTemporaryFile.seekable
-tempfile.SpooledTemporaryFile.writable
 
-# ==========
-# Allowlist entries that cannot or should not be fixed
-# ==========
+# ==============================================================
+# Allowlist entries that cannot or should not be fixed; 3.9 only
+# ==============================================================
 
-# Factory function at runtime
-# but that wouldn't let us use it in type hints
-threading.Lock
-multiprocessing.dummy.Lock
+ast.FormattedValue.conversion  # None on the class, but never None on instances
+_ast.FormattedValue.conversion  # None on the class, but never None on instances
+
+
+# =================================================================
+# Allowlist entries that cannot or should not be fixed; 3.9 to 3.12
+# =================================================================
+
+typing\.Annotated  # Super-special typing primitive
+
+
+# ============================================================
+# Allowlist entries that cannot or should not be fixed; <= 3.9
+# ============================================================
+
+_ssl.RAND_egd  # Depends on the existence and flags of SSL
+builtins.classmethod.__get__  # Runtime signature is incorrect (https://github.com/python/cpython/issues/93021)
+builtins.property.__get__  # Runtime signature is incorrect (https://github.com/python/cpython/issues/93021)
+builtins.staticmethod.__get__  # Runtime signature is incorrect (https://github.com/python/cpython/issues/93021)
+builtins.memoryview.__iter__  # C type that implements __getitem__
+builtins.memoryview.cast  # inspect.signature is incorrect about shape being kw-only
+
+# Adding these reflected dunders to `typing.AbstractSet` causes a large number of false-positives. See #7414.
+collections.Set.__rand__
+collections.Set.__ror__
+collections.Set.__rsub__
+collections.Set.__rxor__
+
+ssl.RAND_egd  # Depends on the existence and flags of SSL
+test  # Modules that exist at runtime, but shouldn't be added to typeshed
+
+# Runtime signature is incorrect (https://github.com/python/cpython/issues/93021)
+types.ClassMethodDescriptorType.__get__
+types.FunctionType.__get__
+types.GetSetDescriptorType.__get__
+types.LambdaType.__get__
+types.MemberDescriptorType.__get__
+types.MethodDescriptorType.__get__
+types.WrapperDescriptorType.__get__
+
+
+# =============================================================
+# Allowlist entries that cannot or should not be fixed; <= 3.10
+# =============================================================
 
 # Side effects from module initialization
 _compat_pickle.excname
@@ -141,10 +234,52 @@ json.encoder.i
 lib2to3.pgen2.grammar.line
 lib2to3.pgen2.grammar.name
 lib2to3.pgen2.grammar.op
-poplib.POP3_SSL.stls  # bad declaration of inherited function. See poplib.pyi
+
+pstats.SortKey.__new__  # Derives from (str, Enum)
 pydoc.Helper.symbol  # Loop variable in class https://github.com/python/typeshed/issues/6401#issuecomment-981178522
 pydoc.Helper.symbols_  # Loop variable in class https://github.com/python/typeshed/issues/6401#issuecomment-981178522
 pydoc.Helper.topic  # Loop variable in class https://github.com/python/typeshed/issues/6401#issuecomment-981178522
+sqlite3.test  # Modules that exist at runtime, but shouldn't be added to typeshed
+sqlite3\.test\..+  # Modules that exist at runtime, but shouldn't be added to typeshed
+tkinter.EventType.__new__  # Derives from (str, Enum)
+types.CodeType.replace  # stubtest thinks default values are None but None doesn't work at runtime
+
+
+# =============================================================
+# Allowlist entries that cannot or should not be fixed; <= 3.11
+# =============================================================
+
+.*.__buffer__  # We lie about the existence of these methods
+.*.__release_buffer__  # We lie about the existence of these methods
+asynchat.async_chat.encoding  # Removed in 3.12
+asynchat.async_chat.use_encoding  # Removed in 3.12
+asynchat.find_prefix_at_end  # Removed in 3.12
+asyncore.dispatcher.addr  # Removed in 3.12
+asyncore.dispatcher.handle_accepted  # Removed in 3.12
+ctypes.test  # Modules that exist at runtime, but shouldn't be added to typeshed
+ctypes\.test\..+  # Modules that exist at runtime, but shouldn't be added to typeshed
+distutils\..*  # Removed in 3.12
+lib2to3.tests  # Modules that exist at runtime, but shouldn't be added to typeshed
+lib2to3\.tests\..+  # Modules that exist at runtime, but shouldn't be added to typeshed
+pkgutil.ImpImporter\..*  # Removed in 3.12
+pkgutil.ImpLoader\..*  # Removed in 3.12
+poplib.POP3_SSL.stls  # bad declaration of inherited function. See poplib.pyi
+tkinter.test  # Modules that exist at runtime, but shouldn't be added to typeshed
+tkinter\.test\..+  # Modules that exist at runtime, but shouldn't be added to typeshed
+
+# Exist at runtime for internal reasons, no need to put them in the stub
+typing_extensions\.TypeAliasType\.__call__
+typing_extensions\.TypeAliasType\.__init_subclass__
+# We call them read-only properties, runtime implementation is slightly different
+typing_extensions\.TypeAliasType\.__(parameters|type_params|name|module|value)__
+
+unittest.test  # Modules that exist at runtime, but shouldn't be added to typeshed
+unittest\.test\..+  # Modules that exist at runtime, but shouldn't be added to typeshed
+
+
+# =============================================================
+# Allowlist entries that cannot or should not be fixed; <= 3.12
+# =============================================================
 
 # Undocumented implementation details
 cgi.FieldStorage.bufsize
@@ -156,45 +291,11 @@ cgi.FieldStorage.read_multi
 cgi.FieldStorage.read_single
 cgi.FieldStorage.read_urlencoded
 cgi.FieldStorage.skip_lines
-pipes.Template.makepipeline
-pipes.Template.open_r
-pipes.Template.open_w
-sunau.Au_read.initfp
-sunau.Au_write.initfp
-typing_extensions\.Annotated
 
-# Adding these reflected dunders to `typing.AbstractSet` causes a large number of false-positives. See #7414.
-collections.Set.__rand__
-collections.Set.__ror__
-collections.Set.__rsub__
-collections.Set.__rxor__
-
-builtins.memoryview.__iter__  # C type that implements __getitem__
-builtins.memoryview.cast  # inspect.signature is incorrect about shape being kw-only
-
-ast.FormattedValue.conversion  # None on the class, but never None on instances
-_ast.FormattedValue.conversion  # None on the class, but never None on instances
-_ast.ImportFrom.level  # None on the class, but never None on instances
-ast.ImportFrom.level  # None on the class, but never None on instances
-
-os.PathLike.__class_getitem__  # PathLike is a protocol; we don't expect all PathLike classes to implement class_getitem
-
-# Runtime signature is incorrect (https://github.com/python/cpython/issues/93021)
-builtins.classmethod.__get__
-builtins.property.__get__
-builtins.staticmethod.__get__
-types.FunctionType.__get__
-types.LambdaType.__get__
-types.ClassMethodDescriptorType.__get__
-types.GetSetDescriptorType.__get__
-types.MemberDescriptorType.__get__
-types.MethodDescriptorType.__get__
-types.WrapperDescriptorType.__get__
-multiprocessing.managers.DictProxy.clear
-multiprocessing.managers.DictProxy.popitem
-
-# Problematic protocol signature at runtime, see source code comments.
-importlib.abc.Traversable.open
+ctypes._endian.DEFAULT_MODE  # Incorrectly star import.
+ctypes._endian.RTLD_GLOBAL  # Incorrectly star import.
+ctypes._endian.RTLD_LOCAL  # Incorrectly star import.
+multiprocessing.dummy.Lock  # Factory function at runtime, but that wouldn't let us use it in type hints
 
 # These multiprocessing proxy methods have *args, **kwargs signatures at runtime,
 # But have more precise (accurate) signatures in the stub
@@ -205,36 +306,17 @@ multiprocessing.managers.DictProxy.items
 multiprocessing.managers.DictProxy.keys
 multiprocessing.managers.DictProxy.values
 
-# Super-special typing primitives
-typing\.NamedTuple
-typing\.Annotated
+# Runtime signature is incorrect (https://github.com/python/cpython/issues/93021)
+multiprocessing.managers.DictProxy.clear
+multiprocessing.managers.DictProxy.popitem
 
-# We lie about the existence of these methods
-.*.__buffer__
-.*.__release_buffer__
+# Undocumented implementation details
+pipes.Template.makepipeline
+pipes.Template.open_r
+pipes.Template.open_w
+sunau.Au_read.initfp
+sunau.Au_write.initfp
 
-# Removed in 3.12
-distutils\..*
-asyncore.dispatcher.addr
-asyncore.dispatcher.handle_accepted
-asynchat.async_chat.encoding
-asynchat.async_chat.use_encoding
-asynchat.find_prefix_at_end
-pkgutil.ImpImporter\..*
-pkgutil.ImpLoader\..*
-
-types.CodeType.replace  # stubtest thinks default values are None but None doesn't work at runtime
+threading.Lock  # Factory function at runtime, but that wouldn't let us use it in type hints
 types.SimpleNamespace.__init__  # class doesn't accept positional arguments but has default C signature
-
-# These enums derive from (str, Enum)
-pstats.SortKey.__new__
-tkinter.EventType.__new__
-
-# Items that depend on the existence and flags of SSL
-ssl.RAND_egd
-_ssl.RAND_egd
-
-# Incorrectly star import.
-ctypes._endian.DEFAULT_MODE
-ctypes._endian.RTLD_GLOBAL
-ctypes._endian.RTLD_LOCAL
+typing_extensions\.Annotated  # Undocumented implementation details

--- a/stdlib/@tests/stubtest_allowlists/py39.txt
+++ b/stdlib/@tests/stubtest_allowlists/py39.txt
@@ -38,13 +38,6 @@ builtins.float.__setformat__  # Internal method for CPython test suite
 typing._SpecialForm.__mro_entries__  # Exists at runtime, but missing from stubs
 
 
-# ===========
-# 3.9 to 3.12
-# ===========
-
-tkinter.tix.[A-Z_]+
-
-
 # ===================================
 # Pre-existing errors from Python 3.8
 # ===================================
@@ -129,6 +122,7 @@ lib2to3.pytree.BasePattern.__new__
 lib2to3.pytree.BasePattern.type
 lib2to3.pytree.NegatedPattern.match
 lib2to3.pytree.NegatedPattern.match_seq
+tkinter.tix.[A-Z_]+
 tkinter.tix.CObjView
 tkinter.tix.DialogShell
 tkinter.tix.ExFileSelectDialog

--- a/stdlib/@tests/stubtest_allowlists/win32-py310.txt
+++ b/stdlib/@tests/stubtest_allowlists/win32-py310.txt
@@ -1,20 +1,6 @@
-# Added in Python 3.10.12
-tarfile.TarInfo.replace
-
-# pathlib methods that exist on Windows, but always raise NotImplementedError,
-# so are omitted from the stub
-pathlib.Path.is_mount
-pathlib.WindowsPath.is_mount
-
-# pathlib functions that rely on modules that don't exist on Windows
-pathlib.Path.owner
-pathlib.Path.group
-
-# Modules that don't exist on Windows
-crypt
-nis
-ossaudiodev
-spwd
+# ===========
+# 3.9 to 3.11
+# ===========
 
 # Incompatible changes introduced in Python 3.10.15
 # (Remove once 3.10.15 becomes available for Windows)
@@ -23,3 +9,36 @@ email._header_value_parser.SPECIALSNL
 email.errors.HeaderWriteError
 email.utils.getaddresses
 email.utils.parseaddr
+
+
+# =======
+# <= 3.10
+# =======
+
+# Added in Python 3.10.12
+tarfile.TarInfo.replace
+
+
+# =============================================================
+# Allowlist entries that cannot or should not be fixed; <= 3.11
+# =============================================================
+
+# pathlib methods that exist on Windows, but always raise NotImplementedError,
+# so are omitted from the stub
+pathlib.Path.is_mount
+pathlib.WindowsPath.is_mount
+
+
+# =============================================================
+# Allowlist entries that cannot or should not be fixed; <= 3.12
+# =============================================================
+
+# Modules that don't exist on Windows
+crypt
+nis
+ossaudiodev
+spwd
+
+# pathlib functions that rely on modules that don't exist on Windows
+pathlib.Path.owner
+pathlib.Path.group

--- a/stdlib/@tests/stubtest_allowlists/win32-py311.txt
+++ b/stdlib/@tests/stubtest_allowlists/win32-py311.txt
@@ -1,17 +1,6 @@
-# pathlib methods that exist on Windows, but always raise NotImplementedError,
-# so are omitted from the stub
-pathlib.Path.is_mount
-pathlib.WindowsPath.is_mount
-
-# pathlib functions that rely on modules that don't exist on Windows
-pathlib.Path.owner
-pathlib.Path.group
-
-# Modules that don't exist on Windows
-crypt
-nis
-ossaudiodev
-spwd
+# ===========
+# 3.9 to 3.11
+# ===========
 
 # Incompatible changes introduced in Python 3.11.10
 # (Remove once 3.11.10 becomes available for Windows)
@@ -20,3 +9,28 @@ email._header_value_parser.SPECIALSNL
 email.errors.HeaderWriteError
 email.utils.getaddresses
 email.utils.parseaddr
+
+
+# =============================================================
+# Allowlist entries that cannot or should not be fixed; <= 3.11
+# =============================================================
+
+# pathlib methods that exist on Windows, but always raise NotImplementedError,
+# so are omitted from the stub
+pathlib.Path.is_mount
+pathlib.WindowsPath.is_mount
+
+
+# =============================================================
+# Allowlist entries that cannot or should not be fixed; <= 3.12
+# =============================================================
+
+# Modules that don't exist on Windows
+crypt
+nis
+ossaudiodev
+spwd
+
+# pathlib functions that rely on modules that don't exist on Windows
+pathlib.Path.owner
+pathlib.Path.group

--- a/stdlib/@tests/stubtest_allowlists/win32-py312.txt
+++ b/stdlib/@tests/stubtest_allowlists/win32-py312.txt
@@ -1,19 +1,34 @@
-_winapi.GetLongPathName
-_winapi.GetShortPathName
-ntpath.exists
-os.path.exists
+# =======
+# >= 3.12
+# =======
 
 # Undocumented internal method, not really for public consumption.
 # (Hard to add types for unless we add stubs for the undocumented _overlapped module...)
 asyncio.IocpProactor.finish_socket_func
 asyncio.windows_events.IocpProactor.finish_socket_func
 
-# pathlib functions that rely on modules that don't exist on Windows
-pathlib.Path.owner
-pathlib.Path.group
+ntpath.exists
+os.path.exists
+
+
+# =========
+# 3.12 only
+# =========
+
+_winapi.GetLongPathName
+_winapi.GetShortPathName
+
+
+# =============================================================
+# Allowlist entries that cannot or should not be fixed; <= 3.12
+# =============================================================
 
 # Modules that don't exist on Windows
 crypt
 nis
 ossaudiodev
 spwd
+
+# pathlib functions that rely on modules that don't exist on Windows
+pathlib.Path.owner
+pathlib.Path.group

--- a/stdlib/@tests/stubtest_allowlists/win32-py313.txt
+++ b/stdlib/@tests/stubtest_allowlists/win32-py313.txt
@@ -1,11 +1,21 @@
+# =======
+# >= 3.13
+# =======
+
 # New in py313 (triage these!)
-ntpath.exists
 ntpath.lexists
 ntpath.splitroot
-os.path.exists
 os.path.lexists
+
+
+# =======
+# >= 3.12
+# =======
 
 # Undocumented internal method, not really for public consumption.
 # (Hard to add types for unless we add stubs for the undocumented _overlapped module...)
 asyncio.IocpProactor.finish_socket_func
 asyncio.windows_events.IocpProactor.finish_socket_func
+
+ntpath.exists
+os.path.exists

--- a/stdlib/@tests/stubtest_allowlists/win32-py38.txt
+++ b/stdlib/@tests/stubtest_allowlists/win32-py38.txt
@@ -1,23 +1,41 @@
+# =======
+# <= 3.10
+# =======
+
 # Added in Python 3.8.17
 tarfile.TarInfo.replace
 
-# ==========
-# Allowlist entries that cannot or should not be fixed
-# ==========
+
+# ============================================================
+# Allowlist entries that cannot or should not be fixed; <= 3.8
+# ============================================================
+
+# pathlib methods that exist on Windows, but always raise NotImplementedError,
+# so are omitted from the stub
+pathlib.WindowsPath.group
+pathlib.WindowsPath.owner
+
+
+# =============================================================
+# Allowlist entries that cannot or should not be fixed; <= 3.11
+# =============================================================
 
 # pathlib methods that exist on Windows, but always raise NotImplementedError,
 # so are omitted from the stub
 pathlib.Path.is_mount
-pathlib.WindowsPath.group
-pathlib.WindowsPath.owner
 pathlib.WindowsPath.is_mount
 
-# pathlib functions that rely on modules that don't exist on Windows
-pathlib.Path.owner
-pathlib.Path.group
+
+# =============================================================
+# Allowlist entries that cannot or should not be fixed; <= 3.12
+# =============================================================
 
 # Modules that don't exist on Windows
 crypt
 nis
 ossaudiodev
 spwd
+
+# pathlib functions that rely on modules that don't exist on Windows
+pathlib.Path.owner
+pathlib.Path.group

--- a/stdlib/@tests/stubtest_allowlists/win32-py39.txt
+++ b/stdlib/@tests/stubtest_allowlists/win32-py39.txt
@@ -1,20 +1,6 @@
-# Added in Python 3.9.17
-tarfile.TarInfo.replace
-
-# pathlib methods that exist on Windows, but always raise NotImplementedError,
-# so are omitted from the stub
-pathlib.Path.is_mount
-pathlib.WindowsPath.is_mount
-
-# pathlib functions that rely on modules that don't exist on Windows
-pathlib.Path.owner
-pathlib.Path.group
-
-# Modules that don't exist on Windows
-crypt
-nis
-ossaudiodev
-spwd
+# ===========
+# 3.9 to 3.11
+# ===========
 
 # Incompatible changes introduced in Python 3.9.20
 # (Remove once 3.9.20 becomes available for Windows)
@@ -23,3 +9,36 @@ email._header_value_parser.SPECIALSNL
 email.errors.HeaderWriteError
 email.utils.getaddresses
 email.utils.parseaddr
+
+
+# =======
+# <= 3.10
+# =======
+
+# Added in Python 3.9.17
+tarfile.TarInfo.replace
+
+
+# =============================================================
+# Allowlist entries that cannot or should not be fixed; <= 3.11
+# =============================================================
+
+# pathlib methods that exist on Windows, but always raise NotImplementedError,
+# so are omitted from the stub
+pathlib.Path.is_mount
+pathlib.WindowsPath.is_mount
+
+
+# =============================================================
+# Allowlist entries that cannot or should not be fixed; <= 3.12
+# =============================================================
+
+# Modules that don't exist on Windows
+crypt
+nis
+ossaudiodev
+spwd
+
+# pathlib functions that rely on modules that don't exist on Windows
+pathlib.Path.owner
+pathlib.Path.group


### PR DESCRIPTION
This makes it easier to ensure that categorization and comments are in sync between one allowlist and another.

With the help of a quick script, I sorted the version-specific allowlists and made sure that comments and fix/don't fix is consistent between the files. Each labeled section is identical to others with the same name, and this should also make consolidating when dropping an old version easier.

On the negative side, this is unfortunately sure to cause a lot of merge conflicts. What do people think? Worth it or not worth it?

There should be no significant differences in overall content in this MR. I did consolidate some comments to an inline version, and there was one entry which had been commented out in all the files where it appeared:

```
# typing.SupportsRound.__round__ # pos-or-kw at runtime, but we pretend it's pos-only in the stub so that e.g. float.__round__ satisfies the interface
```

I'm not sure why it was commented out but not removed; I did remove it as part of this MR. Edit: looks like it's from https://github.com/python/typeshed/pull/7442