### PR TITLE
Remove Python 3.8 from CI

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -37,7 +37,7 @@ jobs:
         # As of 2024-10-18, ubuntu-latest can refer to different Ubuntu versions,
         # which can can cause problems with os module constants.
         os: ["ubuntu-24.04", "windows-latest", "macos-latest"]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
       fail-fast: false
 
     steps:

--- a/.github/workflows/stubtest_stdlib.yml
+++ b/.github/workflows/stubtest_stdlib.yml
@@ -33,7 +33,7 @@ jobs:
         # As of 2024-10-18, ubuntu-latest can refer to different Ubuntu versions,
         # which can can cause problems with os module constants.
         os: ["ubuntu-24.04", "windows-latest", "macos-latest"]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
       fail-fast: false
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,7 +62,7 @@ jobs:
     strategy:
       matrix:
         platform: ["linux", "win32", "darwin"]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -113,7 +113,7 @@ jobs:
     strategy:
       matrix:
         python-platform: ["Linux", "Windows", "Darwin"]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/tests/mypy_test.py
+++ b/tests/mypy_test.py
@@ -44,7 +44,7 @@ except ImportError:
     print_error("Cannot import mypy. Did you install it?")
     sys.exit(1)
 
-SUPPORTED_VERSIONS = ["3.13", "3.12", "3.11", "3.10", "3.9", "3.8"]
+SUPPORTED_VERSIONS = ["3.13", "3.12", "3.11", "3.10", "3.9"]
 SUPPORTED_PLATFORMS = ("linux", "win32", "darwin")
 DIRECTORIES_TO_TEST = [STDLIB_PATH, STUBS_PATH]
 

--- a/tests/regr_test.py
+++ b/tests/regr_test.py
@@ -40,7 +40,7 @@ VENV_DIR = ".venv"
 TYPESHED = "typeshed"
 
 SUPPORTED_PLATFORMS = ["linux", "darwin", "win32"]
-SUPPORTED_VERSIONS = ["3.13", "3.12", "3.11", "3.10", "3.9", "3.8"]
+SUPPORTED_VERSIONS = ["3.13", "3.12", "3.11", "3.10", "3.9"]
 
 
 def distribution_with_test_cases(distribution_name: str) -> DistributionTests:

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -22,7 +22,7 @@ _SKIPPED = colored("Skipped", "yellow")
 _FAILED = colored("Failed", "red")
 # We're using the oldest fully supported version because it's the most likely to produce errors
 # due to unsupported syntax, feature, or bug in a tool.
-_PYTHON_VERSION = "3.8"
+_PYTHON_VERSION = "3.9"
 
 
 def _parse_jsonc(json_text: str) -> str:
@@ -55,7 +55,7 @@ def main() -> None:
     parser.add_argument(
         "--python-version",
         default=_PYTHON_VERSION,
-        choices=("3.8", "3.9", "3.10", "3.11", "3.12", "3.13"),
+        choices=("3.9", "3.10", "3.11", "3.12", "3.13"),
         help="Target Python version for the test (default: %(default)s).",
     )
     parser.add_argument("path", help="Path of the stub to test in format <folder>/<stub>, from the root of the project.")


### PR DESCRIPTION
Part of dropping support for Python 3.8, cf. #12112