### PR TITLE
add codecs.StreamRecoder attributes

### DIFF
--- a/stdlib/codecs.pyi
+++ b/stdlib/codecs.pyi
@@ -254,6 +254,8 @@ class StreamReaderWriter(TextIO):
     def writable(self) -> bool: ...
 
 class StreamRecoder(BinaryIO):
+    data_encoding: str
+    file_encoding: str
     def __init__(
         self,
         stream: _Stream,


### PR DESCRIPTION
That these were missing from the stubs was being silenced by this part of the common allowlist:

```
# See comments in file. List out methods that are delegated by __getattr__ at runtime.
# Used to make the relevant class satisfy BinaryIO interface.
codecs.StreamReaderWriter.\w+
codecs.StreamRecoder.\w+
```

But these weren't part of the group of errors being described, which are errors about things being in the stubs that don't appear to exist at runtime.