### PR TITLE
add `"w:tar"` as a mode for tarfile

### DIFF
--- a/stdlib/tarfile.pyi
+++ b/stdlib/tarfile.pyi
@@ -123,7 +123,7 @@ def open(
 @overload
 def open(
     name: StrOrBytesPath | None,
-    mode: Literal["x", "x:", "a", "a:", "w", "w:"],
+    mode: Literal["x", "x:", "a", "a:", "w", "w:", "w:tar"],
     fileobj: _Fileobj | None = None,
     bufsize: int = 10240,
     *,
@@ -141,7 +141,7 @@ def open(
 def open(
     name: StrOrBytesPath | None = None,
     *,
-    mode: Literal["x", "x:", "a", "a:", "w", "w:"],
+    mode: Literal["x", "x:", "a", "a:", "w", "w:", "w:tar"],
     fileobj: _Fileobj | None = None,
     bufsize: int = 10240,
     format: int | None = ...,


### PR DESCRIPTION
this is an alias for `"w:"` according to the code (which defaults the second segment to `"tar"`)