### PR TITLE
distutils: Allow overriding Command and Distribution boolean attributes with actual bool in subclasses

### DIFF
--- a/stdlib/distutils/cmd.pyi
+++ b/stdlib/distutils/cmd.pyi
@@ -30,7 +30,7 @@ _CommandT = TypeVar("_CommandT", bound=Command)
 _Ts = TypeVarTuple("_Ts")
 
 class Command:
-    dry_run: Literal[0, 1]  # Exposed from __getattr_. Same as Distribution.dry_run
+    dry_run: bool | Literal[0, 1]  # Exposed from __getattr_. Same as Distribution.dry_run
     distribution: Distribution
     # Any to work around variance issues
     sub_commands: ClassVar[list[tuple[str, Callable[[Any], bool] | None]]]

--- a/stdlib/distutils/dist.pyi
+++ b/stdlib/distutils/dist.pyi
@@ -88,9 +88,9 @@ class Distribution:
     display_options: ClassVar[_OptionsList]
     display_option_names: ClassVar[list[str]]
     negative_opt: ClassVar[dict[str, str]]
-    verbose: Literal[0, 1]
-    dry_run: Literal[0, 1]
-    help: Literal[0, 1]
+    verbose: bool | Literal[0, 1]
+    dry_run: bool | Literal[0, 1]
+    help: bool | Literal[0, 1]
     command_packages: list[str] | None
     script_name: str | None
     script_args: list[str] | None


### PR DESCRIPTION
See https://github.com/pypa/setuptools/pull/4872/files#r1988322516