### PR TITLE
Improve stubs for the bisect module

### DIFF
--- a/stdlib/_bisect.pyi
+++ b/stdlib/_bisect.pyi
@@ -1,15 +1,17 @@
 import sys
-from _typeshed import SupportsLenAndGetItem, SupportsRichComparisonT
+from _typeshed import SupportsDunderLT, SupportsLenAndGetItem
 from collections.abc import Callable, MutableSequence
 from typing import TypeVar, overload
 
 _T = TypeVar("_T")
+_U = TypeVar("_U")
 
 if sys.version_info >= (3, 10):
     @overload
     def bisect_left(
-        a: SupportsLenAndGetItem[SupportsRichComparisonT],
-        x: SupportsRichComparisonT,
+        # Valid comparison: a[i] < x
+        a: SupportsLenAndGetItem[SupportsDunderLT[_T]],
+        x: _T,
         lo: int = 0,
         hi: int | None = None,
         *,
@@ -17,17 +19,19 @@ if sys.version_info >= (3, 10):
     ) -> int: ...
     @overload
     def bisect_left(
+        # Valid comparison: key(a[i]) < x
         a: SupportsLenAndGetItem[_T],
-        x: SupportsRichComparisonT,
+        x: _U,
         lo: int = 0,
         hi: int | None = None,
         *,
-        key: Callable[[_T], SupportsRichComparisonT],
+        key: Callable[[_T], SupportsDunderLT[_U]],
     ) -> int: ...
     @overload
     def bisect_right(
-        a: SupportsLenAndGetItem[SupportsRichComparisonT],
-        x: SupportsRichComparisonT,
+        # Valid comparison: x < a[i]
+        a: SupportsLenAndGetItem[_T],
+        x: SupportsDunderLT[_T],
         lo: int = 0,
         hi: int | None = None,
         *,
@@ -35,17 +39,19 @@ if sys.version_info >= (3, 10):
     ) -> int: ...
     @overload
     def bisect_right(
+        # Valid comparison: x < key(a[i])
         a: SupportsLenAndGetItem[_T],
-        x: SupportsRichComparisonT,
+        x: SupportsDunderLT[_U],
         lo: int = 0,
         hi: int | None = None,
         *,
-        key: Callable[[_T], SupportsRichComparisonT],
+        key: Callable[[_T], _U],
     ) -> int: ...
     @overload
     def insort_left(
-        a: MutableSequence[SupportsRichComparisonT],
-        x: SupportsRichComparisonT,
+        # Valid comparison: a[i] < x
+        a: MutableSequence[SupportsDunderLT[_T]],
+        x: _T,
         lo: int = 0,
         hi: int | None = None,
         *,
@@ -53,12 +59,19 @@ if sys.version_info >= (3, 10):
     ) -> None: ...
     @overload
     def insort_left(
-        a: MutableSequence[_T], x: _T, lo: int = 0, hi: int | None = None, *, key: Callable[[_T], SupportsRichComparisonT]
+        # Valid comparison: key(a[i]) < x
+        a: MutableSequence[_T],
+        x: _U,
+        lo: int = 0,
+        hi: int | None = None,
+        *,
+        key: Callable[[_U], SupportsDunderLT[_T]],
     ) -> None: ...
     @overload
     def insort_right(
-        a: MutableSequence[SupportsRichComparisonT],
-        x: SupportsRichComparisonT,
+        # Valid comparison: x < a[i]
+        a: MutableSequence[_T],
+        x: SupportsDunderLT[_T],
         lo: int = 0,
         hi: int | None = None,
         *,
@@ -66,19 +79,43 @@ if sys.version_info >= (3, 10):
     ) -> None: ...
     @overload
     def insort_right(
-        a: MutableSequence[_T], x: _T, lo: int = 0, hi: int | None = None, *, key: Callable[[_T], SupportsRichComparisonT]
+        # Valid comparison: x < key(a[i])
+        a: MutableSequence[_T],
+        x: SupportsDunderLT[_U],
+        lo: int = 0,
+        hi: int | None = None,
+        *,
+        key: Callable[[_T], _U],
     ) -> None: ...
 
 else:
     def bisect_left(
-        a: SupportsLenAndGetItem[SupportsRichComparisonT], x: SupportsRichComparisonT, lo: int = 0, hi: int | None = None
+        # Valid comparison: a[i] < x
+        a: SupportsLenAndGetItem[SupportsDunderLT[_T]],
+        x: _T,
+        lo: int = 0,
+        hi: int | None = None,
     ) -> int: ...
     def bisect_right(
-        a: SupportsLenAndGetItem[SupportsRichComparisonT], x: SupportsRichComparisonT, lo: int = 0, hi: int | None = None
+        # Valid comparison: x < a[i]
+        a: SupportsLenAndGetItem[_T],
+        x: SupportsDunderLT[_T],
+        lo: int = 0,
+        hi: int | None = None,
     ) -> int: ...
     def insort_left(
-        a: MutableSequence[SupportsRichComparisonT], x: SupportsRichComparisonT, lo: int = 0, hi: int | None = None
+        # Valid comparison: a[i] < x
+        a: MutableSequence[SupportsDunderLT[_T]],
+        x: _T,
+        lo: int = 0,
+        hi: int | None = None,
     ) -> None: ...
     def insort_right(
-        a: MutableSequence[SupportsRichComparisonT], x: SupportsRichComparisonT, lo: int = 0, hi: int | None = None
+        # Valid comparison: x < a[i]
+        a: MutableSequence[_T],
+        x: SupportsDunderLT[_T],
+        lo: int = 0,
+        hi: int | None = None,
+        *,
+        key: None = None,
     ) -> None: ...


### PR DESCRIPTION
The stubs were requiring SupportsRichComparisonT, but bisect only uses __lt__. Be more specific as to which comparison is actually required, which depends on the function. This allows using bisect with types that only implement __lt__.

Closes #13347.