### PR TITLE
sort the common allowlist

### DIFF
--- a/stdlib/@tests/stubtest_allowlists/common.txt
+++ b/stdlib/@tests/stubtest_allowlists/common.txt
@@ -9,15 +9,14 @@ _collections_abc.AsyncGenerator.ag_code
 _collections_abc.AsyncGenerator.ag_frame
 _collections_abc.AsyncGenerator.ag_running
 _ctypes.CFuncPtr  # stubtest erroneously thinks it can't be subclassed
-asyncio.BaseEventLoop.subprocess_exec # BaseEventLoop adds several parameters and stubtest fails on the difference if we add them
-asyncio.base_events.BaseEventLoop.subprocess_exec # BaseEventLoop adds several parameters and stubtest fails on the difference if we add them
+asyncio.BaseEventLoop.subprocess_exec  # BaseEventLoop adds several parameters and stubtest fails on the difference if we add them
+asyncio.base_events.BaseEventLoop.subprocess_exec  # BaseEventLoop adds several parameters and stubtest fails on the difference if we add them
 builtins.dict.get
 collections\.ChainMap\.fromkeys  # https://github.com/python/mypy/issues/17023
 configparser.SectionProxy.__getattr__  # SectionProxy can have arbitrary attributes when custom converters are used
-# SectionProxy get functions are set in __init__
-configparser.SectionProxy.getboolean
-configparser.SectionProxy.getfloat
-configparser.SectionProxy.getint
+configparser.SectionProxy.getboolean  # SectionProxy get functions are set in __init__
+configparser.SectionProxy.getfloat  # SectionProxy get functions are set in __init__
+configparser.SectionProxy.getint  # SectionProxy get functions are set in __init__
 contextlib._GeneratorContextManagerBase.__init__  # skipped in the stubs in favor of its child classes
 copy.PyStringMap  # defined only in Jython
 ctypes.CDLL._FuncPtr  # None at class level but initialized in __init__ to this value
@@ -55,12 +54,14 @@ unittest.mock.patch  # It's a complicated overload and I haven't been able to fi
 weakref.WeakKeyDictionary.update
 weakref.WeakValueDictionary.update
 
+
 # ==========
 # TODO: Modules that exist at runtime, but are missing from stubs
 # ==========
 turtledemo
 turtledemo\..+
 xml.sax.expatreader
+
 
 # ==========
 # TODO: Module members that exist at runtime, but are missing from stubs
@@ -103,22 +104,30 @@ tkinter.Misc.config
 
 idlelib
 
+
 # ==========
 # Module members that exist at runtime, but are deliberately missing from stubs
 # ==========
 
 # Undocumented implementation details of a deprecated class
-importlib.machinery.WindowsRegistryFinder.DEBUG_BUILD
-importlib.machinery.WindowsRegistryFinder.REGISTRY_KEY
-importlib.machinery.WindowsRegistryFinder.REGISTRY_KEY_DEBUG
 _frozen_importlib_external.WindowsRegistryFinder.DEBUG_BUILD
 _frozen_importlib_external.WindowsRegistryFinder.REGISTRY_KEY
 _frozen_importlib_external.WindowsRegistryFinder.REGISTRY_KEY_DEBUG
 importlib._bootstrap_external.WindowsRegistryFinder.DEBUG_BUILD
 importlib._bootstrap_external.WindowsRegistryFinder.REGISTRY_KEY
 importlib._bootstrap_external.WindowsRegistryFinder.REGISTRY_KEY_DEBUG
+importlib.machinery.WindowsRegistryFinder.DEBUG_BUILD
+importlib.machinery.WindowsRegistryFinder.REGISTRY_KEY
+importlib.machinery.WindowsRegistryFinder.REGISTRY_KEY_DEBUG
 
 # Undocumented implementation details
+email.contentmanager.get_and_fixup_unknown_message_content
+email.contentmanager.get_message_content
+email.contentmanager.get_non_text_content
+email.contentmanager.get_text_content
+email.contentmanager.set_bytes_content
+email.contentmanager.set_message_content
+email.contentmanager.set_text_content
 profile.Profile.dispatch
 profile.Profile.fake_code
 profile.Profile.fake_frame
@@ -130,21 +139,23 @@ profile.Profile.trace_dispatch_i
 profile.Profile.trace_dispatch_l
 profile.Profile.trace_dispatch_mac
 profile.Profile.trace_dispatch_return
