### PR TITLE
fixing up ctypes.memmove and ctypes.memset

### DIFF
--- a/stdlib/@tests/stubtest_allowlists/common.txt
+++ b/stdlib/@tests/stubtest_allowlists/common.txt
@@ -13,9 +13,6 @@ asyncio.base_events.BaseEventLoop.subprocess_exec  # BaseEventLoop adds several 
 builtins.dict.get
 collections\.ChainMap\.fromkeys  # https://github.com/python/mypy/issues/17023
 contextlib._GeneratorContextManagerBase.__init__  # skipped in the stubs in favor of its child classes
-ctypes.CDLL._FuncPtr  # None at class level but initialized in __init__ to this value
-ctypes.memmove  # CFunctionType
-ctypes.memset  # CFunctionType
 http.client.HTTPConnection.response_class  # the actual type at runtime is abc.ABCMeta
 importlib.abc.Loader.exec_module  # See Lib/importlib/_abc.py. Might be defined for backwards compatibility
 importlib.abc.MetaPathFinder.find_spec  # Not defined on the actual class, but expected to exist.
@@ -321,9 +318,10 @@ csv.Dialect.skipinitialspace
 
 csv.DictReader.__init__  # runtime sig has *args but will error if more than 5 positional args are supplied
 csv.DictWriter.__init__  # runtime sig has *args but will error if more than 5 positional args are supplied
-_?ctypes.Array.raw  # exists but stubtest can't see it; only available if _CT == c_char
 _?ctypes.Array._type_  # _type_ is abstract, https://github.com/python/typeshed/pull/6361
 _?ctypes.Array._length_  # _length_ is abstract, https://github.com/python/typeshed/pull/6361
+_?ctypes.Array.raw  # exists but stubtest can't see it; only available if _CT == c_char
+ctypes.CDLL._FuncPtr  # None at class level but initialized in __init__ to this value
 _?ctypes.Structure.__getattr__  # doesn't exist, but makes things easy if we pretend it does
 _?ctypes.Union.__getattr__  # doesn't exist, but makes things easy if we pretend it does
 

--- a/stdlib/ctypes/__init__.pyi
+++ b/stdlib/ctypes/__init__.pyi
@@ -107,6 +107,9 @@ class _CFunctionType(_CFuncPtr):
     _restype_: ClassVar[type[_CData | _CDataType] | None]
     _flags_: ClassVar[int]
 
+# Legacy name used by pyserial (and maybe others?)
+_FuncPointer: TypeAlias = _FuncPtr | _CFunctionType  # noqa: Y047  # not used here
+
 def CFUNCTYPE(
     restype: type[_CData | _CDataType] | None,
     *argtypes: type[_CData | _CDataType],

--- a/stdlib/ctypes/__init__.pyi
+++ b/stdlib/ctypes/__init__.pyi
@@ -107,7 +107,7 @@ class _CFunctionType(_CFuncPtr):
     _restype_: ClassVar[type[_CData | _CDataType] | None]
     _flags_: ClassVar[int]
 
-# Legacy name used by pyserial (and maybe others?)
+# Alias for either function pointer type
 _FuncPointer: TypeAlias = _FuncPtr | _CFunctionType  # noqa: Y047  # not used here
 
 def CFUNCTYPE(

--- a/stdlib/ctypes/__init__.pyi
+++ b/stdlib/ctypes/__init__.pyi
@@ -54,7 +54,7 @@ class _FuncPtr(_CFuncPtr):
 
 # Not a real class; _FuncPtr with a __name__ set on it.
 @type_check_only
-class _NamedFuncPtr(_FuncPtr):
+class _NamedFuncPointer(_FuncPtr):
     __name__: str
 
 class CDLL:
@@ -72,8 +72,8 @@ class CDLL:
         use_last_error: bool = False,
         winmode: int | None = None,
     ) -> None: ...
-    def __getattr__(self, name: str) -> _NamedFuncPtr: ...
-    def __getitem__(self, name_or_ordinal: str) -> _NamedFuncPtr: ...
+    def __getattr__(self, name: str) -> _NamedFuncPointer: ...
+    def __getitem__(self, name_or_ordinal: str) -> _NamedFuncPointer: ...
 
 if sys.platform == "win32":
     class OleDLL(CDLL): ...


### PR DESCRIPTION
These two are instances of a class created by CFUNCTYPE, not functions. Also moves `ctypes.CDLL._FuncPtr` to "don't fix". There's no reason to capture it as "None" unless we get a way to distinguish that it's None on the class but not an instance of the class.