### PR TITLE
Update compileall.compile_{dir, file, path} to return bool

### DIFF
--- a/stdlib/compileall.pyi
+++ b/stdlib/compileall.pyi
@@ -25,7 +25,7 @@ if sys.version_info >= (3, 10):
         prependdir: StrPath | None = None,
         limit_sl_dest: StrPath | None = None,
         hardlink_dupes: bool = False,
-    ) -> int: ...
+    ) -> bool: ...
     def compile_file(
         fullname: StrPath,
         ddir: StrPath | None = None,
@@ -40,7 +40,7 @@ if sys.version_info >= (3, 10):
         prependdir: StrPath | None = None,
         limit_sl_dest: StrPath | None = None,
         hardlink_dupes: bool = False,
-    ) -> int: ...
+    ) -> bool: ...
 
 elif sys.version_info >= (3, 9):
     def compile_dir(
@@ -59,7 +59,7 @@ elif sys.version_info >= (3, 9):
         prependdir: StrPath | None = None,
         limit_sl_dest: StrPath | None = None,
         hardlink_dupes: bool = False,
-    ) -> int: ...
+    ) -> bool: ...
     def compile_file(
         fullname: StrPath,
         ddir: StrPath | None = None,
@@ -74,7 +74,7 @@ elif sys.version_info >= (3, 9):
         prependdir: StrPath | None = None,
         limit_sl_dest: StrPath | None = None,
         hardlink_dupes: bool = False,
-    ) -> int: ...
+    ) -> bool: ...
 
 else:
     def compile_dir(
@@ -88,7 +88,7 @@ else:
         optimize: int = -1,
         workers: int = 1,
         invalidation_mode: PycInvalidationMode | None = None,
-    ) -> int: ...
+    ) -> bool: ...
     def compile_file(
         fullname: StrPath,
         ddir: StrPath | None = None,
@@ -98,7 +98,7 @@ else:
         legacy: bool = False,
         optimize: int = -1,
         invalidation_mode: PycInvalidationMode | None = None,
-    ) -> int: ...
+    ) -> bool: ...
 
 def compile_path(
     skip_curdir: bool = ...,
@@ -108,4 +108,4 @@ def compile_path(
     legacy: bool = False,
     optimize: int = -1,
     invalidation_mode: PycInvalidationMode | None = None,
-) -> int: ...
+) -> bool: ...


### PR DESCRIPTION
This has been true since Python 3.5 (https://github.com/python/cpython/commit/1e3c3e906c9f1fcc463cfb3641d078eec773666f).


```python
>>> compile_file("/home/ichard26/test.py")
True
>>> compile_file("/home/ichard26/process.py")
Compiling '/home/ichard26/process.py'...
***   File "/home/ichard26/process.py", line 28
    for 
        ^
SyntaxError: invalid syntax

False
```