### PR TITLE
Enable Ruff flake8-builtins (A)

### DIFF
--- a/lib/ts_utils/metadata.py
+++ b/lib/ts_utils/metadata.py
@@ -330,7 +330,7 @@ class PackageDependencies(NamedTuple):
 
 @cache
 def get_pypi_name_to_typeshed_name_mapping() -> Mapping[str, str]:
-    return {read_metadata(dir.name).stub_distribution: dir.name for dir in STUBS_PATH.iterdir()}
+    return {read_metadata(stub_dir.name).stub_distribution: stub_dir.name for stub_dir in STUBS_PATH.iterdir()}
 
 
 @cache

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ exclude = ["**/test_cases/**/*.py"]
 # tell ruff not to flag these as e.g. "unused noqa comments"
 external = ["F821", "Y"]
 select = [
+    "A", # flake8-builtins
     "ARG", # flake8-unused-arguments
     "B", # flake8-bugbear
     "D", # pydocstyle
@@ -181,6 +182,8 @@ ignore = [
     ###
     # Rules that are out of the control of stub authors:
     ###
+    # Names in stubs should match the implementation, even if it's ambiguous.
+    "A", # flake8-builtins
     "F403", # `from . import *` used; unable to detect undefined names
     # Stubs can sometimes re-export entire modules.
     # Issues with using a star-imported name will be caught by type-checkers.

--- a/tests/mypy_test.py
+++ b/tests/mypy_test.py
@@ -610,13 +610,13 @@ def main() -> None:
     args = parser.parse_args(namespace=CommandLineArgs())
     versions = args.python_version or SUPPORTED_VERSIONS
     platforms = args.platform or [sys.platform]
-    filter = args.filter or DIRECTORIES_TO_TEST
+    path_filter = args.filter or DIRECTORIES_TO_TEST
     exclude = args.exclude or []
     summary = TestSummary()
     with tempfile.TemporaryDirectory() as td:
         td_path = Path(td)
         for version, platform in product(versions, platforms):
-            config = TestConfig(args.verbose, filter, exclude, version, platform)
+            config = TestConfig(args.verbose, path_filter, exclude, version, platform)
             version_summary = test_typeshed(args=config, tempdir=td_path)
             summary.merge(version_summary)
 


### PR DESCRIPTION
Ref https://github.com/python/typeshed/issues/13295
[flake8-builtins (A)](https://docs.astral.sh/ruff/rules/#flake8-builtins-a)

- A001-A004 should definitely be disabled in our stubs
- A005 is already disabled in stubs.
- A006 should never happen in stubs since there shouldn't be any lambda.
- See https://github.com/astral-sh/ruff/issues/15293 for more details

At that point, it' easier and more concise to disable the entire group in stubs.

So this group would only apply to our tests/scripts.