### PR TITLE
Unpin webcolors in jsonschema

### DIFF
--- a/stubs/jsonschema/METADATA.toml
+++ b/stubs/jsonschema/METADATA.toml
@@ -6,5 +6,3 @@ partial_stub = true
 [tool.stubtest]
 ignore_missing_stub = true
 extras = ["format"]
-# see https://github.com/python/typeshed/issues/12107 for the reason for the pin
-stubtest_requirements = ["webcolors<24.6.0"]


### PR DESCRIPTION
The pin was due to a bug in jsonschema which was fixed https://github.com/python-jsonschema/jsonschema/issues/1268
