### PR TITLE
sort security backport allowlist entries

### DIFF
--- a/stdlib/@tests/stubtest_allowlists/common.txt
+++ b/stdlib/@tests/stubtest_allowlists/common.txt
@@ -600,29 +600,6 @@ typing(_extensions)?\.IO\.__iter__  # See https://github.com/python/typeshed/com
 xml.etree.ElementTree.XMLParser.__init__  # Defined in C so has general signature
 xml.etree.cElementTree.XMLParser.__init__  # Defined in C so has general signature
 
-# Added or modified in a patch release, backported to all security branches,
-# but have yet to find their way to all GitHub Actions images
-# (tarfile.tar_filter)?
-# (tarfile.fully_trusted_filter)?
-# (tarfile.data_filter)?
-# (tarfile.TarFile.extractall)?
-# (tarfile.TarFile.extract)?
-# (tarfile.SpecialFileError)?
-# (tarfile.OutsideDestinationError)?
-# (tarfile.LinkOutsideDestinationError)?
-# (tarfile.FilterError)?
-# (tarfile.AbsolutePathError)?
-# (tarfile.AbsoluteLinkError)?
-# (shutil.unpack_archive)?
-# (pyexpat.XMLParserType.GetReparseDeferralEnabled)?
-# (pyexpat.XMLParserType.SetReparseDeferralEnabled)?
-# (xml.etree.ElementTree.XMLParser.flush)?
-# (xml.etree.ElementTree.XMLPullParser.flush)?
-# (xml.etree.cElementTree.XMLParser.flush)?
-# (xml.etree.cElementTree.XMLPullParser.flush)?
-# (xml.parsers.expat.XMLParserType.GetReparseDeferralEnabled)?
-# (xml.parsers.expat.XMLParserType.SetReparseDeferralEnabled)?
-
 # enum.auto is magic, see comments
 enum.auto.__or__
 enum.auto.__and__

--- a/stdlib/@tests/stubtest_allowlists/common.txt
+++ b/stdlib/@tests/stubtest_allowlists/common.txt
@@ -602,26 +602,26 @@ xml.etree.cElementTree.XMLParser.__init__  # Defined in C so has general signatu
 
 # Added or modified in a patch release, backported to all security branches,
 # but have yet to find their way to all GitHub Actions images
-(tarfile.tar_filter)?
-(tarfile.fully_trusted_filter)?
-(tarfile.data_filter)?
-(tarfile.TarFile.extractall)?
-(tarfile.TarFile.extract)?
-(tarfile.SpecialFileError)?
-(tarfile.OutsideDestinationError)?
-(tarfile.LinkOutsideDestinationError)?
-(tarfile.FilterError)?
-(tarfile.AbsolutePathError)?
-(tarfile.AbsoluteLinkError)?
-(shutil.unpack_archive)?
-(pyexpat.XMLParserType.GetReparseDeferralEnabled)?
-(pyexpat.XMLParserType.SetReparseDeferralEnabled)?
-(xml.etree.ElementTree.XMLParser.flush)?
-(xml.etree.ElementTree.XMLPullParser.flush)?
-(xml.etree.cElementTree.XMLParser.flush)?
-(xml.etree.cElementTree.XMLPullParser.flush)?
-(xml.parsers.expat.XMLParserType.GetReparseDeferralEnabled)?
-(xml.parsers.expat.XMLParserType.SetReparseDeferralEnabled)?
+# (tarfile.tar_filter)?
+# (tarfile.fully_trusted_filter)?
+# (tarfile.data_filter)?
+# (tarfile.TarFile.extractall)?
+# (tarfile.TarFile.extract)?
+# (tarfile.SpecialFileError)?
+# (tarfile.OutsideDestinationError)?
+# (tarfile.LinkOutsideDestinationError)?
+# (tarfile.FilterError)?
+# (tarfile.AbsolutePathError)?
+# (tarfile.AbsoluteLinkError)?
+# (shutil.unpack_archive)?
+# (pyexpat.XMLParserType.GetReparseDeferralEnabled)?
+# (pyexpat.XMLParserType.SetReparseDeferralEnabled)?
+# (xml.etree.ElementTree.XMLParser.flush)?
+# (xml.etree.ElementTree.XMLPullParser.flush)?
+# (xml.etree.cElementTree.XMLParser.flush)?
+# (xml.etree.cElementTree.XMLPullParser.flush)?
+# (xml.parsers.expat.XMLParserType.GetReparseDeferralEnabled)?
+# (xml.parsers.expat.XMLParserType.SetReparseDeferralEnabled)?
 
 # enum.auto is magic, see comments
 enum.auto.__or__

