### PR TITLE
Allow renovate to upgrade additional_dependencies in Python pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,6 +34,7 @@ repos:
     rev: 7.1.1
     hooks:
       - id: flake8
+        language: python
         additional_dependencies:
           - "flake8-noqa==1.4.0"
           - "flake8-pyi==24.9.0"


### PR DESCRIPTION
make renovatebot will be able to handle additional_dependencies in the future: https://github.com/renovatebot/renovate/pull/33417


https://github.com/python/typeshed/pull/12739
