### PR TITLE
[passlib] Fix for Python 3.13

### DIFF
--- a/stubs/passlib/passlib/hosts.pyi
+++ b/stubs/passlib/passlib/hosts.pyi
@@ -1,3 +1,4 @@
+import sys
 from typing import Any
 
 from passlib.context import CryptContext
@@ -8,4 +9,5 @@ freebsd_context: Any
 openbsd_context: Any
 netbsd_context: Any
 # Only exists if crypt is present
-host_context: CryptContext
+if sys.version_info < (3, 13):
+    host_context: CryptContext


### PR DESCRIPTION
`passlib.hosts.host_context` is not present on Python 3.13.