### PR TITLE
Mark `typing.TYPE_CHECKING` as `Final`

### DIFF
--- a/stdlib/typing.pyi
+++ b/stdlib/typing.pyi
@@ -757,7 +757,7 @@ class MutableMapping(Mapping[_KT, _VT]):
 
 Text = str
 
-TYPE_CHECKING: bool
+TYPE_CHECKING: Final[bool]
 
 # In stubs, the arguments of the IO class are marked as positional-only.
 # This differs from runtime, but better reflects the fact that in reality


### PR DESCRIPTION
Per [PEP 563](https://peps.python.org/pep-0563/#runtime-annotation-resolution-and-type-checking), `typing.TYPE_CHECKING` is intended to be a constant. It seems sensible to annotate it as such.

(Apparently some projects do modify it (e.g. sphinx autodoc [temporarily sets it to `True`](https://github.com/sphinx-doc/sphinx/blob/df3d94ffdad09cc2592caccd179004e31aa63227/sphinx/ext/autodoc/importer.py#L182) to help with import analysis), but that sort of use case seems dubious/exceptional enough to warrant a `# type: ignore`.)