### PR TITLE
update allowlist comment for SupportsAbs and SupportsRound

### DIFF
--- a/stdlib/@tests/stubtest_allowlists/py312.txt
+++ b/stdlib/@tests/stubtest_allowlists/py312.txt
@@ -136,8 +136,7 @@ typing.ParamSpecKwargs.__mro_entries__
 typing.TypeVar.__mro_entries__
 typing.TypeVarTuple.__mro_entries__
 
-# TODO: mypy should infer that this attribute is inherited from builtins.type;
-# why doesn't it infer this?
+# These exist at runtime because the protocol uses PEP-695 syntax in CPython
 typing.SupportsAbs.__type_params__
 typing.SupportsRound.__type_params__
 typing_extensions.SupportsAbs.__type_params__

--- a/stdlib/@tests/stubtest_allowlists/py313.txt
+++ b/stdlib/@tests/stubtest_allowlists/py313.txt
@@ -126,8 +126,7 @@ typing.ParamSpecKwargs.__mro_entries__
 typing.TypeVar.__mro_entries__
 typing.TypeVarTuple.__mro_entries__
 
-# TODO: mypy should infer that this attribute is inherited from builtins.type;
-# why doesn't it infer this?
+# These exist at runtime because the protocol uses PEP-695 syntax in CPython
 typing.SupportsAbs.__type_params__
 typing.SupportsRound.__type_params__
 typing_extensions.SupportsAbs.__type_params__


### PR DESCRIPTION
The answer to the question is that mypy infers it just fine, but stubtest doesn't check for attributes inherited from the metaclass because that's almost never what we want. In this case, the runtime implementation doesn't get `__type_params__` from builtins.type either. It's actually defined for the class due to the use of PEP-695 syntax.