### PR TITLE
Use `astral-sh/setup-uv` to install uv in CI

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -121,8 +121,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - name: Install uv
-        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+      - uses: astral-sh/setup-uv@v5
       - name: Run tests
         run: |
           cd stub_uploader

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,8 +43,7 @@ jobs:
         with:
           # Max supported Python version as of pytype 2024.9.13
           python-version: "3.12"
-      - name: Install uv
-        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+      - uses: astral-sh/setup-uv@v5
       - run: uv pip install -r requirements-tests.txt --system
       - name: Install external dependencies for 3rd-party stubs
         run: |
@@ -121,8 +120,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - name: Install uv
-        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+      - uses: astral-sh/setup-uv@v5
       - name: Install typeshed test-suite requirements
         # Install these so we can run `get_external_stub_requirements.py`
         run: uv pip install -r requirements-tests.txt --system
@@ -183,8 +181,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - name: Install uv
-        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+      - uses: astral-sh/setup-uv@v5
       - name: Run tests
         run: |
           cd stub_uploader


### PR DESCRIPTION
I don't think we can use it to replace `actions/setup-python` yet because of https://github.com/astral-sh/uv/issues/8666 (unless we configure a dummy project name+version in pyproject.toml)