### PR TITLE
Make `code.InteractiveInterpreter#locals` a dict not a mapping

### DIFF
--- a/stdlib/code.pyi
+++ b/stdlib/code.pyi
@@ -1,15 +1,15 @@
 import sys
 from codeop import CommandCompiler
-from collections.abc import Callable, Mapping
+from collections.abc import Callable
 from types import CodeType
 from typing import Any
 
 __all__ = ["InteractiveInterpreter", "InteractiveConsole", "interact", "compile_command"]
 
 class InteractiveInterpreter:
-    locals: Mapping[str, Any]  # undocumented
+    locals: dict[str, Any]  # undocumented
     compile: CommandCompiler  # undocumented
-    def __init__(self, locals: Mapping[str, Any] | None = None) -> None: ...
+    def __init__(self, locals: dict[str, Any] | None = None) -> None: ...
     def runsource(self, source: str, filename: str = "<input>", symbol: str = "single") -> bool: ...
     def runcode(self, code: CodeType) -> None: ...
     if sys.version_info >= (3, 13):
@@ -25,11 +25,11 @@ class InteractiveConsole(InteractiveInterpreter):
     filename: str  # undocumented
     if sys.version_info >= (3, 13):
         def __init__(
-            self, locals: Mapping[str, Any] | None = None, filename: str = "<console>", *, local_exit: bool = False
+            self, locals: dict[str, Any] | None = None, filename: str = "<console>", *, local_exit: bool = False
         ) -> None: ...
         def push(self, line: str, filename: str | None = None) -> bool: ...
     else:
-        def __init__(self, locals: Mapping[str, Any] | None = None, filename: str = "<console>") -> None: ...
+        def __init__(self, locals: dict[str, Any] | None = None, filename: str = "<console>") -> None: ...
         def push(self, line: str) -> bool: ...
 
     def interact(self, banner: str | None = None, exitmsg: str | None = None) -> None: ...
@@ -40,7 +40,7 @@ if sys.version_info >= (3, 13):
     def interact(
         banner: str | None = None,
         readfunc: Callable[[str], str] | None = None,
-        local: Mapping[str, Any] | None = None,
+        local: dict[str, Any] | None = None,
         exitmsg: str | None = None,
         local_exit: bool = False,
     ) -> None: ...
@@ -49,7 +49,7 @@ else:
     def interact(
         banner: str | None = None,
         readfunc: Callable[[str], str] | None = None,
-        local: Mapping[str, Any] | None = None,
+        local: dict[str, Any] | None = None,
         exitmsg: str | None = None,
     ) -> None: ...
 


### PR DESCRIPTION
Fixes #13768

```pycon
>>> interact(local=MappingProxyType({"a": 5}))
Python 3.13.1 (tags/v3.13.1:0671451, Dec  3 2024, 19:06:28) [MSC v.1942 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
(InteractiveConsole)
>>> a
TypeError: exec() globals must be a dict, not mappingproxy
```