-email.contentmanager.get_and_fixup_unknown_message_content
-email.contentmanager.get_message_content
-email.contentmanager.get_non_text_content
-email.contentmanager.get_text_content
-email.contentmanager.set_bytes_content
-email.contentmanager.set_message_content
-email.contentmanager.set_text_content
 turtle.ScrolledCanvas.adjustScrolls
 turtle.ScrolledCanvas.onResize
 wave.Wave_read.initfp
 wave.Wave_write.initfp
 
+
 # ==========
 # Platform and installation differences
 # ==========
+
+# LC_MESSAGES is sometimes present in __all__, sometimes not,
+# so stubtest will sometimes complain about exported names being different at runtime to the exported names in the stub
+(locale.__all__)?
+
+# Loadable SQLite extensions are disabled on GitHub runners
+(sqlite3(.dbapi2)?.Connection.enable_load_extension)?
+(sqlite3(.dbapi2)?.Connection.load_extension)?
 
 # Platform differences that cannot be captured by the type system
 socket.AF_DECnet
@@ -158,31 +169,23 @@ sys.ps1
 sys.ps2
 sys.tracebacklimit
 
-# LC_MESSAGES is sometimes present in __all__, sometimes not,
-# so stubtest will sometimes complain about exported names being different at runtime to the exported names in the stub
-(locale.__all__)?
-
-# Loadable SQLite extensions are disabled on GitHub runners
-(sqlite3(.dbapi2)?.Connection.enable_load_extension)?
-(sqlite3(.dbapi2)?.Connection.load_extension)?
 
 # ==========
 # Other allowlist entries that cannot or should not be fixed
 # ==========
-
-# Runtime AST node runtime constructor behaviour is too loose.
-# For static typing, the loose behaviour is undesirable (https://github.com/python/typeshed/issues/8378).
-# For the runtime, the loose behaviour is deprecated in Python 3.13 (https://github.com/python/cpython/issues/105858)
-_?ast.AST.__init__
-_?ast.excepthandler.__init__
-_?ast.expr.__init__
-_?ast.stmt.__init__
 
 # async at runtime, deliberately not in the stub, see #7491
 _collections_abc.AsyncGenerator.asend  # pos-only differences also.
 _collections_abc.AsyncGenerator.__anext__
 _collections_abc.AsyncGenerator.aclose
 _collections_abc.AsyncIterator.__anext__
+
+# Pretend typing.ByteString is a Union, to better match its documented semantics.
+# As a side effect, this changes the definition of collections.abc.ByteString, which is okay,
+# because it's not an ABC that makes any sense and was deprecated in 3.12
+_collections_abc.ByteString
+
+_collections_abc.Callable  # Typing-related weirdness
 
 # Coroutine and Generator properties are added programmatically
 _collections_abc.Coroutine.cr_await
@@ -203,38 +206,34 @@ _collections_abc.Set.__ror__
 _collections_abc.Set.__rsub__
 _collections_abc.Set.__rxor__
 
-collections.abc.*  # Types are re-exported from _collections_abc, so errors should be fixed there
-
-_?ctypes.Array.raw  # exists but stubtest can't see it; only available if _CT == c_char
-_?ctypes.Array._type_  # _type_ is abstract, https://github.com/python/typeshed/pull/6361
-_?ctypes.Array._length_ # _length_ is abstract, https://github.com/python/typeshed/pull/6361
-_?ctypes.Structure.__getattr__  # doesn't exist, but makes things easy if we pretend it does
-_?ctypes.Union.__getattr__  # doesn't exist, but makes things easy if we pretend it does
-
-# runtime is *args, **kwargs due to a wrapper
-# we have more accurate signatures in the stubs
+# runtime is *args, **kwargs due to a wrapper; we have more accurate signatures in the stubs
 _frozen_importlib_external.ExtensionFileLoader.get_filename
 _frozen_importlib_external.FileLoader.get_filename
 _frozen_importlib_external.FileLoader.get_resource_reader
 _frozen_importlib_external.FileLoader.load_module
 
 _pydecimal.*  # See comments in file
+_typeshed.*  # Utility types for typeshed, doesn't exist at runtime
 argparse.ArgumentParser.__init__  # stubtest doesn't recognise the runtime default (a class) as being compatible with a callback protocol (the stub annotation)
 argparse.Namespace.__getattr__  # The whole point of this class is its attributes are dynamic
 
