### PR TITLE
Fix mypy test temporary config file creation

### DIFF
--- a/tests/mypy_test.py
+++ b/tests/mypy_test.py
@@ -214,7 +214,7 @@ def run_mypy(
     env_vars = dict(os.environ)
     if mypypath is not None:
         env_vars["MYPYPATH"] = mypypath
-    with tempfile.NamedTemporaryFile("w+") as temp:
+    with tempfile.NamedTemporaryFile("w+", delete_on_close=False) as temp:
         temp.write("[mypy]\n")
         for dist_conf in configurations:
             temp.write(f"[mypy-{dist_conf.module_name}]\n")

--- a/tests/mypy_test.py
+++ b/tests/mypy_test.py
@@ -290,7 +290,7 @@ def add_third_party_files(
         if name.startswith("."):
             continue
         add_files(files, (root / name), args)
-        add_configuration(configurations, distribution)
+    add_configuration(configurations, distribution)
 
 
 class TestResult(NamedTuple):

--- a/tests/mypy_test.py
+++ b/tests/mypy_test.py
@@ -214,7 +214,8 @@ def run_mypy(
     env_vars = dict(os.environ)
     if mypypath is not None:
         env_vars["MYPYPATH"] = mypypath
-    with tempfile.NamedTemporaryFile("w+", delete_on_close=False) as temp:
+    # TODO: Use delete_on_close on Python 3.12
+    with tempfile.NamedTemporaryFile("w+", delete=False) as temp:
         temp.write("[mypy]\n")
         for dist_conf in configurations:
             temp.write(f"[mypy-{dist_conf.module_name}]\n")

--- a/tests/mypy_test.py
+++ b/tests/mypy_test.py
@@ -55,7 +55,7 @@ else:
     from contextlib import contextmanager
 
     @contextmanager
-    def _named_temporary_file() -> Generator[tempfile._TemporaryFileWrapper[str]]:
+    def _named_temporary_file() -> Generator[tempfile._TemporaryFileWrapper[str]]:  # pyright: ignore[reportPrivateUsage]
         temp = tempfile.NamedTemporaryFile("w+", delete=False)  # noqa: SIM115
         try:
             yield temp

--- a/tests/mypy_test.py
+++ b/tests/mypy_test.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 
 import argparse
 import concurrent.futures
+import functools
 import os
 import subprocess
 import sys
 import tempfile
 import time
 from collections import defaultdict
+from collections.abc import Generator
 from dataclasses import dataclass
 from enum import Enum
 from itertools import product
@@ -43,6 +45,24 @@ try:
 except ImportError:
     print_error("Cannot import mypy. Did you install it?")
     sys.exit(1)
+
+# We need to work around a limitation of tempfile.NamedTemporaryFile on Windows
+# For details, see https://github.com/python/typeshed/pull/13620#discussion_r1990185997
+# Python 3.12 added a workaround with `tempfile.NamedTemporaryFile("w+", delete_on_close=False)`
+if sys.platform != "win32":
+    _named_temporary_file = functools.partial(tempfile.NamedTemporaryFile, "w+")
+else:
+    from contextlib import contextmanager
+
+    @contextmanager
+    def _named_temporary_file() -> Generator[tempfile._TemporaryFileWrapper[str]]:
+        temp = tempfile.NamedTemporaryFile("w+", delete=False)  # noqa: SIM115
+        try:
+            yield temp
+        finally:
+            temp.close()
+            os.remove(temp.name)
+
 
 SUPPORTED_VERSIONS = ["3.13", "3.12", "3.11", "3.10", "3.9"]
 SUPPORTED_PLATFORMS = ("linux", "win32", "darwin")
@@ -214,8 +234,8 @@ def run_mypy(
     env_vars = dict(os.environ)
     if mypypath is not None:
         env_vars["MYPYPATH"] = mypypath
-    # TODO: Use delete_on_close on Python 3.12
-    with tempfile.NamedTemporaryFile("w+", delete=False) as temp:
+
+    with _named_temporary_file() as temp:
         temp.write("[mypy]\n")
         for dist_conf in configurations:
             temp.write(f"[mypy-{dist_conf.module_name}]\n")


### PR DESCRIPTION
For a long while now I noticed that when the mypy test fails, `No [mypy] section in config file` is printed, but I never really paid attention to it. Turns our the temporary mypy config file was never actually being written to.

I also noticed an additional bug where the same config section would be repeated a lot.

I have an upcoming experimental PR that depends on the `[mypy-tests]` feature, so here you go with a bugfix and removing a bogus error line that affects current tests.

## When there's a mypy error:

### Before:
```
testing setuptools (104 files)... failure (exit code 1)

stubs\setuptools\setuptools\namespaces.pyi:10: error: Name "this_name_doesnt_exist" is not defined  [name-defined]

C:\Users\Avasam\AppData\Local\Temp\tmpe41876qa: No [mypy] section in config file
```

### After:
```
testing setuptools (104 files)... failure (exit code 1)

stubs\setuptools\setuptools\namespaces.pyi:10: error: Name "this_name_doesnt_exist" is not defined  [name-defined]
```

## On top of the above fix, with the following in METADATA.toml:
```toml
[mypy-tests.example]
module_name = "example"
values = { "follow_untyped_imports" = true }
```

### Before (content written to temp file):
```
[mypy]
[mypy-example]
follow_untyped_imports = True
[mypy-example]
follow_untyped_imports = True
[mypy-example]
follow_untyped_imports = True
[mypy-example]
follow_untyped_imports = True
```

### After (content written to temp file):
```
[mypy]
[mypy-example]
follow_untyped_imports = True
```