### PR TITLE
fix deprecated ast classes

### DIFF
--- a/stdlib/@tests/stubtest_allowlists/py310.txt
+++ b/stdlib/@tests/stubtest_allowlists/py310.txt
@@ -188,8 +188,6 @@ unittest.case.TestCase.__init_subclass__  # Runtime has *args, **kwargs, but wil
 _ast.ImportFrom.level  # None on the class, but never None on instances
 _weakref.ProxyType.__reversed__  # Doesn't really exist
 ast.ImportFrom.level  # None on the class, but never None on instances
-ast.ExtSlice.__new__  # C signature is broader than what is actually accepted
-ast.Index.__new__  # C signature is broader than what is actually accepted
 
 # Treated an alias of a typing class in the stubs,
 # they are generic to type checkers anyway.

--- a/stdlib/@tests/stubtest_allowlists/py311.txt
+++ b/stdlib/@tests/stubtest_allowlists/py311.txt
@@ -169,8 +169,6 @@ unittest.case.TestCase.__init_subclass__  # Runtime has *args, **kwargs, but wil
 _ast.ImportFrom.level  # None on the class, but never None on instances
 _weakref.ProxyType.__reversed__  # Doesn't really exist
 ast.ImportFrom.level  # None on the class, but never None on instances
-ast.ExtSlice.__new__  # C signature is broader than what is actually accepted
-ast.Index.__new__  # C signature is broader than what is actually accepted
 
 # Treated an alias of a typing class in the stubs,
 # they are generic to type checkers anyway.

--- a/stdlib/@tests/stubtest_allowlists/py312.txt
+++ b/stdlib/@tests/stubtest_allowlists/py312.txt
@@ -183,8 +183,6 @@ unittest.case.TestCase.__init_subclass__  # Runtime has *args, **kwargs, but wil
 _ast.ImportFrom.level  # None on the class, but never None on instances
 _weakref.ProxyType.__reversed__  # Doesn't really exist
 ast.ImportFrom.level  # None on the class, but never None on instances
-ast.ExtSlice.__new__  # C signature is broader than what is actually accepted
-ast.Index.__new__  # C signature is broader than what is actually accepted
 
 # Treated an alias of a typing class in the stubs,
 # they are generic to type checkers anyway.

--- a/stdlib/@tests/stubtest_allowlists/py313.txt
+++ b/stdlib/@tests/stubtest_allowlists/py313.txt
@@ -196,8 +196,6 @@ unittest.case.TestCase.__init_subclass__  # Runtime has *args, **kwargs, but wil
 _ast.ImportFrom.level  # None on the class, but never None on instances
 _weakref.ProxyType.__reversed__  # Doesn't really exist
 ast.ImportFrom.level  # None on the class, but never None on instances
-ast.ExtSlice.__new__  # C signature is broader than what is actually accepted
-ast.Index.__new__  # C signature is broader than what is actually accepted
 
 # Treated an alias of a typing class in the stubs,
 # they are generic to type checkers anyway.

--- a/stdlib/@tests/stubtest_allowlists/py39.txt
+++ b/stdlib/@tests/stubtest_allowlists/py39.txt
@@ -149,8 +149,6 @@ tkinter.tix.TkVersion
 _ast.ImportFrom.level  # None on the class, but never None on instances
 _weakref.ProxyType.__reversed__  # Doesn't really exist
 ast.ImportFrom.level  # None on the class, but never None on instances
-ast.ExtSlice.__new__  # C signature is broader than what is actually accepted
-ast.Index.__new__  # C signature is broader than what is actually accepted
 
 # Treated an alias of a typing class in the stubs,
 # they are generic to type checkers anyway.

--- a/stdlib/ast.pyi
+++ b/stdlib/ast.pyi
@@ -7,7 +7,7 @@ from _ast import (
     PyCF_TYPE_COMMENTS as PyCF_TYPE_COMMENTS,
 )
 from _typeshed import ReadableBuffer, Unused
-from collections.abc import Iterator
+from collections.abc import Iterable, Iterator
 from typing import Any, ClassVar, Generic, Literal, TypedDict, TypeVar as _TypeVar, overload
 from typing_extensions import Self, Unpack, deprecated
 
@@ -1186,12 +1186,18 @@ class Slice(_Slice):
         ) -> Self: ...
 
 class ExtSlice(slice):  # deprecated and moved to ast.py if sys.version_info >= (3, 9)
