### PR TITLE
Add missing exceptions field to TracebackException

### DIFF
--- a/stdlib/traceback.pyi
+++ b/stdlib/traceback.pyi
@@ -115,6 +115,8 @@ if sys.version_info >= (3, 11):
 class TracebackException:
     __cause__: TracebackException
     __context__: TracebackException
+    if sys.version_info >= (3, 11):
+        exceptions: list[TracebackException] | None
     __suppress_context__: bool
     stack: StackSummary
     filename: str


### PR DESCRIPTION
This matches the docstring for TracebackException:

https://github.com/python/cpython/blob/8b3cccf3f9508572d85b0044519f2bd5715dacad/Lib/traceback.py#L1007-L1008