--- a/stdlib/@tests/stubtest_allowlists/darwin-py310.txt
+++ b/stdlib/@tests/stubtest_allowlists/darwin-py310.txt
@@ -14,8 +14,32 @@ email.utils.parseaddr
 # <= 3.10
 # =======
 
-# Added in Python 3.10.12
+# Incompatible changes introduced in Python 3.10.12
+# (Remove once 3.10.12 becomes available for GitHub Actions)
+shutil.unpack_archive
+tarfile.AbsoluteLinkError
+tarfile.AbsolutePathError
+tarfile.FilterError
+tarfile.LinkOutsideDestinationError
+tarfile.OutsideDestinationError
+tarfile.SpecialFileError
+tarfile.TarFile.extract
+tarfile.TarFile.extractall
 tarfile.TarInfo.replace
+tarfile.data_filter
+tarfile.fully_trusted_filter
+tarfile.tar_filter
+
+# Incompatible changes introduced in Python 3.9.14
+# (Remove once 3.9.14 becomes available for GitHub Actions)
+pyexpat.XMLParserType.GetReparseDeferralEnabled
+pyexpat.XMLParserType.SetReparseDeferralEnabled
+xml.etree.ElementTree.XMLParser.flush
+xml.etree.ElementTree.XMLPullParser.flush
+xml.etree.cElementTree.XMLParser.flush
+xml.etree.cElementTree.XMLPullParser.flush
+xml.parsers.expat.XMLParserType.GetReparseDeferralEnabled
+xml.parsers.expat.XMLParserType.SetReparseDeferralEnabled
 
 
 # =============================================================

--- a/stdlib/@tests/stubtest_allowlists/darwin-py38.txt
+++ b/stdlib/@tests/stubtest_allowlists/darwin-py38.txt
@@ -11,8 +11,32 @@ sys.get_int_max_str_digits
 # <= 3.10
 # =======
 
-# Added in Python 3.8.17
+# Incompatible changes introduced in Python 3.8.17
+# (Remove once 3.8.17 becomes available for GitHub Actions)
+shutil.unpack_archive
+tarfile.AbsoluteLinkError
+tarfile.AbsolutePathError
+tarfile.FilterError
+tarfile.LinkOutsideDestinationError
+tarfile.OutsideDestinationError
+tarfile.SpecialFileError
+tarfile.TarFile.extract
+tarfile.TarFile.extractall
 tarfile.TarInfo.replace
+tarfile.data_filter
+tarfile.fully_trusted_filter
+tarfile.tar_filter
+
+# Incompatible changes introduced in Python 3.8.19
+# (Remove once 3.8.19 becomes available for GitHub Actions)
+pyexpat.XMLParserType.GetReparseDeferralEnabled
+pyexpat.XMLParserType.SetReparseDeferralEnabled
+xml.etree.ElementTree.XMLParser.flush
+xml.etree.ElementTree.XMLPullParser.flush
+xml.etree.cElementTree.XMLParser.flush
+xml.etree.cElementTree.XMLPullParser.flush
+xml.parsers.expat.XMLParserType.GetReparseDeferralEnabled
+xml.parsers.expat.XMLParserType.SetReparseDeferralEnabled
 
 
 # =============================================================

