### PR TITLE
Small improvement of `ts_utils.get_gitignore_spec`

### DIFF
--- a/lib/ts_utils/utils.py
+++ b/lib/ts_utils/utils.py
@@ -209,7 +209,7 @@ def allowlists(distribution_name: str) -> list[str]:
 @cache
 def get_gitignore_spec() -> pathspec.PathSpec:
     with open(".gitignore", encoding="UTF-8") as f:
-        return pathspec.PathSpec.from_lines("gitwildmatch", f.readlines())
+        return pathspec.GitIgnoreSpec.from_lines(f)
 
 
 def spec_matches_path(spec: pathspec.PathSpec, path: Path) -> bool:


### PR DESCRIPTION
https://github.com/python/typeshed/pull/13795#discussion_r2029337823
> There is a specialized class, ``pathspec.GitIgnoreSpec``, which more closely
implements the behavior of **gitignore**. This uses ``GitWildMatchPattern``
pattern by default and handles some edge cases differently from the generic
``PathSpec`` class. ``GitIgnoreSpec`` can be used without specifying the pattern
factory::
> 
> 	>>> spec = pathspec.GitIgnoreSpec.from_lines(spec_text.splitlines())

https://github.com/python/typeshed/pull/13795#discussion_r2029346786
> Could also omit the call to `.readlines()`. `GitIgnoreSpec.from_lines` takes an iterable of lines, so passing the file i/o object directly would work. Not sure if there's any reason to prefer one way or another, though

