### PR TITLE
sort platform allowlists

### DIFF
--- a/stdlib/@tests/stubtest_allowlists/common.txt
+++ b/stdlib/@tests/stubtest_allowlists/common.txt
@@ -1,6 +1,6 @@
-# ==========
+# ============================================
 # TODO: Allowlist entries that should be fixed
-# ==========
+# ============================================
 
 # Please keep sorted alphabetically
 
@@ -55,17 +55,19 @@ weakref.WeakKeyDictionary.update
 weakref.WeakValueDictionary.update
 
 
-# ==========
+# ===============================================================
 # TODO: Modules that exist at runtime, but are missing from stubs
-# ==========
+# ===============================================================
+
 turtledemo
 turtledemo\..+
 xml.sax.expatreader
 
 
-# ==========
+# ======================================================================
 # TODO: Module members that exist at runtime, but are missing from stubs
-# ==========
+# ======================================================================
+
 _thread.RLock
 multiprocessing.managers.Server.accepter
 multiprocessing.managers.Server.create
@@ -98,16 +100,16 @@ multiprocessing.synchronize.Semaphore.get_value
 tkinter.Misc.config
 
 
-# ==========
+# ======================================================================
 # Modules that exist at runtime, but are deliberately missing from stubs
-# ==========
+# ======================================================================
 
 idlelib
 
 
-# ==========
+# =============================================================================
 # Module members that exist at runtime, but are deliberately missing from stubs
-# ==========
+# =============================================================================
 
 # Undocumented implementation details of a deprecated class
 _frozen_importlib_external.WindowsRegistryFinder.DEBUG_BUILD
@@ -145,9 +147,9 @@ wave.Wave_read.initfp
 wave.Wave_write.initfp
 
 
-# ==========
+# =====================================
 # Platform and installation differences
-# ==========
+# =====================================
 
 # LC_MESSAGES is sometimes present in __all__, sometimes not,
 # so stubtest will sometimes complain about exported names being different at runtime to the exported names in the stub
@@ -167,9 +169,9 @@ sys.ps2  # Available in interactive mode
 sys.tracebacklimit  # Must be set first
 
 
-# ==========
+# ==========================================================
 # Other allowlist entries that cannot or should not be fixed
-# ==========
+# ==========================================================
 
 # async at runtime, deliberately not in the stub, see #7491
 _collections_abc.AsyncGenerator.asend  # pos-only differences also.

--- a/stdlib/@tests/stubtest_allowlists/darwin.txt
+++ b/stdlib/@tests/stubtest_allowlists/darwin.txt
@@ -1,26 +1,27 @@
-curses.has_key
+# ============================================
+# TODO: Allowlist entries that should be fixed
+# ============================================
+
 (os|posix).sched_param  # system dependent. Unclear if macos has it.
 
 # Sometimes these seem to exist on darwin, sometimes not
-(_curses.A_ITALIC)?
-(curses.A_ITALIC)?
-(_socket.MSG_NOSIGNAL)?
-(socket.MsgFlag.MSG_NOSIGNAL)?
-(socket.MSG_NOSIGNAL)?
+(_gdbm)?
+(_?curses.A_ITALIC)?
+(fcntl.F_GETLEASE)?
+(fcntl.F_SETLEASE)?
 (os.preadv)?
 (os.pwritev)?
 (posix.preadv)?
 (posix.pwritev)?
 (readline.append_history_file)?
-(fcntl.F_GETLEASE)?
-(fcntl.F_SETLEASE)?
-(_gdbm)?
+(_?socket.MSG_NOSIGNAL)?
+(socket.MsgFlag.MSG_NOSIGNAL)?
 
-# ==========
-# Allowlist entries that cannot or should not be fixed
-# ==========
 
-# Modules that do not exist on macos systems
+# ==========================================
+# Modules that do not exist on MacOS systems
+# ==========================================
+
 _winapi
 asyncio.windows_events
 asyncio.windows_utils
@@ -31,23 +32,29 @@ nt
 winreg
 winsound
 
-# multiprocessing.popen_spawn_win32 exists on Darwin but fail to import
-multiprocessing.popen_spawn_win32
 
