### PR TITLE
fixes to select module constants

### DIFF
--- a/stdlib/@tests/stubtest_allowlists/darwin.txt
+++ b/stdlib/@tests/stubtest_allowlists/darwin.txt
@@ -1,8 +1,6 @@
 curses.has_key
 (os|posix).sched_param  # system dependent. Unclear if macos has it.
-select.KQ_FILTER_NETDEV  # system dependent
 select.kqueue.__init__  # default C signature is wrong
-select.POLLMSG   # system dependent
 
 # Sometimes these seem to exist on darwin, sometimes not
 (_curses.A_ITALIC)?

--- a/stdlib/@tests/stubtest_allowlists/darwin.txt
+++ b/stdlib/@tests/stubtest_allowlists/darwin.txt
@@ -1,6 +1,5 @@
 curses.has_key
 (os|posix).sched_param  # system dependent. Unclear if macos has it.
-select.kqueue.__init__  # default C signature is wrong
 
 # Sometimes these seem to exist on darwin, sometimes not
 (_curses.A_ITALIC)?
@@ -34,6 +33,8 @@ winsound
 
 # multiprocessing.popen_spawn_win32 exists on Darwin but fail to import
 multiprocessing.popen_spawn_win32
+
+select.kqueue.__init__  # default C signature is wrong
 
 # Some of these exist on non-windows, but they are useless and this is not intended
 stat.FILE_ATTRIBUTE_[A-Z_]+

--- a/stdlib/select.pyi
+++ b/stdlib/select.pyi
@@ -10,7 +10,8 @@ if sys.platform != "win32":
     POLLERR: int
     POLLHUP: int
     POLLIN: int
-    POLLMSG: int
+    if sys.platform == "linux":
+        POLLMSG: int
     POLLNVAL: int
     POLLOUT: int
     POLLPRI: int
@@ -77,7 +78,8 @@ if sys.platform != "linux" and sys.platform != "win32":
     KQ_EV_ONESHOT: int
     KQ_EV_SYSFLAGS: int
     KQ_FILTER_AIO: int
-    KQ_FILTER_NETDEV: int
+    if sys.platform != "darwin":
+        KQ_FILTER_NETDEV: int
     KQ_FILTER_PROC: int
     KQ_FILTER_READ: int
     KQ_FILTER_SIGNAL: int


### PR DESCRIPTION
`KQ_FILTER_NETDEV` is documented as not being available on MacOS.

`POLLMSG` is by observation available on linux but not MacOS or FreeBSD.