### PR TITLE
Annotate `sys.platform` as `LiteralString`

### DIFF
--- a/stdlib/sys/__init__.pyi
+++ b/stdlib/sys/__init__.pyi
@@ -6,7 +6,7 @@ from collections.abc import AsyncGenerator, Callable, Sequence
 from io import TextIOWrapper
 from types import FrameType, ModuleType, TracebackType
 from typing import Any, Final, Literal, NoReturn, Protocol, TextIO, TypeVar, final, type_check_only
-from typing_extensions import TypeAlias
+from typing_extensions import LiteralString, TypeAlias
 
 _T = TypeVar("_T")
 
@@ -45,7 +45,7 @@ if sys.version_info >= (3, 10):
 path: list[str]
 path_hooks: list[Callable[[str], PathEntryFinderProtocol]]
 path_importer_cache: dict[str, PathEntryFinderProtocol | None]
-platform: str
+platform: LiteralString
 if sys.version_info >= (3, 9):
     platlibdir: str
 prefix: str


### PR DESCRIPTION
CPython defines `sys.platform` in [`Python/sysmodule.c`], which refers to [`Py_GetPlatform`], which in turn just returns a compile constant `PLATFORM` (defined in the build process).

The value for `sys.platform` is therefore built into the interpreter. It is a string that can not change, so conceptually, it seems to make sense to annotate it using `LiteralString`.

There are probably a lot more things in `sys` that could be annotated using `LiteralString` instead of `str` (`sys.version`, `sys.copyright`), but since `sys.platform` is used for [platform checks] that typecheckers are supposed to understand, it probably makes sense to start with this and make the type a bit more precise, even if there is no immediate benefit that I can think of.

[`Python/sysmodule.c`]: https://github.com/python/cpython/blob/b2adf556747d080f04b53ba4063b627c2dbe41d1/Python/sysmodule.c#L3553
[`Py_GetPlatform`]: https://github.com/python/cpython/blob/b2adf556747d080f04b53ba4063b627c2dbe41d1/Python/getplatform.c#L9C1-L12
[platform checks]: https://peps.python.org/pep-0484/#version-and-platform-checking