### PR TITLE
[requests] Remove Session.redirect_cache

### DIFF
--- a/stubs/requests/requests/sessions.pyi
+++ b/stubs/requests/requests/sessions.pyi
@@ -3,8 +3,6 @@ from collections.abc import Callable, Iterable, Mapping, MutableMapping
 from typing import Any, TypedDict
 from typing_extensions import Self, TypeAlias
 
-from urllib3._collections import RecentlyUsedContainer
-
 from . import adapters, auth as _auth, compat, cookies, exceptions, hooks, models, status_codes, utils
 from .models import Response
 from .structures import CaseInsensitiveDict as CaseInsensitiveDict
@@ -132,7 +130,6 @@ class Session(SessionRedirectMixin):
     trust_env: bool
     cookies: RequestsCookieJar
     adapters: MutableMapping[str, adapters.BaseAdapter]
-    redirect_cache: RecentlyUsedContainer[Any, Any]
     def __init__(self) -> None: ...
     def __enter__(self) -> Self: ...
     def __exit__(self, *args: Unused) -> None: ...


### PR DESCRIPTION
This attribute doesn't exist anymore, at least as of requests 2.32.0.

Unblocks #13722