### PR TITLE
Update to mypy 1.14

### DIFF
--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,6 +1,6 @@
 # Type checkers that we test our stubs against. These should always
 # be pinned to a specific version to make failure reproducible.
-mypy==1.13.0
+mypy==1.14.0
 pyright==1.1.389
 # pytype can be installed on Windows, but requires building wheels, let's not do that on the CI
 pytype==2024.10.11; platform_system != "Windows" and python_version >= "3.10" and python_version < "3.13"

--- a/stdlib/@tests/stubtest_allowlists/common.txt
+++ b/stdlib/@tests/stubtest_allowlists/common.txt
@@ -8,6 +8,7 @@ _collections_abc.AsyncGenerator.ag_await
 _collections_abc.AsyncGenerator.ag_code
 _collections_abc.AsyncGenerator.ag_frame
 _collections_abc.AsyncGenerator.ag_running
+asyncio.__all__
 asyncio.BaseEventLoop.subprocess_exec  # BaseEventLoop adds several parameters and stubtest fails on the difference if we add them
 asyncio.base_events.BaseEventLoop.subprocess_exec  # BaseEventLoop adds several parameters and stubtest fails on the difference if we add them
 builtins.dict.get

--- a/stubs/PyYAML/@tests/stubtest_allowlist.txt
+++ b/stubs/PyYAML/@tests/stubtest_allowlist.txt
@@ -1,3 +1,17 @@
+# TODO: missing from stub
+yaml.composer.__all__
+yaml.constructor.__all__
+yaml.dumper.__all__
+yaml.emitter.__all__
+yaml.error.__all__
+yaml.loader.__all__
+yaml.parser.__all__
+yaml.reader.__all__
+yaml.representer.__all__
+yaml.resolver.__all__
+yaml.scanner.__all__
+yaml.serializer.__all__
+
 # yaml._yaml is for backwards compatibility so none of it matters anyway
 yaml._yaml.__test__
 

--- a/stubs/WTForms/@tests/stubtest_allowlist.txt
+++ b/stubs/WTForms/@tests/stubtest_allowlist.txt
@@ -1,3 +1,6 @@
+# TODO: missing from stub
+wtforms.form.__all__
+
 # Error: is not present at runtime
 # =============================
 # This is hack to get around Field.__new__ not being able to return

--- a/stubs/WebOb/@tests/stubtest_allowlist.txt
+++ b/stubs/WebOb/@tests/stubtest_allowlist.txt
@@ -1,3 +1,18 @@
+# TODO: missing from stub
+webob.__all__
+webob.byterange.__all__
+webob.client.__all__
+webob.cookies.__all__
+webob.datetime_utils.__all__
+webob.dec.__all__
+webob.etag.__all__
+webob.exc.__all__
+webob.headers.__all__
+webob.multidict.__all__
+webob.request.__all__
+webob.response.__all__
+webob.static.__all__
+
 # Error: is not present in stub
 # =============================
 # These are plain strings, regex strings or compiled regex patterns

--- a/stubs/aiofiles/@tests/stubtest_allowlist.txt
+++ b/stubs/aiofiles/@tests/stubtest_allowlist.txt
@@ -1,3 +1,8 @@
+# TODO: missing from stub
+aiofiles.__all__
+aiofiles.tempfile.__all__
+aiofiles.threadpool.__all__
+
 # These all delegate using *args,**kwargs, but stubs use signature of
 # method they are being delegated to.
 aiofiles.threadpool.binary.AsyncBufferedIOBase.close

--- a/stubs/boltons/@tests/stubtest_allowlist.txt
+++ b/stubs/boltons/@tests/stubtest_allowlist.txt
@@ -1,2 +1,19 @@
+# TODO: missing from stub
+boltons.debugutils.__all__
+boltons.dictutils.__all__
+boltons.excutils.__all__
+boltons.fileutils.__all__
+boltons.formatutils.__all__
+boltons.gcutils.__all__
+boltons.jsonutils.__all__
+boltons.listutils.__all__
+boltons.namedutils.__all__
+boltons.pathutils.__all__
+boltons.queueutils.__all__
+boltons.setutils.__all__
+boltons.strutils.__all__
+boltons.tableutils.__all__
+boltons.tbutils.__all__
+
 boltons.funcutils.CachedInstancePartial.__partialmethod__
 boltons.funcutils.InstancePartial.__partialmethod__

--- a/stubs/cffi/@tests/stubtest_allowlist.txt
+++ b/stubs/cffi/@tests/stubtest_allowlist.txt
@@ -1,3 +1,6 @@
+# TODO: missing from stub
+cffi.__all__
+
 # added dynamically and not detected by stubtest
 cffi.(api.)?FFI.CData
 cffi.(api.)?FFI.CType