--- a/stdlib/@tests/stubtest_allowlists/darwin-py39.txt
+++ b/stdlib/@tests/stubtest_allowlists/darwin-py39.txt
@@ -23,8 +23,32 @@ sys.get_int_max_str_digits
 # <= 3.10
 # =======
 
-# Added in Python 3.9.17
+# Incompatible changes introduced in Python 3.9.17
+# (Remove once 3.9.17 becomes available for GitHub Actions)
+shutil.unpack_archive
+tarfile.AbsoluteLinkError
+tarfile.AbsolutePathError
+tarfile.FilterError
+tarfile.LinkOutsideDestinationError
+tarfile.OutsideDestinationError
+tarfile.SpecialFileError
+tarfile.TarFile.extract
+tarfile.TarFile.extractall
 tarfile.TarInfo.replace
+tarfile.data_filter
+tarfile.fully_trusted_filter
+tarfile.tar_filter
+
+# Incompatible changes introduced in Python 3.9.19
+# (Remove once 3.9.19 becomes available for GitHub Actions)
+pyexpat.XMLParserType.GetReparseDeferralEnabled
+pyexpat.XMLParserType.SetReparseDeferralEnabled
+xml.etree.ElementTree.XMLParser.flush
+xml.etree.ElementTree.XMLPullParser.flush
+xml.etree.cElementTree.XMLParser.flush
+xml.etree.cElementTree.XMLPullParser.flush
+xml.parsers.expat.XMLParserType.GetReparseDeferralEnabled
+xml.parsers.expat.XMLParserType.SetReparseDeferralEnabled
 
 
 # =============================================================

--- a/stdlib/@tests/stubtest_allowlists/linux-py38.txt
+++ b/stdlib/@tests/stubtest_allowlists/linux-py38.txt
@@ -1,4 +1,20 @@
 # ======
+# <= 3.8
+# ======
+
+# Incompatible changes introduced in Python 3.8.19
+# (Remove once 3.8.19 becomes available for GitHub Actions)
+pyexpat.XMLParserType.GetReparseDeferralEnabled
+pyexpat.XMLParserType.SetReparseDeferralEnabled
+xml.etree.ElementTree.XMLParser.flush
+xml.etree.ElementTree.XMLPullParser.flush
+xml.etree.cElementTree.XMLParser.flush
+xml.etree.cElementTree.XMLPullParser.flush
+xml.parsers.expat.XMLParserType.GetReparseDeferralEnabled
+xml.parsers.expat.XMLParserType.SetReparseDeferralEnabled
+
+
+# ======
 # <= 3.9
 # ======
 

--- a/stdlib/@tests/stubtest_allowlists/win32-py310.txt
+++ b/stdlib/@tests/stubtest_allowlists/win32-py310.txt
@@ -15,8 +15,32 @@ email.utils.parseaddr
 # <= 3.10
 # =======
 
-# Added in Python 3.10.12
+# Incompatible changes introduced in Python 3.10.12
+# (Remove once 3.10.12 becomes available for GitHub Actions)
+shutil.unpack_archive
+tarfile.AbsoluteLinkError
+tarfile.AbsolutePathError
+tarfile.FilterError
+tarfile.LinkOutsideDestinationError
+tarfile.OutsideDestinationError
+tarfile.SpecialFileError
+tarfile.TarFile.extract
+tarfile.TarFile.extractall
 tarfile.TarInfo.replace
+tarfile.data_filter
+tarfile.fully_trusted_filter
+tarfile.tar_filter
+
+# Incompatible changes introduced in Python 3.9.14
+# (Remove once 3.9.14 becomes available for GitHub Actions)
+pyexpat.XMLParserType.GetReparseDeferralEnabled
+pyexpat.XMLParserType.SetReparseDeferralEnabled
+xml.etree.ElementTree.XMLParser.flush
+xml.etree.ElementTree.XMLPullParser.flush
+xml.etree.cElementTree.XMLParser.flush
+xml.etree.cElementTree.XMLPullParser.flush
+xml.parsers.expat.XMLParserType.GetReparseDeferralEnabled
+xml.parsers.expat.XMLParserType.SetReparseDeferralEnabled
 
 
 # =============================================================

