### PR TITLE
Bump protobuf to ~=5.29.1

### DIFF
--- a/stubs/protobuf/METADATA.toml
+++ b/stubs/protobuf/METADATA.toml
@@ -1,7 +1,7 @@
 # Using an exact number in the specifier for scripts/sync_protobuf/google_protobuf.py
-version = "~=5.28.3"
+version = "~=5.29.1"
 upstream_repository = "https://github.com/protocolbuffers/protobuf"
-extra_description = "Partially generated using [mypy-protobuf==3.6.0](https://github.com/nipunn1313/mypy-protobuf/tree/v3.6.0) and libprotoc 27.2 on [protobuf v28.3](https://github.com/protocolbuffers/protobuf/releases/tag/v28.3) (python `protobuf==5.28.3`)."
+extra_description = "Partially generated using [mypy-protobuf==3.6.0](https://github.com/nipunn1313/mypy-protobuf/tree/v3.6.0) and libprotoc 28.1 on [protobuf v29.1](https://github.com/protocolbuffers/protobuf/releases/tag/v29.1) (python `protobuf==5.29.1`)."
 partial_stub = true
 
 [tool.stubtest]

--- a/stubs/protobuf/google/protobuf/api_pb2.pyi
+++ b/stubs/protobuf/google/protobuf/api_pb2.pyi
@@ -220,7 +220,7 @@ class Mixin(google.protobuf.message.Message):
     The mixin construct implies that all methods in `AccessControl` are
     also declared with same name and request/response types in
     `Storage`. A documentation generator or annotation processor will
-    see the effective `Storage.GetAcl` method after inherting
+    see the effective `Storage.GetAcl` method after inheriting
     documentation and annotations as follows:
 
         service Storage {

--- a/stubs/protobuf/google/protobuf/descriptor_pb2.pyi
+++ b/stubs/protobuf/google/protobuf/descriptor_pb2.pyi
@@ -54,7 +54,7 @@ class _EditionEnumTypeWrapper(google.protobuf.internal.enum_type_wrapper._EnumTy
     EDITION_2024: _Edition.ValueType  # 1001
     EDITION_1_TEST_ONLY: _Edition.ValueType  # 1
     """Placeholder editions for testing feature resolution.  These should not be
-    used or relyed on outside of tests.
+    used or relied on outside of tests.
     """
     EDITION_2_TEST_ONLY: _Edition.ValueType  # 2
     EDITION_99997_TEST_ONLY: _Edition.ValueType  # 99997
@@ -90,7 +90,7 @@ comparison.
 EDITION_2024: Edition.ValueType  # 1001
 EDITION_1_TEST_ONLY: Edition.ValueType  # 1
 """Placeholder editions for testing feature resolution.  These should not be
-used or relyed on outside of tests.
+used or relied on outside of tests.
 """
 EDITION_2_TEST_ONLY: Edition.ValueType  # 2
 EDITION_99997_TEST_ONLY: Edition.ValueType  # 99997
@@ -1188,10 +1188,7 @@ class FieldOptions(google.protobuf.message.Message):
         RETENTION_SOURCE: FieldOptions._OptionRetention.ValueType  # 2
 
     class OptionRetention(_OptionRetention, metaclass=_OptionRetentionEnumTypeWrapper):
-        """If set to RETENTION_SOURCE, the option will be omitted from the binary.
-        Note: as of January 2023, support for this is in progress and does not yet
-        have an effect (b/264593489).
-        """
+        """If set to RETENTION_SOURCE, the option will be omitted from the binary."""
 
     RETENTION_UNKNOWN: FieldOptions.OptionRetention.ValueType  # 0
     RETENTION_RUNTIME: FieldOptions.OptionRetention.ValueType  # 1
@@ -1217,8 +1214,7 @@ class FieldOptions(google.protobuf.message.Message):
     class OptionTargetType(_OptionTargetType, metaclass=_OptionTargetTypeEnumTypeWrapper):
         """This indicates the types of entities that the field may apply to when used
         as an option. If it is unset, then the field may be freely used as an
-        option on any kind of entity. Note: as of January 2023, support for this is
-        in progress and does not yet have an effect (b/264593489).
+        option on any kind of entity.
         """
 
     TARGET_TYPE_UNKNOWN: FieldOptions.OptionTargetType.ValueType  # 0


### PR DESCRIPTION
Closes #13142
Contains docstring changes only (reran `scripts/sync_protobuf/google_protobuf.py`)