### PR TITLE
Restore JACK-Client macOS stubtest

### DIFF
--- a/stubs/JACK-Client/METADATA.toml
+++ b/stubs/JACK-Client/METADATA.toml
@@ -5,8 +5,8 @@ requires = ["numpy>=1.20", "types-cffi"]
 
 [tool.stubtest]
 # darwin and win32 are equivalent
-platforms = ["linux"]
+platforms = ["darwin", "linux"]
 apt_dependencies = ["libjack-dev"]
-# brew_dependencies = ["jack"]
+brew_dependencies = ["jack"]
 # No need to install on the CI. Leaving here as information for Windows contributors.
 # choco_dependencies = ["jack"]


### PR DESCRIPTION
Disabled by @hauntsaninja last year in https://github.com/python/typeshed/pull/11821 to get daily tests passing.

The other two macOS stubtests that were disabled have been restored since then. Let's see about this one.