-# runtime is *args, **kwargs due to a wrapper, but we have more accurate signatures in the stubs
-ast.Bytes.__new__
-ast.Ellipsis.__new__
-ast.NameConstant.__new__
-ast.Num.__new__
-ast.Str.__new__
+# Runtime AST node runtime constructor behaviour is too loose.
+# For static typing, the loose behaviour is undesirable (https://github.com/python/typeshed/issues/8378).
+# For the runtime, the loose behaviour is deprecated in Python 3.13 (https://github.com/python/cpython/issues/105858)
+_?ast.AST.__init__
+_?ast.excepthandler.__init__
+_?ast.expr.__init__
+_?ast.stmt.__init__
 
+ast.Bytes.__new__  # runtime is *args, **kwargs due to a wrapper, but we have more accurate signatures in the stubs
+ast.Ellipsis.__new__  # runtime is *args, **kwargs due to a wrapper, but we have more accurate signatures in the stubs
+ast.NameConstant.__new__  # runtime is *args, **kwargs due to a wrapper, but we have more accurate signatures in the stubs
+ast.Num.__new__  # runtime is *args, **kwargs due to a wrapper, but we have more accurate signatures in the stubs
+ast.Str.__new__  # runtime is *args, **kwargs due to a wrapper, but we have more accurate signatures in the stubs
 ast.NodeVisitor.visit_\w+  # Methods are discovered dynamically, see #3796
-asyncio.proactor_events.BaseProactorEventLoop.sock_recv # nbytes parameter has different name 'n' in implementation
-asyncio.selector_events.BaseSelectorEventLoop.sock_recv # nbytes parameter has different name 'n' in implementation
-
-_asyncio.Future.__init__  # Usually initialized from c object
-asyncio.Future.__init__  # Usually initialized from c object
+asyncio.proactor_events.BaseProactorEventLoop.sock_recv  # nbytes parameter has different name 'n' in implementation
+asyncio.selector_events.BaseSelectorEventLoop.sock_recv  # nbytes parameter has different name 'n' in implementation
+_?asyncio.Future.__init__  # Usually initialized from c object
 asyncio.futures.Future.__init__  # Usually initialized from c object
 
 # Condition functions are exported in __init__
@@ -244,10 +243,6 @@ asyncio.Condition.release
 asyncio.locks.Condition.acquire
 asyncio.locks.Condition.locked
 asyncio.locks.Condition.release
-threading.Condition.acquire
-threading.Condition.release
-multiprocessing.dummy.Condition.acquire
-multiprocessing.dummy.Condition.release
 
 # Weird special builtins that are typed as functions, but aren't functions
 builtins.copyright
@@ -257,10 +252,10 @@ builtins.help
 builtins.license
 builtins.quit
 
+builtins.OSError.characters_written  # GetSetDescriptor that always raises AttributeError
 builtins.float.__getformat__  # Internal method for CPython test suite
 builtins.memoryview.__contains__  # C type that implements __getitem__
 builtins.object.__init__  # default C signature is incorrect
-builtins.OSError.characters_written  # GetSetDescriptor that always raises AttributeError
 builtins.reveal_locals  # Builtins that type checkers pretends exist
 builtins.reveal_type  # Builtins that type checkers pretends exist
 builtins.type.__dict__  # read-only but not actually a property; stubtest thinks it's a mutable attribute.
@@ -279,6 +274,12 @@ codecs.CodecInfo.incrementalencoder
 codecs.CodecInfo.streamreader
 codecs.CodecInfo.streamwriter
 
+# See comments in file. List out methods that are delegated by __getattr__ at runtime.
+# Used to make the relevant class satisfy BinaryIO interface.
+codecs.StreamReaderWriter.\w+
+codecs.StreamRecoder.\w+
+
+collections.abc.*  # Types are re-exported from _collections_abc, so errors should be fixed there
 collections.UserList.sort  # Runtime has *args but will error if any are supplied
 _?contextvars.Context.__init__  # C signature is broader than what is actually accepted
 
@@ -291,14 +292,43 @@ csv.Dialect.skipinitialspace
 
 csv.DictReader.__init__  # runtime sig has *args but will error if more than 5 positional args are supplied
 csv.DictWriter.__init__  # runtime sig has *args but will error if more than 5 positional args are supplied
