### PR TITLE
`networkx.algorithms.connectivity.edge_kcomponents.EdgeComponentAuxGraph.construct` first param is not `cls` at runtime

### DIFF
--- a/stubs/networkx/networkx/algorithms/connectivity/edge_kcomponents.pyi
+++ b/stubs/networkx/networkx/algorithms/connectivity/edge_kcomponents.pyi
@@ -1,6 +1,6 @@
 from _typeshed import Incomplete
 from collections.abc import Generator
-from typing import Self
+from typing_extensions import Self
 
 from networkx.classes.graph import Graph, _Node
 from networkx.utils.backends import _dispatchable

--- a/stubs/networkx/networkx/algorithms/connectivity/edge_kcomponents.pyi
+++ b/stubs/networkx/networkx/algorithms/connectivity/edge_kcomponents.pyi
@@ -1,5 +1,6 @@
 from _typeshed import Incomplete
 from collections.abc import Generator
+from typing import Self
 
 from networkx.classes.graph import Graph, _Node
 from networkx.utils.backends import _dispatchable
@@ -16,6 +17,6 @@ class EdgeComponentAuxGraph:
     H: Incomplete
 
     @classmethod
-    def construct(cls, G): ...
+    def construct(EdgeComponentAuxGraph, G) -> Self: ...
     def k_edge_components(self, k: int) -> Generator[Incomplete, Incomplete, None]: ...
     def k_edge_subgraphs(self, k: int) -> Generator[Incomplete, Incomplete, None]: ...


### PR DESCRIPTION
Mainly just testing if the following mypy/stubtest issue is solved: https://github.com/python/mypy/issues/16583