### PR TITLE
Enable Ruff PLW (Pylint Warning)

### DIFF
--- a/lib/ts_utils/utils.py
+++ b/lib/ts_utils/utils.py
@@ -123,11 +123,11 @@ def parse_stdlib_versions_file() -> SupportedVersionsDict:
     result: dict[str, tuple[VersionTuple, VersionTuple]] = {}
     with VERSIONS_PATH.open(encoding="UTF-8") as f:
         for line in f:
-            line = strip_comments(line)
-            if line == "":
+            stripped_line = strip_comments(line)
+            if stripped_line == "":
                 continue
-            m = VERSION_LINE_RE.match(line)
-            assert m, f"invalid VERSIONS line: {line}"
+            m = VERSION_LINE_RE.match(stripped_line)
+            assert m, f"invalid VERSIONS line: {stripped_line}"
             mod: str = m.group(1)
             assert mod not in result, f"Duplicate module {mod} in VERSIONS"
             min_version = _parse_version(m.group(2))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,9 +53,7 @@ select = [
     "I", # isort
     "N", # pep8-naming
     "PGH", # pygrep-hooks
-    "PLC", # Pylint Convention
-    "PLE", # Pylint Error
-    "PLR", # Pylint Refactor
+    "PL", # Pylint
     "RUF", # Ruff-specific and unused-noqa
     "TRY", # tryceratops
     "UP", # pyupgrade
@@ -183,15 +181,19 @@ ignore = [
     # Rules that are out of the control of stub authors:
     ###
     # Names in stubs should match the implementation, even if it's ambiguous.
+    # https://github.com/astral-sh/ruff/issues/15293
     "A", # flake8-builtins
-    "F403", # `from . import *` used; unable to detect undefined names
     # Stubs can sometimes re-export entire modules.
     # Issues with using a star-imported name will be caught by type-checkers.
+    "F403", # `from . import *` used; unable to detect undefined names
     "F405", # may be undefined, or defined from star imports
     # Most pep8-naming rules don't apply for third-party stubs like typeshed.
     # N811 to N814 could apply, but we often use them to disambiguate a name whilst making it look like a more common one
     "N8", # pep8-naming
+    # Stubs are allowed to use private variables (pyright's reportPrivateUsage is also disabled)
     "PLC2701", # Private name import from external module
+    # Names in stubs should match implementation
+    "PLW0211", # First argument of a static method should not be named `{argument_name}`
 ]
 "lib/ts_utils/**" = [
     # Doesn't affect stubs. The only re-exports we have should be in our local lib ts_utils

--- a/scripts/create_baseline_stubs.py
+++ b/scripts/create_baseline_stubs.py
@@ -59,17 +59,17 @@ def run_stubgen(package: str, output: str) -> None:
 
 def run_stubdefaulter(stub_dir: str) -> None:
     print(f"Running stubdefaulter: stubdefaulter --packages {stub_dir}")
-    subprocess.run(["stubdefaulter", "--packages", stub_dir])
+    subprocess.run(["stubdefaulter", "--packages", stub_dir], check=False)
 
 
 def run_black(stub_dir: str) -> None:
     print(f"Running Black: black {stub_dir}")
-    subprocess.run(["pre-commit", "run", "black", "--files", *glob.iglob(f"{stub_dir}/**/*.pyi")])
+    subprocess.run(["pre-commit", "run", "black", "--files", *glob.iglob(f"{stub_dir}/**/*.pyi")], check=False)
 
 
 def run_ruff(stub_dir: str) -> None:
     print(f"Running Ruff: ruff check {stub_dir} --fix-only")
-    subprocess.run([sys.executable, "-m", "ruff", "check", stub_dir, "--fix-only"])
+    subprocess.run([sys.executable, "-m", "ruff", "check", stub_dir, "--fix-only"], check=False)
 
 
 async def get_project_urls_from_pypi(project: str, session: aiohttp.ClientSession) -> dict[str, str]:
@@ -102,9 +102,9 @@ async def get_upstream_repo_url(project: str) -> str | None:
             url for url_name, url in project_urls.items() if url_name not in url_names_probably_pointing_to_source
         )
 
-        for url in urls_to_check:
+        for url_to_check in urls_to_check:
             # Remove `www.`; replace `http://` with `https://`
-            url = re.sub(r"^(https?://)?(www\.)?", "https://", url)
+            url = re.sub(r"^(https?://)?(www\.)?", "https://", url_to_check)
             netloc = urllib.parse.urlparse(url).netloc
             if netloc in {"gitlab.com", "github.com", "bitbucket.org", "foss.heptapod.net"}:
                 # truncate to https://site.com/user/repo

--- a/scripts/stubsabot.py
+++ b/scripts/stubsabot.py
@@ -754,8 +754,8 @@ async def main() -> None:
         dists_to_update = [path.name for path in STUBS_PATH.iterdir()]
 
     if args.action_level > ActionLevel.nothing:
-        subprocess.run(["git", "update-index", "--refresh"], capture_output=True)
-        diff_result = subprocess.run(["git", "diff-index", "HEAD", "--name-only"], text=True, capture_output=True)
+        subprocess.run(["git", "update-index", "--refresh"], capture_output=True, check=False)
+        diff_result = subprocess.run(["git", "diff-index", "HEAD", "--name-only"], text=True, capture_output=True, check=False)
         if diff_result.returncode:
             print("Unexpected exception!")
             print(diff_result.stdout)

--- a/scripts/sync_protobuf/_utils.py
+++ b/scripts/sync_protobuf/_utils.py
@@ -35,7 +35,9 @@ def run_protoc(
 ) -> str:
     """TODO: Describe parameters and return."""
     protoc_version = (
-        subprocess.run([sys.executable, "-m", "grpc_tools.protoc", "--version"], capture_output=True).stdout.decode().strip()
+        subprocess.run([sys.executable, "-m", "grpc_tools.protoc", "--version"], capture_output=True, check=False)
+        .stdout.decode()
+        .strip()
     )
     print()
     print(protoc_version)

--- a/scripts/sync_protobuf/google_protobuf.py
+++ b/scripts/sync_protobuf/google_protobuf.py
@@ -90,7 +90,7 @@ and {protoc_version} on \
     print("Updated protobuf/METADATA.toml")
 
     # Run pre-commit to cleanup the stubs
-    subprocess.run((sys.executable, "-m", "pre_commit", "run", "--files", *STUBS_FOLDER.rglob("*_pb2.pyi")))
+    subprocess.run((sys.executable, "-m", "pre_commit", "run", "--files", *STUBS_FOLDER.rglob("*_pb2.pyi")), check=False)
 
 
 if __name__ == "__main__":

--- a/scripts/sync_protobuf/s2clientprotocol.py
+++ b/scripts/sync_protobuf/s2clientprotocol.py
@@ -69,7 +69,7 @@ and {protoc_version} on \
     print("Updated s2clientprotocol/METADATA.toml")
 
     # Run pre-commit to cleanup the stubs
-    subprocess.run((sys.executable, "-m", "pre_commit", "run", "--files", *STUBS_FOLDER.rglob("*_pb2.pyi")))
+    subprocess.run((sys.executable, "-m", "pre_commit", "run", "--files", *STUBS_FOLDER.rglob("*_pb2.pyi")), check=False)
 
 
 if __name__ == "__main__":

--- a/scripts/sync_protobuf/tensorflow.py
+++ b/scripts/sync_protobuf/tensorflow.py
@@ -72,7 +72,7 @@ def post_creation() -> None:
 
     for path in STUBS_FOLDER.rglob("*_pb2.pyi"):
         print(f"Fixing imports in '{path}'")
-        with open(path) as file:
+        with open(path, encoding="utf-8") as file:
             filedata = file.read()
 
         # Replace the target string
@@ -80,7 +80,7 @@ def post_creation() -> None:
         filedata = re.sub(XLA_IMPORT_PATTERN, "\\1tensorflow.compiler.xla.", filedata)
 
         # Write the file out again
-        with open(path, "w") as file:
+        with open(path, "w", encoding="utf-8") as file:
             file.write(filedata)
 
     print()
@@ -137,7 +137,7 @@ and {protoc_version} on `tensorflow=={PACKAGE_VERSION}`.""",
     print("Updated tensorflow/METADATA.toml")
 
     # Run pre-commit to cleanup the stubs
-    subprocess.run((sys.executable, "-m", "pre_commit", "run", "--files", *STUBS_FOLDER.rglob("*_pb2.pyi")))
+    subprocess.run((sys.executable, "-m", "pre_commit", "run", "--files", *STUBS_FOLDER.rglob("*_pb2.pyi")), check=False)
 
 
 if __name__ == "__main__":

--- a/tests/mypy_test.py
+++ b/tests/mypy_test.py
@@ -277,7 +277,7 @@ def run_mypy(
         mypy_command = [python_path, "-m", "mypy", *mypy_args]
         if args.verbose:
             print(colored(f"running {' '.join(mypy_command)}", "blue"))
-        result = subprocess.run(mypy_command, capture_output=True, text=True, env=env_vars)
+        result = subprocess.run(mypy_command, capture_output=True, text=True, env=env_vars, check=False)
         if result.returncode:
             print_error(f"failure (exit code {result.returncode})\n")
             if result.stdout:
@@ -286,7 +286,7 @@ def run_mypy(
                 print_error(result.stderr)
             if non_types_dependencies and args.verbose:
                 print("Ran with the following environment:")
-                subprocess.run(["uv", "pip", "freeze"], env={**os.environ, "VIRTUAL_ENV": str(venv_dir)})
+                subprocess.run(["uv", "pip", "freeze"], env={**os.environ, "VIRTUAL_ENV": str(venv_dir)}, check=False)
                 print()
         else:
             print_success_msg()

--- a/tests/pyright_test.py
+++ b/tests/pyright_test.py
@@ -24,7 +24,7 @@ def main() -> None:
         sys.exit(1)
 
     try:
-        subprocess.run([npx, "--version"])
+        subprocess.run([npx, "--version"], check=False)
     except OSError:
         print("error running npx; is Node.js installed?", file=sys.stderr)
         sys.exit(1)
@@ -40,7 +40,7 @@ def main() -> None:
     command = [npx, f"pyright@{pyright_version}"] + sys.argv[1:]
     print_command(command)
 
-    ret = subprocess.run(command).returncode
+    ret = subprocess.run(command, check=False).returncode
     sys.exit(ret)
 
 

--- a/tests/regr_test.py
+++ b/tests/regr_test.py
@@ -224,7 +224,7 @@ def run_testcases(
             msg += f"{description}: MYPYPATH not set"
         msg += "\n"
         verbose_log(msg)
-    return subprocess.run(mypy_command, capture_output=True, text=True, env=env_vars)
+    return subprocess.run(mypy_command, capture_output=True, text=True, env=env_vars, check=False)
 
 
 @dataclass(frozen=True)

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -76,10 +76,10 @@ def main() -> None:
     pytype_result: subprocess.CompletedProcess[bytes] | None = None
 
     print("\nRunning pre-commit...")
-    pre_commit_result = subprocess.run(["pre-commit", "run", "--files", *Path(path).rglob("*")])
+    pre_commit_result = subprocess.run(["pre-commit", "run", "--files", *Path(path).rglob("*")], check=False)
 
     print("\nRunning check_typeshed_structure.py...")
-    check_structure_result = subprocess.run([sys.executable, "tests/check_typeshed_structure.py"])
+    check_structure_result = subprocess.run([sys.executable, "tests/check_typeshed_structure.py"], check=False)
 
     strict_params = _get_strict_params(path)
     print(f"\nRunning Pyright ({'stricter' if strict_params else 'base' } configs) for Python {python_version}...")
@@ -87,6 +87,7 @@ def main() -> None:
         [sys.executable, "tests/pyright_test.py", path, "--pythonversion", python_version, *strict_params],
         stderr=subprocess.PIPE,
         text=True,
+        check=False,
     )
     if re.match(_NPX_ERROR_PATTERN, pyright_result.stderr):
         print(_NPX_ERROR_MESSAGE)
@@ -98,16 +99,16 @@ def main() -> None:
         pyright_skipped = False
 
     print(f"\nRunning mypy for Python {python_version}...")
-    mypy_result = subprocess.run([sys.executable, "tests/mypy_test.py", path, "--python-version", python_version])
+    mypy_result = subprocess.run([sys.executable, "tests/mypy_test.py", path, "--python-version", python_version], check=False)
     # If mypy failed, stubtest will fail without any helpful error
     if mypy_result.returncode == 0:
         if folder == "stdlib":
             print("\nRunning stubtest...")
-            stubtest_result = subprocess.run([sys.executable, "tests/stubtest_stdlib.py", stub])
+            stubtest_result = subprocess.run([sys.executable, "tests/stubtest_stdlib.py", stub], check=False)
         else:
             if run_stubtest:
                 print("\nRunning stubtest...")
-                stubtest_result = subprocess.run([sys.executable, "tests/stubtest_third_party.py", stub])
+                stubtest_result = subprocess.run([sys.executable, "tests/stubtest_third_party.py", stub], check=False)
             else:
                 print(
                     colored(
@@ -122,7 +123,7 @@ def main() -> None:
 
     if find_spec("pytype"):
         print("\nRunning pytype...")
-        pytype_result = subprocess.run([sys.executable, "tests/pytype_test.py", path])
+        pytype_result = subprocess.run([sys.executable, "tests/pytype_test.py", path], check=False)
     else:
         print(
             colored(
@@ -149,7 +150,7 @@ def main() -> None:
             "-p",
             _TESTCASES_CONFIG_FILE,
         ]
-        pyright_testcases_result = subprocess.run(command, stderr=subprocess.PIPE, text=True)
+        pyright_testcases_result = subprocess.run(command, stderr=subprocess.PIPE, text=True, check=False)
         if re.match(_NPX_ERROR_PATTERN, pyright_testcases_result.stderr):
             print(_NPX_ERROR_MESSAGE)
             pyright_testcases_returncode = 0
@@ -164,6 +165,7 @@ def main() -> None:
             [sys.executable, "tests/regr_test.py", "stdlib" if folder == "stdlib" else stub, "--python-version", python_version],
             stderr=subprocess.PIPE,
             text=True,
+            check=False,
         )
         # No test means they all ran successfully (0 out of 0). Not all 3rd-party stubs have regression tests.
         if "No test cases found" in regr_test_result.stderr:

--- a/tests/stubtest_third_party.py
+++ b/tests/stubtest_third_party.py
@@ -147,11 +147,11 @@ def run_stubtest(
 
             print_divider()
             print("Python version: ", end="", flush=True)
-            ret = subprocess.run([sys.executable, "-VV"], capture_output=True)
+            ret = subprocess.run([sys.executable, "-VV"], capture_output=True, check=False)
             print_command_output(ret)
 
             print("\nRan with the following environment:")
-            ret = subprocess.run([pip_exe, "freeze", "--all"], capture_output=True)
+            ret = subprocess.run([pip_exe, "freeze", "--all"], capture_output=True, check=False)
             print_command_output(ret)
             if keep_tmp_dir:
                 print("Path to virtual environment:", venv_dir, flush=True)
@@ -163,7 +163,7 @@ def run_stubtest(
                 print()
             else:
                 print(f"Re-running stubtest with --generate-allowlist.\nAdd the following to {main_allowlist_path}:")
-                ret = subprocess.run([*stubtest_cmd, "--generate-allowlist"], env=stubtest_env, capture_output=True)
+                ret = subprocess.run([*stubtest_cmd, "--generate-allowlist"], env=stubtest_env, capture_output=True, check=False)
                 print_command_output(ret)
 
             print_divider()

--- a/tests/typecheck_typeshed.py
+++ b/tests/typecheck_typeshed.py
@@ -72,7 +72,7 @@ def run_mypy_as_subprocess(directory: str, platform: str, version: str) -> Retur
         "--custom-typeshed-dir",
         ".",
     ]
-    result = subprocess.run(command, capture_output=True, text=True)
+    result = subprocess.run(command, capture_output=True, text=True, check=False)
     if result.stderr:
         print_error(result.stderr)
     if result.stdout:


### PR DESCRIPTION
Ref https://github.com/python/typeshed/issues/13295
Rules: [Pylint Warning (PLW)](https://docs.astral.sh/ruff/rules/#warning-plw)

Having all 4 Pylint-based groups enabled slightly simplifies the selection to `PL`

[subprocess-run-without-check (PLW1510)](https://docs.astral.sh/ruff/rules/subprocess-run-without-check/#subprocess-run-without-check-plw1510) is the rule that asks for an explicit `check=` param to `subprocess.run` (might be good to also validate whether some of those calls *should* check the result).

[redefined-loop-name (PLW2901)](https://docs.astral.sh/ruff/rules/redefined-loop-name/#redefined-loop-name-plw2901) disallows overwriting a loop variable with an assignement.
Can catch some good code smells, but what it caught here feels quite pedantic. Maybe we could feature-request an exception for immediatly-reassigned loop variables? (which also feels cleaner than an additional comprehension/map)
