### PR TITLE
fix Telnet#expect (stdlib/telnetlib.pyi)

### DIFF
--- a/stdlib/telnetlib.pyi
+++ b/stdlib/telnetlib.pyi
@@ -1,5 +1,5 @@
 import socket
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, MutableSequence, Sequence
 from re import Match, Pattern
 from types import TracebackType
 from typing import Any
@@ -114,7 +114,7 @@ class Telnet:
     def mt_interact(self) -> None: ...
     def listener(self) -> None: ...
     def expect(
-        self, list: Sequence[Pattern[bytes] | bytes], timeout: float | None = None
+        self, list: MutableSequence[Pattern[bytes] | bytes] | Sequence[Pattern[bytes]], timeout: float | None = None
     ) -> tuple[int, Match[bytes] | None, bytes]: ...
     def __enter__(self) -> Self: ...
     def __exit__(


### PR DESCRIPTION
`telnetlib.Telnet#expect` copies given sequence and may modify it. https://github.com/python/cpython/blob/2dc476bcb9142cd25d7e1d52392b73a3dcdf1756/Lib/telnetlib.py#L612-L617
So, when a read-only sequence contains `bytes` (e.g. `tuple` of `bytes`) is passed to `expect`, `TypeError` is raised at runtime.

This PR fixes the argument type of the `list` parameter of `Telnet#expect` to reject `Sequence` containing `bytes`.

I know telnetlib is already removed from stdlib in Python 3.13, but this fix may help users of 3.12 and future users of https://pypi.org/project/standard-telnetlib/ etc.