+_?ctypes.Array.raw  # exists but stubtest can't see it; only available if _CT == c_char
+_?ctypes.Array._type_  # _type_ is abstract, https://github.com/python/typeshed/pull/6361
+_?ctypes.Array._length_  # _length_ is abstract, https://github.com/python/typeshed/pull/6361
+_?ctypes.Structure.__getattr__  # doesn't exist, but makes things easy if we pretend it does
+_?ctypes.Union.__getattr__  # doesn't exist, but makes things easy if we pretend it does
+
+# Iterable classes that don't define __iter__ at runtime (usually iterable via __getitem__)
+# These would ideally be special-cased by type checkers; see https://github.com/python/mypy/issues/2220
+_?ctypes.Array.__iter__
 
 dataclasses.field  # White lies around defaults
+
+# __all__-related weirdness (see #6523)
+email.__all__
+email.base64mime
+email.charset
+email.encoders
+email.errors
+email.feedparser
+email.generator
+email.header
+email.iterators
+email.message
+email.mime
+email.parser
+email.quoprimime
+email.utils
+
 email.policy.EmailPolicy.message_factory  # "type" at runtime, but protocol in stubs
+enum.auto.__or__  # enum.auto is magic, see comments
+enum.auto.__and__  # enum.auto is magic, see comments
+enum.auto.__xor__  # enum.auto is magic, see comments
 _?hashlib.scrypt  # Raises TypeError if salt, n, r or p are None
 hmac.HMAC.blocksize  # use block_size instead
+imaplib.IMAP4_SSL.ssl  # Depends on the existence and flags of SSL
 
-# runtime is *args, **kwargs due to a wrapper
-# we have more accurate signatures in the stubs
+# runtime is *args, **kwargs due to a wrapper; we have more accurate signatures in the stubs
 importlib._bootstrap_external.ExtensionFileLoader.get_filename
 importlib._bootstrap_external.FileLoader.get_filename
 importlib._bootstrap_external.FileLoader.get_resource_reader
@@ -314,12 +344,24 @@ inspect.Signature.__init__
 inspect.Parameter.empty  # set as private marker _empty
 inspect.Signature.empty  # set as private marker _empty
 
+# Iterable classes that don't define __iter__ at runtime (usually iterable via __getitem__)
+# These would ideally be special-cased by type checkers; see https://github.com/python/mypy/issues/2220
+mmap.mmap.__iter__
+mmap.mmap.__contains__
+
+multiprocessing.dummy.Condition.acquire  # Condition functions are exported in __init__
+multiprocessing.dummy.Condition.release  # Condition functions are exported in __init__
+
 # At runtime, these are functions from multiprocessing.context._default_context.
 # Typeshed makes them classes instead, which matches CPython documentation.
 # This has been heavily discussed, see #4266 for the primary issue about it.
 multiprocessing.JoinableQueue
 multiprocessing.Queue
 multiprocessing.SimpleQueue
+
+# A factory function that returns 'most efficient lock'.
+# Marking it as a function will make it impossible for users to use the Lock type as an annotation.
+multiprocessing.dummy.RLock
 
 # These multiprocessing proxy methods have *args, **kwargs signatures at runtime,
 # But have more precise (accurate) signatures in the stub
@@ -336,12 +378,13 @@ multiprocessing.managers.SyncManager.Namespace
 multiprocessing.managers.SyncManager.RLock
 
 multiprocessing.(dummy|managers).Namespace.__[gs]etattr__  # Any field can be set on Namespace
+
 # alias for a class defined elsewhere,
 # mypy infers the variable has type `(*args) -> ForkingPickler`
 # but stubtest infers the runtime type as <class ForkingPickler>
 multiprocessing.reduction.AbstractReducer.ForkingPickler
-# Non-private parameter on __del__
-multiprocessing.pool.Pool.__del__
+
+multiprocessing.pool.Pool.__del__  # Non-private parameter on __del__
 
 # These are because the ctx argument has a default value in the stubs but not
 # at runtime. This is a compromise between the runtime signatures of (for example)
@@ -359,163 +402,31 @@ multiprocessing.synchronize.Condition.release
 multiprocessing.synchronize.SemLock.acquire
 multiprocessing.synchronize.SemLock.release
 
