### PR TITLE
fix(Deprecated): fix missing extra_stacklevel kwarg for deprecated()

### DIFF
--- a/stubs/Deprecated/deprecated/classic.pyi
+++ b/stubs/Deprecated/deprecated/classic.pyi
@@ -27,5 +27,10 @@ class ClassicAdapter:
 def deprecated(wrapped: _F, /) -> _F: ...
 @overload
 def deprecated(
-    reason: str = ..., *, version: str = ..., action: _Actions | None = ..., category: type[Warning] | None = ...
+    reason: str = ...,
+    *,
+    version: str = ...,
+    action: _Actions | None = ...,
+    category: type[Warning] | None = ...,
+    extra_stacklevel: int = 0,
 ) -> Callable[[_F], _F]: ...

--- a/stubs/Deprecated/deprecated/sphinx.pyi
+++ b/stubs/Deprecated/deprecated/sphinx.pyi
@@ -32,4 +32,5 @@ def deprecated(
     *,
     action: _Actions | None = ...,
     category: type[Warning] | None = ...,
+    extra_stacklevel: int = 0,
 ) -> Callable[[_F], _F]: ...


### PR DESCRIPTION
In #13020 the stubs were upgrade for 1.2.15, but it missed the kwarg added to the classic.deprecated() and sphinx.deprecated() decorators.