### PR TITLE
Flask-socketio 5.5 + add type of kwargs

### DIFF
--- a/stubs/Flask-SocketIO/flask_socketio/__init__.pyi
+++ b/stubs/Flask-SocketIO/flask_socketio/__init__.pyi
@@ -2,8 +2,8 @@ from _typeshed import Incomplete
 from collections.abc import Callable
 from logging import Logger
 from threading import Thread
-from typing import Any, Literal, Protocol, TypedDict, TypeVar, Unpack, overload
-from typing_extensions import ParamSpec, TypeAlias
+from typing import Any, Literal, Protocol, TypedDict, TypeVar, overload
+from typing_extensions import ParamSpec, TypeAlias, Unpack
 
 from flask import Flask
 from flask.testing import FlaskClient

--- a/stubs/Flask-SocketIO/flask_socketio/__init__.pyi
+++ b/stubs/Flask-SocketIO/flask_socketio/__init__.pyi
@@ -22,6 +22,8 @@ class _ExceptionHandlerDecorator(Protocol):
     def __call__(self, exception_handler: _ExceptionHandler[_R_co]) -> _ExceptionHandler[_R_co]: ...
 
 class SocketIO:
+    # This is an alias for `socketio.Server.reason` in `python-socketio`, which is not typed.
+    reason: Incomplete
     # Many instance attributes are deliberately not included here,
     # as the maintainer of Flask-SocketIO considers them private, internal details:
     # https://github.com/python/typeshed/pull/10735#discussion_r1330768869

--- a/stubs/Flask-SocketIO/flask_socketio/__init__.pyi
+++ b/stubs/Flask-SocketIO/flask_socketio/__init__.pyi
@@ -1,7 +1,8 @@
 from _typeshed import Incomplete
 from collections.abc import Callable
+from logging import Logger
 from threading import Thread
-from typing import Any, Protocol, TypeVar, overload
+from typing import Any, Literal, Protocol, TypedDict, TypeVar, overload
 from typing_extensions import ParamSpec, TypeAlias
 
 from flask import Flask
@@ -21,6 +22,30 @@ class _HandlerDecorator(Protocol):
 class _ExceptionHandlerDecorator(Protocol):
     def __call__(self, exception_handler: _ExceptionHandler[_R_co]) -> _ExceptionHandler[_R_co]: ...
 
+class _SocketIOServerOptions(TypedDict, total=False):
+    client_manager: Incomplete
+    logger: Logger | bool
+    json: Incomplete
+    async_handlers: bool
+    always_connect: bool
+
+class _EngineIOServerConfig(TypedDict, total=False):
+    async_mode: Literal["threading", "eventlet", "gevent", "gevent_uwsgi"]
+    ping_interval: int  # seconds
+    ping_timeout: int  # seconds
+    max_http_buffer_size: int
+    allow_upgrades: bool
+    http_compression: bool
+    compression_threshold: int
+    cookie: str | dict[str, Any] | None
+    cors_allowed_origins: str | list[str]
+    cors_credentials: bool
+    monitor_clients: bool
+    engineio_logger: Logger | bool
+
+class _SocketIOKwargs(_SocketIOServerOptions, _EngineIOServerConfig):
+    pass
+
 class SocketIO:
     # This is an alias for `socketio.Server.reason` in `python-socketio`, which is not typed.
     reason: Incomplete
@@ -37,7 +62,7 @@ class SocketIO:
         channel: str = "flask-socketio",
         path: str = "socket.io",
         resource: str = "socket.io",
-        **kwargs,  # TODO: Socket.IO server options, Engine.IO server config
+        **kwargs: _SocketIOKwargs,
     ) -> None: ...
     def init_app(
         self,
@@ -49,7 +74,7 @@ class SocketIO:
         channel: str = "flask-socketio",
         path: str = "socket.io",
         resource: str = "socket.io",
-        **kwargs,  # TODO: Socket.IO server options, Engine.IO server config: ...
+        **kwargs: _SocketIOKwargs,
     ) -> None: ...
     def on(self, message: str, namespace: str | None = None) -> _HandlerDecorator: ...
     def on_error(self, namespace: str | None = None) -> _ExceptionHandlerDecorator: ...

--- a/stubs/Flask-SocketIO/flask_socketio/__init__.pyi
+++ b/stubs/Flask-SocketIO/flask_socketio/__init__.pyi
@@ -2,7 +2,7 @@ from _typeshed import Incomplete
 from collections.abc import Callable
 from logging import Logger
 from threading import Thread
-from typing import Any, Literal, Protocol, TypedDict, TypeVar, overload
+from typing import Any, Literal, Protocol, TypedDict, TypeVar, Unpack, overload
 from typing_extensions import ParamSpec, TypeAlias
 
 from flask import Flask
@@ -31,8 +31,8 @@ class _SocketIOServerOptions(TypedDict, total=False):
 
 class _EngineIOServerConfig(TypedDict, total=False):
     async_mode: Literal["threading", "eventlet", "gevent", "gevent_uwsgi"]
-    ping_interval: int  # seconds
-    ping_timeout: int  # seconds
+    ping_interval: float | tuple[float, float]  # seconds
+    ping_timeout: float  # seconds
     max_http_buffer_size: int
     allow_upgrades: bool
     http_compression: bool
@@ -62,7 +62,7 @@ class SocketIO:
         channel: str = "flask-socketio",
         path: str = "socket.io",
         resource: str = "socket.io",
-        **kwargs: _SocketIOKwargs,
+        **kwargs: Unpack[_SocketIOKwargs],
     ) -> None: ...
     def init_app(
         self,
@@ -74,7 +74,7 @@ class SocketIO:
         channel: str = "flask-socketio",
         path: str = "socket.io",
         resource: str = "socket.io",
-        **kwargs: _SocketIOKwargs,
+        **kwargs: Unpack[_SocketIOKwargs],
     ) -> None: ...
     def on(self, message: str, namespace: str | None = None) -> _HandlerDecorator: ...
     def on_error(self, namespace: str | None = None) -> _ExceptionHandlerDecorator: ...


### PR DESCRIPTION
closes https://github.com/python/typeshed/pull/13268

The new member is a type alias for something in python-socketio (untyped) by the same author, so I don't think I can add an annotation for it.

That class's constructor has a TODO for typing the kwargs, so I added types for those. There's two groups of configs so I defined two separate typed dicts.

SocketIO options
https://github.com/miguelgrinberg/Flask-SocketIO/blob/main/src/flask_socketio/__init__.py#L82

EngineIO options
https://github.com/miguelgrinberg/Flask-SocketIO/blob/main/src/flask_socketio/__init__.py#L114

