### PR TITLE
Enable Ruff flake8-async (ASYNC)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ exclude = ["**/test_cases/**/*.py"]
 external = ["F821", "Y"]
 select = [
     "ARG", # flake8-unused-arguments
+    "ASYNC", # flake8-async
     "B", # flake8-bugbear
     "D", # pydocstyle
     "EXE", # flake8-executable

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -6,6 +6,7 @@ pyright==1.1.397
 pytype==2024.10.11; platform_system != "Windows" and python_version >= "3.10" and python_version < "3.13"
 
 # Libraries used by our various scripts.
+anyio
 aiohttp==3.10.11
 grpcio-tools>=1.66.2 # For grpc_tools.protoc
 mypy-protobuf==3.6.0


### PR DESCRIPTION
Ref https://github.com/python/typeshed/issues/13295
[flake8-async (ASYNC)](https://docs.astral.sh/ruff/rules/#flake8-async-async)

A handful of async-related rules that look reasonable. We happen to already respect all of them except 1: [run-process-in-async-function (ASYNC221)](https://docs.astral.sh/ruff/rules/run-process-in-async-function/#run-process-in-async-function-async221)

I followed the rule's recommendation using `anyio` for the sole reason that it's lighter than `trio`, and it's better than writing something like the followign (unless we add it to our internal lib):
![image](https://github.com/user-attachments/assets/5f40d9a6-a173-4977-8d71-9a3419c88f81)

But I don't know what's the actual impacts, if any. Can someone else tell me if async subprocess call in async method has real benefits or if we should just ignore that rule?