### PR TITLE
[CI] Quieten apt-get

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -80,7 +80,7 @@ jobs:
 
           if [ "${{ runner.os }}" = "Linux" ]; then
             if [ -n "$PACKAGES" ]; then
-              sudo apt-get update && sudo apt-get install -y $PACKAGES
+              sudo apt-get update -q && sudo apt-get install -qy $PACKAGES
             fi
 
             PYTHON_EXECUTABLE="xvfb-run python"

--- a/.github/workflows/stubtest_third_party.yml
+++ b/.github/workflows/stubtest_third_party.yml
@@ -67,7 +67,7 @@ jobs:
             if [ "${{ runner.os }}" = "Linux" ]; then
               if [ -n "$PACKAGES" ]; then
                 echo "Installing apt packages: $PACKAGES"
-                sudo apt-get update && sudo apt-get install -y $PACKAGES
+                sudo apt-get update -q && sudo apt-get install -qy $PACKAGES
               fi
 
               PYTHON_EXECUTABLE="xvfb-run python"


### PR DESCRIPTION
Don't print progress when installing packages via apt-get. This prevent spurious output in CI logs.