### PR TITLE
fix ctypes.GetLastError

### DIFF
--- a/stdlib/@tests/stubtest_allowlists/win32.txt
+++ b/stdlib/@tests/stubtest_allowlists/win32.txt
@@ -2,7 +2,6 @@
 # TODO: Allowlist entries that should be fixed
 # ============================================
 
-ctypes.GetLastError  # Is actually a pointer
 # alias for a class defined elsewhere,
 # mypy infers the variable has type `(*args) -> DupHandle` but stubtest infers the runtime type as <class DupHandle>
 multiprocessing.reduction.AbstractReducer.DupHandle

--- a/stdlib/ctypes/__init__.pyi
+++ b/stdlib/ctypes/__init__.pyi
@@ -159,7 +159,14 @@ def ARRAY(typ: _CT, len: int) -> Array[_CT]: ...  # Soft Deprecated, no plans to
 if sys.platform == "win32":
     def DllCanUnloadNow() -> int: ...
     def DllGetClassObject(rclsid: Any, riid: Any, ppv: Any) -> int: ...  # TODO not documented
-    def GetLastError() -> int: ...
+
+    # Actually just an instance of _NamedFuncPointer (aka _CDLLFuncPointer),
+    # but we want to set a more specific __call__
+    @type_check_only
+    class _GetLastErrorFunctionType(_NamedFuncPointer):
+        def __call__(self) -> int: ...
+
+    GetLastError: _GetLastErrorFunctionType
 
 # Actually just an instance of _CFunctionType, but we want to set a more
 # specific __call__.


### PR DESCRIPTION
This is the same basic idea as https://github.com/python/typeshed/pull/13252 which did this for ctypes.mmove and ctypes.memset.