### PR TITLE
Add new fields to TracebackException, fix cause/context/lineno types

### DIFF
--- a/stdlib/traceback.pyi
+++ b/stdlib/traceback.pyi
@@ -113,17 +113,26 @@ if sys.version_info >= (3, 11):
         def emit(self, text_gen: str | Iterable[str], margin_char: str | None = None) -> Generator[str, None, None]: ...
 
 class TracebackException:
-    __cause__: TracebackException
-    __context__: TracebackException
+    __cause__: TracebackException | None
+    __context__: TracebackException | None
     if sys.version_info >= (3, 11):
         exceptions: list[TracebackException] | None
     __suppress_context__: bool
+    if sys.version_info >= (3, 11):
+        __notes__: list[str] | None
     stack: StackSummary
+
+    # These fields only exist for `SyntaxError`s, but there is no way to express that in the type system.
     filename: str
-    lineno: int
+    lineno: str | None
+    if sys.version_info >= (3, 10):
+        end_lineno: str | None
     text: str
     offset: int
+    if sys.version_info >= (3, 10):
+        end_offset: int | None
     msg: str
+
     if sys.version_info >= (3, 13):
         @property
         def exc_type_str(self) -> str: ...


### PR DESCRIPTION
These are derived from the TracebackException docs: https://docs.python.org/3/library/traceback.html#traceback.TracebackException

and the source code:
https://github.com/python/cpython/blob/8b3cccf3f9508572d85b0044519f2bd5715dacad/Lib/traceback.py#L989