### PR TITLE
add socket.AF_DECnet value

### DIFF
--- a/stdlib/@tests/stubtest_allowlists/common.txt
+++ b/stdlib/@tests/stubtest_allowlists/common.txt
@@ -146,9 +146,6 @@ wave.Wave_write.initfp
 # Platform and installation differences
 # ==========
 
-# Platform differences that cannot be captured by the type system
-socket.AF_DECnet
-
 # sys attributes that are not always defined
 sys.gettotalrefcount  # Available on python debug builds
 sys.last_traceback

--- a/stdlib/socket.pyi
+++ b/stdlib/socket.pyi
@@ -1046,7 +1046,6 @@ class AddressFamily(IntEnum):
     AF_INET = 2
     AF_INET6 = 10
     AF_APPLETALK = 5
-    AF_DECnet = 12
     AF_IPX = 4
     AF_SNA = 22
     AF_UNSPEC = 0
@@ -1096,7 +1095,7 @@ class AddressFamily(IntEnum):
 AF_INET = AddressFamily.AF_INET
 AF_INET6 = AddressFamily.AF_INET6
 AF_APPLETALK = AddressFamily.AF_APPLETALK
-AF_DECnet = AddressFamily.AF_DECnet
+AF_DECnet: Literal[12]
 AF_IPX = AddressFamily.AF_IPX
 AF_SNA = AddressFamily.AF_SNA
 AF_UNSPEC = AddressFamily.AF_UNSPEC

--- a/stdlib/socket.pyi
+++ b/stdlib/socket.pyi
@@ -1046,7 +1046,7 @@ class AddressFamily(IntEnum):
     AF_INET = 2
     AF_INET6 = 10
     AF_APPLETALK = 5
-    AF_DECnet = ...
+    AF_DECnet = 12
     AF_IPX = 4
     AF_SNA = 22
     AF_UNSPEC = 0


### PR DESCRIPTION
I suspect this was never added just because it didn't get collapsed into the `socket.[A-Z0-9_]+` regex. Let's see what the gitlab runners say.