-# C signature is broader than what is actually accepted
-_?queue.SimpleQueue.__init__
-
-# Items that depend on the existence and flags of SSL
-imaplib.IMAP4_SSL.ssl
-ssl.PROTOCOL_SSLv2
-ssl.PROTOCOL_SSLv3
-
+os._wrap_close.read  # Methods that come from __getattr__() at runtime
+os._wrap_close.readable  # Methods that come from __getattr__() at runtime
+os._wrap_close.readline  # Methods that come from __getattr__() at runtime
+os._wrap_close.readlines  # Methods that come from __getattr__() at runtime
+os._wrap_close.writable  # Methods that come from __getattr__() at runtime
+os._wrap_close.write  # Methods that come from __getattr__() at runtime
+os._wrap_close.writelines  # Methods that come from __getattr__() at runtime
 pickle._Pickler\..*  # Best effort typing for undocumented internals
 pickle._Unpickler\..*  # Best effort typing for undocumented internals
 pickle.Pickler.memo  # undocumented implementation detail, has different type in C/Python implementations
 pickle.Pickler.persistent_id  # C pickler persistent_id is an attribute
 pickle.Unpickler.memo  # undocumented implementation detail, has different type in C/Python implementations
 pickle.Unpickler.persistent_load  # C unpickler persistent_load is an attribute
+_?queue.SimpleQueue.__init__  # C signature is broader than what is actually accepted
 re.Pattern.scanner  # Undocumented and not useful. #6405
-tempfile._TemporaryFileWrapper.[\w_]+  # Dynamically specified by __getattr__, and thus don't exist on the class
-
-# Details of runtime definition don't need to be in stubs
-typing_extensions\._SpecialForm.*
-typing_extensions\.TypeVar.*
-typing_extensions\.ParamSpec.*
-typing(_extensions)?\.Generic
-typing\.Protocol
-typing(_extensions)?\._TypedDict
-typing(_extensions)?\.TypedDict
-typing._Final
-typing._Final.__init_subclass__
-
-# Special primitives
-typing_extensions\.Final
-typing_extensions\.NamedTuple
-typing_extensions\.LiteralString
-typing_extensions\.Coroutine
-typing_extensions\.Awaitable
-typing(_extensions)?\.AsyncIterator
-typing(_extensions)?\.AsyncIterable
-typing(_extensions)?\.AsyncGenerator
-typing(_extensions)?\.ValuesView
-typing(_extensions)?\.Sized
-typing(_extensions)?\.Sequence
-typing(_extensions)?\.Reversible
-typing(_extensions)?\.Pattern
-typing(_extensions)?\.MutableSet
-typing(_extensions)?\.MutableSequence
-typing(_extensions)?\.MutableMapping
-typing(_extensions)?\.Match
-typing(_extensions)?\.MappingView
-typing(_extensions)?\.Mapping
-typing(_extensions)?\.KeysView
-typing(_extensions)?\.Iterator
-typing(_extensions)?\.Iterable
-typing(_extensions)?\.ItemsView
-typing(_extensions)?\.Hashable
-typing(_extensions)?\.Generator
-typing(_extensions)?\.Coroutine
-typing(_extensions)?\.Collection
-typing(_extensions)?\.Container
-typing\.ByteString
-typing(_extensions)?\.Awaitable
-typing(_extensions)?\.AbstractSet
-
-typing_extensions.NewType.__mro_entries__  # just exists for an error message
-
-# Typing-related weirdness
-_collections_abc.Callable
-_typeshed.*  # Utility types for typeshed, doesn't exist at runtime
-typing._SpecialForm.__call__
-typing._SpecialForm.__init__
-
-# Pretend typing.ByteString is a Union, to better match its documented semantics.
-# As a side effect, this changes the definition of collections.abc.ByteString, which is okay,
-# because it's not an ABC that makes any sense and was deprecated in 3.12
-_collections_abc.ByteString
-
-# These are abstract properties at runtime,
-# but marking them as such in the stub breaks half the the typed-Python ecosystem (see #8726)
-typing(_extensions)?\.IO\.closed
-typing(_extensions)?\.IO\.mode
-typing(_extensions)?\.IO\.name
-typing(_extensions)?\.TextIO\.buffer
-typing(_extensions)?\.TextIO\.encoding
-typing(_extensions)?\.TextIO\.errors
-typing(_extensions)?\.TextIO\.line_buffering
-typing(_extensions)?\.TextIO\.newlines
-
-# These are typing._SpecialGenericAlias at runtime, which is not a real type, but it
-# behaves like one in most cases
-typing(_extensions)?\.(Async)?ContextManager
-
-types.MethodType.__closure__  # read-only but not actually a property; stubtest thinks it doesn't exist.
-types.MethodType.__code__  # read-only but not actually a property; stubtest thinks it doesn't exist.
-types.MethodType.__defaults__  # read-only but not actually a property; stubtest thinks it doesn't exist.
-types.ModuleType.__dict__  # read-only but not actually a property; stubtest thinks it's a mutable attribute.
-types.ModuleType.__getattr__  # this doesn't exist at runtime
-
+ssl.PROTOCOL_SSLv2  # Depends on the existence and flags of SSL
+ssl.PROTOCOL_SSLv3  # Depends on the existence and flags of SSL
 sys.implementation  # Actually SimpleNamespace but then you wouldn't have convenient attributes
