### PR TITLE
Enable Ruff flake8-blind-except (BLE)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ external = ["F821", "Y"]
 select = [
     "ARG", # flake8-unused-arguments
     "B", # flake8-bugbear
+    "BLE", # flake8-blind-except
     "D", # pydocstyle
     "EXE", # flake8-executable
     "FA", # flake8-future-annotations

--- a/tests/pytype_test.py
+++ b/tests/pytype_test.py
@@ -87,7 +87,7 @@ def run_pytype(*, filename: str, python_version: str, missing_modules: Iterable[
         with pytype_config.verbosity_from(options):
             ast = loader.load_file(_get_module_name(filename), filename)
             loader.finish_and_verify_ast(ast)
-    except Exception:
+    except Exception:  # noqa: BLE001 # Forwarding the traceback for logging
         stderr = traceback.format_exc()
     else:
         stderr = None


### PR DESCRIPTION
Ref https://github.com/python/typeshed/issues/13295
[flake8-blind-except (BLE)](https://docs.astral.sh/ruff/rules/#flake8-blind-except-ble)

Contains a single rule: [blind-except (BLE001)](https://docs.astral.sh/ruff/rules/blind-except/#blind-except-ble001)
I think it's worth making sure we explain when blindly catching any exception in a script/test.

The one time we currently do it seems to be acceptable as per the rule's description.