### PR TITLE
Use `threading.RLock` for `logging.Handler.lock`

### DIFF
--- a/stdlib/logging/__init__.pyi
+++ b/stdlib/logging/__init__.pyi
@@ -246,7 +246,7 @@ NOTSET: Final = 0
 class Handler(Filterer):
     level: int  # undocumented
     formatter: Formatter | None  # undocumented
-    lock: threading.Lock | None  # undocumented
+    lock: threading.RLock | None  # Corrected type
     name: str | None  # undocumented
     def __init__(self, level: _Level = 0) -> None: ...
     def get_name(self) -> str: ...  # undocumented


### PR DESCRIPTION
### Fixing Type Annotation for lock in Handler class
_The type annotation for the lock attribute in the Handler class was previously incorrectly defined as threading.Lock | None in the typeshed stub. This is inconsistent with the CPython implementation, which uses threading.RLock (a reentrant lock) instead of a simple lock._

### Changes made:
- Updated the type annotation for the lock attribute in the Handler class from threading.Lock | None to threading.RLock | None.
- This change aligns the typeshed stub with the actual implementation in CPython, where RLock is used instead of Lock.

### Reasoning:
- The CPython source code (from version 2.5 onward) uses threading.RLock instead of threading.Lock for the lock attribute in the Handler class.
- RLock is not a subclass of Lock, so using Lock in the typeshed definition was incorrect.
- This update ensures the correct typing is reflected and avoids confusion when using static analysis tools or type checkers.