### PR TITLE
sorted() does not enforce comparable items in an iterable of tuples is fixed #13297

### DIFF
--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -1764,7 +1764,14 @@ def sorted(
     iterable: Iterable[SupportsRichComparisonT], /, *, key: None = None, reverse: bool = False
 ) -> list[SupportsRichComparisonT]: ...
 @overload
-def sorted(iterable: Iterable[_T], /, *, key: Callable[[_T], SupportsRichComparison], reverse: bool = False) -> list[_T]: ...
+def sorted(
+    iterable: Iterable[_T], /, *, key: Callable[[_T], SupportsRichComparison], reverse: bool = False
+) -> list[_T]: ...
+
+@overload
+def sorted(
+    iterable: Iterable[tuple[SupportsRichComparisonT, ...]], /, *, key: None = None, reverse: bool = False
+) -> list[tuple[SupportsRichComparisonT, ...]]: ...
 
 _AddableT1 = TypeVar("_AddableT1", bound=SupportsAdd[Any, Any])
 _AddableT2 = TypeVar("_AddableT2", bound=SupportsAdd[Any, Any])

--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -1764,10 +1764,7 @@ def sorted(
     iterable: Iterable[SupportsRichComparisonT], /, *, key: None = None, reverse: bool = False
 ) -> list[SupportsRichComparisonT]: ...
 @overload
-def sorted(
-    iterable: Iterable[_T], /, *, key: Callable[[_T], SupportsRichComparison], reverse: bool = False
-) -> list[_T]: ...
-
+def sorted(iterable: Iterable[_T], /, *, key: Callable[[_T], SupportsRichComparison], reverse: bool = False) -> list[_T]: ...
 @overload
 def sorted(
     iterable: Iterable[tuple[SupportsRichComparisonT, ...]], /, *, key: None = None, reverse: bool = False


### PR DESCRIPTION
I’ve added an overload for the sorted() function that explicitly handles tuples with elements that support SupportsRichComparison. This ensures that the tuples only contain comparable elements, and the type checker will catch any issues before runtime.

Explain :
**Added a Specialized Overload for Tuples:**

The third overload explicitly specifies that when sorting tuples, all elements in the tuple must satisfy SupportsRichComparison.
This ensures that sorted only works for tuples where every element is fully comparable.If a key function is provided, the burden of ensuring comparability is transferred to the result of the key function.