### PR TITLE
Add `google.protobuf.runtime_version`

### DIFF
--- a/stubs/protobuf/google/protobuf/runtime_version.pyi
+++ b/stubs/protobuf/google/protobuf/runtime_version.pyi
@@ -1,20 +1,20 @@
 from enum import Enum
-from typing import Final, Literal
+from typing import Final
 
 class Domain(Enum):
     GOOGLE_INTERNAL = 1
     PUBLIC = 2
 
-OSS_DOMAIN: Final[Literal[Domain.PUBLIC]]
-OSS_MAJOR: Final = 5
-OSS_MINOR: Final = 28
-OSS_PATCH: Final = 3
-OSS_SUFFIX: Final = ""
-DOMAIN: Final[Literal[Domain.PUBLIC]]
-MAJOR: Final = OSS_MAJOR
-MINOR: Final = OSS_MINOR
-PATCH: Final = OSS_PATCH
-SUFFIX: Final = OSS_SUFFIX
+OSS_DOMAIN: Final[Domain]
+OSS_MAJOR: Final[int]
+OSS_MINOR: Final[int]
+OSS_PATCH: Final[int]
+OSS_SUFFIX: Final[str]
+DOMAIN: Final[Domain]
+MAJOR: Final[int]
+MINOR: Final[int]
+PATCH: Final[int]
+SUFFIX: Final[str]
 
 class VersionError(Exception): ...
 

--- a/stubs/protobuf/google/protobuf/runtime_version.pyi
+++ b/stubs/protobuf/google/protobuf/runtime_version.pyi
@@ -1,0 +1,23 @@
+from enum import Enum
+from typing import Final, Literal
+
+class Domain(Enum):
+    GOOGLE_INTERNAL = 1
+    PUBLIC = 2
+
+OSS_DOMAIN: Final[Literal[Domain.PUBLIC]]
+OSS_MAJOR: Final = 5
+OSS_MINOR: Final = 28
+OSS_PATCH: Final = 3
+OSS_SUFFIX: Final = ""
+DOMAIN: Final[Literal[Domain.PUBLIC]]
+MAJOR: Final = OSS_MAJOR
+MINOR: Final = OSS_MINOR
+PATCH: Final = OSS_PATCH
+SUFFIX: Final = OSS_SUFFIX
+
+class VersionError(Exception): ...
+
+def ValidateProtobufRuntimeVersion(
+    gen_domain: Domain, gen_major: int, gen_minor: int, gen_patch: int, gen_suffix: str, location: str
+) -> None: ...


### PR DESCRIPTION
Closes https://github.com/python/typeshed/issues/13045

Source code says 
> It should only be accessed by Protobuf gencodes and tests. DO NOT USE it elsewhere.

But some users are using it presumably to avoid parsing `google.protobuf.__version__`. This module is not using the `_` prefix and is pretty simple. May as well add it now that it's been requested.