### PR TITLE
Enable Ruff ARG (flake8-unsued-arguments) and remove unused arguments

### DIFF
--- a/lib/ts_utils/utils.py
+++ b/lib/ts_utils/utils.py
@@ -17,7 +17,7 @@ try:
     from termcolor import colored as colored  # pyright: ignore[reportAssignmentType]
 except ImportError:
 
-    def colored(text: str, color: str | None = None, **kwargs: Any) -> str:  # type: ignore[misc]
+    def colored(text: str, color: str | None = None, **kwargs: Any) -> str:  # type: ignore[misc] # noqa: ARG001
         return text
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ exclude = ["**/test_cases/**/*.py"]
 # tell ruff not to flag these as e.g. "unused noqa comments"
 external = ["F821", "NQA", "Y"]
 select = [
+    "ARG", # flake8-unused-arguments
     "B", # flake8-bugbear
     "FA", # flake8-future-annotations
     "I", # isort

--- a/tests/regr_test.py
+++ b/tests/regr_test.py
@@ -237,7 +237,7 @@ class Result:
     test_case_dir: Path
     tempdir: Path
 
-    def print_description(self, *, verbosity: Verbosity) -> None:
+    def print_description(self) -> None:
         if self.code:
             print(f"{self.command_run}:", end=" ")
             print_error("FAILURE\n")
@@ -382,7 +382,7 @@ def main() -> ReturnCode:
     print()
 
     for result in results:
-        result.print_description(verbosity=verbosity)
+        result.print_description()
 
     code = max(result.code for result in results)
 

--- a/tests/stubtest_third_party.py
+++ b/tests/stubtest_third_party.py
@@ -140,7 +140,7 @@ def run_stubtest(
 
             print_divider()
             print("Commands run:")
-            print_commands(dist, pip_cmd, stubtest_cmd, mypypath)
+            print_commands(pip_cmd, stubtest_cmd, mypypath)
 
             print_divider()
             print("Command output:\n")
@@ -183,7 +183,7 @@ def run_stubtest(
             rmtree(venv_dir)
 
     if verbose:
-        print_commands(dist, pip_cmd, stubtest_cmd, mypypath)
+        print_commands(pip_cmd, stubtest_cmd, mypypath)
 
     return True
 
@@ -358,7 +358,7 @@ def setup_uwsgi_stubtest_command(dist: Path, venv_dir: Path, stubtest_cmd: list[
     return True
 
 
-def print_commands(dist: Path, pip_cmd: list[str], stubtest_cmd: list[str], mypypath: str) -> None:
+def print_commands(pip_cmd: list[str], stubtest_cmd: list[str], mypypath: str) -> None:
     print()
     print(" ".join(pip_cmd))
     print(f"MYPYPATH={mypypath}", " ".join(stubtest_cmd))


### PR DESCRIPTION
Ref https://github.com/python/typeshed/issues/13295
https://docs.astral.sh/ruff/rules/#flake8-unused-arguments-arg

This found https://github.com/python/typeshed/pull/9512#discussion_r1899045263 and https://github.com/python/typeshed/pull/10714#discussion_r1899045425

CC @AlexWaygood as the original author of that code. Since `print_description` only prints errors, I don't think verbosity applies, but you can tell me if that assumption is wrong.