### PR TITLE
Fix type for `run_coroutine_threadsafe`

### DIFF
--- a/stdlib/asyncio/tasks.pyi
+++ b/stdlib/asyncio/tasks.pyi
@@ -8,8 +8,8 @@ from _asyncio import (
     _unregister_task as _unregister_task,
 )
 from collections.abc import AsyncIterator, Awaitable, Coroutine, Generator, Iterable, Iterator
-from typing import Any, Literal, Protocol, TypeVar, overload
 from types import CoroutineType
+from typing import Any, Literal, Protocol, TypeVar, overload
 from typing_extensions import TypeAlias
 
 from . import _CoroutineLike
@@ -83,7 +83,6 @@ else:
 
 _TaskYieldType: TypeAlias = Future[object] | None
 _ThreadsafeCouroutineType: TypeAlias = Coroutine[Any, Any, _T] | CoroutineType[Any, Any, _T]
-
 
 FIRST_COMPLETED = concurrent.futures.FIRST_COMPLETED
 FIRST_EXCEPTION = concurrent.futures.FIRST_EXCEPTION

--- a/stdlib/asyncio/tasks.pyi
+++ b/stdlib/asyncio/tasks.pyi
@@ -9,6 +9,7 @@ from _asyncio import (
 )
 from collections.abc import AsyncIterator, Awaitable, Coroutine, Generator, Iterable, Iterator
 from typing import Any, Literal, Protocol, TypeVar, overload
+from types import CoroutineType
 from typing_extensions import TypeAlias
 
 from . import _CoroutineLike
@@ -79,7 +80,10 @@ if sys.version_info >= (3, 12):
     _FutureLike: TypeAlias = Future[_T] | Awaitable[_T]
 else:
     _FutureLike: TypeAlias = Future[_T] | Generator[Any, None, _T] | Awaitable[_T]
+
 _TaskYieldType: TypeAlias = Future[object] | None
+_ThreadsafeCouroutineType: TypeAlias = Coroutine[Any, Any, _T] | CoroutineType[Any, Any, _T]
+
 
 FIRST_COMPLETED = concurrent.futures.FIRST_COMPLETED
 FIRST_EXCEPTION = concurrent.futures.FIRST_EXCEPTION
@@ -347,7 +351,8 @@ else:
         *coros_or_futures: _FutureLike[_T], loop: AbstractEventLoop | None = None, return_exceptions: bool
     ) -> Future[list[_T | BaseException]]: ...
 
-def run_coroutine_threadsafe(coro: _FutureLike[_T], loop: AbstractEventLoop) -> concurrent.futures.Future[_T]: ...
+# unlike some asyncio apis, This does strict runtime checking of actually being a coroutine, not of any future-like.
+def run_coroutine_threadsafe(coro: _ThreadsafeCouroutineType[_T], loop: AbstractEventLoop) -> concurrent.futures.Future[_T]: ...
 
 if sys.version_info >= (3, 10):
     def shield(arg: _FutureLike[_T]) -> Future[_T]: ...

--- a/stdlib/asyncio/tasks.pyi
+++ b/stdlib/asyncio/tasks.pyi
@@ -8,7 +8,6 @@ from _asyncio import (
     _unregister_task as _unregister_task,
 )
 from collections.abc import AsyncIterator, Awaitable, Coroutine, Generator, Iterable, Iterator
-from types import CoroutineType
 from typing import Any, Literal, Protocol, TypeVar, overload
 from typing_extensions import TypeAlias
 
@@ -82,7 +81,6 @@ else:
     _FutureLike: TypeAlias = Future[_T] | Generator[Any, None, _T] | Awaitable[_T]
 
 _TaskYieldType: TypeAlias = Future[object] | None
-_ThreadsafeCouroutineType: TypeAlias = Coroutine[Any, Any, _T] | CoroutineType[Any, Any, _T]
 
 FIRST_COMPLETED = concurrent.futures.FIRST_COMPLETED
 FIRST_EXCEPTION = concurrent.futures.FIRST_EXCEPTION
@@ -351,7 +349,7 @@ else:
     ) -> Future[list[_T | BaseException]]: ...
 
 # unlike some asyncio apis, This does strict runtime checking of actually being a coroutine, not of any future-like.
-def run_coroutine_threadsafe(coro: _ThreadsafeCouroutineType[_T], loop: AbstractEventLoop) -> concurrent.futures.Future[_T]: ...
+def run_coroutine_threadsafe(coro: Coroutine[Any, Any, _T], loop: AbstractEventLoop) -> concurrent.futures.Future[_T]: ...
 
 if sys.version_info >= (3, 10):
     def shield(arg: _FutureLike[_T]) -> Future[_T]: ...


### PR DESCRIPTION
The prior typing here is too permissive, this is strictly checked against these two types at runtime. Attempting to pass a task or future, each of which are FutureLike to this API results in a runtime error.