### PR TITLE
Add edges() override in MultiGraph to support the "keys" argument

### DIFF
--- a/stubs/networkx/networkx/classes/multigraph.pyi
+++ b/stubs/networkx/networkx/classes/multigraph.pyi
@@ -5,6 +5,7 @@ from typing_extensions import TypeAlias
 from networkx.classes.coreviews import MultiAdjacencyView
 from networkx.classes.graph import Graph, _Node
 from networkx.classes.multidigraph import MultiDiGraph
+from networkx.classes.reportviews import OutMultiEdgeView
 
 _MultiEdge: TypeAlias = tuple[_Node, _Node, int]  # noqa: Y047
 
@@ -23,3 +24,5 @@ class MultiGraph(Graph[_Node]):
     def to_directed(self, as_view: bool = False) -> MultiDiGraph[_Node]: ...
     def to_undirected(self, as_view: bool = False) -> MultiGraph[_Node]: ...
     def number_of_edges(self, u: _Node | None = None, v: _Node | None = None) -> int: ...
+    @cached_property
+    def edges(self) -> OutMultiEdgeView[_Node]: ...


### PR DESCRIPTION
Small fix to correct the typing for the `edges()` method of the MultiGraph class, which, adds a `keys` argument in order to differentiate multiple edges between the same pair of vertices.

Without this fix, code like:

```
for _sourceId, targetId, key, data in graph.edges(sourceId, data=True, keys=True):
  pass
```
...produces a mypy error like the following even though the code executes correctly:

```
graph.py:218: error: No overload variant of "__call__" of "OutEdgeView" matches argument types "str", "bool", "bool"  [call-overload]
graph.py:218: note: Possible overload variants:
graph.py:218: note:     def __call__(self, nbunch: None = ..., data: Literal[False] = ..., *, default: object = ...) -> OutEdgeView[Any]
graph.py:218: note:     def __call__(self, nbunch: Any | Iterable[Any], data: Literal[False] = ..., *, default: None = ...) -> OutEdgeDataView[Any, tuple[Any, Any]]
graph.py:218: note:     def __call__(self, nbunch: Any | Iterable[Any] | None, data: Literal[True], *, default: None = ...) -> OutEdgeDataView[Any, tuple[Any, Any, dict[str, Any]]]
graph.py:218: note:     def __call__(self, nbunch: Any | Iterable[Any] | None = ..., *, data: Literal[True], default: None = ...) -> OutEdgeDataView[Any, tuple[Any, Any, dict[str, Any]]]
graph.py:218: note:     def [_U] __call__(self, nbunch: Any | Iterable[Any] | None, data: str, *, default: _U | None = ...) -> OutEdgeDataView[Any, tuple[Any, Any, _U]]
graph.py:218: note:     def [_U] __call__(self, nbunch: Any | Iterable[Any] | None = ..., *, data: str, default: _U | None = ...) -> OutEdgeDataView[Any, tuple[Any, Any, _U]]
```

Thank you!