### PR TITLE
Use stricter pyright settings on `dirhash` in CI

### DIFF
--- a/pyrightconfig.stricter.json
+++ b/pyrightconfig.stricter.json
@@ -38,7 +38,6 @@
         "stubs/corus",
         "stubs/dateparser",
         "stubs/defusedxml",
-        "stubs/dirhash",
         "stubs/docker",
         "stubs/docutils",
         "stubs/Flask-SocketIO",


### PR DESCRIPTION
It's fully annotated.

Fixes https://github.com/AlexWaygood/typeshed-stats/issues/322