--- a/stubs/click-default-group/@tests/stubtest_allowlist.txt
+++ b/stubs/click-default-group/@tests/stubtest_allowlist.txt
@@ -1,0 +1,2 @@
+# TODO: missing from stub
+click_default_group.__all__

--- a/stubs/console-menu/@tests/stubtest_allowlist.txt
+++ b/stubs/console-menu/@tests/stubtest_allowlist.txt
@@ -1,0 +1,4 @@
+# TODO: missing from stub
+consolemenu.__all__
+consolemenu.format.__all__
+consolemenu.items.__all__

--- a/stubs/editdistance/@tests/stubtest_allowlist.txt
+++ b/stubs/editdistance/@tests/stubtest_allowlist.txt
@@ -1,2 +1,5 @@
+# TODO: missing from stub
+editdistance.__all__
+
 # Not public API -- the submodule is an implementation detail due to it being a cythonized package
 editdistance.bycython

--- a/stubs/fpdf2/fpdf/enums.pyi
+++ b/stubs/fpdf2/fpdf/enums.pyi
@@ -8,15 +8,15 @@ class SignatureFlag(IntEnum):
     SIGNATURES_EXIST = 1
     APPEND_ONLY = 2
 
-class CoerciveEnum(Enum):
+class CoerciveEnum(Enum):  # type: ignore[misc]  # Enum with no members
     @classmethod
     def coerce(cls, value: Self | str) -> Self: ...
 
-class CoerciveIntEnum(IntEnum):
+class CoerciveIntEnum(IntEnum):  # type: ignore[misc]  # Enum with no members
     @classmethod
     def coerce(cls, value: Self | str | int) -> Self: ...
 
-class CoerciveIntFlag(IntFlag):
+class CoerciveIntFlag(IntFlag):  # type: ignore[misc]  # Enum with no members
     @classmethod
     def coerce(cls, value: Self | str | int) -> Self: ...
 

--- a/stubs/gevent/@tests/stubtest_allowlist.txt
+++ b/stubs/gevent/@tests/stubtest_allowlist.txt
@@ -5,7 +5,6 @@ gevent._ffi.watcher.__all__
 gevent._greenlet_primitives.__all__
 gevent._ident.__all__
 gevent._imap.__all__
-gevent.ares.__all__
 gevent.backdoor.__all__
 gevent.baseserver.__all__
 gevent.event.__all__
@@ -16,7 +15,6 @@ gevent.greenlet.__all__
 gevent.hub.__all__
 gevent.libev.__all__
 gevent.libev.corecext.__all__
-gevent.libev.corecffi.__all__
 gevent.libuv.__all__
 gevent.libuv.loop.__all__
 gevent.libuv.watcher.__all__
@@ -24,11 +22,9 @@ gevent.local.__all__
 gevent.monkey.__all__
 gevent.os.__all__
 gevent.resolver.__all__
-gevent.resolver.ares.__all__
 gevent.resolver.blocking.__all__
 gevent.resolver.dnspython.__all__
 gevent.resolver.thread.__all__
-gevent.resolver_ares.__all__
 gevent.resolver_thread.__all__
 gevent.server.__all__
 gevent.signal.__all__

--- a/stubs/gevent/@tests/stubtest_allowlist.txt
+++ b/stubs/gevent/@tests/stubtest_allowlist.txt
@@ -1,3 +1,45 @@
+# TODO: missing from stub
+gevent._abstract_linkable.__all__
+gevent._ffi.loop.__all__
+gevent._ffi.watcher.__all__
+gevent._greenlet_primitives.__all__
+gevent._ident.__all__
+gevent._imap.__all__
+gevent.ares.__all__
+gevent.backdoor.__all__
+gevent.baseserver.__all__
+gevent.event.__all__
+gevent.events.__all__
+gevent.exceptions.__all__
+gevent.fileobject.__all__
+gevent.greenlet.__all__
+gevent.hub.__all__
+gevent.libev.__all__
+gevent.libev.corecext.__all__
+gevent.libev.corecffi.__all__
+gevent.libuv.__all__
+gevent.libuv.loop.__all__
+gevent.libuv.watcher.__all__
+gevent.local.__all__
+gevent.monkey.__all__
+gevent.os.__all__
+gevent.resolver.__all__
+gevent.resolver.ares.__all__
+gevent.resolver.blocking.__all__
+gevent.resolver.dnspython.__all__
+gevent.resolver.thread.__all__
+gevent.resolver_ares.__all__
+gevent.resolver_thread.__all__
+gevent.server.__all__
+gevent.signal.__all__
+gevent.socket.__all__
+gevent.ssl.__all__
+gevent.subprocess.__all__
+gevent.threadpool.__all__
+gevent.timeout.__all__
+gevent.util.__all__
+gevent.win32util.__all__
+
 # Error: failed to find stubs
 # =============================
 # testing modules are not included in type stubs

