### PR TITLE
Make typing.pyi container types alias builtins/collections

### DIFF
--- a/stdlib/typing.pyi
+++ b/stdlib/typing.pyi
@@ -1,8 +1,6 @@
 # Since this module defines "overload" it is not recognized by Ruff as typing.overload
 # ruff: noqa: F811
-# TODO: The collections import is required, otherwise mypy crashes.
-# https://github.com/python/mypy/issues/16744
-import collections  # noqa: F401  # pyright: ignore[reportUnusedImport]
+import collections
 import sys
 import typing_extensions
 from _collections_abc import dict_items, dict_keys, dict_values
@@ -372,20 +370,15 @@ def type_check_only(func_or_cls: _FT) -> _FT: ...
 
 # Type aliases and type constructors
 
-class _Alias:
-    # Class for defining generic aliases for library types.
-    def __getitem__(self, typeargs: Any) -> Any: ...
-
-List = _Alias()
-Dict = _Alias()
-DefaultDict = _Alias()
-Set = _Alias()
-FrozenSet = _Alias()
-Counter = _Alias()
-Deque = _Alias()
-ChainMap = _Alias()
-
-OrderedDict = _Alias()
+List = list
+Dict = dict
+DefaultDict = collections.defaultdict
+Set = set
+FrozenSet = frozenset
+Counter = collections.Counter
+Deque = collections.deque
+ChainMap = collections.ChainMap
+OrderedDict = collections.OrderedDict
 
 if sys.version_info >= (3, 9):
     Annotated: _SpecialForm

--- a/stdlib/typing_extensions.pyi
+++ b/stdlib/typing_extensions.pyi
@@ -1,4 +1,5 @@
 import abc
+import collections
 import sys
 import typing
 from _collections_abc import dict_items, dict_keys, dict_values
@@ -55,7 +56,6 @@ from typing import (  # noqa: Y022,Y037,Y038,Y039
     TypedDict as TypedDict,
     Union as Union,
     ValuesView as ValuesView,
-    _Alias,
     cast as cast,
     no_type_check as no_type_check,
     no_type_check_decorator as no_type_check_decorator,
@@ -252,7 +252,7 @@ class _TypedDict(Mapping[str, object], metaclass=abc.ABCMeta):
         # Since this module defines "Self" it is not recognized by Ruff as typing_extensions.Self
         def __ior__(self, value: Self, /) -> Self: ...  # type: ignore[misc]
 
-OrderedDict = _Alias()
+OrderedDict = collections.OrderedDict
 
 def get_type_hints(
     obj: Callable[..., Any],


### PR DESCRIPTION
Since 3.9 is the minimum supported version (https://github.com/python/typeshed/issues/12112), we could update these definitions in typing.pyi to be regular aliases since the builtin/collection versions support subscripting now.

Could this be done now? Or should we wait till april?

cc @ndmitchell