### PR TITLE
Support `uv` for installing third party dependencies

### DIFF
--- a/scripts/install_all_third_party_dependencies.py
+++ b/scripts/install_all_third_party_dependencies.py
@@ -1,6 +1,14 @@
 import subprocess
+import sys
 
 from ts_utils.requirements import get_external_stub_requirements
 
+use_uv = "--uv" in sys.argv
+if use_uv:
+    sys.argv.remove("--uv")
+    pip_command = ["uv", "pip", "install"]
+else:
+    pip_command = ["pip", "install"]
+
 requirements = get_external_stub_requirements()
-subprocess.check_call(("pip", "install", *[str(requirement) for requirement in requirements]))
+subprocess.check_call(pip_command + [str(requirement) for requirement in requirements])

--- a/scripts/install_all_third_party_dependencies.py
+++ b/scripts/install_all_third_party_dependencies.py
@@ -5,7 +5,6 @@ from ts_utils.requirements import get_external_stub_requirements
 
 use_uv = "--uv" in sys.argv
 if use_uv:
-    sys.argv.remove("--uv")
     pip_command = ["uv", "pip", "install"]
 else:
     pip_command = ["pip", "install"]


### PR DESCRIPTION
Could it be possible to add support for `uv` as a way to install third party dependencies?

`uv` seems to be most useful when installing a lot of libs.
I think it would speed up the work a lot :relaxed:  especially if you often have to change virtual environment and reinstall packages

I suggest just leaving it behind the `--uv` flag:
```bash
 python3 scripts/install_all_third_party_dependencies.py --uv
 ```