### PR TITLE
Use TypedDict argument unpacking for setuptools/distutils's setup

### DIFF
--- a/stdlib/distutils/core.pyi
+++ b/stdlib/distutils/core.pyi
@@ -3,7 +3,49 @@ from collections.abc import Mapping
 from distutils.cmd import Command as Command
 from distutils.dist import Distribution as Distribution
 from distutils.extension import Extension as Extension
-from typing import Any, Final, Literal
+from typing import Final, Literal, TypedDict, type_check_only
+from typing_extensions import Unpack
+
+@type_check_only
+class _SetupArgs(TypedDict, total=False):  # total=False for custom Distributions that could accept more arguments
+    name: str
+    version: str
+    description: str
+    long_description: str
+    author: str
+    author_email: str
+    maintainer: str
+    maintainer_email: str
+    url: str
+    download_url: str
+    packages: list[str]
+    py_modules: list[str]
+    scripts: list[str]
+    ext_modules: list[Extension]
+    classifiers: list[str]
+    distclass: type[Distribution]
+    script_name: str
+    script_args: list[str]
+    options: Mapping[str, Incomplete]
+    license: str
+    keywords: list[str] | str
+    platforms: list[str] | str
+    cmdclass: Mapping[str, type[Command]]
+    data_files: list[tuple[str, list[str]]]
+    package_dir: Mapping[str, str]
+    obsoletes: list[str]
+    provides: list[str]
+    requires: list[str]
+    command_packages: list[str]
+    command_options: Mapping[str, Mapping[str, tuple[Incomplete, Incomplete]]]
+    package_data: Mapping[str, list[str]]
+    include_package_data: bool | Literal[0, 1]
+    libraries: list[str]
+    headers: list[str]
+    ext_package: str
+    include_dirs: list[str]
+    password: str
+    fullname: str
 
 USAGE: Final[str]
 
@@ -12,47 +54,5 @@ def gen_usage(script_name: StrOrBytesPath) -> str: ...
 setup_keywords: tuple[str, ...]
 extension_keywords: tuple[str, ...]
 
-def setup(
-    *,
-    name: str = ...,
-    version: str = ...,
-    description: str = ...,
-    long_description: str = ...,
-    author: str = ...,
-    author_email: str = ...,
-    maintainer: str = ...,
-    maintainer_email: str = ...,
-    url: str = ...,
-    download_url: str = ...,
-    packages: list[str] = ...,
-    py_modules: list[str] = ...,
-    scripts: list[str] = ...,
-    ext_modules: list[Extension] = ...,
-    classifiers: list[str] = ...,
-    distclass: type[Distribution] = ...,
-    script_name: str = ...,
-    script_args: list[str] = ...,
-    options: Mapping[str, Incomplete] = ...,
-    license: str = ...,
-    keywords: list[str] | str = ...,
-    platforms: list[str] | str = ...,
-    cmdclass: Mapping[str, type[Command]] = ...,
-    data_files: list[tuple[str, list[str]]] = ...,
-    package_dir: Mapping[str, str] = ...,
-    obsoletes: list[str] = ...,
-    provides: list[str] = ...,
-    requires: list[str] = ...,
-    command_packages: list[str] = ...,
-    command_options: Mapping[str, Mapping[str, tuple[Incomplete, Incomplete]]] = ...,
-    package_data: Mapping[str, list[str]] = ...,
-    include_package_data: bool | Literal[0, 1] = ...,
-    libraries: list[str] = ...,
-    headers: list[str] = ...,
-    ext_package: str = ...,
-    include_dirs: list[str] = ...,
-    password: str = ...,
-    fullname: str = ...,
-    # Custom Distributions could accept more params
-    **attrs: Any,
-) -> Distribution: ...
+def setup(**attrs: Unpack[_SetupArgs]) -> Distribution: ...
 def run_setup(script_name: str, script_args: list[str] | None = None, stop_after: str = "run") -> Distribution: ...

--- a/stubs/setuptools/@tests/stubtest_allowlist.txt
+++ b/stubs/setuptools/@tests/stubtest_allowlist.txt
@@ -91,7 +91,6 @@ setuptools._distutils.command.install_data
 setuptools._distutils.command.install_egg_info
 setuptools._distutils.command.install_headers
 setuptools._distutils.compat.py39
-setuptools._distutils.core
 setuptools._distutils.cygwinccompiler
 setuptools._distutils.debug
 setuptools._distutils.dir_util

