### PR TITLE
Still allow passing `None` to `shutil.rmtree`'s `onerror` parameter on Python 3.12+

### DIFF
--- a/stdlib/shutil.pyi
+++ b/stdlib/shutil.pyi
@@ -83,7 +83,7 @@ class _RmtreeType(Protocol):
             self,
             path: StrOrBytesPath,
             ignore_errors: bool,
-            onerror: _OnErrorCallback,
+            onerror: _OnErrorCallback | None,
             *,
             onexc: None = None,
             dir_fd: int | None = None,
@@ -95,7 +95,7 @@ class _RmtreeType(Protocol):
             path: StrOrBytesPath,
             ignore_errors: bool = False,
             *,
-            onerror: _OnErrorCallback,
+            onerror: _OnErrorCallback | None,
             onexc: None = None,
             dir_fd: int | None = None,
         ) -> None: ...


### PR DESCRIPTION
Resolves https://github.com/python/typeshed/issues/13480

Allow explicitly passing `None` whilst still getting the deprecation warning.