### PR TITLE
Mention uv for the initial install in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,7 @@ Note that some tests require extra setup steps to install the required dependenc
 
   </td>
 </tr>
+<tr><!-- disables zebra striping --></tr>
 <tr>
   <td>Windows</td>
   <td>
@@ -91,6 +92,7 @@ as it's currently excluded from the requirements file:
 
   </td>
 </tr>
+<tr><!-- disables zebra striping --></tr>
 <tr>
   <td>Using uv</td>
   <td>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,6 +100,7 @@ as it's currently excluded from the requirements file:
   If you already have [uv](https://docs.astral.sh/uv/getting-started/installation/) installed, you can simply replace the commands above with:
 
   ```shell
+  uv venv
   uv pip install -r requirements-tests.txt
   ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,37 +50,64 @@ please refer to this
 
 Note that some tests require extra setup steps to install the required dependencies.
 
-### Linux/Mac OS/WSL
+<table>
+<tr>
+  <td>Linux / macOS / WSL</td>
+  <td>
 
-On Linux and Mac OS, you will be able to run the full test suite on Python
-3.9-3.12.
-To install the necessary requirements, run the following commands from a
-terminal window:
+  On Linux and macOS, you will be able to run the full test suite on Python
+  3.9-3.12.
+  To install the necessary requirements, run the following commands from a
+  terminal window:
 
-```bash
-$ python3 -m venv .venv
-$ source .venv/bin/activate
-(.venv)$ pip install -U pip
-(.venv)$ pip install -r requirements-tests.txt
-```
+  ```bash
+  $ python3 -m venv .venv
+  $ source .venv/bin/activate
+  (.venv)$ pip install -U pip
+  (.venv)$ pip install -r requirements-tests.txt
+  ```
 
-### Windows
+  </td>
+</tr>
+<tr>
+  <td>Windows</td>
+  <td>
 
-Run the following commands from a Windows terminal to install all requirements:
+  Run the following commands from a Windows terminal to install all requirements:
 
-```powershell
-> python -m venv .venv
-> .venv\Scripts\activate
-(.venv) > pip install -U pip
-(.venv) > pip install -r "requirements-tests.txt"
-```
+  ```powershell
+  > python -m venv .venv
+  > .venv\Scripts\activate
+  (.venv) > pip install -U pip
+  (.venv) > pip install -r requirements-tests.txt
+  ```
 
-To be able to run pytype tests, you'll also need to install it manually
+  To be able to run pytype tests, you'll also need to install it manually
 as it's currently excluded from the requirements file:
 
-```powershell
-(.venv) > pip install -U pytype
-```
+  ```powershell
+  (.venv) > pip install -U pytype
+  ```
+
+  </td>
+</tr>
+<tr>
+  <td>Using uv</td>
+  <td>
+
+  If you already have [uv](https://docs.astral.sh/uv/getting-started/installation/) installed, you can simply replace the commands above with:
+
+  ```shell
+  uv pip install -r requirements-tests.txt
+  ```
+
+  ```shell
+  uv pip install -U pytype
+  ```
+
+  </td>
+</tr>
+</table>
 
 ## Code formatting
 


### PR DESCRIPTION
Even if we update all our scripts to depend on uv (given it's in our dev requirements), we can't assume it's already installed for the initial installation if we want to stay flexible. So that section is likely to stay even long-term. I added a mention of `uv` to show how simpler it is.

Renamed `Mac OS` --> `macOS`

I'm also experimenting with rendering that section as a table. Let me know if you like it or not. you can preview at: https://github.com/Avasam/typeshed/blob/mention-uv-in-the-initial-install/CONTRIBUTING.md