--- a/stubs/setuptools/distutils/core.pyi
+++ b/stubs/setuptools/distutils/core.pyi
@@ -1,0 +1,1 @@
+from setuptools._distutils.core import *

--- a/stubs/setuptools/setuptools/__init__.pyi
+++ b/stubs/setuptools/setuptools/__init__.pyi
@@ -1,10 +1,10 @@
 from abc import abstractmethod
 from collections.abc import Sequence
-from distutils.core import _SetupArgs as _DistutilsSetupArgs
 from typing import Any, Literal, TypedDict, TypeVar, overload, type_check_only
 from typing_extensions import NotRequired, Unpack
 
 from ._distutils.cmd import Command as _Command
+from ._distutils.core import _SetupArgs as _DistutilsSetupArgs
 from .command.alias import alias
 from .command.bdist_egg import bdist_egg
 from .command.bdist_rpm import bdist_rpm

--- a/stubs/setuptools/setuptools/__init__.pyi
+++ b/stubs/setuptools/setuptools/__init__.pyi
@@ -1,8 +1,8 @@
-from _typeshed import Incomplete
 from abc import abstractmethod
-from collections.abc import Mapping, Sequence
+from collections.abc import Sequence
+from distutils.core import _SetupArgs as _DistutilsSetupArgs
 from typing import Any, Literal, TypedDict, TypeVar, overload, type_check_only
-from typing_extensions import NotRequired
+from typing_extensions import NotRequired, Unpack
 
 from ._distutils.cmd import Command as _Command
 from .command.alias import alias
@@ -55,54 +55,17 @@ class _BuildInfo(TypedDict):
     include_dirs: NotRequired[list[str]]
     cflags: NotRequired[list[str]]
 
+@type_check_only
+class _SetupArgs(_DistutilsSetupArgs, total=False):  # total=False for custom Distributions that could accept more arguments
+    long_description_content_type: str
+    ext_modules: Sequence[Extension]  # type: ignore[misc] # Overwriting on purpose
+    # libraries for `Distribution` or `build_clib`, not `Extension`, `build_ext` or `CCompiler`
+    libraries: list[tuple[str, _BuildInfo]]  # type: ignore[misc] # Overwriting on purpose
+
 find_packages = _Finder.find
 find_namespace_packages = _Finder.find
 
-def setup(
-    *,
-    name: str = ...,
-    version: str = ...,
-    description: str = ...,
-    long_description: str = ...,
-    long_description_content_type: str = ...,
-    author: str = ...,
-    author_email: str = ...,
-    maintainer: str = ...,
-    maintainer_email: str = ...,
-    url: str = ...,
-    download_url: str = ...,
-    packages: list[str] = ...,
-    py_modules: list[str] = ...,
-    scripts: list[str] = ...,
-    ext_modules: Sequence[Extension] = ...,
-    classifiers: list[str] = ...,
-    distclass: type[Distribution] = ...,
-    script_name: str = ...,
-    script_args: list[str] = ...,
-    options: Mapping[str, Incomplete] = ...,
-    license: str = ...,
-    keywords: list[str] | str = ...,
-    platforms: list[str] | str = ...,
-    cmdclass: Mapping[str, type[_Command]] = ...,
-    data_files: list[tuple[str, list[str]]] = ...,
-    package_dir: Mapping[str, str] = ...,
-    obsoletes: list[str] = ...,
-    provides: list[str] = ...,
-    requires: list[str] = ...,
-    command_packages: list[str] = ...,
-    command_options: Mapping[str, Mapping[str, tuple[Incomplete, Incomplete]]] = ...,
-    package_data: Mapping[str, list[str]] = ...,
-    include_package_data: bool = ...,
-    # libraries for `Distribution` or `build_clib`, not `Extension`, `build_ext` or `CCompiler`
-    libraries: list[tuple[str, _BuildInfo]] = ...,
-    headers: list[str] = ...,
-    ext_package: str = ...,
-    include_dirs: list[str] = ...,
-    password: str = ...,
-    fullname: str = ...,
-    # Custom Distributions could accept more params
-    **attrs: Any,
-) -> Distribution: ...
+def setup(**attrs: Unpack[_SetupArgs]) -> Distribution: ...
 
 class Command(_Command):
     command_consumes_arguments: bool

--- a/stubs/setuptools/setuptools/_distutils/core.pyi
+++ b/stubs/setuptools/setuptools/_distutils/core.pyi
@@ -1,10 +1,11 @@
 from _typeshed import Incomplete, StrOrBytesPath
 from collections.abc import Iterable, Mapping
