### PR TITLE
Use stricter pyright settings when testing `hnswlib` in CI

### DIFF
--- a/pyrightconfig.stricter.json
+++ b/pyrightconfig.stricter.json
@@ -47,7 +47,6 @@
         "stubs/geopandas",
         "stubs/google-cloud-ndb",
         "stubs/hdbcli/hdbcli/dbapi.pyi",
-        "stubs/hnswlib",
         "stubs/html5lib",
         "stubs/httplib2",
         "stubs/humanfriendly",


### PR DESCRIPTION
Following https://github.com/python/typeshed/commit/2d4d7be276b6c07dad0a16dbb33ef0ba0f3a53da, it appears that these stubs no longer have any unannotated parameters or return types 🎉

Fixes https://github.com/AlexWaygood/typeshed-stats/issues/321