### PR TITLE
sys.tracebacklimit can be set to `None`

### DIFF
--- a/stdlib/@tests/stubtest_allowlists/common.txt
+++ b/stdlib/@tests/stubtest_allowlists/common.txt
@@ -151,12 +151,12 @@ socket.AF_DECnet
 
 # sys attributes that are not always defined
 sys.gettotalrefcount  # Available on python debug builds
-sys.last_traceback
-sys.last_type
-sys.last_value
-sys.ps1
-sys.ps2
-sys.tracebacklimit
+sys.last_traceback  # Available after an unhandled error has occured
+sys.last_type  # Available after an unhandled error has occured
+sys.last_value  # Available after an unhandled error has occured
+sys.ps1  # Available in interactive mode
+sys.ps2  # Available in interactive mode
+sys.tracebacklimit  # Must be set first
 
 # LC_MESSAGES is sometimes present in __all__, sometimes not,
 # so stubtest will sometimes complain about exported names being different at runtime to the exported names in the stub

--- a/stdlib/sys/__init__.pyi
+++ b/stdlib/sys/__init__.pyi
@@ -73,7 +73,7 @@ if sys.version_info >= (3, 10):
 __stdin__: Final[TextIOWrapper | None]  # Contains the original value of stdin
 __stdout__: Final[TextIOWrapper | None]  # Contains the original value of stdout
 __stderr__: Final[TextIOWrapper | None]  # Contains the original value of stderr
-tracebacklimit: int
+tracebacklimit: int | None
 version: str
 api_version: int
 warnoptions: Any


### PR DESCRIPTION
Valid since 3.7. Includes notes on availability for all the sometimes-available sys attributes