-    dims: list[slice]
-    def __init__(self, dims: list[slice], **kwargs: Unpack[_SliceAttributes]) -> None: ...
+    if sys.version_info >= (3, 9):
+        def __new__(cls, dims: Iterable[slice] = (), **kwargs: Unpack[_SliceAttributes]) -> Tuple: ...  # type: ignore[misc]
+    else:
+        dims: list[slice]
+        def __init__(self, dims: list[slice], **kwargs: Unpack[_SliceAttributes]) -> None: ...
 
 class Index(slice):  # deprecated and moved to ast.py if sys.version_info >= (3, 9)
-    value: expr
-    def __init__(self, value: expr, **kwargs: Unpack[_SliceAttributes]) -> None: ...
+    if sys.version_info >= (3, 9):
+        def __new__(cls, value: expr, **kwargs: Unpack[_SliceAttributes]) -> expr: ...  # type: ignore[misc]
+    else:
+        value: expr
+        def __init__(self, value: expr, **kwargs: Unpack[_SliceAttributes]) -> None: ...
 
 class expr_context(AST): ...
 class AugLoad(expr_context): ...  # deprecated and moved to ast.py if sys.version_info >= (3, 9)

--- a/stdlib/ast.pyi
+++ b/stdlib/ast.pyi
@@ -1154,6 +1154,7 @@ class Tuple(expr):
     if sys.version_info >= (3, 14):
         def __replace__(self, *, elts: list[expr] = ..., ctx: expr_context = ..., **kwargs: Unpack[_Attributes]) -> Self: ...
 
+@deprecated("Deprecated since Python 3.9.")
 class slice(AST): ...  # deprecated and moved to ast.py for >= (3, 9)
 
 if sys.version_info >= (3, 9):
@@ -1185,6 +1186,7 @@ class Slice(_Slice):
             **kwargs: Unpack[_SliceAttributes],
         ) -> Self: ...
 
+@deprecated("Deprecated since Python 3.9. Use ast.Tuple instead.")
 class ExtSlice(slice):  # deprecated and moved to ast.py if sys.version_info >= (3, 9)
     if sys.version_info >= (3, 9):
         def __new__(cls, dims: Iterable[slice] = (), **kwargs: Unpack[_SliceAttributes]) -> Tuple: ...  # type: ignore[misc]
@@ -1192,6 +1194,7 @@ class ExtSlice(slice):  # deprecated and moved to ast.py if sys.version_info >= 
         dims: list[slice]
         def __init__(self, dims: list[slice], **kwargs: Unpack[_SliceAttributes]) -> None: ...
 
+@deprecated("Deprecated since Python 3.9. Use the index value directly instead.")
 class Index(slice):  # deprecated and moved to ast.py if sys.version_info >= (3, 9)
     if sys.version_info >= (3, 9):
         def __new__(cls, value: expr, **kwargs: Unpack[_SliceAttributes]) -> expr: ...  # type: ignore[misc]
@@ -1200,13 +1203,21 @@ class Index(slice):  # deprecated and moved to ast.py if sys.version_info >= (3,
         def __init__(self, value: expr, **kwargs: Unpack[_SliceAttributes]) -> None: ...
 
 class expr_context(AST): ...
+
+@deprecated("Deprecated since Python 3.9. Unused in Python 3.")
 class AugLoad(expr_context): ...  # deprecated and moved to ast.py if sys.version_info >= (3, 9)
+
+@deprecated("Deprecated since Python 3.9. Unused in Python 3.")
 class AugStore(expr_context): ...  # deprecated and moved to ast.py if sys.version_info >= (3, 9)
+
+@deprecated("Deprecated since Python 3.9. Unused in Python 3.")
 class Param(expr_context): ...  # deprecated and moved to ast.py if sys.version_info >= (3, 9)
 
+@deprecated("Deprecated since Python 3.9. Unused in Python 3.")
 class Suite(mod):  # deprecated and moved to ast.py if sys.version_info >= (3, 9)
-    body: list[stmt]
-    def __init__(self, body: list[stmt]) -> None: ...
+    if sys.version_info < (3, 9):
+        body: list[stmt]
+        def __init__(self, body: list[stmt]) -> None: ...
 
 class Load(expr_context): ...
 class Store(expr_context): ...


### PR DESCRIPTION
The comment on these was incorrect, but there were a lot of other AST classes where that was the case. Here, they switched from an `__init__` to a `__new__` when they were deprecated, in order to return an instance of their replacement.