### PR TITLE
stdlib: new signature for CDLL in 3.12

### DIFF
--- a/stdlib/@tests/test_cases/ctypes/check_CDLL.py
+++ b/stdlib/@tests/test_cases/ctypes/check_CDLL.py
@@ -1,8 +1,7 @@
-import sys
-from typing_extensions import assert_type
-
 import ctypes
+import sys
 from pathlib import Path
+from typing_extensions import assert_type
 
 assert_type(ctypes.CDLL(None), ctypes.CDLL)
 assert_type(ctypes.CDLL("."), ctypes.CDLL)

--- a/stdlib/@tests/test_cases/ctypes/check_CDLL.py
+++ b/stdlib/@tests/test_cases/ctypes/check_CDLL.py
@@ -1,0 +1,12 @@
+import sys
+from typing_extensions import assert_type
+
+import ctypes
+from pathlib import Path
+
+assert_type(ctypes.CDLL(None), ctypes.CDLL)
+assert_type(ctypes.CDLL("."), ctypes.CDLL)
+
+# https://github.com/python/cpython/pull/7032
+if sys.version_info >= (3, 12):
+    assert_type(ctypes.CDLL(Path(".")), ctypes.CDLL)

--- a/stdlib/ctypes/__init__.pyi
+++ b/stdlib/ctypes/__init__.pyi
@@ -24,6 +24,7 @@ from _ctypes import (
     set_errno as set_errno,
     sizeof as sizeof,
 )
+from _typeshed import StrPath
 from ctypes._endian import BigEndianStructure as BigEndianStructure, LittleEndianStructure as LittleEndianStructure
 from typing import Any, ClassVar, Generic, TypeVar, type_check_only
 from typing_extensions import Self, TypeAlias, deprecated
@@ -57,6 +58,11 @@ class _CDLLFuncPointer(_CFuncPtr):
 class _NamedFuncPointer(_CDLLFuncPointer):
     __name__: str
 
+if sys.version_info >= (3, 12):
+    _NameTypes: TypeAlias = StrPath | None
+else:
+    _NameTypes: TypeAlias = str | None
+
 class CDLL:
     _func_flags_: ClassVar[int]
     _func_restype_: ClassVar[type[_CDataType]]
@@ -65,7 +71,7 @@ class CDLL:
     _FuncPtr: type[_CDLLFuncPointer]
     def __init__(
         self,
-        name: str | None,
+        name: _NameTypes,
         mode: int = ...,
         handle: int | None = None,
         use_errno: bool = False,


### PR DESCRIPTION
CDLL and descendants accept `Path` objects as `name` since 3.12