### PR TITLE
covariant `warnings.catch_warnings` type-parameter with default

### DIFF
--- a/stdlib/warnings.pyi
+++ b/stdlib/warnings.pyi
@@ -21,7 +21,8 @@ if sys.version_info >= (3, 13):
     __all__ += ["deprecated"]
 
 _T = TypeVar("_T")
-_W = TypeVar("_W", bound=list[WarningMessage] | None)
+_W_co = TypeVar("_W_co", bound=list[WarningMessage] | None, covariant=True)
+
 if sys.version_info >= (3, 14):
     _ActionKind: TypeAlias = Literal["default", "error", "ignore", "always", "module", "once"]
 else:
@@ -66,7 +67,7 @@ class WarningMessage:
         source: Any | None = None,
     ) -> None: ...
 
-class catch_warnings(Generic[_W]):
+class catch_warnings(Generic[_W_co]):
     if sys.version_info >= (3, 11):
         @overload
         def __init__(
@@ -113,7 +114,7 @@ class catch_warnings(Generic[_W]):
             self: catch_warnings[list[WarningMessage] | None], *, record: bool, module: ModuleType | None = None
         ) -> None: ...
 
-    def __enter__(self) -> _W: ...
+    def __enter__(self) -> _W_co: ...
     def __exit__(
         self, exc_type: type[BaseException] | None, exc_val: BaseException | None, exc_tb: TracebackType | None
     ) -> None: ...

--- a/stdlib/warnings.pyi
+++ b/stdlib/warnings.pyi
@@ -3,8 +3,8 @@ import sys
 from _warnings import warn as warn, warn_explicit as warn_explicit
 from collections.abc import Sequence
 from types import ModuleType, TracebackType
-from typing import Any, Generic, Literal, TextIO, TypeVar, overload
-from typing_extensions import LiteralString, TypeAlias
+from typing import Any, Generic, Literal, TextIO, overload
+from typing_extensions import LiteralString, TypeAlias, TypeVar
 
 __all__ = [
     "warn",
@@ -21,7 +21,7 @@ if sys.version_info >= (3, 13):
     __all__ += ["deprecated"]
 
 _T = TypeVar("_T")
-_W_co = TypeVar("_W_co", bound=list[WarningMessage] | None, covariant=True)
+_W_co = TypeVar("_W_co", bound=list[WarningMessage] | None, default=list[WarningMessage] | None, covariant=True)
 
 if sys.version_info >= (3, 14):
     _ActionKind: TypeAlias = Literal["default", "error", "ignore", "always", "module", "once"]
@@ -93,7 +93,7 @@ class catch_warnings(Generic[_W_co]):
         ) -> None: ...
         @overload
         def __init__(
-            self: catch_warnings[list[WarningMessage] | None],
+            self,
             *,
             record: bool,
             module: ModuleType | None = None,
@@ -110,9 +110,7 @@ class catch_warnings(Generic[_W_co]):
             self: catch_warnings[list[WarningMessage]], *, record: Literal[True], module: ModuleType | None = None
         ) -> None: ...
         @overload
-        def __init__(
-            self: catch_warnings[list[WarningMessage] | None], *, record: bool, module: ModuleType | None = None
-        ) -> None: ...
+        def __init__(self, *, record: bool, module: ModuleType | None = None) -> None: ...
 
     def __enter__(self) -> _W_co: ...
     def __exit__(


### PR DESCRIPTION
This changes the type parameter of `warnings.catch_warnings` in two ways:

- set `covariant=True` &mdash; as it's only used within output positions &mdash;  and renamed it accordingly
- have it `default` to its upper `bound` so that it isn't required anymore to pass a type-argument to a class that is not subscriptable at runtime

The invariance was causing issues within the numpy stubs for a generic a subclass:
https://github.com/numpy/numpy/blob/0aafd8553a986c7d39dde489ac5d42e53322b090/numpy/testing/_private/utils.pyi#L138-L147 to be precise