### PR TITLE
`shutil.which` cannot return `PathLike`, and fails with `cmd: PathLike` on Windows Python < 3.12

### DIFF
--- a/stdlib/shutil.pyi
+++ b/stdlib/shutil.pyi
@@ -36,7 +36,6 @@ __all__ = [
 ]
 
 _StrOrBytesPathT = TypeVar("_StrOrBytesPathT", bound=StrOrBytesPath)
-_StrPathT = TypeVar("_StrPathT", bound=StrPath)
 # Return value of some functions that may either return a path-like object that was passed in or
 # a string
 _PathReturn: TypeAlias = Any

--- a/stdlib/shutil.pyi
+++ b/stdlib/shutil.pyi
@@ -3,7 +3,7 @@ import sys
 from _typeshed import BytesPath, ExcInfo, FileDescriptorOrPath, StrOrBytesPath, StrPath, SupportsRead, SupportsWrite
 from collections.abc import Callable, Iterable, Sequence
 from tarfile import _TarfileFilter
-from typing import Any, AnyStr, NamedTuple, Protocol, TypeVar, overload
+from typing import Any, AnyStr, NamedTuple, NoReturn, Protocol, TypeVar, overload
 from typing_extensions import TypeAlias, deprecated
 
 __all__ = [
@@ -185,8 +185,13 @@ else:
     @overload
     def chown(path: FileDescriptorOrPath, user: str | int, group: str | int) -> None: ...
 
+if sys.platform == "win32" and sys.version_info < (3, 12):
+    @overload
+    @deprecated("On Windows before Python 3.12, using a PathLike as `cmd` would always fail or return `None`.")
+    def which(cmd: os.PathLike[str], mode: int = 1, path: StrPath | None = None) -> NoReturn: ...
+
 @overload
-def which(cmd: _StrPathT, mode: int = 1, path: StrPath | None = None) -> str | _StrPathT | None: ...
+def which(cmd: StrPath, mode: int = 1, path: StrPath | None = None) -> str | None: ...
 @overload
 def which(cmd: bytes, mode: int = 1, path: StrPath | None = None) -> bytes | None: ...
 def make_archive(


### PR DESCRIPTION
As found on Python's Discord: https://discord.com/channels/267624335836053506/891788761371906108/1346539455267213372

Linux:
```py
>>> import shutil
>>> from pathlib import Path
>>> which(Path("bash"))
'/usr/bin/bash'
```

Python 3.10, Windows:
```py
>>> import shutil
>>> from pathlib import Path
>>> shutil.which(Path("python"))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\Avasam\AppData\Local\Programs\Python\Python310\lib\shutil.py", line 1492, in which
    if any(cmd.lower().endswith(ext.lower()) for ext in pathext):
  File "C:\Users\Avasam\AppData\Local\Programs\Python\Python310\lib\shutil.py", line 1492, in <genexpr>
    if any(cmd.lower().endswith(ext.lower()) for ext in pathext):
AttributeError: 'WindowsPath' object has no attribute 'lower'. Did you mean: 'owner'?
```

Python 3.12 & 3.13, Windows:
```py
>>> import shutil
>>> from pathlib import Path
>>> shutil.which(Path("python"))
'E:\\Program Files\\uv\\cache\\archive-v0\\9TtCCyEjyO6hv113bBovk\\Scripts\\python.EXE'
```

Oh and all cases I found, folders return `None`

Relevant CPython PR (I think) that fixed Path on Windows: https://github.com/python/cpython/pull/103179