### PR TITLE
Set build system for `ts_utils`

### DIFF
--- a/lib/pyproject.toml
+++ b/lib/pyproject.toml
@@ -1,1 +1,9 @@
 # Utilities for typeshed infrastructure scripts.
+
+[project]
+name = "ts_utils"
+version = "0.0.0"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"


### PR DESCRIPTION
Closes https://github.com/python/typeshed/issues/13591.

I chose `hatchling`, because it was smallest build backend that was supported by `uv`.