### PR TITLE
fix yield type of `tqdm.as_completed`

### DIFF
--- a/stubs/tqdm/tqdm/asyncio.pyi
+++ b/stubs/tqdm/tqdm/asyncio.pyi
@@ -1,5 +1,6 @@
-from _typeshed import Incomplete, SupportsWrite
-from collections.abc import AsyncIterator, Awaitable, Callable, Generator, Iterable, Iterator, Mapping
+from _typeshed import SupportsWrite
+from asyncio import Future
+from collections.abc import AsyncIterator, Awaitable, Callable, Iterable, Iterator, Mapping
 from typing import NoReturn, TypeVar, overload
 from typing_extensions import Self
 
@@ -48,7 +49,7 @@ class tqdm_asyncio(std_tqdm[_T]):
         nrows: int | None = ...,
         colour: str | None = ...,
         delay: float | None = ...,
-    ) -> Generator[Incomplete, Incomplete, None]: ...
+    ) -> Iterator[Future[_T]]: ...
     @classmethod
     async def gather(
         cls,


### PR DESCRIPTION
Make the type of `tqdm.asyncio.tqdm.as_completed` more compatible with stdlib's `asyncio.as_completed`.

The container type is still `Iterator` (= `Generator[_, Any, None]`) because it seems `tqdm.as_completed` cannot be an async iterator, unlike `asyncio.as_completed` in Python>=3.13.
https://github.com/tqdm/tqdm/blob/v4.67.1/tqdm/asyncio.py#L67-L68