### PR TITLE
[setuptools] Remove stubs for setuptools.compat private modules

### DIFF
--- a/stubs/setuptools/@tests/stubtest_allowlist.txt
+++ b/stubs/setuptools/@tests/stubtest_allowlist.txt
@@ -108,6 +108,7 @@ setuptools._distutils.zosccompiler
 distutils\..+
 
 # Private APIs, tests and other vendored code
+setuptools.compat.*
 setuptools.config._validate_pyproject.*
 setuptools.command.build_py.build_py.existing_egg_info_dir
 .+?\.tests.*

--- a/stubs/setuptools/setuptools/compat/py310.pyi
+++ b/stubs/setuptools/setuptools/compat/py310.pyi
@@ -1,9 +1,0 @@
-import sys
-
-__all__ = ["tomllib"]
-
-if sys.version_info >= (3, 11):
-    import tomllib
-else:
-    # This is actually vendored
-    import tomli as tomllib  # type: ignore[import-not-found] # pyright: ignore[reportMissingImports]

--- a/stubs/setuptools/setuptools/compat/py311.pyi
+++ b/stubs/setuptools/setuptools/compat/py311.pyi
@@ -1,4 +1,0 @@
-from _typeshed import StrOrBytesPath
-from shutil import _OnExcCallback
-
-def shutil_rmtree(path: StrOrBytesPath, ignore_errors: bool = False, onexc: _OnExcCallback | None = None) -> None: ...

--- a/stubs/setuptools/setuptools/compat/py312.pyi
+++ b/stubs/setuptools/setuptools/compat/py312.pyi
@@ -1,3 +1,0 @@
-from typing import Final
-
-PTH_ENCODING: Final[str | None]

--- a/stubs/setuptools/setuptools/compat/py39.pyi
+++ b/stubs/setuptools/setuptools/compat/py39.pyi
@@ -1,7 +1,0 @@
-import sys
-from typing import Final
-
-if sys.version_info >= (3, 10):
-    LOCALE_ENCODING: Final = "locale"
-else:
-    LOCALE_ENCODING: Final = None


### PR DESCRIPTION
As described in https://github.com/python/typeshed/pull/13101#issuecomment-2498572819, this causes CI failures with pyright on Python versions 3.10 and older.

As described in https://github.com/python/typeshed/pull/13101#issuecomment-2498749551, `setuptools.compat` modules are private and do not need stubs coverage.
