### PR TITLE
annotate `unittest.TestCase.__init_subclass__`

### DIFF
--- a/stdlib/@tests/stubtest_allowlists/py310.txt
+++ b/stdlib/@tests/stubtest_allowlists/py310.txt
@@ -164,8 +164,6 @@ builtins.property.__set_name__  # Doesn't actually exist
 collections\.UserList\.index  # ignoring pos-or-keyword parameter
 dataclasses.KW_ONLY  # white lies around defaults
 importlib.metadata._meta.SimplePath.joinpath  # Runtime definition of protocol is incorrect
-unittest.TestCase.__init_subclass__  # Runtime has *args, **kwargs, but will error if any are supplied
-unittest.case.TestCase.__init_subclass__  # Runtime has *args, **kwargs, but will error if any are supplied
 
 
 # ===============================================================

--- a/stdlib/@tests/stubtest_allowlists/py311.txt
+++ b/stdlib/@tests/stubtest_allowlists/py311.txt
@@ -145,8 +145,6 @@ builtins.property.__set_name__  # Doesn't actually exist
 collections\.UserList\.index  # ignoring pos-or-keyword parameter
 dataclasses.KW_ONLY  # white lies around defaults
 importlib.metadata._meta.SimplePath.joinpath  # Runtime definition of protocol is incorrect
-unittest.TestCase.__init_subclass__  # Runtime has *args, **kwargs, but will error if any are supplied
-unittest.case.TestCase.__init_subclass__  # Runtime has *args, **kwargs, but will error if any are supplied
 
 
 # ===============================================================

--- a/stdlib/@tests/stubtest_allowlists/py312.txt
+++ b/stdlib/@tests/stubtest_allowlists/py312.txt
@@ -157,8 +157,6 @@ builtins.property.__set_name__  # Doesn't actually exist
 collections\.UserList\.index  # ignoring pos-or-keyword parameter
 dataclasses.KW_ONLY  # white lies around defaults
 importlib.metadata._meta.SimplePath.joinpath  # Runtime definition of protocol is incorrect
-unittest.TestCase.__init_subclass__  # Runtime has *args, **kwargs, but will error if any are supplied
-unittest.case.TestCase.__init_subclass__  # Runtime has *args, **kwargs, but will error if any are supplied
 
 
 # ===============================================================

--- a/stdlib/@tests/stubtest_allowlists/py313.txt
+++ b/stdlib/@tests/stubtest_allowlists/py313.txt
@@ -147,5 +147,3 @@ builtins.property.__set_name__  # Doesn't actually exist
 collections\.UserList\.index  # ignoring pos-or-keyword parameter
 dataclasses.KW_ONLY  # white lies around defaults
 importlib.metadata._meta.SimplePath.joinpath  # Runtime definition of protocol is incorrect
-unittest.TestCase.__init_subclass__  # Runtime has *args, **kwargs, but will error if any are supplied
-unittest.case.TestCase.__init_subclass__  # Runtime has *args, **kwargs, but will error if any are supplied

--- a/stdlib/unittest/case.pyi
+++ b/stdlib/unittest/case.pyi
@@ -20,7 +20,7 @@ from typing import (
     TypeVar,
     overload,
 )
-from typing_extensions import ParamSpec, Self, TypeAlias
+from typing_extensions import Never, ParamSpec, Self, TypeAlias
 from warnings import WarningMessage
 
 if sys.version_info >= (3, 9):
@@ -322,6 +322,10 @@ class TestCase:
         def assertDictContainsSubset(
             self, subset: Mapping[Any, Any], dictionary: Mapping[Any, Any], msg: object = None
         ) -> None: ...
+
+    if sys.version_info >= (3, 10):
+        # Runtime has *args, **kwargs, but will error if any are supplied
+        def __init_subclass__(cls, *args: Never, **kwargs: Never) -> None: ...
 
 class FunctionTestCase(TestCase):
     def __init__(


### PR DESCRIPTION
NumPy re-exports `unittest.TestCase` in several modules, which caused `stubtest` to complain about incorrect `__init_subclass__` signature (see e.g. https://github.com/numpy/numtype/pull/283/commits/d6af1ad343e47b22d711451db4041c6f86e491cb). 

I noticed that in the relevant typeshed allowlists there was a comment that said

> Runtime has *args, **kwargs, but will error if any are supplied

So I figured that `Never` could also fulfill be used to fulfill that role. That way we can have the cake and eat it too. 

Thoughts?