### PR TITLE
Add stubs for `rfc3339-validator`

### DIFF
--- a/pyrightconfig.stricter.json
+++ b/pyrightconfig.stricter.json
@@ -88,6 +88,7 @@
         "stubs/reportlab",
         "stubs/requests",
         "stubs/requests-oauthlib",
+        "stubs/rfc3339-validator",
         "stubs/seaborn",
         "stubs/setuptools/setuptools",
         "stubs/shapely",

--- a/stubs/rfc3339-validator/METADATA.toml
+++ b/stubs/rfc3339-validator/METADATA.toml
@@ -1,0 +1,2 @@
+version = "0.1.*"
+upstream_repository = "https://github.com/naimetti/rfc3339-validator"

--- a/stubs/rfc3339-validator/rfc3339_validator.pyi
+++ b/stubs/rfc3339-validator/rfc3339_validator.pyi
@@ -1,0 +1,7 @@
+import re
+
+__version__: str
+RFC3339_REGEX_FLAGS: int
+RFC3339_REGEX: re.Pattern[str]
+
+def validate_rfc3339(date_string: str) -> bool: ...


### PR DESCRIPTION
This is a very frequently downloaded library, so I think it would be useful to have stubs for it.\
Statistics from [PyPI Stats](https://pypistats.org/packages/rfc3339-validator):
> Downloads last day: 710,009
> Downloads last week: 7,921,981
> Downloads last month: 33,567,640

And the last commit was 3 years ago