+# ==========================================================
+# Other allowlist entries that cannot or should not be fixed
+# ==========================================================
+
+# Not available on python distributions compiled without sqlite3 loadable extension support
+_sqlite3.Connection.load_extension
+_sqlite3.Connection.enable_load_extension
+
+_?curses.ACS_.*  # ACS codes are initialized only after initscr call
+curses.COLORS  # Initialized after start_color
+curses.COLOR_PAIRS  # Initialized after start_color
+curses.COLS  # Initialized only after initscr call
+curses.LINES  # Initialized only after initscr call
+curses.has_key  # stubtest gets confused because this is both a module and a function in curses
+multiprocessing.popen_spawn_win32  # exists on Darwin but fails to import
 select.kqueue.__init__  # default C signature is wrong
 
 # Some of these exist on non-windows, but they are useless and this is not intended
 stat.FILE_ATTRIBUTE_[A-Z_]+
 
-# Methods that come from __getattr__() at runtime
-tkinter.Tk.createfilehandler
-tkinter.Tk.deletefilehandler
-
-_?curses.ACS_.* # ACS codes are initialized only after initscr call
-curses.COLORS  # Initialized after start_color
-curses.COLOR_PAIRS  # Initialized after start_color
-curses.COLS  # Initialized only after initscr call
-curses.LINES  # Initialized only after initscr call
+tkinter.Tk.createfilehandler  # Methods that come from __getattr__() at runtime
+tkinter.Tk.deletefilehandler  # Methods that come from __getattr__() at runtime
 
 # These entries looks like a `setup-python` bug:
 (dbm.gnu)?
@@ -57,7 +64,3 @@ curses.LINES  # Initialized only after initscr call
 (_?locale.dgettext)?
 (_?locale.gettext)?
 (_?locale.textdomain)?
-
-# Not available on python distributions compiled without sqlite3 loadable extension support
-_sqlite3.Connection.load_extension
-_sqlite3.Connection.enable_load_extension

--- a/stdlib/@tests/stubtest_allowlists/darwin.txt
+++ b/stdlib/@tests/stubtest_allowlists/darwin.txt
@@ -5,17 +5,9 @@
 (os|posix).sched_param  # system dependent. Unclear if macos has it.
 
 # Sometimes these seem to exist on darwin, sometimes not
-(_gdbm)?
-(_?curses.A_ITALIC)?
-(fcntl.F_GETLEASE)?
-(fcntl.F_SETLEASE)?
-(os.preadv)?
-(os.pwritev)?
-(posix.preadv)?
-(posix.pwritev)?
-(readline.append_history_file)?
-(_?socket.MSG_NOSIGNAL)?
-(socket.MsgFlag.MSG_NOSIGNAL)?
+(_?curses.A_ITALIC)?  # ncurses extension
+(fcntl.F_GETLEASE)?  # GNU extension
+(fcntl.F_SETLEASE)?  # GNU extension
 
 
 # ==========================================
@@ -37,6 +29,8 @@ winsound
 # Other allowlist entries that cannot or should not be fixed
 # ==========================================================
 
+_gdbm  # Only available if compiled with libgdbm
+
 # Not available on python distributions compiled without sqlite3 loadable extension support
 _sqlite3.Connection.load_extension
 _sqlite3.Connection.enable_load_extension
@@ -48,6 +42,7 @@ curses.COLS  # Initialized only after initscr call
 curses.LINES  # Initialized only after initscr call
 curses.has_key  # stubtest gets confused because this is both a module and a function in curses
 multiprocessing.popen_spawn_win32  # exists on Darwin but fails to import
+readline.append_history_file  # Only available if compiled with GNU readline, not editline
 select.kqueue.__init__  # default C signature is wrong
 
 # Some of these exist on non-windows, but they are useless and this is not intended

--- a/stdlib/@tests/stubtest_allowlists/linux.txt
+++ b/stdlib/@tests/stubtest_allowlists/linux.txt
@@ -1,15 +1,14 @@
-# ==========
-# TODO: Review the following
-# ==========
+# ============================================
+# TODO: Allowlist entries that should be fixed
+# ============================================
 
-curses.has_key
 selectors.KqueueSelector
 
-# ==========
-# Allowlist entries that cannot or should not be fixed
-# ==========
 
+# ==========================================
 # Modules that do not exist on Linux systems
+# ==========================================
+
 _winapi
 asyncio.windows_events
 asyncio.windows_utils
@@ -20,24 +19,19 @@ nt
 winreg
 winsound
 
-# multiprocessing.popen_spawn_win32 exists on Linux but fail to import
-multiprocessing.popen_spawn_win32
 
-# Platform differences that cannot be captured by the type system
-fcntl.I_[A-Z0-9_]+
+# ==========================================================
+# Other allowlist entries that cannot or should not be fixed
+# ==========================================================
 
