### PR TITLE
Add `--strict-bytes` and `--local-partial-types` to self check

### DIFF
--- a/tests/pytype_test.py
+++ b/tests/pytype_test.py
@@ -40,7 +40,7 @@ from ts_utils.utils import SupportedVersionsDict, parse_stdlib_versions_file, su
 
 TYPESHED_SUBDIRS = ["stdlib", "stubs"]
 TYPESHED_HOME = "TYPESHED_HOME"
-_LOADERS = {}
+_LOADERS: dict[str, tuple[pytype_config.Options, load_pytd.Loader]] = {}
 
 
 def main() -> None:

--- a/tests/typecheck_typeshed.py
+++ b/tests/typecheck_typeshed.py
@@ -55,6 +55,8 @@ def run_mypy_as_subprocess(directory: str, platform: str, version: str) -> Retur
         "--python-version",
         version,
         "--strict",
+        "--strict-bytes",
+        "--local-partial-types",
         "--pretty",
         "--show-traceback",
         "--no-error-summary",


### PR DESCRIPTION
These two options will be on by default in `--strict` in `mypy@2.0`