### PR TITLE
Drop Python 3.8 support in typeshed utilities

### DIFF
--- a/lib/ts_utils/metadata.py
+++ b/lib/ts_utils/metadata.py
@@ -10,8 +10,8 @@ import urllib.parse
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Final, NamedTuple, final
-from typing_extensions import Annotated, TypeGuard
+from typing import Annotated, Final, NamedTuple, final
+from typing_extensions import TypeGuard
 
 import tomli
 import tomlkit

--- a/lib/ts_utils/utils.py
+++ b/lib/ts_utils/utils.py
@@ -7,7 +7,7 @@ import sys
 from collections.abc import Iterable, Mapping
 from functools import lru_cache
 from pathlib import Path
-from typing import Any, Dict, Final, NamedTuple, Tuple
+from typing import Any, Final, NamedTuple
 from typing_extensions import TypeAlias
 
 import pathspec
@@ -111,8 +111,8 @@ def get_mypy_req() -> str:
 # Parsing the stdlib/VERSIONS file
 # ====================================================================
 
-VersionTuple: TypeAlias = Tuple[int, int]
-SupportedVersionsDict: TypeAlias = Dict[str, Tuple[VersionTuple, VersionTuple]]
+VersionTuple: TypeAlias = tuple[int, int]
+SupportedVersionsDict: TypeAlias = dict[str, tuple[VersionTuple, VersionTuple]]
 
 VERSIONS_PATH = STDLIB_PATH / "VERSIONS"
 VERSION_LINE_RE = re.compile(r"^([a-zA-Z_][a-zA-Z0-9_.]*): ([23]\.\d{1,2})-([23]\.\d{1,2})?$")

--- a/scripts/sync_protobuf/_utils.py
+++ b/scripts/sync_protobuf/_utils.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import subprocess
 import sys
+from collections.abc import Iterable
 from http.client import HTTPResponse
-from typing import TYPE_CHECKING, Iterable
+from typing import TYPE_CHECKING
 from urllib.request import urlopen
 from zipfile import ZipFile
 

--- a/tests/mypy_test.py
+++ b/tests/mypy_test.py
@@ -18,8 +18,8 @@ from enum import Enum
 from itertools import product
 from pathlib import Path
 from threading import Lock
-from typing import Any, NamedTuple
-from typing_extensions import Annotated, TypeAlias
+from typing import Annotated, Any, NamedTuple
+from typing_extensions import TypeAlias
 
 import tomli
 from packaging.requirements import Requirement


### PR DESCRIPTION
Refs #12112

Resolves some things ruff complains about when using `target-version = "py39"`.