--- a/stubs/gevent/@tests/stubtest_allowlist_darwin.txt
+++ b/stubs/gevent/@tests/stubtest_allowlist_darwin.txt
@@ -1,3 +1,9 @@
+# TODO: missing from stub
+gevent.ares.__all__
+gevent.libev.corecffi.__all__
+gevent.resolver.ares.__all__
+gevent.resolver_ares.__all__
+
 # Error: is not present in stub
 # =============================
 # internal API stuff we dropped because it wasn't necessary

--- a/stubs/gevent/@tests/stubtest_allowlist_linux.txt
+++ b/stubs/gevent/@tests/stubtest_allowlist_linux.txt
@@ -1,3 +1,9 @@
+# TODO: missing from stub
+gevent.ares.__all__
+gevent.libev.corecffi.__all__
+gevent.resolver.ares.__all__
+gevent.resolver_ares.__all__
+
 # Error: is not present in stub
 # =============================
 # internal API stuff we dropped because it wasn't necessary

--- a/stubs/greenlet/@tests/stubtest_allowlist.txt
+++ b/stubs/greenlet/@tests/stubtest_allowlist.txt
@@ -1,3 +1,6 @@
+# TODO: missing from stub
+greenlet.__all__
+
 # Error: is not present in stub
 # =============================
 # this module only contains C code and exports no Python code, so it's better

--- a/stubs/hdbcli/@tests/stubtest_allowlist.txt
+++ b/stubs/hdbcli/@tests/stubtest_allowlist.txt
@@ -1,3 +1,6 @@
+# TODO: missing from stub
+hdbcli.__all__
+
 # Are set to `None` by default, initialized later:
 hdbcli.dbapi.Error.errorcode
 hdbcli.dbapi.Error.errortext

--- a/stubs/httplib2/@tests/stubtest_allowlist.txt
+++ b/stubs/httplib2/@tests/stubtest_allowlist.txt
@@ -1,2 +1,5 @@
+# TODO: missing from stub
+httplib2.__all__
+
 # __getattr__() replaced with actual field in stub
 httplib2.Response.dict

--- a/stubs/humanfriendly/@tests/stubtest_allowlist.txt
+++ b/stubs/humanfriendly/@tests/stubtest_allowlist.txt
@@ -1,3 +1,20 @@
+# TODO: missing from stub
+humanfriendly.__all__
+humanfriendly.case.__all__
+humanfriendly.cli.__all__
+humanfriendly.compat.__all__
+humanfriendly.decorators.__all__
+humanfriendly.deprecation.__all__
+humanfriendly.prompts.__all__
+humanfriendly.sphinx.__all__
+humanfriendly.tables.__all__
+humanfriendly.terminal.__all__
+humanfriendly.terminal.html.__all__
+humanfriendly.terminal.spinners.__all__
+humanfriendly.testing.__all__
+humanfriendly.text.__all__
+humanfriendly.usage.__all__
+
 # Re-exports:
 humanfriendly.usage.import_module
 humanfriendly.compat.which

--- a/stubs/influxdb-client/@tests/stubtest_allowlist.txt
+++ b/stubs/influxdb-client/@tests/stubtest_allowlist.txt
@@ -1,0 +1,2 @@
+# TODO: missing from stub
+influxdb_client.extras.__all__

--- a/stubs/jwcrypto/jwcrypto/jwk.pyi
+++ b/stubs/jwcrypto/jwcrypto/jwk.pyi
@@ -29,10 +29,10 @@ priv_bytes: Incomplete
 JWKTypesRegistry: Incomplete
 
 class ParmType(Enum):
-    name: str
-    b64: str
-    b64u: str
-    unsupported: str
+    name = "A string with a name"
+    b64 = "Base64url Encoded"
+    b64u = "Base64urlUint Encoded"
+    unsupported = "Unsupported Parameter"
 
 class JWKParameter(NamedTuple):
     description: Incomplete

--- a/stubs/jwcrypto/jwcrypto/jwk.pyi
+++ b/stubs/jwcrypto/jwcrypto/jwk.pyi
@@ -29,7 +29,7 @@ priv_bytes: Incomplete
 JWKTypesRegistry: Incomplete
 
 class ParmType(Enum):
-    name = "A string with a name"
+    name = "A string with a name"  # pyright: ignore[reportAssignmentType]
     b64 = "Base64url Encoded"
     b64u = "Base64urlUint Encoded"
     unsupported = "Unsupported Parameter"