--- a/stdlib/@tests/stubtest_allowlists/win32-py38.txt
+++ b/stdlib/@tests/stubtest_allowlists/win32-py38.txt
@@ -2,8 +2,32 @@
 # <= 3.10
 # =======
 
-# Added in Python 3.8.17
+# Incompatible changes introduced in Python 3.8.17
+# (Remove once 3.8.17 becomes available for GitHub Actions)
+shutil.unpack_archive
+tarfile.AbsoluteLinkError
+tarfile.AbsolutePathError
+tarfile.FilterError
+tarfile.LinkOutsideDestinationError
+tarfile.OutsideDestinationError
+tarfile.SpecialFileError
+tarfile.TarFile.extract
+tarfile.TarFile.extractall
 tarfile.TarInfo.replace
+tarfile.data_filter
+tarfile.fully_trusted_filter
+tarfile.tar_filter
+
+# Incompatible changes introduced in Python 3.8.19
+# (Remove once 3.8.19 becomes available for GitHub Actions)
+pyexpat.XMLParserType.GetReparseDeferralEnabled
+pyexpat.XMLParserType.SetReparseDeferralEnabled
+xml.etree.ElementTree.XMLParser.flush
+xml.etree.ElementTree.XMLPullParser.flush
+xml.etree.cElementTree.XMLParser.flush
+xml.etree.cElementTree.XMLPullParser.flush
+xml.parsers.expat.XMLParserType.GetReparseDeferralEnabled
+xml.parsers.expat.XMLParserType.SetReparseDeferralEnabled
 
 
 # ============================================================

--- a/stdlib/@tests/stubtest_allowlists/win32-py39.txt
+++ b/stdlib/@tests/stubtest_allowlists/win32-py39.txt
@@ -15,8 +15,32 @@ email.utils.parseaddr
 # <= 3.10
 # =======
 
-# Added in Python 3.9.17
+# Incompatible changes introduced in Python 3.9.17
+# (Remove once 3.9.17 becomes available for GitHub Actions)
+shutil.unpack_archive
+tarfile.AbsoluteLinkError
+tarfile.AbsolutePathError
+tarfile.FilterError
+tarfile.LinkOutsideDestinationError
+tarfile.OutsideDestinationError
+tarfile.SpecialFileError
+tarfile.TarFile.extract
+tarfile.TarFile.extractall
 tarfile.TarInfo.replace
+tarfile.data_filter
+tarfile.fully_trusted_filter
+tarfile.tar_filter
+
+# Incompatible changes introduced in Python 3.9.19
+# (Remove once 3.9.19 becomes available for GitHub Actions)
+pyexpat.XMLParserType.GetReparseDeferralEnabled
+pyexpat.XMLParserType.SetReparseDeferralEnabled
+xml.etree.ElementTree.XMLParser.flush
+xml.etree.ElementTree.XMLPullParser.flush
+xml.etree.cElementTree.XMLParser.flush
+xml.etree.cElementTree.XMLPullParser.flush
+xml.parsers.expat.XMLParserType.GetReparseDeferralEnabled
+xml.parsers.expat.XMLParserType.SetReparseDeferralEnabled
 
 
 # =============================================================


### PR DESCRIPTION
The current matrix of python versions is:

```
linux	3.8.18	3.9.20	3.10.15	3.11.10	3.12.7	3.13.0
win32	3.8.10	3.9.13	3.10.11	3.11.9	3.12.7	3.13.0
darwin	3.8.10	3.9.13	3.10.11	3.11.9	3.12.7	3.13.0
```
