### PR TITLE
Update vscode recommended settings to not cleanup noqa'd unused imports

### DIFF
--- a/.vscode/settings.default.json
+++ b/.vscode/settings.default.json
@@ -70,13 +70,14 @@
         "editor.defaultFormatter": "ms-python.black-formatter",
         "editor.codeActionsOnSave": {
             // Let Ruff lint fixes handle imports
-            "source.organizeImports": "never"
+            "source.organizeImports": "never",
+            "source.unusedImports": "never"
         }
     },
     // python.analysis is Pylance (pyright) configurations
     "python.analysis.fixAll": [
-        "source.unusedImports"
         // Explicitly omiting "source.convertImportFormat", some stubs use relative imports
+        // Explicitly omiting "source.unusedImports", Let Ruff lint fixes handle imports
     ],
     "python.analysis.typeshedPaths": [
         "${workspaceFolder}"


### PR DESCRIPTION
Updated VSCode's recommended settings to stop it from removing the following lines on saving the file:
https://github.com/python/typeshed/blob/33d1b169c1780529e8c2b91858caf58852d73220/stdlib/typing.pyi#L5
https://github.com/python/typeshed/blob/33d1b169c1780529e8c2b91858caf58852d73220/tests/mypy_test.py#L42

This has been annoying me for a while and I finally figured out which setting is responsible for that.