### PR TITLE
Move error handling to main function

### DIFF
--- a/tests/stubtest_third_party.py
+++ b/tests/stubtest_third_party.py
@@ -33,7 +33,6 @@ from ts_utils.utils import (
 def run_stubtest(
     dist: Path,
     *,
-    parser: argparse.ArgumentParser,
     verbose: bool = False,
     specified_platforms_only: bool = False,
     keep_tmp_dir: bool = False,
@@ -41,10 +40,7 @@ def run_stubtest(
     """Run stubtest for a single distribution."""
 
     dist_name = dist.name
-    try:
-        metadata = read_metadata(dist_name)
-    except NoSuchStubError as e:
-        parser.error(str(e))
+    metadata = read_metadata(dist_name)
     print(f"{dist_name}... ", end="", flush=True)
 
     t = time()
@@ -410,14 +406,16 @@ def main() -> NoReturn:
     for i, dist in enumerate(dists):
         if i % args.num_shards != args.shard_index:
             continue
-        if not run_stubtest(
-            dist,
-            parser=parser,
-            verbose=args.verbose,
-            specified_platforms_only=args.specified_platforms_only,
-            keep_tmp_dir=args.keep_tmp_dir,
-        ):
-            result = 1
+        try:
+            if not run_stubtest(
+                dist,
+                verbose=args.verbose,
+                specified_platforms_only=args.specified_platforms_only,
+                keep_tmp_dir=args.keep_tmp_dir,
+            ):
+                result = 1
+        except NoSuchStubError as e:
+            parser.error(str(e))
     sys.exit(result)
 
 

--- a/tests/stubtest_third_party.py
+++ b/tests/stubtest_third_party.py
@@ -31,11 +31,7 @@ from ts_utils.utils import (
 
 
 def run_stubtest(
-    dist: Path,
-    *,
-    verbose: bool = False,
-    specified_platforms_only: bool = False,
-    keep_tmp_dir: bool = False,
+    dist: Path, *, verbose: bool = False, specified_platforms_only: bool = False, keep_tmp_dir: bool = False
 ) -> bool:
     """Run stubtest for a single distribution."""
 
@@ -408,10 +404,7 @@ def main() -> NoReturn:
             continue
         try:
             if not run_stubtest(
-                dist,
-                verbose=args.verbose,
-                specified_platforms_only=args.specified_platforms_only,
-                keep_tmp_dir=args.keep_tmp_dir,
+                dist, verbose=args.verbose, specified_platforms_only=args.specified_platforms_only, keep_tmp_dir=args.keep_tmp_dir
             ):
                 result = 1
         except NoSuchStubError as e:


### PR DESCRIPTION
* This makes is easier to call `run_stubtest()` manually, for example when testing the script - no need to construct an `ArgumentParser` instance.
* This concentrates argument error handling in the `main()` function and prevents an unexpected process exit when calling `run_stubtest()`.