### PR TITLE
add the `buffersize` param of `concurrent.futures.Executor.map`

### DIFF
--- a/stdlib/concurrent/futures/_base.pyi
+++ b/stdlib/concurrent/futures/_base.pyi
@@ -62,9 +62,15 @@ class Executor:
     else:
         def submit(self, fn: Callable[_P, _T], *args: _P.args, **kwargs: _P.kwargs) -> Future[_T]: ...
 
-    def map(
-        self, fn: Callable[..., _T], *iterables: Iterable[Any], timeout: float | None = None, chunksize: int = 1
-    ) -> Iterator[_T]: ...
+    if sys.version_info >= (3, 14):
+        def map(
+            self, fn: Callable[..., _T], *iterables: Iterable[Any], timeout: float | None = None, chunksize: int = 1, buffersize: int | None = None
+        ) -> Iterator[_T]: ...
+    else:
+        def map(
+            self, fn: Callable[..., _T], *iterables: Iterable[Any], timeout: float | None = None, chunksize: int = 1
+        ) -> Iterator[_T]: ...
+
     if sys.version_info >= (3, 9):
         def shutdown(self, wait: bool = True, *, cancel_futures: bool = False) -> None: ...
     else:

--- a/stdlib/concurrent/futures/_base.pyi
+++ b/stdlib/concurrent/futures/_base.pyi
@@ -64,7 +64,12 @@ class Executor:
 
     if sys.version_info >= (3, 14):
         def map(
-            self, fn: Callable[..., _T], *iterables: Iterable[Any], timeout: float | None = None, chunksize: int = 1, buffersize: int | None = None
+            self,
+            fn: Callable[..., _T],
+            *iterables: Iterable[Any],
+            timeout: float | None = None,
+            chunksize: int = 1,
+            buffersize: int | None = None,
         ) -> Iterator[_T]: ...
     else:
         def map(


### PR DESCRIPTION
Preparing for the merge of https://github.com/python/cpython/pull/125663