--- a/stubs/libsass/@tests/stubtest_allowlist.txt
+++ b/stubs/libsass/@tests/stubtest_allowlist.txt
@@ -1,3 +1,9 @@
+# TODO: missing from stub
+sassutils.builder.__all__
+sassutils.distutils.__all__
+sassutils.wsgi.__all__
+sass.__all__
+
 # Error: is not present in stub
 # =============================
 # These are only implemented for the purposes of emitting an error

--- a/stubs/mysqlclient/@tests/stubtest_allowlist.txt
+++ b/stubs/mysqlclient/@tests/stubtest_allowlist.txt
@@ -1,1 +1,5 @@
+# TODO: missing from stub
+MySQLdb.__all__
+MySQLdb.constants.__all__
+
 MySQLdb.Connection

--- a/stubs/passlib/@tests/stubtest_allowlist.txt
+++ b/stubs/passlib/@tests/stubtest_allowlist.txt
@@ -1,3 +1,45 @@
+# TODO: missing from stub
+passlib.apache.__all__
+passlib.context.__all__
+passlib.crypto._blowfish.__all__
+passlib.crypto._blowfish.base.__all__
+passlib.crypto._blowfish.unrolled.__all__
+passlib.crypto._md4.__all__
+passlib.crypto.digest.__all__
+passlib.crypto.scrypt.__all__
+passlib.crypto.scrypt._builtin.__all__
+passlib.handlers.argon2.__all__
+passlib.handlers.bcrypt.__all__
+passlib.handlers.cisco.__all__
+passlib.handlers.des_crypt.__all__
+passlib.handlers.digests.__all__
+passlib.handlers.django.__all__
+passlib.handlers.fshp.__all__
+passlib.handlers.md5_crypt.__all__
+passlib.handlers.misc.__all__
+passlib.handlers.mssql.__all__
+passlib.handlers.pbkdf2.__all__
+passlib.handlers.phpass.__all__
+passlib.handlers.postgres.__all__
+passlib.handlers.roundup.__all__
+passlib.handlers.scram.__all__
+passlib.handlers.scrypt.__all__
+passlib.handlers.sha1_crypt.__all__
+passlib.handlers.sha2_crypt.__all__
+passlib.handlers.sun_md5_crypt.__all__
+passlib.handlers.windows.__all__
+passlib.hosts.__all__
+passlib.ifc.__all__
+passlib.pwd.__all__
+passlib.registry.__all__
+passlib.totp.__all__
+passlib.utils.binary.__all__
+passlib.utils.decor.__all__
+passlib.utils.handlers.__all__
+passlib.utils.md4.__all__
+passlib.utils.pbkdf2.__all__
+passlib.win32.__all__
+
 # proxy module that uses some import magic incompatible with stubtest
 passlib.hash
 

--- a/stubs/peewee/@tests/stubtest_allowlist.txt
+++ b/stubs/peewee/@tests/stubtest_allowlist.txt
@@ -1,3 +1,6 @@
+# TODO: missing from stub
+peewee.__all__
+
 # Stubtest doesn't recognize __ as indicating positional-only arg at runtime
 # https://github.com/python/mypy/issues/15302
 peewee.Model.insert

--- a/stubs/polib/@tests/stubtest_allowlist.txt
+++ b/stubs/polib/@tests/stubtest_allowlist.txt
@@ -1,0 +1,2 @@
+# TODO: missing from stub
+polib.__all__

--- a/stubs/psutil/@tests/stubtest_allowlist.txt
+++ b/stubs/psutil/@tests/stubtest_allowlist.txt
@@ -1,3 +1,9 @@
+# TODO: missing from stub
+psutil.__all__
+psutil._common.__all__
+psutil._compat.__all__
+psutil._psposix.__all__
+
 # These super() dunders don't seem to be particularly useful,
 # and having them pop up on autocomplete suggestions would be annoying
 psutil._compat.super.__self__

--- a/stubs/pynput/pynput/keyboard/_base.pyi
+++ b/stubs/pynput/pynput/keyboard/_base.pyi
@@ -2,7 +2,7 @@ import contextlib
 import enum
 import sys
 from collections.abc import Callable, Generator, Iterable, Iterator
-from typing import Any, ClassVar
+from typing import Any, ClassVar, cast
 from typing_extensions import Self
 
 from pynput._util import AbstractListener
@@ -25,71 +25,71 @@ class KeyCode:
     def from_dead(cls, char: str, **kwargs: Any) -> Self: ...
 
 class Key(enum.Enum):
