### PR TITLE
Deprecate CGIHTTPRequestHandler

### DIFF
--- a/stdlib/http/server.pyi
+++ b/stdlib/http/server.pyi
@@ -73,6 +73,7 @@ class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
 
 def executable(path: StrPath) -> bool: ...  # undocumented
 
+@deprecated("Deprecated in Python 3.13; removal scheduled for Python 3.15")
 class CGIHTTPRequestHandler(SimpleHTTPRequestHandler):
     cgi_directories: list[str]
     have_fork: bool  # undocumented


### PR DESCRIPTION
why mention the `executable` function?
it is an internal function for `CGIHTTPRequestHandler` and it is also undocumented.

if you want to create stubs for all functions that do not start with `_` then there is also [`nobody_uid`](https://github.com/python/cpython/blob/a936af924efc6e2fb59e27990dcd905b7819470a/Lib/http/server.py#L965) (another internal function)

