### PR TITLE
`ChainMap.fromkeys` is positional-only

### DIFF
--- a/stdlib/@tests/stubtest_allowlists/common.txt
+++ b/stdlib/@tests/stubtest_allowlists/common.txt
@@ -11,7 +11,6 @@ _collections_abc.AsyncGenerator.ag_running
 asyncio.BaseEventLoop.subprocess_exec  # BaseEventLoop adds several parameters and stubtest fails on the difference if we add them
 asyncio.base_events.BaseEventLoop.subprocess_exec  # BaseEventLoop adds several parameters and stubtest fails on the difference if we add them
 builtins.dict.get
-collections\.ChainMap\.fromkeys  # https://github.com/python/mypy/issues/17023
 contextlib._GeneratorContextManagerBase.__init__  # skipped in the stubs in favor of its child classes
 ctypes.CDLL._FuncPtr  # None at class level but initialized in __init__ to this value
 ctypes.memmove  # CFunctionType
@@ -39,7 +38,7 @@ tkinter.simpledialog.[A-Z_]+
 tkinter.simpledialog.TclVersion
 tkinter.simpledialog.TkVersion
 tkinter.Misc.after  # we intentionally don't allow everything that "works" at runtime
-tkinter.Text.count  # stubtest somehow thinks that index1 parameter has a default value, but it doesn't in any of the overloads
+tkinter.Text.count  # https://github.com/python/mypy/issues/17023 mixed pos-or-kw and pos-only params confuse stubtest
 unittest.mock.patch  # It's a complicated overload and I haven't been able to figure out why stubtest doesn't like it
 weakref.WeakKeyDictionary.update
 weakref.WeakValueDictionary.update

--- a/stdlib/collections/__init__.pyi
+++ b/stdlib/collections/__init__.pyi
@@ -478,7 +478,7 @@ class ChainMap(MutableMapping[_KT, _VT]):
     # so the signature should be kept in line with `dict.fromkeys`.
     @classmethod
     @overload
-    def fromkeys(cls, iterable: Iterable[_T]) -> ChainMap[_T, Any | None]: ...
+    def fromkeys(cls, iterable: Iterable[_T], /) -> ChainMap[_T, Any | None]: ...
     @classmethod
     @overload
     # Special-case None: the user probably wants to add non-None values later.


### PR DESCRIPTION
This one took me on a journey. I was looking at `tkinter.Text.count` originally, and realized it was a bug in stubtest Signatures.

I fixed the bug with https://github.com/python/mypy/pull/18287 which only converts parameter names to index-based names if they're positional-only across all overloads. That MR makes the `tkinter.Text.count` error go away without any typeshed changes.

I realized it was the same bug that the `ChainMap.fromkeys` allowlist entry is commented with, and I removed the line to see what was going on with it with the bug fixed. Stubtest was complaining that it wasn't positional-only. So it doesn't need to wait for that bug to get fixed after all, unless there's a reason I'm missing to go against the implementation on this. It's definitely positional-only at runtime: https://github.com/python/cpython/blob/ba2d2fda93a03a91ac6cdff319fd23ef51848d51/Lib/collections/__init__.py#L1053