-# Some of these exist on non-windows, but they are useless and this is not intended
-stat.FILE_ATTRIBUTE_[A-Z_]+
-
-# Methods that come from __getattr__() at runtime
-tkinter.Tk.createfilehandler
-tkinter.Tk.deletefilehandler
-
-_?curses.ACS_.* # ACS codes are initialized only after initscr call
+_?curses.ACS_.*  # ACS codes are initialized only after initscr call
 curses.COLORS  # Initialized after start_color
 curses.COLOR_PAIRS  # Initialized after start_color
 curses.COLS  # Initialized only after initscr call
 curses.LINES  # Initialized only after initscr call
+curses.has_key  # stubtest gets confused because this is both a module and a function in curses
+fcntl.I_[A-Z0-9_]+  # Platform differences that cannot be captured by the type system
+multiprocessing.popen_spawn_win32  # exists on Linux but fails to import
 
 # These seem like they should be available on Linux, but they're not
 # on GitHub Actions runners for some reason.
@@ -66,6 +60,12 @@ _?socket.SOL_IPX
 _?socket.SOL_NETROM
 _?socket.SOL_ROSE
 
+# Some of these exist on non-windows, but they are useless and this is not intended
+stat.FILE_ATTRIBUTE_[A-Z_]+
+
 # This is available on Linux, but it's documented as for kernel debugging and
 # not present on GitHub Actions runners.
 termios.TIOCTTYGSTRUCT
+
+tkinter.Tk.createfilehandler  # Methods that come from __getattr__() at runtime
+tkinter.Tk.deletefilehandler  # Methods that come from __getattr__() at runtime

--- a/stdlib/@tests/stubtest_allowlists/win32-py38.txt
+++ b/stdlib/@tests/stubtest_allowlists/win32-py38.txt
@@ -1,3 +1,12 @@
+# ======
+# <= 3.9
+# ======
+
+# Added in Python 3.8.14
+sys.set_int_max_str_digits
+sys.get_int_max_str_digits
+
+
 # =======
 # <= 3.10
 # =======

--- a/stdlib/@tests/stubtest_allowlists/win32-py39.txt
+++ b/stdlib/@tests/stubtest_allowlists/win32-py39.txt
@@ -11,6 +11,15 @@ email.utils.getaddresses
 email.utils.parseaddr
 
 
+# ======
+# <= 3.9
+# ======
+
+# Added in Python 3.9.14
+sys.set_int_max_str_digits
+sys.get_int_max_str_digits
+
+
 # =======
 # <= 3.10
 # =======

--- a/stdlib/@tests/stubtest_allowlists/win32.txt
+++ b/stdlib/@tests/stubtest_allowlists/win32.txt
@@ -1,3 +1,7 @@
+# ============================================
+# TODO: Allowlist entries that should be fixed
+# ============================================
+
 ctypes.GetLastError  # Is actually a pointer
 # alias for a class defined elsewhere,
 # mypy infers the variable has type `(*args) -> DupHandle` but stubtest infers the runtime type as <class DupHandle>
@@ -10,11 +14,10 @@ _winapi.OpenFileMapping
 _winapi.VirtualQuerySize
 
 
-# ==========
-# Allowlist entries that cannot or should not be fixed
-# ==========
-
+# ============================================
 # Modules that do not exist on Windows systems
+# ============================================
+
 _curses
 _dbm
 _gdbm
@@ -32,24 +35,23 @@ syslog
 termios
 xxlimited
 
-# multiprocessing.popen_fork, popen_forkserver, and popen_spawn_posix exist on Windows but fail to import
-multiprocessing.popen_fork
-multiprocessing.popen_forkserver
-multiprocessing.popen_spawn_posix
-
 # Modules that rely on _curses
+_curses_panel
 curses
 curses.ascii
 curses.has_key
 curses.panel
 curses.textpad
-_curses_panel
 
 # Modules that rely on termios
 pty
 tty
 
-# Added in a patch release, backported to all security branches,
-# but have yet to find their way to all GitHub Actions images
-(sys.get_int_max_str_digits)?
-(sys.set_int_max_str_digits)?
+
+# ==========================================================
+# Other allowlist entries that cannot or should not be fixed
+# ==========================================================
+
+multiprocessing.popen_fork  # exists on Windows but fails to import
+multiprocessing.popen_forkserver  # exists on Windows but fails to import
+multiprocessing.popen_spawn_posix  # exists on Windows but fails to import


### PR DESCRIPTION
`curses.has_key` is on all three platforms, so it could be moved to common.txt, but the reason it errors is different on windows and non-windows, so I decided to keep it in the platform files. After that I sorted the (non-versioned) platform allowlists.