### PR TITLE
Fix incorrect keyword-only arguments in tarfile.open()

### DIFF
--- a/stdlib/@tests/test_cases/check_tarfile.py
+++ b/stdlib/@tests/test_cases/check_tarfile.py
@@ -11,3 +11,7 @@ tarfile.open("test.tar.xz", "w:xz", preset=9)
 # Test with invalid preset values
 tarfile.open("test.tar.xz", "w:xz", preset=-1)  # type: ignore
 tarfile.open("test.tar.xz", "w:xz", preset=10)  # type: ignore
+
+# Test pipe modes
+tarfile.open("test.tar.xz", "r|*")
+tarfile.open("test.tar.xz", mode="r|*")

--- a/stdlib/tarfile.pyi
+++ b/stdlib/tarfile.pyi
@@ -306,11 +306,49 @@ class TarFile:
     @classmethod
     def open(
         cls,
+        name: StrOrBytesPath | ReadableBuffer | None,
+        mode: Literal["r|*", "r|", "r|gz", "r|bz2", "r|xz"],
+        fileobj: _Fileobj | None = None,
+        bufsize: int = 10240,
+        *,
+        format: int | None = ...,
+        tarinfo: type[TarInfo] | None = ...,
+        dereference: bool | None = ...,
+        ignore_zeros: bool | None = ...,
+        encoding: str | None = ...,
+        errors: str = ...,
+        pax_headers: Mapping[str, str] | None = ...,
+        debug: int | None = ...,
+        errorlevel: int | None = ...,
+    ) -> Self: ...
+    @overload
+    @classmethod
+    def open(
+        cls,
         name: StrOrBytesPath | ReadableBuffer | None = None,
         *,
         mode: Literal["r|*", "r|", "r|gz", "r|bz2", "r|xz"],
         fileobj: _Fileobj | None = None,
         bufsize: int = 10240,
+        format: int | None = ...,
+        tarinfo: type[TarInfo] | None = ...,
+        dereference: bool | None = ...,
+        ignore_zeros: bool | None = ...,
+        encoding: str | None = ...,
+        errors: str = ...,
+        pax_headers: Mapping[str, str] | None = ...,
+        debug: int | None = ...,
+        errorlevel: int | None = ...,
+    ) -> Self: ...
+    @overload
+    @classmethod
+    def open(
+        cls,
+        name: StrOrBytesPath | WriteableBuffer | None,
+        mode: Literal["w|", "w|xz"],
+        fileobj: _Fileobj | None = None,
+        bufsize: int = 10240,
+        *,
         format: int | None = ...,
         tarinfo: type[TarInfo] | None = ...,
         dereference: bool | None = ...,
@@ -339,6 +377,26 @@ class TarFile:
         pax_headers: Mapping[str, str] | None = ...,
         debug: int | None = ...,
         errorlevel: int | None = ...,
+    ) -> Self: ...
+    @overload
+    @classmethod
+    def open(
+        cls,
+        name: StrOrBytesPath | WriteableBuffer | None,
+        mode: Literal["w|gz", "w|bz2"],
+        fileobj: _Fileobj | None = None,
+        bufsize: int = 10240,
+        *,
+        format: int | None = ...,
+        tarinfo: type[TarInfo] | None = ...,
+        dereference: bool | None = ...,
+        ignore_zeros: bool | None = ...,
+        encoding: str | None = ...,
+        errors: str = ...,
+        pax_headers: Mapping[str, str] | None = ...,
+        debug: int | None = ...,
+        errorlevel: int | None = ...,
+        compresslevel: int = 9,
     ) -> Self: ...
     @overload
     @classmethod


### PR DESCRIPTION
Per https://docs.python.org/3/library/tarfile.html#tarfile.open all of `name`, `mode`, `fileobj`, and `bufsize` are permitted to be positional.