+tempfile._TemporaryFileWrapper.[\w_]+  # Dynamically specified by __getattr__, and thus don't exist on the class
+threading.Condition.acquire  # Condition functions are exported in __init__
+threading.Condition.release  # Condition functions are exported in __init__
 
 # A factory function that returns 'most efficient lock'.
 # Marking it as a function will make it impossible for users to use the Lock type as an annotation.
 threading.RLock
-multiprocessing.dummy.RLock
-
-# Dynamically created, has unnecessary *args
-turtle.ScrolledCanvas.find_all
-turtle.ScrolledCanvas.select_clear
-turtle.ScrolledCanvas.select_item
-
-# Attributes that are intended to be private
-uuid.bytes_
-uuid.int_
-
-# Always overridden in inheriting class
-webbrowser.UnixBrowser.remote_action
-webbrowser.UnixBrowser.remote_action_newtab
-webbrowser.UnixBrowser.remote_action_newwin
-
-# Undocumented and have a comment in the source code saying "State variables (don't mess with these)"
-wsgiref.handlers.BaseHandler.bytes_sent
-wsgiref.handlers.BaseHandler.headers
-wsgiref.handlers.BaseHandler.headers_sent
-wsgiref.handlers.BaseHandler.result
-wsgiref.handlers.BaseHandler.status
-
-_?weakref\.(ref|ReferenceType)\.__init__  # C implementation has incorrect signature
-_?weakref\.(ref|ReferenceType)\.__call__  # C function default annotation is wrong
-_?weakref\.CallableProxyType\.__getattr__  # Should have all attributes of proxy
-_?weakref\.ProxyType\.__bytes__  # Doesn't actually exist
-_?weakref\.ProxyType\.__getattr__  # Should have all attributes of proxy
-weakref.WeakValueDictionary.setdefault  # has a default value for the "default" argument, but always errors out if no value is supplied for the parameter by the user
-xml.dom.minidom.StringTypes  # Unnecessary re-export
-
-# See comments in file. List out methods that are delegated by __getattr__ at runtime.
-# Used to make the relevant class satisfy BinaryIO interface.
-codecs.StreamReaderWriter.\w+
-codecs.StreamRecoder.\w+
-urllib.response.addbase.\w+
-
-# __all__-related weirdness (see #6523)
-email.__all__
-email.base64mime
-email.charset
-email.encoders
-email.errors
-email.feedparser
-email.generator
-email.header
-email.iterators
-email.message
-email.mime
-email.parser
-email.quoprimime
-email.utils
-xml.__all__
-xml.dom
-xml.etree
-xml.parsers
-xml.sax
 
 # Missing aliases to existing methods that not many people seem to use.
 # Complicated multiple inheritance, confuses type checkers.
@@ -548,13 +459,6 @@ tkinter.Place.place_slaves
 tkinter.Place.slaves
 
 # Methods that come from __getattr__() at runtime
-os._wrap_close.read
-os._wrap_close.readable
-os._wrap_close.readline
-os._wrap_close.readlines
-os._wrap_close.writable
-os._wrap_close.write
-os._wrap_close.writelines
 tkinter.Tk.adderrorinfo
 tkinter.Tk.call
 tkinter.Tk.createcommand
@@ -575,30 +479,129 @@ tkinter.Tk.splitlist
 tkinter.Tk.unsetvar
 tkinter.Tk.wantobjects
 tkinter.Tk.willdispatch
