### PR TITLE
tqdm: Improve wrapattr

### DIFF
--- a/stubs/tqdm/tqdm/std.pyi
+++ b/stubs/tqdm/tqdm/std.pyi
@@ -226,22 +226,12 @@ class tqdm(Comparable, Generic[_T]):
     @overload
     @classmethod
     def wrapattr(
-        cls,
-        stream: SupportsRead[_U],
-        method: Literal["read"],
-        total: float | None = None,
-        bytes: bool = True,
-        **tqdm_kwargs: Incomplete,
+        cls, stream: SupportsRead[_U], method: Literal["read"], total: float | None = None, bytes: bool = True, **tqdm_kwargs
     ) -> contextlib._GeneratorContextManager[SupportsRead[_U]]: ...
     @overload
     @classmethod
     def wrapattr(
-        cls,
-        stream: SupportsWrite[_U],
-        method: Literal["write"],
-        total: float | None = None,
-        bytes: bool = True,
-        **tqdm_kwargs: Incomplete,
+        cls, stream: SupportsWrite[_U], method: Literal["write"], total: float | None = None, bytes: bool = True, **tqdm_kwargs
     ) -> contextlib._GeneratorContextManager[SupportsWrite[_U]]: ...
 
 @overload

--- a/stubs/tqdm/tqdm/std.pyi
+++ b/stubs/tqdm/tqdm/std.pyi
@@ -1,5 +1,5 @@
 import contextlib
-from _typeshed import Incomplete, SupportsWrite
+from _typeshed import Incomplete, SupportsRead, SupportsWrite
 from collections.abc import Callable, Iterable, Iterator, Mapping, MutableMapping
 from types import TracebackType
 from typing import Any, ClassVar, Generic, Literal, NoReturn, TypeVar, overload
@@ -30,6 +30,7 @@ class TqdmDeprecationWarning(TqdmWarning, DeprecationWarning): ...
 class TqdmMonitorWarning(TqdmWarning, RuntimeWarning): ...
 
 _T = TypeVar("_T")
+_U = TypeVar("_U")
 
 class tqdm(Comparable, Generic[_T]):
     monitor_interval: ClassVar[int]
@@ -222,10 +223,26 @@ class tqdm(Comparable, Generic[_T]):
     @property
     def format_dict(self) -> MutableMapping[str, Any]: ...
     def display(self, msg: str | None = None, pos: int | None = None) -> None: ...
+    @overload
     @classmethod
     def wrapattr(
-        cls, stream, method: Literal["read", "write"], total: float | None = None, bytes: bool | None = True, **tqdm_kwargs
-    ) -> contextlib._GeneratorContextManager[Incomplete]: ...
+        cls,
+        stream: SupportsRead[_U],
+        method: Literal["read"],
+        total: float | None = None,
+        bytes: bool = True,
+        **tqdm_kwargs: Incomplete,
+    ) -> contextlib._GeneratorContextManager[SupportsRead[_U]]: ...
+    @overload
+    @classmethod
+    def wrapattr(
+        cls,
+        stream: SupportsWrite[_U],
+        method: Literal["write"],
+        total: float | None = None,
+        bytes: bool = True,
+        **tqdm_kwargs: Incomplete,
+    ) -> contextlib._GeneratorContextManager[SupportsWrite[_U]]: ...
 
 @overload
 def trange(


### PR DESCRIPTION
The stub for tqdm.wrapattr does not type the `stream` parameter and the generator is marked as `Incomplete`. This PR fixes both.

Example of error from Pylance that is fixed:
```
Type of "wrapattr" is partially unknown
  Type of "wrapattr" is "(stream: Unknown, method: Literal['read', 'write'], total: float | None = None, bytes: bool = True, **tqdm_kwargs: Unknown) -> _GeneratorContextManager[Any]
```

```python
file_size = os.stat("source.txt").st_size

# Either wrap the dest
with open("source.txt", "rb") as source, open("dest.txt", "wb") as dest:
    with tqdm.wrapattr(dest, "write", total=member.file_size, desc="Copying source.txt to dest.txt") as dest_tqdm:
        shutil.copyfileobj(source, dest_tqdm)

# or the source
with open("source.txt", "rb") as source, open("dest.txt", "wb") as dest:
    with tqdm.wrapattr(source, "read", total=member.file_size, desc="Copying source.txt to dest.txt") as source_tqdm:
        shutil.copyfileobj(source_tqdm, dest)
```

Also:
 * `bytes` is marked as just `bool` as this seems to better represent the [tqdm implementation](https://github.com/tqdm/tqdm/blob/0ed5d7f18fa3153834cbac0aa57e8092b217cc16/tqdm/std.py#L1502)
 * `**tqdm_kwargs` is marked as `Incomplete`


Pylance is not happy with the `dest_tqdm` argument to `shutil.copyfileobj` and reports this error, any suggestions on how to address would be appreciated.
```
Argument of type "SupportsWrite[ReadableBuffer]" cannot be assigned to parameter "fdst" of type "SupportsWrite[AnyStr@copyfileobj]" in function "copyfileobj"
  "SupportsWrite[ReadableBuffer]" is not assignable to "SupportsWrite[AnyStr@copyfileobj]"
    Type parameter "_T_contra@SupportsWrite" is contravariant, but "ReadableBuffer" is not a supertype of "AnyStr@copyfileobj"
      Type "ReadableBuffer" is not assignable to constrained type variable "AnyStr"
```