### PR TITLE
Remove uncompletable TODO in test.yml

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -110,9 +110,6 @@ jobs:
           DEPENDENCIES=$( python tests/get_external_stub_requirements.py )
           if [ -n "$DEPENDENCIES" ]; then
               printf "Installing packages:\n  $(echo $DEPENDENCIES | sed 's/ /\n  /g')\n"
-              # TODO: We need to specify the platform here, but the platforms
-              # strings supported by uv are different from the ones supported by
-              # pyright.
               uv pip install --python-version ${{ matrix.python-version }} $DEPENDENCIES
           fi
       - name: Activate the isolated venv for the rest of the job


### PR DESCRIPTION
Closes #13484 As seen in that PR, some packages can't be installed at all on certain platforms / OSes.

We don't currently have a need to run this test on multiple different platforms, so it seems the TODO was more about future-proofing.

If we need to run this test on different platforms, we'd have to add a matrix for `runs-on`. Let's cross that bridge when we get there, if we get there.

https://github.com/python/typeshed/pull/13484#issuecomment-2684754413
> I think we should just remove the TODO comment.