### PR TITLE
Fix constructor args for two vobject classes

### DIFF
--- a/stubs/vobject/vobject/vcard.pyi
+++ b/stubs/vobject/vobject/vcard.pyi
@@ -8,7 +8,14 @@ class Name:
     additional: Incomplete
     prefix: Incomplete
     suffix: Incomplete
-    def __init__(self, family: str = "", given: str = "", additional: str = "", prefix: str = "", suffix: str = "") -> None: ...
+    def __init__(
+        self,
+        family: str | list[str] = "",
+        given: str | list[str] = "",
+        additional: str | list[str] = "",
+        prefix: str | list[str] = "",
+        suffix: str | list[str] = "",
+    ) -> None: ...
     @staticmethod
     def toString(val): ...
     def __eq__(self, other): ...
@@ -23,13 +30,13 @@ class Address:
     country: Incomplete
     def __init__(
         self,
-        street: str = "",
-        city: str = "",
-        region: str = "",
-        code: str = "",
-        country: str = "",
-        box: str = "",
-        extended: str = "",
+        street: str | list[str] = "",
+        city: str | list[str] = "",
+        region: str | list[str] = "",
+        code: str | list[str] = "",
+        country: str | list[str] = "",
+        box: str | list[str] = "",
+        extended: str | list[str] = "",
     ) -> None: ...
     @staticmethod
     def toString(val, join_char: str = "\n"): ...


### PR DESCRIPTION
The upstream source code has a docstring explicitly stating that these arguments can be strings or lists of strings:
https://github.com/py-vobject/vobject/blob/662db24688df1f6d8f12d68462a13975bd0d08de/vobject/vcard.py#L18 https://github.com/py-vobject/vobject/blob/662db24688df1f6d8f12d68462a13975bd0d08de/vobject/vcard.py#L58