### PR TITLE
Run the "typecheck our own code" workflow on PRs touching the `lib/` directory

### DIFF
--- a/.github/workflows/meta_tests.yml
+++ b/.github/workflows/meta_tests.yml
@@ -10,6 +10,7 @@ on:
     paths:
       - "scripts/**"
       - "tests/**"
+      - "lib/**"
       - ".github/workflows/meta_tests.yml"
       - "requirements-tests.txt"
       - "pyproject.toml"


### PR DESCRIPTION
Currently it's not running on PRs that only touch the `lib/` directory, which is causing a fair amount of user confusion (https://github.com/python/typeshed/pull/13287, https://github.com/python/typeshed/pull/13393)