### PR TITLE
Introduce the _HashObject protocol

### DIFF
--- a/stdlib/_hashlib.pyi
+++ b/stdlib/_hashlib.pyi
@@ -2,12 +2,25 @@ import sys
 from _typeshed import ReadableBuffer
 from collections.abc import Callable
 from types import ModuleType
-from typing import AnyStr, final, overload
+from typing import AnyStr, Protocol, final, overload, type_check_only
 from typing_extensions import Self, TypeAlias
 
-_DigestMod: TypeAlias = str | Callable[[], HASH] | ModuleType | None
+_DigestMod: TypeAlias = str | Callable[[], _HashObject] | ModuleType | None
 
 openssl_md_meth_names: frozenset[str]
+
+@type_check_only
+class _HashObject(Protocol):
+    @property
+    def digest_size(self) -> int: ...
+    @property
+    def block_size(self) -> int: ...
+    @property
+    def name(self) -> str: ...
+    def copy(self) -> Self: ...
+    def digest(self) -> bytes: ...
+    def hexdigest(self) -> str: ...
+    def update(self, obj: ReadableBuffer, /) -> None: ...
 
 class HASH:
     @property

--- a/stdlib/hashlib.pyi
+++ b/stdlib/hashlib.pyi
@@ -2,6 +2,7 @@ import sys
 from _blake2 import blake2b as blake2b, blake2s as blake2s
 from _hashlib import (
     HASH,
+    _HashObject,
     openssl_md5 as md5,
     openssl_sha1 as sha1,
     openssl_sha224 as sha224,
@@ -97,7 +98,7 @@ if sys.version_info >= (3, 11):
         def readable(self) -> bool: ...
 
     def file_digest(
-        fileobj: _BytesIOLike | _FileDigestFileObj, digest: str | Callable[[], HASH], /, *, _bufsize: int = 262144
+        fileobj: _BytesIOLike | _FileDigestFileObj, digest: str | Callable[[], _HashObject], /, *, _bufsize: int = 262144
     ) -> HASH: ...
 
 # Legacy typing-only alias

--- a/stdlib/hmac.pyi
+++ b/stdlib/hmac.pyi
@@ -1,12 +1,12 @@
 import sys
-from _hashlib import HASH as _HashlibHash
+from _hashlib import _HashObject
 from _typeshed import ReadableBuffer, SizedBuffer
 from collections.abc import Callable
 from types import ModuleType
 from typing import AnyStr, overload
 from typing_extensions import TypeAlias
 
-_DigestMod: TypeAlias = str | Callable[[], _HashlibHash] | ModuleType
+_DigestMod: TypeAlias = str | Callable[[], _HashObject] | ModuleType
 
 trans_5C: bytes
 trans_36: bytes


### PR DESCRIPTION
This protocol corresponds to what is called "hash object" in the hashlib documentation. In particular, it includes the non-OpenSSL BLAKE2 implementations which do not inherit HASH.

Supersedes https://github.com/python/typeshed/pull/13518