### PR TITLE
make the type-parameter of `ctypes.py_object` optional

### DIFF
--- a/stdlib/ctypes/__init__.pyi
+++ b/stdlib/ctypes/__init__.pyi
@@ -27,8 +27,8 @@ from _ctypes import (
 from _typeshed import StrPath
 from ctypes._endian import BigEndianStructure as BigEndianStructure, LittleEndianStructure as LittleEndianStructure
 from types import GenericAlias
-from typing import Any, ClassVar, Generic, TypeVar, type_check_only
-from typing_extensions import Self, TypeAlias, deprecated
+from typing import Any, ClassVar, Generic, type_check_only
+from typing_extensions import Self, TypeAlias, TypeVar, deprecated
 
 if sys.platform == "win32":
     from _ctypes import FormatError as FormatError, get_last_error as get_last_error, set_last_error as set_last_error
@@ -36,7 +36,7 @@ if sys.platform == "win32":
 if sys.version_info >= (3, 11):
     from ctypes._endian import BigEndianUnion as BigEndianUnion, LittleEndianUnion as LittleEndianUnion
 
-_T = TypeVar("_T")
+_T = TypeVar("_T", default=Any)
 _DLLT = TypeVar("_DLLT", bound=CDLL)
 _CT = TypeVar("_CT", bound=_CData)
 


### PR DESCRIPTION
Type-checkers currently require a generic type argument for `ctypes.py_object`. But at runtime this can raise a `TypeError` if not quoted.
We can avoid this contradictory paradox that's sending conflicting mixed signals by setting the type-parameter default of `ctypes.py_object` to `Any`.