### PR TITLE
annotate `pathlib.Path.{owner,group,is_mount}` on windows

### DIFF
--- a/stdlib/@tests/stubtest_allowlists/win32-py310.txt
+++ b/stdlib/@tests/stubtest_allowlists/win32-py310.txt
@@ -45,16 +45,6 @@ xml.sax.expatreader.ExpatParser.flush
 
 
 # =============================================================
-# Allowlist entries that cannot or should not be fixed; <= 3.11
-# =============================================================
-
-# pathlib methods that exist on Windows, but always raise NotImplementedError,
-# so are omitted from the stub
-pathlib.Path.is_mount
-pathlib.WindowsPath.is_mount
-
-
-# =============================================================
 # Allowlist entries that cannot or should not be fixed; <= 3.12
 # =============================================================
 

--- a/stdlib/@tests/stubtest_allowlists/win32-py310.txt
+++ b/stdlib/@tests/stubtest_allowlists/win32-py310.txt
@@ -53,7 +53,3 @@ crypt
 nis
 ossaudiodev
 spwd
-
-# pathlib functions that rely on modules that don't exist on Windows
-pathlib.Path.owner
-pathlib.Path.group

--- a/stdlib/@tests/stubtest_allowlists/win32-py311.txt
+++ b/stdlib/@tests/stubtest_allowlists/win32-py311.txt
@@ -20,7 +20,3 @@ crypt
 nis
 ossaudiodev
 spwd
-
-# pathlib functions that rely on modules that don't exist on Windows
-pathlib.Path.owner
-pathlib.Path.group

--- a/stdlib/@tests/stubtest_allowlists/win32-py311.txt
+++ b/stdlib/@tests/stubtest_allowlists/win32-py311.txt
@@ -12,16 +12,6 @@ email.utils.parseaddr
 
 
 # =============================================================
-# Allowlist entries that cannot or should not be fixed; <= 3.11
-# =============================================================
-
-# pathlib methods that exist on Windows, but always raise NotImplementedError,
-# so are omitted from the stub
-pathlib.Path.is_mount
-pathlib.WindowsPath.is_mount
-
-
-# =============================================================
 # Allowlist entries that cannot or should not be fixed; <= 3.12
 # =============================================================
 

--- a/stdlib/@tests/stubtest_allowlists/win32-py312.txt
+++ b/stdlib/@tests/stubtest_allowlists/win32-py312.txt
@@ -25,7 +25,3 @@ crypt
 nis
 ossaudiodev
 spwd
-
-# pathlib functions that rely on modules that don't exist on Windows
-pathlib.Path.owner
-pathlib.Path.group

--- a/stdlib/@tests/stubtest_allowlists/win32-py39.txt
+++ b/stdlib/@tests/stubtest_allowlists/win32-py39.txt
@@ -54,16 +54,6 @@ xml.sax.expatreader.ExpatParser.flush
 
 
 # =============================================================
-# Allowlist entries that cannot or should not be fixed; <= 3.11
-# =============================================================
-
-# pathlib methods that exist on Windows, but always raise NotImplementedError,
-# so are omitted from the stub
-pathlib.Path.is_mount
-pathlib.WindowsPath.is_mount
-
-
-# =============================================================
 # Allowlist entries that cannot or should not be fixed; <= 3.12
 # =============================================================
 

--- a/stdlib/@tests/stubtest_allowlists/win32-py39.txt
+++ b/stdlib/@tests/stubtest_allowlists/win32-py39.txt
@@ -62,7 +62,3 @@ crypt
 nis
 ossaudiodev
 spwd
-
-# pathlib functions that rely on modules that don't exist on Windows
-pathlib.Path.owner
-pathlib.Path.group

--- a/stdlib/pathlib.pyi
+++ b/stdlib/pathlib.pyi
@@ -226,9 +226,13 @@ class Path(PurePath):
     def open(
         self, mode: str, buffering: int = -1, encoding: str | None = None, errors: str | None = None, newline: str | None = None
     ) -> IO[Any]: ...
-    if sys.platform != "win32":
-        # These methods do "exist" on Windows, but they always raise NotImplementedError,
-        # so it's safer to pretend they don't exist
+
+    # These methods do "exist" on Windows on <3.13, but they always raise NotImplementedError.
+    if sys.platform == "win32":
+        if sys.version_info < (3, 13):
+            def owner(self: Never) -> str: ...  # type: ignore[misc]
+            def group(self: Never) -> str: ...  # type: ignore[misc]
+    else:
         if sys.version_info >= (3, 13):
             def owner(self, *, follow_symlinks: bool = True) -> str: ...
             def group(self, *, follow_symlinks: bool = True) -> str: ...

--- a/stdlib/pathlib.pyi
+++ b/stdlib/pathlib.pyi
@@ -16,7 +16,7 @@ from io import BufferedRandom, BufferedReader, BufferedWriter, FileIO, TextIOWra
 from os import PathLike, stat_result
 from types import TracebackType
 from typing import IO, Any, BinaryIO, ClassVar, Literal, overload
-from typing_extensions import Self, deprecated
+from typing_extensions import Never, Self, deprecated
 
 if sys.version_info >= (3, 9):
     from types import GenericAlias
@@ -238,7 +238,9 @@ class Path(PurePath):
 
     # This method does "exist" on Windows on <3.12, but always raises NotImplementedError
     # On py312+, it works properly on Windows, as with all other platforms
-    if sys.platform != "win32" or sys.version_info >= (3, 12):
+    if sys.platform == "win32" and sys.version_info < (3, 12):
+        def is_mount(self: Never) -> bool: ...  # type: ignore[misc]
+    else:
         def is_mount(self) -> bool: ...
 
     if sys.version_info >= (3, 9):


### PR DESCRIPTION
This basically is uses the same partytrick as #13602, but applied to `Never` itself, and leads to similar issues in the NumPy stubs, as well.

Attempting to use these methods on windows <3.12 will now be reported by mypy as a classic `misc`, instead of `attr-defined`, which IMO was a bit more confusing.
Pyright users won't even notice the difference &mdash; they'll still be confronted with very same `reportAttributeAccessIssue` and `reportUnknownMemberType` power chords.
