### PR TITLE
Officially drop Python 3.8 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ the project the stubs are for, but instead report them here to typeshed.**
 Further documentation on stub files, typeshed, and Python's typing system in
 general, can also be found at https://typing.readthedocs.io/en/latest/.
 
-Typeshed supports Python versions 3.8 to 3.13.
+Typeshed supports Python versions 3.9 to 3.13.
 
 ## Using
 

--- a/lib/ts_utils/metadata.py
+++ b/lib/ts_utils/metadata.py
@@ -268,7 +268,6 @@ def read_metadata(distribution: str) -> StubMetadata:
     else:
         assert type(requires_python_str) is str
         requires_python = Specifier(requires_python_str)
-        assert requires_python != oldest_supported_python_specifier, f'requires_python="{requires_python}" is redundant'
         assert requires_python.operator == ">=", "'requires_python' should be a minimum version specifier, use '>=3.x'"
 
     empty_tools: dict[object, object] = {}

--- a/lib/ts_utils/metadata.py
+++ b/lib/ts_utils/metadata.py
@@ -269,10 +269,6 @@ def read_metadata(distribution: str) -> StubMetadata:
         assert type(requires_python_str) is str
         requires_python = Specifier(requires_python_str)
         assert requires_python != oldest_supported_python_specifier, f'requires_python="{requires_python}" is redundant'
-        # Check minimum Python version is not less than the oldest version of Python supported by typeshed
-        assert oldest_supported_python_specifier.contains(
-            requires_python.version
-        ), f"'requires_python' contains versions lower than typeshed's oldest supported Python ({oldest_supported_python})"
         assert requires_python.operator == ">=", "'requires_python' should be a minimum version specifier, use '>=3.x'"
 
     empty_tools: dict[object, object] = {}

--- a/lib/ts_utils/metadata.py
+++ b/lib/ts_utils/metadata.py
@@ -269,6 +269,10 @@ def read_metadata(distribution: str) -> StubMetadata:
         assert type(requires_python_str) is str
         requires_python = Specifier(requires_python_str)
         assert requires_python != oldest_supported_python_specifier, f'requires_python="{requires_python}" is redundant'
+        # Check minimum Python version is not less than the oldest version of Python supported by typeshed
+        assert oldest_supported_python_specifier.contains(
+            requires_python.version
+        ), f"'requires_python' contains versions lower than typeshed's oldest supported Python ({oldest_supported_python})"
         assert requires_python.operator == ">=", "'requires_python' should be a minimum version specifier, use '>=3.x'"
 
     empty_tools: dict[object, object] = {}

--- a/lib/ts_utils/metadata.py
+++ b/lib/ts_utils/metadata.py
@@ -268,6 +268,7 @@ def read_metadata(distribution: str) -> StubMetadata:
     else:
         assert type(requires_python_str) is str
         requires_python = Specifier(requires_python_str)
+        assert requires_python != oldest_supported_python_specifier, f'requires_python="{requires_python}" is redundant'
         assert requires_python.operator == ">=", "'requires_python' should be a minimum version specifier, use '>=3.x'"
 
     empty_tools: dict[object, object] = {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,4 +171,4 @@ extra-standard-library = [
 known-first-party = ["_utils", "ts_utils"]
 
 [tool.typeshed]
-oldest_supported_python = "3.8"
+oldest_supported_python = "3.9"

--- a/stubs/icalendar/METADATA.toml
+++ b/stubs/icalendar/METADATA.toml
@@ -1,10 +1,6 @@
 version = "6.1.*"
 upstream_repository = "https://github.com/collective/icalendar"
-requires = [
-    "types-python-dateutil",
-    "types-pytz",
-    "backports.zoneinfo; python_version<'3.9'",
-]
+requires = ["types-python-dateutil", "types-pytz"]
 
 [tool.stubtest]
 stubtest_requirements = ["pytz"]

--- a/stubs/pycocotools/METADATA.toml
+++ b/stubs/pycocotools/METADATA.toml
@@ -1,5 +1,3 @@
 version = "2.0.*"
 upstream_repository = "https://github.com/ppwwyyxx/cocoapi"
-requires = ["numpy>=2.0.0rc1; python_version>='3.9'"]
-# numpy>=2.0.0 requires Python >=3.9
-requires_python = ">=3.9"
+requires = ["numpy>=2.0.0rc1"]

--- a/stubs/seaborn/METADATA.toml
+++ b/stubs/seaborn/METADATA.toml
@@ -1,14 +1,4 @@
 version = "0.13.2"
 # Requires a version of numpy and matplotlib with a `py.typed` file
-#
-# TODO: Specifying the python-version for matplotlib should not be necessary,
-# because of the requires_python field. However, this needs changes to
-# get_typeshed_stub_version.py (see there).
-requires = [
-    "matplotlib>=3.8; python_version>='3.9'",
-    "numpy>=1.20",
-    "pandas-stubs",
-]
-# matplotlib>=3.8 requires Python >=3.9
-requires_python = ">=3.9"
+requires = ["matplotlib>=3.8", "numpy>=1.20", "pandas-stubs"]
 upstream_repository = "https://github.com/mwaskom/seaborn"


### PR DESCRIPTION
This is part of gradually dropping support, cf. #12112