### PR TITLE
Disable Python version updates for `actions/setup-python` from Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -18,6 +18,16 @@
       "schedule": ["every 3 months on the first day of the month"]
     },
     {
+      // This package rule disables updates for `actions/setup-python` Python versions:
+      // it's better to do these manually as there's often a reason why we can't use
+      // the latest Python version in CI for a specific job
+      groupName: "Python versions",
+      matchManagers: ["github-actions"],
+      matchPackageNames: ["python"],
+      description: "Disable PRs updating Python versions",
+      enabled: false,
+    },
+    {
       "groupName": "most test/lint dependencies",
       "matchManagers": ["pip_requirements", "pre-commit"],
       "excludePackageNames": ["pytype", "pyright"],


### PR DESCRIPTION
This PR:
- Adds a new group with `enabled: false` that covers Python version updates such as https://github.com/python/typeshed/pull/13753. I think it's better for us to do these manually: there's often a specific reason why we can't use the latest Python version for a certain CI job, so automated PRs are just annoying.
- Switches our Renovate config to use `.json5` as the file format rather than `.json`. JSON5 is an extended version of JSON that allows you to use comments, trailing commas, and some other nice things.

Closes https://github.com/python/typeshed/pull/13753