### PR TITLE
`ctypes.CDLL._func_restype_` is a type, not an instance

### DIFF
--- a/stdlib/ctypes/__init__.pyi
+++ b/stdlib/ctypes/__init__.pyi
@@ -202,7 +202,10 @@ if sys.platform == "win32":
     class HRESULT(_SimpleCData[int]): ...  # TODO undocumented
 
 if sys.version_info >= (3, 12):
-    c_time_t: type[c_int32 | c_int64]  # alias for one or the other at runtime
+    # At runtime, this is an alias for either c_int32 or c_int64,
+    # which are themselves an alias for one of c_short, c_int, c_long, or c_longlong
+    # This covers all our bases.
+    c_time_t: type[c_int32 | c_int64 | c_short | c_int | c_long | c_longlong]
 
 class py_object(_CanCastTo, _SimpleCData[_T]): ...
 

--- a/stdlib/ctypes/__init__.pyi
+++ b/stdlib/ctypes/__init__.pyi
@@ -47,7 +47,7 @@ class ArgumentError(Exception): ...
 
 class CDLL:
     _func_flags_: ClassVar[int]
-    _func_restype_: ClassVar[_CDataType]
+    _func_restype_: ClassVar[type[_CDataType]]
     _name: str
     _handle: int
     _FuncPtr: type[_FuncPointer]


### PR DESCRIPTION
Surfaced by https://github.com/python/mypy/pull/18251

Also expand the union for `ctypes.c_time_t` so the actual runtime class is included, whatever that ends up being. I'm not sure if the full range of c_short through c_longlong is needed; is there a machine out there where a short is 32-bits wide? I don't know enough to say.