### PR TITLE
add CLONE_NEWTIME to os.__all__

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -34,7 +34,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
+        # As of 2024-10-18, ubuntu-latest can refer to different Ubuntu versions,
+        # which can can cause problems with os module constants.
+        os: ["ubuntu-latest-24.04", "windows-latest", "macos-latest"]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
       fail-fast: false
 

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -36,7 +36,7 @@ jobs:
       matrix:
         # As of 2024-10-18, ubuntu-latest can refer to different Ubuntu versions,
         # which can can cause problems with os module constants.
-        os: ["ubuntu-latest-24.04", "windows-latest", "macos-latest"]
+        os: ["ubuntu-24.04", "windows-latest", "macos-latest"]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
       fail-fast: false
 

--- a/.github/workflows/stubtest_stdlib.yml
+++ b/.github/workflows/stubtest_stdlib.yml
@@ -30,7 +30,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
+        # As of 2024-10-18, ubuntu-latest can refer to different Ubuntu versions,
+        # which can can cause problems with os module constants.
+        os: ["ubuntu-24.04", "windows-latest", "macos-latest"]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
       fail-fast: false
 

--- a/stdlib/@tests/stubtest_allowlists/linux-py312.txt
+++ b/stdlib/@tests/stubtest_allowlists/linux-py312.txt
@@ -1,13 +1,3 @@
-# =======
-# >= 3.12
-# =======
-
-# These seem like they should be available on Linux, but they're not
-# on GitHub Actions runners for some reason.
-os.CLONE_NEWTIME
-posix.CLONE_NEWTIME
-
-
 # =============================================================
 # Allowlist entries that cannot or should not be fixed; <= 3.12
 # =============================================================

--- a/stdlib/@tests/stubtest_allowlists/linux-py313.txt
+++ b/stdlib/@tests/stubtest_allowlists/linux-py313.txt
@@ -1,8 +1,0 @@
-# =======
-# >= 3.12
-# =======
-
-# These seem like they should be available on Linux, but they're not
-# on GitHub Actions runners for some reason.
-os.CLONE_NEWTIME
-posix.CLONE_NEWTIME

--- a/stdlib/os/__init__.pyi
+++ b/stdlib/os/__init__.pyi
@@ -231,6 +231,7 @@ if sys.platform == "linux" and sys.version_info >= (3, 12):
         "CLONE_NEWNET",
         "CLONE_NEWNS",
         "CLONE_NEWPID",
+        "CLONE_NEWTIME",
         "CLONE_NEWUSER",
         "CLONE_NEWUTS",
         "CLONE_SIGHAND",


### PR DESCRIPTION
A new failure that showed up in the github runners for https://github.com/python/typeshed/pull/13220

Looks like maybe the version of Ubuntu that the runners use got bumped? The comment in `os/__init__.pyi` says it's Linux 5.6+.