### PR TITLE
Make `signal` global enum constants annotated as literals

### DIFF
--- a/stdlib/signal.pyi
+++ b/stdlib/signal.pyi
@@ -3,7 +3,7 @@ from _typeshed import structseq
 from collections.abc import Callable, Iterable
 from enum import IntEnum
 from types import FrameType
-from typing import Any, Final, final
+from typing import Any, Final, Literal, final
 from typing_extensions import Never, TypeAlias
 
 NSIG: int
@@ -61,8 +61,8 @@ class Handlers(IntEnum):
     SIG_DFL = 0
     SIG_IGN = 1
 
-SIG_DFL: Handlers
-SIG_IGN: Handlers
+SIG_DFL: Literal[Handlers.SIG_DFL]
+SIG_IGN: Literal[Handlers.SIG_IGN]
 
 _SIGNUM: TypeAlias = int | Signals
 _HANDLER: TypeAlias = Callable[[int, FrameType | None], Any] | int | Handlers | None
@@ -77,45 +77,45 @@ else:
     def getsignal(signalnum: _SIGNUM, /) -> _HANDLER: ...
     def signal(signalnum: _SIGNUM, handler: _HANDLER, /) -> _HANDLER: ...
 
-SIGABRT: Signals
-SIGFPE: Signals
-SIGILL: Signals
-SIGINT: Signals
-SIGSEGV: Signals
-SIGTERM: Signals
+SIGABRT: Literal[Signals.SIGABRT]
+SIGFPE: Literal[Signals.SIGFPE]
+SIGILL: Literal[Signals.SIGILL]
+SIGINT: Literal[Signals.SIGINT]
+SIGSEGV: Literal[Signals.SIGSEGV]
+SIGTERM: Literal[Signals.SIGTERM]
 
 if sys.platform == "win32":
-    SIGBREAK: Signals
-    CTRL_C_EVENT: Signals
-    CTRL_BREAK_EVENT: Signals
+    SIGBREAK: Literal[Signals.SIGBREAK]
+    CTRL_C_EVENT: Literal[Signals.CTRL_C_EVENT]
+    CTRL_BREAK_EVENT: Literal[Signals.CTRL_BREAK_EVENT]
 else:
     if sys.platform != "linux":
-        SIGINFO: Signals
-        SIGEMT: Signals
-    SIGALRM: Signals
-    SIGBUS: Signals
-    SIGCHLD: Signals
-    SIGCONT: Signals
-    SIGHUP: Signals
-    SIGIO: Signals
-    SIGIOT: Signals
-    SIGKILL: Signals
-    SIGPIPE: Signals
-    SIGPROF: Signals
-    SIGQUIT: Signals
-    SIGSTOP: Signals
-    SIGSYS: Signals
-    SIGTRAP: Signals
-    SIGTSTP: Signals
-    SIGTTIN: Signals
-    SIGTTOU: Signals
-    SIGURG: Signals
-    SIGUSR1: Signals
-    SIGUSR2: Signals
-    SIGVTALRM: Signals
-    SIGWINCH: Signals
-    SIGXCPU: Signals
-    SIGXFSZ: Signals
+        SIGINFO: Literal[Signals.SIGINFO]
+        SIGEMT: Literal[Signals.SIGEMT]
+    SIGALRM: Literal[Signals.SIGALRM]
+    SIGBUS: Literal[Signals.SIGBUS]
+    SIGCHLD: Literal[Signals.SIGCHLD]
+    SIGCONT: Literal[Signals.SIGCONT]
+    SIGHUP: Literal[Signals.SIGHUP]
+    SIGIO: Literal[Signals.SIGIO]
+    SIGIOT: Literal[Signals.SIGIOT]
+    SIGKILL: Literal[Signals.SIGKILL]
+    SIGPIPE: Literal[Signals.SIGPIPE]
+    SIGPROF: Literal[Signals.SIGPROF]
+    SIGQUIT: Literal[Signals.SIGQUIT]
+    SIGSTOP: Literal[Signals.SIGSTOP]
+    SIGSYS: Literal[Signals.SIGSYS]
+    SIGTRAP: Literal[Signals.SIGTRAP]
+    SIGTSTP: Literal[Signals.SIGTSTP]
+    SIGTTIN: Literal[Signals.SIGTTIN]
+    SIGTTOU: Literal[Signals.SIGTTOU]
+    SIGURG: Literal[Signals.SIGURG]
+    SIGUSR1: Literal[Signals.SIGUSR1]
+    SIGUSR2: Literal[Signals.SIGUSR2]
+    SIGVTALRM: Literal[Signals.SIGVTALRM]
+    SIGWINCH: Literal[Signals.SIGWINCH]
+    SIGXCPU: Literal[Signals.SIGXCPU]
+    SIGXFSZ: Literal[Signals.SIGXFSZ]
 
     class ItimerError(OSError): ...
     ITIMER_PROF: int