-from distutils.cmd import Command as Command
-from distutils.dist import Distribution as Distribution
-from distutils.extension import Extension as Extension
 from typing import Final, TypedDict, type_check_only
 from typing_extensions import Unpack
+
+from ..dist import Distribution as Distribution
+from ..extension import Extension as Extension
+from .cmd import Command as Command
 
 @type_check_only
 class _SetupArgs(TypedDict, total=False):  # total=False for custom Distributions that could accept more arguments

--- a/stubs/setuptools/setuptools/_distutils/core.pyi
+++ b/stubs/setuptools/setuptools/_distutils/core.pyi
@@ -7,6 +7,8 @@ from .cmd import Command as Command
 from .dist import Distribution as Distribution
 from .extension import Extension as Extension
 
+__all__ = ["Distribution", "Command", "Extension", "setup"]
+
 @type_check_only
 class _SetupArgs(TypedDict, total=False):  # total=False for custom Distributions that could accept more arguments
     name: str

--- a/stubs/setuptools/setuptools/_distutils/core.pyi
+++ b/stubs/setuptools/setuptools/_distutils/core.pyi
@@ -3,9 +3,9 @@ from collections.abc import Iterable, Mapping
 from typing import Final, TypedDict, type_check_only
 from typing_extensions import Unpack
 
-from ..dist import Distribution as Distribution
-from ..extension import Extension as Extension
 from .cmd import Command as Command
+from .dist import Distribution as Distribution
+from .extension import Extension as Extension
 
 @type_check_only
 class _SetupArgs(TypedDict, total=False):  # total=False for custom Distributions that could accept more arguments

--- a/stubs/setuptools/setuptools/_distutils/core.pyi
+++ b/stubs/setuptools/setuptools/_distutils/core.pyi
@@ -1,0 +1,58 @@
+from _typeshed import Incomplete, StrOrBytesPath
+from collections.abc import Iterable, Mapping
+from distutils.cmd import Command as Command
+from distutils.dist import Distribution as Distribution
+from distutils.extension import Extension as Extension
+from typing import Final, TypedDict, type_check_only
+from typing_extensions import Unpack
+
+@type_check_only
+class _SetupArgs(TypedDict, total=False):  # total=False for custom Distributions that could accept more arguments
+    name: str
+    version: str
+    description: str
+    long_description: str
+    author: str
+    author_email: str
+    maintainer: str
+    maintainer_email: str
+    url: str
+    download_url: str
+    packages: list[str]
+    py_modules: list[str]
+    scripts: list[str]
+    ext_modules: list[Extension]
+    classifiers: list[str]
+    distclass: type[Distribution]
+    script_name: str
+    script_args: list[str]
+    options: Mapping[str, Incomplete]
+    license: str
+    keywords: list[str] | str
+    platforms: list[str] | str
+    cmdclass: Mapping[str, type[Command]]
+    data_files: list[tuple[str, list[str]]]
+    package_dir: Mapping[str, str]
+    obsoletes: list[str]
+    provides: list[str]
+    requires: list[str]
+    command_packages: list[str]
+    command_options: Mapping[str, Mapping[str, tuple[Incomplete, Incomplete]]]
+    package_data: Mapping[str, list[str]]
+    include_package_data: bool
+    libraries: list[str]
+    headers: list[str]
+    ext_package: str
+    include_dirs: list[str]
+    password: str
+    fullname: str
+
+USAGE: Final[str]
+
+def gen_usage(script_name: StrOrBytesPath) -> str: ...
+
+setup_keywords: tuple[str, ...]
+extension_keywords: tuple[str, ...]
+
+def setup(**attrs: Unpack[_SetupArgs]) -> Distribution: ...
+def run_setup(script_name: str, script_args: Iterable[str] | None = None, stop_after: str = "run") -> Distribution: ...


### PR DESCRIPTION
Less repetition, feels cleaner, and can be extended.
I also plan on using this technique in setuptools directly (https://github.com/pypa/setuptools/issues/2345#issuecomment-1627561833) after which it'll be really close to be ready to be marked as `py.typed`

Edit: hmm, I have to add `setuptools._distutils.core`, kinda muddles my "less repetition" point above...
Edit 2: Unpacked TypedDict as kwargs doesn't seem to work as expected form the mypy_primer hit. Maybe that's something to be added to the spec. Or a mypy issue, idk