### PR TITLE
Fix logging.Handler.lock can't be None

### DIFF
--- a/stdlib/logging/__init__.pyi
+++ b/stdlib/logging/__init__.pyi
@@ -246,7 +246,7 @@ NOTSET: Final = 0
 class Handler(Filterer):
     level: int  # undocumented
     formatter: Formatter | None  # undocumented
-    lock: threading.Lock | None  # undocumented
+    lock: threading.Lock  # undocumented
     name: str | None  # undocumented
     def __init__(self, level: _Level = 0) -> None: ...
     def get_name(self) -> str: ...  # undocumented


### PR DESCRIPTION
Fixes: https://github.com/python/typeshed/issues/13381
