### PR TITLE
allowlist updates for new patch releases of 3.12 and 3.13

### DIFF
--- a/stdlib/@tests/stubtest_allowlists/darwin-py313.txt
+++ b/stdlib/@tests/stubtest_allowlists/darwin-py313.txt
@@ -8,4 +8,3 @@ _?curses.unget_wch
 _?curses.window.get_wch
 
 (mmap.MAP_32BIT)?  # Exists locally on MacOS but not on GitHub
-posixpath.splitroot

--- a/stdlib/@tests/stubtest_allowlists/linux-py313.txt
+++ b/stdlib/@tests/stubtest_allowlists/linux-py313.txt
@@ -1,12 +1,4 @@
 # =======
-# >= 3.13
-# =======
-
-# TODO: triage these (new in py313)
-posixpath.splitroot
-
-
-# =======
 # >= 3.12
 # =======
 

--- a/stdlib/@tests/stubtest_allowlists/py312.txt
+++ b/stdlib/@tests/stubtest_allowlists/py312.txt
@@ -2,6 +2,13 @@
 # New errors in Python 3.12
 # =========================
 
+# TODO: New in 3.12.8
+argparse.ArgumentParser._parse_known_args
+concurrent.futures.process._SafeQueue.__init__
+pickletools.read_stringnl
+token.__all__
+tokenize.__all__
+
 
 # =======
 # >= 3.12

--- a/stdlib/@tests/stubtest_allowlists/py313.txt
+++ b/stdlib/@tests/stubtest_allowlists/py313.txt
@@ -2,6 +2,14 @@
 # New errors in Python 3.13
 # =========================
 
+# TODO: New in 3.13.1
+argparse.ArgumentParser._parse_known_args
+codeop.Compile.__call__
+concurrent.futures.process._SafeQueue.__init__
+pickletools.read_stringnl
+token.__all__
+tokenize.__all__
+
 
 # =======
 # >= 3.13
@@ -9,7 +17,6 @@
 
 # TODO: triage these new errors
 _tkinter.create
-os.path.splitroot
 tkinter.Misc.after_info
 tkinter.Misc.busy
 tkinter.Misc.busy_cget

--- a/stdlib/@tests/stubtest_allowlists/win32-py312.txt
+++ b/stdlib/@tests/stubtest_allowlists/win32-py312.txt
@@ -7,9 +7,6 @@
 asyncio.IocpProactor.finish_socket_func
 asyncio.windows_events.IocpProactor.finish_socket_func
 
-ntpath.exists
-os.path.exists
-
 
 # =========
 # 3.12 only

--- a/stdlib/@tests/stubtest_allowlists/win32-py313.txt
+++ b/stdlib/@tests/stubtest_allowlists/win32-py313.txt
@@ -1,14 +1,4 @@
 # =======
-# >= 3.13
-# =======
-
-# New in py313 (triage these!)
-ntpath.lexists
-ntpath.splitroot
-os.path.lexists
-
-
-# =======
 # >= 3.12
 # =======
 
@@ -16,6 +6,3 @@ os.path.lexists
 # (Hard to add types for unless we add stubs for the undocumented _overlapped module...)
 asyncio.IocpProactor.finish_socket_func
 asyncio.windows_events.IocpProactor.finish_socket_func
-
-ntpath.exists
-os.path.exists


### PR DESCRIPTION
New versions of 3.12 and 3.13 are in the gitlab runners now. This is a quick fix for getting pipelines working again.