### PR TITLE
Enable Ruff TRY (tryceratops)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ select = [
     "N", # pep8-naming
     "PGH", # pygrep-hooks
     "RUF", # Ruff-specific and unused-noqa
+    "TRY", # tryceratops
     "UP", # pyupgrade
     "YTT", # flake8-2020
     # Flake8 base rules
@@ -116,6 +117,8 @@ ignore = [
     # Used for direct, non-subclass type comparison, for example: `type(val) is str`
     # see https://github.com/astral-sh/ruff/issues/6465
     "E721", # Do not compare types, use `isinstance()`
+    # Mostly from scripts and tests, it's ok to have messages passed directly to exceptions
+    "TRY003", # Avoid specifying long messages outside the exception class
     # Slower and more verbose https://github.com/astral-sh/ruff/issues/7871
     "UP038", # Use `X | Y` in `isinstance` call instead of `(X, Y)`
     ###


### PR DESCRIPTION
Ref https://github.com/python/typeshed/issues/13295
https://docs.astral.sh/ruff/rules/#tryceratops-try

Coding patterns around raising exceptions. We seem to already be respecting all of them except [raise-vanilla-args (TRY003)](https://docs.astral.sh/ruff/rules/raise-vanilla-args/#raise-vanilla-args-try003), but I think that rule is too vague. (relevant: https://github.com/astral-sh/ruff/issues/14398 )