-    alt: KeyCode
-    alt_l: KeyCode
-    alt_r: KeyCode
-    alt_gr: KeyCode
-    backspace: KeyCode
-    caps_lock: KeyCode
-    cmd: KeyCode
-    cmd_l: KeyCode
-    cmd_r: KeyCode
-    ctrl: KeyCode
-    ctrl_l: KeyCode
-    ctrl_r: KeyCode
-    delete: KeyCode
-    down: KeyCode
-    end: KeyCode
-    enter: KeyCode
-    esc: KeyCode
-    f1: KeyCode
-    f2: KeyCode
-    f3: KeyCode
-    f4: KeyCode
-    f5: KeyCode
-    f6: KeyCode
-    f7: KeyCode
-    f8: KeyCode
-    f9: KeyCode
-    f10: KeyCode
-    f11: KeyCode
-    f12: KeyCode
-    f13: KeyCode
-    f14: KeyCode
-    f15: KeyCode
-    f16: KeyCode
-    f17: KeyCode
-    f18: KeyCode
-    f19: KeyCode
-    f20: KeyCode
+    alt = cast(KeyCode, ...)
+    alt_l = cast(KeyCode, ...)
+    alt_r = cast(KeyCode, ...)
+    alt_gr = cast(KeyCode, ...)
+    backspace = cast(KeyCode, ...)
+    caps_lock = cast(KeyCode, ...)
+    cmd = cast(KeyCode, ...)
+    cmd_l = cast(KeyCode, ...)
+    cmd_r = cast(KeyCode, ...)
+    ctrl = cast(KeyCode, ...)
+    ctrl_l = cast(KeyCode, ...)
+    ctrl_r = cast(KeyCode, ...)
+    delete = cast(KeyCode, ...)
+    down = cast(KeyCode, ...)
+    end = cast(KeyCode, ...)
+    enter = cast(KeyCode, ...)
+    esc = cast(KeyCode, ...)
+    f1 = cast(KeyCode, ...)
+    f2 = cast(KeyCode, ...)
+    f3 = cast(KeyCode, ...)
+    f4 = cast(KeyCode, ...)
+    f5 = cast(KeyCode, ...)
+    f6 = cast(KeyCode, ...)
+    f7 = cast(KeyCode, ...)
+    f8 = cast(KeyCode, ...)
+    f9 = cast(KeyCode, ...)
+    f10 = cast(KeyCode, ...)
+    f11 = cast(KeyCode, ...)
+    f12 = cast(KeyCode, ...)
+    f13 = cast(KeyCode, ...)
+    f14 = cast(KeyCode, ...)
+    f15 = cast(KeyCode, ...)
+    f16 = cast(KeyCode, ...)
+    f17 = cast(KeyCode, ...)
+    f18 = cast(KeyCode, ...)
+    f19 = cast(KeyCode, ...)
+    f20 = cast(KeyCode, ...)
     if sys.platform == "win32":
-        f21: KeyCode
-        f22: KeyCode
-        f23: KeyCode
-        f24: KeyCode
-    home: KeyCode
-    left: KeyCode
-    page_down: KeyCode
-    page_up: KeyCode
-    right: KeyCode
-    shift: KeyCode
-    shift_l: KeyCode
-    shift_r: KeyCode
-    space: KeyCode
-    tab: KeyCode
-    up: KeyCode
-    media_play_pause: KeyCode
-    media_volume_mute: KeyCode
-    media_volume_down: KeyCode
-    media_volume_up: KeyCode
-    media_previous: KeyCode
-    media_next: KeyCode
-    insert: KeyCode
-    menu: KeyCode
-    num_lock: KeyCode
-    pause: KeyCode
-    print_screen: KeyCode
-    scroll_lock: KeyCode
+        f21 = cast(KeyCode, ...)
+        f22 = cast(KeyCode, ...)
+        f23 = cast(KeyCode, ...)
+        f24 = cast(KeyCode, ...)
+    home = cast(KeyCode, ...)
+    left = cast(KeyCode, ...)
+    page_down = cast(KeyCode, ...)
+    page_up = cast(KeyCode, ...)
+    right = cast(KeyCode, ...)
+    shift = cast(KeyCode, ...)
+    shift_l = cast(KeyCode, ...)
+    shift_r = cast(KeyCode, ...)
+    space = cast(KeyCode, ...)
+    tab = cast(KeyCode, ...)
+    up = cast(KeyCode, ...)
+    media_play_pause = cast(KeyCode, ...)
+    media_volume_mute = cast(KeyCode, ...)
+    media_volume_down = cast(KeyCode, ...)
+    media_volume_up = cast(KeyCode, ...)
+    media_previous = cast(KeyCode, ...)
+    media_next = cast(KeyCode, ...)
+    insert = cast(KeyCode, ...)
+    menu = cast(KeyCode, ...)
+    num_lock = cast(KeyCode, ...)
+    pause = cast(KeyCode, ...)
+    print_screen = cast(KeyCode, ...)
+    scroll_lock = cast(KeyCode, ...)
 
 class Controller:
     _KeyCode: ClassVar[type[KeyCode]]  # undocumented

