### PR TITLE
Remove Any from _NotImplementedType inheritance

### DIFF
--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -1283,7 +1283,7 @@ class property:
     def __delete__(self, instance: Any, /) -> None: ...
 
 @final
-class _NotImplementedType(Any):
+class _NotImplementedType:
     __call__: None
 
 NotImplemented: _NotImplementedType


### PR DESCRIPTION
It does seem like this was first added in ecb43149f7fd3ea282a362a3c3235a2b04ea03ad and does not serve a bigger purpose.

I hope the fallout is not too big in Mypy primer, but we'll see.