### PR TITLE
Mark attributes in `json.encoder` as undocumented

### DIFF
--- a/stdlib/json/encoder.pyi
+++ b/stdlib/json/encoder.pyi
@@ -2,11 +2,11 @@ from collections.abc import Callable, Iterator
 from re import Pattern
 from typing import Any, Final
 
-ESCAPE: Final[Pattern[str]]
-ESCAPE_ASCII: Final[Pattern[str]]
-HAS_UTF8: Final[Pattern[bytes]]
-ESCAPE_DCT: Final[dict[str, str]]
-INFINITY: Final[float]
+ESCAPE: Final[Pattern[str]]  # undocumented
+ESCAPE_ASCII: Final[Pattern[str]]  # undocumented
+HAS_UTF8: Final[Pattern[bytes]]  # undocumented
+ESCAPE_DCT: Final[dict[str, str]]  # undocumented
+INFINITY: Final[float]  # undocumented
 
 def py_encode_basestring(s: str) -> str: ...  # undocumented
 def py_encode_basestring_ascii(s: str) -> str: ...  # undocumented


### PR DESCRIPTION
As recommended in https://github.com/python/typeshed/pull/13405#discussion_r1921215703