--- a/stubs/pyserial/@tests/stubtest_allowlist.txt
+++ b/stubs/pyserial/@tests/stubtest_allowlist.txt
@@ -1,6 +1,3 @@
-# TODO: missing from stub
-serial.win32.__all__
-
 # Error: failed to import
 # =======================
 serial.__main__  # SystemExit

--- a/stubs/pyserial/@tests/stubtest_allowlist.txt
+++ b/stubs/pyserial/@tests/stubtest_allowlist.txt
@@ -1,3 +1,6 @@
+# TODO: missing from stub
+serial.win32.__all__
+
 # Error: failed to import
 # =======================
 serial.__main__  # SystemExit

--- a/stubs/pyserial/@tests/stubtest_allowlist_win32.txt
+++ b/stubs/pyserial/@tests/stubtest_allowlist_win32.txt
@@ -1,3 +1,6 @@
+# TODO: missing from stub
+serial.win32.__all__
+
 # Error: failed to import
 # =======================
 serial.serialposix  # Posix only

--- a/stubs/pytz/@tests/stubtest_allowlist.txt
+++ b/stubs/pytz/@tests/stubtest_allowlist.txt
@@ -1,3 +1,8 @@
+# TODO: missing from stub
+pytz.__all__
+pytz.reference.__all__
+pytz.tzinfo.__all__
+
 # "Abstract" methods, see the .pyi file for more details.
 pytz.BaseTzInfo.localize
 pytz.BaseTzInfo.normalize

--- a/stubs/pywin32/_win32typing.pyi
+++ b/stubs/pywin32/_win32typing.pyi
@@ -170,13 +170,13 @@ class PRINTER_DEFAULTS:
 class PyACL:
     def Initialize(self) -> None: ...
     def IsValid(self) -> bool: ...
+    @overload
     @deprecated(
         """\
 Early versions of this function supported only two arguments. \
 This has been deprecated in preference of the three argument version, \
 which reflects the win32 API and the new functions in this module."""
     )
-    @overload
     def AddAccessAllowedAce(self, access: int, sid: PySID, /) -> None: ...
     @overload
     def AddAccessAllowedAce(self, revision: int, access: int, sid: PySID, /) -> None: ...
@@ -184,13 +184,13 @@ which reflects the win32 API and the new functions in this module."""
     def AddAccessAllowedObjectAce(
         self, AceRevision, AceFlags, AccessMask, ObjectTypeGuid: PyIID, InheritedObjectTypeGuid: PyIID, sid: PySID, /
     ) -> None: ...
+    @overload
     @deprecated(
         """\
 Early versions of this function supported only two arguments. \
 This has been deprecated in preference of the three argument version, \
 which reflects the win32 API and the new functions in this module."""
     )
-    @overload
     def AddAccessDeniedAce(self, access: int, sid: PySID, /) -> None: ...
     @overload
     def AddAccessDeniedAce(self, revision: int, access: int, sid: PySID, /) -> None: ...
@@ -240,6 +240,7 @@ class PyCERTSTORE:
     def HCERTSTORE(self): ...
     @overload
     def CertCloseStore(self) -> None: ...
+    @overload
     @deprecated(
         """\
 `Flags` argument has been deprecated as it is likely to crash the process if \