-unittest.runner._WritelnDecorator.flush
-unittest.runner._WritelnDecorator.write
 
 tkinter.font.Font.__getitem__  # Argument name differs (doesn't matter for __dunder__ methods)
 tkinter.Misc.grid_propagate  # The noarg placeholder is a set value list
 tkinter.Misc.pack_propagate  # The noarg placeholder is a set value list
 tkinter.Tk.report_callback_exception  # A bit of a lie, since it's actually a method, but typing it as an attribute allows it to be assigned to
 tkinter.Wm.wm_iconphoto  # Default value of argument can't be used without runtime error
-
 traceback.TracebackException.from_exception  # explicitly expanding arguments going into TracebackException __init__
-urllib.request.HTTPPasswordMgrWithPriorAuth.__init__  # Args are passed as is to super, so super args are specified
+turtle.ScrolledCanvas.find_all  # Dynamically created, has unnecessary *args
+turtle.ScrolledCanvas.select_clear  # Dynamically created, has unnecessary *args
+turtle.ScrolledCanvas.select_item  # Dynamically created, has unnecessary *args
+
+# Details of runtime definition don't need to be in stubs
+typing._Final
+typing._Final.__init_subclass__
+typing\.Protocol
+typing(_extensions)?\._TypedDict
+typing(_extensions)?\.Generic
+typing(_extensions)?\.TypedDict
+typing_extensions\.ParamSpec.*
+typing_extensions\.TypeVar.*
+typing_extensions\._SpecialForm.*
+
+# Special primitives
+typing\.ByteString
+typing(_extensions)?\.AbstractSet
+typing(_extensions)?\.AsyncGenerator
+typing(_extensions)?\.AsyncIterable
+typing(_extensions)?\.AsyncIterator
+typing(_extensions)?\.Awaitable
+typing(_extensions)?\.Collection
+typing(_extensions)?\.Container
+typing(_extensions)?\.Coroutine
+typing(_extensions)?\.Generator
+typing(_extensions)?\.Hashable
+typing(_extensions)?\.ItemsView
+typing(_extensions)?\.Iterable
+typing(_extensions)?\.Iterator
+typing(_extensions)?\.KeysView
+typing(_extensions)?\.Mapping
+typing(_extensions)?\.MappingView
+typing(_extensions)?\.Match
+typing(_extensions)?\.MutableMapping
+typing(_extensions)?\.MutableSequence
+typing(_extensions)?\.MutableSet
+typing(_extensions)?\.Pattern
+typing(_extensions)?\.Reversible
+typing(_extensions)?\.Sequence
+typing(_extensions)?\.Sized
+typing(_extensions)?\.ValuesView
+typing_extensions\.Awaitable
+typing_extensions\.Coroutine
+typing_extensions\.Final
+typing_extensions\.LiteralString
+typing_extensions\.NamedTuple
+
+typing._SpecialForm.__call__  # Typing-related weirdness
+typing._SpecialForm.__init__  # Typing-related weirdness
+typing_extensions.NewType.__mro_entries__  # just exists for an error message
+
+# These are abstract properties at runtime,
+# but marking them as such in the stub breaks half the the typed-Python ecosystem (see #8726)
+typing(_extensions)?\.IO\.closed
+typing(_extensions)?\.IO\.mode
+typing(_extensions)?\.IO\.name
+typing(_extensions)?\.TextIO\.buffer
+typing(_extensions)?\.TextIO\.encoding
+typing(_extensions)?\.TextIO\.errors
+typing(_extensions)?\.TextIO\.line_buffering
+typing(_extensions)?\.TextIO\.newlines
+
+# These are typing._SpecialGenericAlias at runtime, which is not a real type, but it
+# behaves like one in most cases
+typing(_extensions)?\.(Async)?ContextManager
 
 # Iterable classes that don't define __iter__ at runtime (usually iterable via __getitem__)
 # These would ideally be special-cased by type checkers; see https://github.com/python/mypy/issues/2220
-_ctypes.Array.__iter__
-ctypes.Array.__iter__
-mmap.mmap.__iter__
-mmap.mmap.__contains__
-xml.etree.ElementTree.Element.__iter__
-xml.etree.cElementTree.Element.__iter__
 typing(_extensions)?\.IO\.__iter__  # See https://github.com/python/typeshed/commit/97bc450acd60c1bcdafef3ce8fbe3b95a9c0cac3
 
