### PR TITLE
Enable Ruff flake8-use-pathlib (PTH) (autofix only)

### DIFF
--- a/lib/ts_utils/paths.py
+++ b/lib/ts_utils/paths.py
@@ -5,7 +5,7 @@ from typing import Final
 # installed into the user's virtual env, so we can't determine the path
 # to typeshed. Installing ts_utils editable would solve that, see
 # https://github.com/python/typeshed/pull/12806.
-TS_BASE_PATH: Final = Path("")
+TS_BASE_PATH: Final = Path()
 STDLIB_PATH: Final = TS_BASE_PATH / "stdlib"
 STUBS_PATH: Final = TS_BASE_PATH / "stubs"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,9 @@ select = [
     "FURB169", # Compare the identities of `{object}` and None instead of their respective types
     "FURB177", # Prefer `Path.cwd()` over `Path().resolve()` for current-directory lookups
     "FURB187", # Use of assignment of `reversed` on list `{name}`
+    # Autofixable flake8-use-pathlib only
+    "PTH201", # Do not pass the current directory explicitly to `Path`
+    "PTH210", # Invalid suffix passed to `.with_suffix()`
     # PYI: only enable rules that have autofixes and that we always want to fix (even manually),
     # avoids duplicate # noqa with flake8-pyi
     "PYI009", # Empty body should contain `...`, not pass


### PR DESCRIPTION
Ref https://github.com/python/typeshed/issues/13295
[flake8-use-pathlib (PTH)](https://docs.astral.sh/ruff/rules/#flake8-use-pathlib-pth)

This category has a lot of good rules regarding `pathlib`, but some rules are also basically asking for a refactoring.
So let's start easy with what's autofixable. We'll look at the other rules in a different PR.