### PR TITLE
[CI] Shorten job names

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -29,7 +29,7 @@ env:
 
 jobs:
   stubtest-stdlib:
-    name: stubtest: stdlib
+    name: "stubtest: stdlib"
     if: ${{ github.repository == 'python/typeshed' || github.event_name == 'workflow_dispatch' }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -54,7 +54,7 @@ jobs:
         run: python tests/stubtest_stdlib.py
 
   stubtest-third-party:
-    name: stubtest: third party
+    name: "stubtest: third party"
     if: ${{ github.repository == 'python/typeshed' || github.event_name == 'workflow_dispatch' }}
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -99,7 +99,7 @@ jobs:
           $PYTHON_EXECUTABLE tests/stubtest_third_party.py --specified-platforms-only --num-shards 4 --shard-index ${{ matrix.shard-index }}
 
   stub-uploader:
-    name: stub_uploader
+    name: stub_uploader tests
     if: ${{ github.repository == 'python/typeshed' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -29,7 +29,7 @@ env:
 
 jobs:
   stubtest-stdlib:
-    name: Check stdlib with stubtest
+    name: stubtest: stdlib
     if: ${{ github.repository == 'python/typeshed' || github.event_name == 'workflow_dispatch' }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -54,7 +54,7 @@ jobs:
         run: python tests/stubtest_stdlib.py
 
   stubtest-third-party:
-    name: Check third party stubs with stubtest
+    name: stubtest: third party
     if: ${{ github.repository == 'python/typeshed' || github.event_name == 'workflow_dispatch' }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -99,7 +99,7 @@ jobs:
           $PYTHON_EXECUTABLE tests/stubtest_third_party.py --specified-platforms-only --num-shards 4 --shard-index ${{ matrix.shard-index }}
 
   stub-uploader:
-    name: Run the stub_uploader tests
+    name: stub_uploader
     if: ${{ github.repository == 'python/typeshed' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     steps:
@@ -124,7 +124,7 @@ jobs:
 
   # https://github.community/t/run-github-actions-job-only-if-previous-job-has-failed/174786/2
   create-issue-on-failure:
-    name: Create an issue if daily tests failed
+    name: Create issue on failure
     runs-on: ubuntu-latest
     needs: [stubtest-stdlib, stubtest-third-party, stub-uploader]
     if: ${{ github.repository == 'python/typeshed' && always() && github.event_name == 'schedule' && (needs.stubtest-stdlib.result == 'failure' || needs.stubtest-third-party.result == 'failure' || needs.stub-uploader.result == 'failure') }}

--- a/.github/workflows/meta_tests.yml
+++ b/.github/workflows/meta_tests.yml
@@ -28,7 +28,7 @@ concurrency:
 
 jobs:
   mypy:
-    name: Run mypy against the scripts and tests directories
+    name: Run mypy against scripts and tests
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -43,7 +43,7 @@ jobs:
       - run: uv pip install -r requirements-tests.txt --system
       - run: python ./tests/typecheck_typeshed.py --platform=${{ matrix.platform }}
   pyright:
-    name: Run pyright against the scripts and tests directories
+    name: Run pyright against scripts and tests
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/meta_tests.yml
+++ b/.github/workflows/meta_tests.yml
@@ -28,7 +28,7 @@ concurrency:
 
 jobs:
   mypy:
-    name: Run mypy against scripts and tests
+    name: Check scripts and tests with mypy
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -43,7 +43,7 @@ jobs:
       - run: uv pip install -r requirements-tests.txt --system
       - run: python ./tests/typecheck_typeshed.py --platform=${{ matrix.platform }}
   pyright:
-    name: Run pyright against scripts and tests
+    name: Check scripts and tests with pyright
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/stubsabot.yml
+++ b/.github/workflows/stubsabot.yml
@@ -39,7 +39,7 @@ jobs:
 
   # https://github.community/t/run-github-actions-job-only-if-previous-job-has-failed/174786/2
   create-issue-on-failure:
-    name: Create an issue if stubsabot failed
+    name: Create issue on failure
     runs-on: ubuntu-latest
     needs: [stubsabot]
     if: ${{ github.repository == 'python/typeshed' && always() && (needs.stubsabot.result == 'failure') }}

--- a/.github/workflows/stubtest_stdlib.yml
+++ b/.github/workflows/stubtest_stdlib.yml
@@ -26,7 +26,7 @@ concurrency:
 
 jobs:
   stubtest-stdlib:
-    name: Check stdlib with stubtest
+    name: stubtest: stdlib
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/stubtest_stdlib.yml
+++ b/.github/workflows/stubtest_stdlib.yml
@@ -26,7 +26,7 @@ concurrency:
 
 jobs:
   stubtest-stdlib:
-    name: stubtest: stdlib
+    name: "stubtest: stdlib"
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/stubtest_third_party.yml
+++ b/.github/workflows/stubtest_third_party.yml
@@ -27,7 +27,7 @@ concurrency:
 
 jobs:
   stubtest-third-party:
-    name: Check third party stubs with stubtest
+    name: stubtest: third party
 
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/stubtest_third_party.yml
+++ b/.github/workflows/stubtest_third_party.yml
@@ -27,7 +27,7 @@ concurrency:
 
 jobs:
   stubtest-third-party:
-    name: stubtest: third party
+    name: "stubtest: third party"
 
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
       - run: python ./tests/check_typeshed_structure.py
 
   pytype:
-    name: pytype: Check stubs
+    name: "pytype: Check stubs"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -56,7 +56,7 @@ jobs:
       - run: ./tests/pytype_test.py --print-stderr
 
   mypy:
-    name: mypy: Check stubs
+    name: "mypy: Check stubs"
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -73,7 +73,7 @@ jobs:
       - run: python ./tests/mypy_test.py --platform=${{ matrix.platform }} --python-version=${{ matrix.python-version }}
 
   regression-tests:
-    name: mypy: Run test cases
+    name: "mypy: Run test cases"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -87,7 +87,7 @@ jobs:
       - run: python ./tests/regr_test.py --all --verbosity QUIET
 
   pyright:
-    name: pyright: Run test cases
+    name: "pyright: Run test cases"
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -141,7 +141,7 @@ jobs:
           project: ./pyrightconfig.testcases.json
 
   stub-uploader:
-    name: Run stub_uploader tests
+    name: stub_uploader tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout typeshed

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
       - run: python ./tests/check_typeshed_structure.py
 
   pytype:
-    name: Run pytype against the stubs
+    name: pytype: Check stubs
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -56,7 +56,7 @@ jobs:
       - run: ./tests/pytype_test.py --print-stderr
 
   mypy:
-    name: Run mypy against the stubs
+    name: mypy: Check stubs
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -73,7 +73,7 @@ jobs:
       - run: python ./tests/mypy_test.py --platform=${{ matrix.platform }} --python-version=${{ matrix.python-version }}
 
   regression-tests:
-    name: Run mypy on the test cases
+    name: mypy: Run test cases
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -87,7 +87,7 @@ jobs:
       - run: python ./tests/regr_test.py --all --verbosity QUIET
 
   pyright:
-    name: Test typeshed with pyright
+    name: pyright: Run test cases
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -141,7 +141,7 @@ jobs:
           project: ./pyrightconfig.testcases.json
 
   stub-uploader:
-    name: Run the stub_uploader tests
+    name: Run stub_uploader tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout typeshed


### PR DESCRIPTION
When looking at GitHub's action runs, the individual jobs are listed in the left sidebar, but since the job names are fairly long, they get cut off, leading to a lot of guessing when finding the correct job. Shorter job names should fix this.

![Bildschirmfoto vom 2025-03-17 14-06-47](https://github.com/user-attachments/assets/dcfc88a9-c7d3-4501-b6f5-3b00c20012c2)
