### PR TITLE
Mark AST with kwargs as deprecated

### DIFF
--- a/stdlib/ast.pyi
+++ b/stdlib/ast.pyi
@@ -34,6 +34,12 @@ class _Attributes(TypedDict, Generic[_EndPositionT], total=False):
 # but they consider themselves to live in the ast module,
 # so we'll define the stubs in this file.
 class AST:
+    @overload
+    def __init__(self) -> None: ...
+    if sys.version_info < (3, 15):
+        @deprecated("Support for arbitrary keyword arguments is deprecated and will be removed in Python 3.15.")
+        @overload
+        def __init__(self, **kwargs: Any) -> None: ...
     if sys.version_info >= (3, 10):
         __match_args__ = ()
     _attributes: ClassVar[tuple[str, ...]]

--- a/stdlib/ast.pyi
+++ b/stdlib/ast.pyi
@@ -37,8 +37,8 @@ class AST:
     @overload
     def __init__(self) -> None: ...
     if sys.version_info < (3, 15):
-        @deprecated("Support for arbitrary keyword arguments is deprecated and will be removed in Python 3.15.")
         @overload
+        @deprecated("Support for arbitrary keyword arguments is deprecated and will be removed in Python 3.15.")
         def __init__(self, **kwargs: Any) -> None: ...
     if sys.version_info >= (3, 10):
         __match_args__ = ()


### PR DESCRIPTION
Closes #4760

Even if this PR is rejected (preferring to not even expose the kwargs functionality in the first place), then I think #4760 should still be closed as everything else seems to be completed.