### PR TITLE
Enable more PYI autofixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,16 +57,20 @@ select = [
     "PYI014", # Only simple default values allowed for arguments
     "PYI015", # Only simple default values allowed for assignments
     "PYI016", # Duplicate union member `{}`
+    "PYI019", # Methods like `{method_name}` should return `Self` instead of a custom `TypeVar`
     "PYI020", # Quoted annotations should not be included in stubs
     "PYI025", # Use `from collections.abc import Set as AbstractSet` to avoid confusion with the `set` builtin
     # "PYI026", Waiting for this mypy bug to be fixed: https://github.com/python/mypy/issues/16581
     "PYI030", # Multiple literal members in a union. Use a single literal, e.g. `Literal[{}]`
     "PYI032", # Prefer `object` to `Any` for the second parameter to `{method_name}`
+    "PYI034", # `__new__` methods usually return self at runtime
     "PYI036", # Star-args in `{method_name}` should be annotated with `object`
     "PYI044", # `from __future__ import annotations` has no effect in stub files, since type checkers automatically treat stubs as having those semantics
     "PYI055", # Multiple `type[T]` usages in a union. Combine them into one, e.g., `type[{union_str}]`.
     "PYI058", # Use `{return_type}` as the return value for simple `{method}` methods
+    # "PYI061", # TODO: Enable when out of preview
     "PYI062", # Duplicate literal member `{}`
+    "PYI064", # `Final[Literal[{literal}]]` can be replaced with a bare Final
 ]
 extend-safe-fixes = [
     "UP036", # Remove unnecessary `sys.version_info` blocks

--- a/stdlib/typing_extensions.pyi
+++ b/stdlib/typing_extensions.pyi
@@ -1,3 +1,5 @@
+# Since this module defines "Self" it is not recognized by Ruff as typing_extensions.Self
+# ruff: noqa: PYI034
 import abc
 import sys
 import typing


### PR DESCRIPTION
This enables more autofixes that have been added to Ruff in the last few versions.