@@ -127,9 +127,9 @@ else:
         SIG_UNBLOCK = 1
         SIG_SETMASK = 2
 
-    SIG_BLOCK = Sigmasks.SIG_BLOCK
-    SIG_UNBLOCK = Sigmasks.SIG_UNBLOCK
-    SIG_SETMASK = Sigmasks.SIG_SETMASK
+    SIG_BLOCK: Literal[Sigmasks.SIG_BLOCK]
+    SIG_UNBLOCK: Literal[Sigmasks.SIG_UNBLOCK]
+    SIG_SETMASK: Literal[Sigmasks.SIG_SETMASK]
     def alarm(seconds: int, /) -> int: ...
     def getitimer(which: int, /) -> tuple[float, float]: ...
     def pause() -> None: ...
@@ -147,13 +147,13 @@ else:
     else:
         def sigwait(sigset: Iterable[int], /) -> _SIGNUM: ...
     if sys.platform != "darwin":
-        SIGCLD: Signals
-        SIGPOLL: Signals
-        SIGPWR: Signals
-        SIGRTMAX: Signals
-        SIGRTMIN: Signals
+        SIGCLD: Literal[Signals.SIGCLD]
+        SIGPOLL: Literal[Signals.SIGPOLL]
+        SIGPWR: Literal[Signals.SIGPWR]
+        SIGRTMAX: Literal[Signals.SIGRTMAX]
+        SIGRTMIN: Literal[Signals.SIGRTMIN]
         if sys.version_info >= (3, 11):
-            SIGSTKFLT: Signals
+            SIGSTKFLT: Literal[Signals.SIGSTKFLT]
 
         @final
         class struct_siginfo(structseq[int], tuple[int, int, int, int, int, int, int]):

--- a/stdlib/signal.pyi
+++ b/stdlib/signal.pyi
@@ -98,7 +98,7 @@ else:
     SIGCONT: Literal[Signals.SIGCONT]
     SIGHUP: Literal[Signals.SIGHUP]
     SIGIO: Literal[Signals.SIGIO]
-    SIGIOT: Literal[Signals.SIGIOT]
+    SIGIOT: Literal[Signals.SIGABRT]  # alias
     SIGKILL: Literal[Signals.SIGKILL]
     SIGPIPE: Literal[Signals.SIGPIPE]
     SIGPROF: Literal[Signals.SIGPROF]
@@ -147,8 +147,8 @@ else:
     else:
         def sigwait(sigset: Iterable[int], /) -> _SIGNUM: ...
     if sys.platform != "darwin":
-        SIGCLD: Literal[Signals.SIGCLD]
-        SIGPOLL: Literal[Signals.SIGPOLL]
+        SIGCLD: Literal[Signals.SIGCHLD]  # alias
+        SIGPOLL: Literal[Signals.SIGIO]  # alias
         SIGPWR: Literal[Signals.SIGPWR]
         SIGRTMAX: Literal[Signals.SIGRTMAX]
         SIGRTMIN: Literal[Signals.SIGRTMIN]


### PR DESCRIPTION
Apart from regular rewrites of annotations from `GLOBAL: EnumClassName` to `GLOBAL: Literal[EnumClassName.MEMBER]`, you may notice a small different kind of change:

```diff
-    SIG_BLOCK = Sigmasks.SIG_BLOCK
-    SIG_UNBLOCK = Sigmasks.SIG_UNBLOCK
-    SIG_SETMASK = Sigmasks.SIG_SETMASK
+    SIG_BLOCK: Literal[Sigmasks.SIG_BLOCK]
+    SIG_UNBLOCK: Literal[Sigmasks.SIG_UNBLOCK]
+    SIG_SETMASK: Literal[Sigmasks.SIG_SETMASK]
```

The reason why I did is because this unifies the outcomes across pyright and mypy (`reveal_type(SIG_BLOCK)` for old `SIG_BLOCK` is `Sigmasks` according to mypy and `Literal[Sigmasks.SIG_BLOCK]` according to pyright) -- with the new version, both checkers see literal types.