@@ -247,7 +248,6 @@ class PyCERTSTORE:
 always called with `CERT_CLOSE_STORE_CHECK_FLAG`, and support for this \
 param will be dropped at some point in the future."""
     )
-    @overload
     def CertCloseStore(self, Flags: int) -> None: ...
     def CertControlStore(self, Flags, CtrlType, CtrlPara: int) -> None: ...
     def CertEnumCertificatesInStore(self) -> list[PyCERT_CONTEXT]: ...

--- a/stubs/qrbill/qrbill/bill.pyi
+++ b/stubs/qrbill/qrbill/bill.pyi
@@ -114,8 +114,8 @@ class QRBill:
         payment_line: bool = True,
         font_factor: int = 1,
     ) -> None: ...
-    @deprecated("ref_number is deprecated and replaced by reference_number")
     @overload
+    @deprecated("ref_number is deprecated and replaced by reference_number")
     def __init__(
         self,
         account: str,
@@ -135,8 +135,8 @@ class QRBill:
         payment_line: bool = True,
         font_factor: int = 1,
     ) -> None: ...
-    @deprecated("extra_infos is deprecated and replaced by additional_information")
     @overload
+    @deprecated("extra_infos is deprecated and replaced by additional_information")
     def __init__(
         self,
         account: str,

--- a/stubs/regex/@tests/stubtest_allowlist.txt
+++ b/stubs/regex/@tests/stubtest_allowlist.txt
@@ -1,3 +1,8 @@
+# TODO: missing from stub
+regex.__all__
+regex._regex_core.__all__
+regex.regex.__all__
+
 # Not exported in C modules:
 regex._regex.Splitter
 regex._regex.Scanner

--- a/stubs/reportlab/@tests/stubtest_allowlist.txt
+++ b/stubs/reportlab/@tests/stubtest_allowlist.txt
@@ -1,27 +1,26 @@
 # TODO: missing from stub
-error: reportlab.graphics.barcode.__all__ is not present in stub
-error: reportlab.graphics.barcode.dmtx.__all__ is not present in stub
-error: reportlab.graphics.barcode.eanbc.__all__ is not present in stub
-error: reportlab.graphics.barcode.ecc200datamatrix.__all__ is not present in stub
-error: reportlab.graphics.barcode.usps4s.__all__ is not present in stub
-error: reportlab.graphics.barcode.widgets.__all__ is not present in stub
-error: reportlab.graphics.svgpath.__all__ is not present in stub
-error: reportlab.graphics.transform.__all__ is not present in stub
-error: reportlab.graphics.utils.__all__ is not present in stub
-error: reportlab.lib.arciv.__all__ is not present in stub
-error: reportlab.lib.formatters.__all__ is not present in stub
-error: reportlab.lib.pygments2xpre.__all__ is not present in stub
-error: reportlab.lib.rl_accel.__all__ is not present in stub
-error: reportlab.lib.rltempfile.__all__ is not present in stub
-error: reportlab.lib.styles.__all__ is not present in stub
-error: reportlab.pdfgen.canvas.__all__ is not present in stub
-error: reportlab.platypus.frames.__all__ is not present in stub
-error: reportlab.platypus.multicol.__all__ is not present in stub
-error: reportlab.platypus.paragraph.__all__ is not present in stub
-error: reportlab.platypus.xpreformatted.__all__ is not present in stub
-error: reportlab.rl_config.__all__ is not present in stub
-error: reportlab.rl_settings.__all__ is not present in stub
-
+reportlab.graphics.barcode.__all__
+reportlab.graphics.barcode.dmtx.__all__
+reportlab.graphics.barcode.eanbc.__all__
+reportlab.graphics.barcode.ecc200datamatrix.__all__
+reportlab.graphics.barcode.usps4s.__all__
+reportlab.graphics.barcode.widgets.__all__
+reportlab.graphics.svgpath.__all__
+reportlab.graphics.transform.__all__
+reportlab.graphics.utils.__all__
+reportlab.lib.arciv.__all__
+reportlab.lib.formatters.__all__
+reportlab.lib.pygments2xpre.__all__
+reportlab.lib.rl_accel.__all__
+reportlab.lib.rltempfile.__all__
+reportlab.lib.styles.__all__
+reportlab.pdfgen.canvas.__all__
+reportlab.platypus.frames.__all__
+reportlab.platypus.multicol.__all__
+reportlab.platypus.paragraph.__all__
+reportlab.platypus.xpreformatted.__all__
+reportlab.rl_config.__all__
+reportlab.rl_settings.__all__
 
 # Error: is inconsistent
 # ======================

--- a/stubs/reportlab/@tests/stubtest_allowlist.txt
+++ b/stubs/reportlab/@tests/stubtest_allowlist.txt
@@ -1,3 +1,28 @@
+# TODO: missing from stub
+error: reportlab.graphics.barcode.__all__ is not present in stub
+error: reportlab.graphics.barcode.dmtx.__all__ is not present in stub
+error: reportlab.graphics.barcode.eanbc.__all__ is not present in stub
+error: reportlab.graphics.barcode.ecc200datamatrix.__all__ is not present in stub
+error: reportlab.graphics.barcode.usps4s.__all__ is not present in stub
+error: reportlab.graphics.barcode.widgets.__all__ is not present in stub
+error: reportlab.graphics.svgpath.__all__ is not present in stub
+error: reportlab.graphics.transform.__all__ is not present in stub
+error: reportlab.graphics.utils.__all__ is not present in stub
+error: reportlab.lib.arciv.__all__ is not present in stub
+error: reportlab.lib.formatters.__all__ is not present in stub
+error: reportlab.lib.pygments2xpre.__all__ is not present in stub
+error: reportlab.lib.rl_accel.__all__ is not present in stub
+error: reportlab.lib.rltempfile.__all__ is not present in stub
+error: reportlab.lib.styles.__all__ is not present in stub
+error: reportlab.pdfgen.canvas.__all__ is not present in stub
+error: reportlab.platypus.frames.__all__ is not present in stub
+error: reportlab.platypus.multicol.__all__ is not present in stub
+error: reportlab.platypus.paragraph.__all__ is not present in stub
+error: reportlab.platypus.xpreformatted.__all__ is not present in stub
+error: reportlab.rl_config.__all__ is not present in stub
+error: reportlab.rl_settings.__all__ is not present in stub
+
+
 # Error: is inconsistent
 # ======================
 # The drawOn method violates LSP all over the place and it's usually

--- a/stubs/retry/@tests/stubtest_allowlist.txt
+++ b/stubs/retry/@tests/stubtest_allowlist.txt
@@ -1,3 +1,6 @@
+# TODO: missing from stub
+retry.__all__
+
 retry.compat
 retry.tests
 retry.tests.test_retry

--- a/stubs/shapely/@tests/stubtest_allowlist.txt
+++ b/stubs/shapely/@tests/stubtest_allowlist.txt
@@ -1,3 +1,6 @@
+# TODO: missing from stub
+shapely._ragged_array.__all__
+
 shapely\.geometry\.conftest
 shapely\.tests.*
 

--- a/stubs/shapely/shapely/_enum.pyi
+++ b/stubs/shapely/shapely/_enum.pyi
@@ -1,5 +1,5 @@
 from enum import IntEnum
 
-class ParamEnum(IntEnum):
+class ParamEnum(IntEnum):  # type: ignore[misc]  # Enum with no members
     @classmethod
     def get_value(cls, item: str) -> int: ...

--- a/stubs/simplejson/@tests/stubtest_allowlist.txt
+++ b/stubs/simplejson/@tests/stubtest_allowlist.txt
@@ -1,3 +1,8 @@
+# TODO: missing from stub
+simplejson.__all__
+simplejson.decoder.__all__
+simplejson.scanner.__all__
+
 # Speedups (C vs Python inconsistency):
 simplejson.scanner.make_scanner
 simplejson.scanner.JSONDecodeError.__init__

--- a/stubs/singledispatch/@tests/stubtest_allowlist.txt
+++ b/stubs/singledispatch/@tests/stubtest_allowlist.txt
@@ -1,0 +1,2 @@
+# TODO: missing from stub
+singledispatch.__all__

--- a/stubs/toposort/@tests/stubtest_allowlist.txt
+++ b/stubs/toposort/@tests/stubtest_allowlist.txt
@@ -1,0 +1,2 @@
+# TODO: missing from stub
+toposort.__all__

--- a/stubs/tqdm/@tests/stubtest_allowlist.txt
+++ b/stubs/tqdm/@tests/stubtest_allowlist.txt
@@ -1,2 +1,8 @@
+# TODO: missing from stub
+tqdm._main.__all__
+tqdm._tqdm.__all__
+tqdm._tqdm_gui.__all__
+tqdm._tqdm_notebook.__all__
+
 # Cannot import in stubtest
 tqdm.__main__

--- a/stubs/whatthepatch/@tests/stubtest_allowlist.txt
+++ b/stubs/whatthepatch/@tests/stubtest_allowlist.txt
@@ -1,0 +1,2 @@
+# TODO: missing from stub
+whatthepatch.__all__

--- a/stubs/workalendar/@tests/stubtest_allowlist.txt
+++ b/stubs/workalendar/@tests/stubtest_allowlist.txt
@@ -1,3 +1,13 @@
+# TODO: missing from stub
+workalendar.africa.__all__
+workalendar.america.__all__
+workalendar.asia.__all__
+workalendar.astronomy.__all__
+workalendar.europe.__all__
+workalendar.europe.scotland.mixins.__all__
+workalendar.oceania.__all__
+workalendar.usa.__all__
+
 workalendar.core.CoreCalendar.name
 workalendar.europe.scotland.mixins.VictoriaDayTuesdayAfterFirstMondayMay
 workalendar.skyfield_astronomy


### PR DESCRIPTION
I don't know if you normally wait a little before moving to the new version of mypy in typeshed. Personally, I've been waiting for it to come out because disentangling `types.DynamicClassAttribute` from `builtins.property` is one of the last things on my inheritance check todo list, and https://github.com/python/mypy/pull/18150 in the new version enables that.

Just one new allowlist entry needed, which will be resolved by https://github.com/python/typeshed/pull/13038 if/when it's accepted.

