### PR TITLE
make blake2b and blake2s inherit HASH

### DIFF
--- a/stdlib/_blake2.pyi
+++ b/stdlib/_blake2.pyi
@@ -1,4 +1,5 @@
 import sys
+from _hashlib import HASH
 from _typeshed import ReadableBuffer
 from typing import ClassVar, final
 from typing_extensions import Self
@@ -13,7 +14,7 @@ BLAKE2S_PERSON_SIZE: int = 8
 BLAKE2S_SALT_SIZE: int = 8
 
 @final
-class blake2b:
+class blake2b(HASH):
     MAX_DIGEST_SIZE: ClassVar[int] = 64
     MAX_KEY_SIZE: ClassVar[int] = 64
     PERSON_SIZE: ClassVar[int] = 16
@@ -65,7 +66,7 @@ class blake2b:
     def update(self, data: ReadableBuffer, /) -> None: ...
 
 @final
-class blake2s:
+class blake2s(HASH):
     MAX_DIGEST_SIZE: ClassVar[int] = 32
     MAX_KEY_SIZE: ClassVar[int] = 32
     PERSON_SIZE: ClassVar[int] = 8


### PR DESCRIPTION
The [opposite change](https://github.com/python/typeshed/pull/12878) was made back when `HASH` was `_Hash`.

This means things like this do not work:

```py
from hashlib import blake2b, file_digest
from io import BytesIO

file_digest(BytesIO(), lambda: blake2b())
```

Causing:

```
error: Argument of type "() -> blake2b" cannot be assigned to parameter "digest" of type "str | (() -> HASH)" in function "file_digest"
```

Now [_hashlib was split](https://github.com/python/typeshed/pull/13030) we can import it in _blake2b and restore the inheritance.