### PR TITLE
Enable Ruff YTT

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ select = [
     "PGH", # pygrep-hooks
     "RUF", # Ruff-specific and unused-noqa
     "UP", # pyupgrade
+    "YTT", # flake8-2020
     # Flake8 base rules
     "E", # pycodestyle Error
     "F", # Pyflakes


### PR DESCRIPTION
Ref https://github.com/python/typeshed/issues/13295
https://docs.astral.sh/ruff/rules/#flake8-2020-ytt

typeshed already passes as-is.
I think this group of rules is overall nice to catch odd version checks that flake8-PYI might not. I don't think we'd accept any of the formats it catches, so it can be caught before even going to review.