### PR TITLE
Revert "Remove unnecessary pyright supressions"

### DIFF
--- a/lib/ts_utils/metadata.py
+++ b/lib/ts_utils/metadata.py
@@ -280,7 +280,7 @@ def read_metadata(distribution: str) -> StubMetadata:
     assert isinstance(tools_settings, dict)
     assert tools_settings.keys() <= _KNOWN_METADATA_TOOL_FIELDS.keys(), f"Unrecognised tool for {distribution!r}"
     for tool, tk in _KNOWN_METADATA_TOOL_FIELDS.items():
-        settings_for_tool: object = tools_settings.get(tool, {})
+        settings_for_tool: object = tools_settings.get(tool, {})  # pyright: ignore[reportUnknownMemberType]
         assert isinstance(settings_for_tool, dict)
         for key in settings_for_tool:
             assert key in tk, f"Unrecognised {tool} key {key!r} for {distribution!r}"
@@ -311,9 +311,9 @@ def update_metadata(distribution: str, **new_values: object) -> tomlkit.TOMLDocu
             data = tomlkit.load(file)
     except FileNotFoundError:
         raise NoSuchStubError(f"Typeshed has no stubs for {distribution!r}!") from None
-    data.update(new_values)
+    data.update(new_values)  # pyright: ignore[reportUnknownMemberType] # tomlkit.TOMLDocument.update is partially typed
     with path.open("w", encoding="UTF-8") as file:
-        tomlkit.dump(data, file)
+        tomlkit.dump(data, file)  # pyright: ignore[reportUnknownMemberType] # tomlkit.dump has partially unknown Mapping type
     return data
 
 

--- a/lib/ts_utils/utils.py
+++ b/lib/ts_utils/utils.py
@@ -14,7 +14,7 @@ import pathspec
 from packaging.requirements import Requirement
 
 try:
-    from termcolor import colored as colored
+    from termcolor import colored as colored  # pyright: ignore[reportAssignmentType]
 except ImportError:
 
     def colored(text: str, color: str | None = None, **kwargs: Any) -> str:  # type: ignore[misc]


### PR DESCRIPTION
Reverts python/typeshed#13287

They're not unnecessary; the relevant pyright checks are now failing on main (e.g. https://github.com/python/typeshed/actions/runs/12476935411/job/34822431014). See https://github.com/python/typeshed/pull/13287#issuecomment-2561492850.

I haven't yet investigated why the relevant CI jobs didn't run on that PR before it was merged