### PR TITLE
Allow any number of trailing font options in tkinter font description

### DIFF
--- a/stdlib/tkinter/font.pyi
+++ b/stdlib/tkinter/font.pyi
@@ -3,7 +3,7 @@ import itertools
 import sys
 import tkinter
 from typing import Any, ClassVar, Final, Literal, TypedDict, overload
-from typing_extensions import TypeAlias
+from typing_extensions import TypeAlias, Unpack
 
 if sys.version_info >= (3, 9):
     __all__ = ["NORMAL", "ROMAN", "BOLD", "ITALIC", "nametofont", "Font", "families", "names"]
@@ -18,9 +18,9 @@ _FontDescription: TypeAlias = (
     | Font  # A font object constructed in Python
     | list[Any]  # ["Helvetica", 12, BOLD]
     | tuple[str]  # ("Liberation Sans",) needs wrapping in tuple/list to handle spaces
-    | tuple[str, int]  # ("Liberation Sans", 12)
-    | tuple[str, int, str]  # ("Liberation Sans", 12, "bold")
-    | tuple[str, int, list[str] | tuple[str, ...]]  # e.g. bold and italic
+    # ("Liberation Sans", 12) or ("Liberation Sans", 12, "bold", "italic", "underline")
+    | tuple[str, int, Unpack[tuple[str, ...]]]  # Any number of trailing options is permitted
+    | tuple[str, int, list[str] | tuple[str, ...]]  # Options can also be passed as list/tuple
     | _tkinter.Tcl_Obj  # A font object constructed in Tcl
 )
 


### PR DESCRIPTION
Fixes #13226

It seems any number of trailing options is accepted:

```python
import tkinter as tk

l = tk.Label()
l.pack()

l.configure(  # renders OK
    text="foo",
    font=("arial", 12, "normal", "italic", "underline", "overstrike", "roman", "italic", "normal", "bold"),
    width=10,
)

>>> l.cget("font")
'arial 12 normal italic underline overstrike roman italic normal bold'
```