+types.MethodType.__closure__  # read-only but not actually a property; stubtest thinks it doesn't exist.
+types.MethodType.__code__  # read-only but not actually a property; stubtest thinks it doesn't exist.
+types.MethodType.__defaults__  # read-only but not actually a property; stubtest thinks it doesn't exist.
+types.ModuleType.__dict__  # read-only but not actually a property; stubtest thinks it's a mutable attribute.
+types.ModuleType.__getattr__  # this doesn't exist at runtime
+unittest.runner._WritelnDecorator.flush  # Methods that come from __getattr__() at runtime
+unittest.runner._WritelnDecorator.write  # Methods that come from __getattr__() at runtime
+
+# See comments in file. List out methods that are delegated by __getattr__ at runtime.
+# Used to make the relevant class satisfy BinaryIO interface.
+urllib.response.addbase.\w+
+
+urllib.request.HTTPPasswordMgrWithPriorAuth.__init__  # Args are passed as is to super, so super args are specified
+uuid.bytes_  # Attributes that are intended to be private
+uuid.int_  # Attributes that are intended to be private
+_?weakref\.(ref|ReferenceType)\.__init__  # C implementation has incorrect signature
+_?weakref\.(ref|ReferenceType)\.__call__  # C function default annotation is wrong
+_?weakref\.CallableProxyType\.__getattr__  # Should have all attributes of proxy
+_?weakref\.ProxyType\.__bytes__  # Doesn't actually exist
+_?weakref\.ProxyType\.__getattr__  # Should have all attributes of proxy
+weakref.WeakValueDictionary.setdefault  # has a default value for the "default" argument, but always errors out if no value is supplied for the parameter by the user
+webbrowser.UnixBrowser.remote_action  # Always overridden in inheriting class
+webbrowser.UnixBrowser.remote_action_newtab  # Always overridden in inheriting class
+webbrowser.UnixBrowser.remote_action_newwin  # Always overridden in inheriting class
+
+# Undocumented and have a comment in the source code saying "State variables (don't mess with these)"
+wsgiref.handlers.BaseHandler.bytes_sent
+wsgiref.handlers.BaseHandler.headers
+wsgiref.handlers.BaseHandler.headers_sent
+wsgiref.handlers.BaseHandler.result
+wsgiref.handlers.BaseHandler.status
+
+xml.__all__  # __all__-related weirdness (see #6523)
+xml.dom  # __all__-related weirdness (see #6523)
+xml.etree  # __all__-related weirdness (see #6523)
+xml.parsers  # __all__-related weirdness (see #6523)
+xml.sax  # __all__-related weirdness (see #6523)
+xml.dom.minidom.StringTypes  # Unnecessary re-export
 xml.etree.ElementTree.XMLParser.__init__  # Defined in C so has general signature
 xml.etree.cElementTree.XMLParser.__init__  # Defined in C so has general signature
+
+# Iterable classes that don't define __iter__ at runtime (usually iterable via __getitem__)
+# These would ideally be special-cased by type checkers; see https://github.com/python/mypy/issues/2220
+xml.etree.ElementTree.Element.__iter__
+xml.etree.cElementTree.Element.__iter__
 
 # Added or modified in a patch release, backported to all security branches,
 # but have yet to find their way to all GitHub Actions images
@@ -622,8 +625,3 @@ xml.etree.cElementTree.XMLParser.__init__  # Defined in C so has general signatu
 (xml.etree.cElementTree.XMLPullParser.flush)?
 (xml.parsers.expat.XMLParserType.GetReparseDeferralEnabled)?
 (xml.parsers.expat.XMLParserType.SetReparseDeferralEnabled)?
-
-# enum.auto is magic, see comments
-enum.auto.__or__
-enum.auto.__and__
-enum.auto.__xor__


### PR DESCRIPTION
Mostly getting the "don't fix" section back into (roughly) alphabetical order. The existing file was inconsistent about sorting modules with an underscore. I normalized to sorting by the underscore if it was a literal, and sorting by ignoring the underscore if it was a `_?foo` regex. I left the patch-release differences block at the end of the file alone, since those need to be tested manually for when they can be removed. 

I also normalized whitespace (two spaces before a inline comment, two blank lines before a new section header).

