### PR TITLE
auth0-python: Cleanup re-exports leftovers from stubgen

### DIFF
--- a/stubs/auth0-python/@tests/stubtest_allowlist.txt
+++ b/stubs/auth0-python/@tests/stubtest_allowlist.txt
@@ -5,13 +5,6 @@ auth0\.test.*
 auth0\..*_async
 
 # Inconsistently implemented, ommitted
-auth0.asyncify.AsyncRestClient.file_post
-auth0.authentication.async_token_verifier.AsyncRestClient.file_post
 auth0.management.Auth0\..*
 auth0.rest_async.AsyncRestClient.file_post
 auth0.authentication.async_token_verifier.AsyncTokenVerifier.verify
-
-# TYPE_CHECKING override makes these show up wrong
-auth0.management.async_auth0.RestClientOptions
-auth0.management.auth0.RestClientOptions
-auth0.rest.RequestsResponse

--- a/stubs/auth0-python/auth0/__init__.pyi
+++ b/stubs/auth0-python/auth0/__init__.pyi
@@ -1,7 +1,3 @@
-from auth0.exceptions import (
-    Auth0Error as Auth0Error,
-    RateLimitError as RateLimitError,
-    TokenValidationError as TokenValidationError,
-)
+from auth0.exceptions import Auth0Error, RateLimitError, TokenValidationError
 
 __all__ = ("Auth0Error", "RateLimitError", "TokenValidationError")

--- a/stubs/auth0-python/auth0/asyncify.pyi
+++ b/stubs/auth0-python/auth0/asyncify.pyi
@@ -1,6 +1,6 @@
-from auth0.authentication import Users as Users
-from auth0.authentication.base import AuthenticationBase as AuthenticationBase
-from auth0.rest import RestClientOptions as RestClientOptions
-from auth0.rest_async import AsyncRestClient as AsyncRestClient
+from typing import TypeVar
 
-def asyncify(cls): ...
+_T = TypeVar("_T")
+
+# See note in stubs/auth0-python/@tests/stubtest_allowlist.txt about _async methods
+def asyncify(cls: type[_T]) -> type[_T]: ...

--- a/stubs/auth0-python/auth0/authentication/__init__.pyi
+++ b/stubs/auth0-python/auth0/authentication/__init__.pyi
@@ -1,10 +1,10 @@
-from .database import Database as Database
-from .delegated import Delegated as Delegated
-from .enterprise import Enterprise as Enterprise
-from .get_token import GetToken as GetToken
-from .passwordless import Passwordless as Passwordless
-from .revoke_token import RevokeToken as RevokeToken
-from .social import Social as Social
-from .users import Users as Users
+from .database import Database
+from .delegated import Delegated
+from .enterprise import Enterprise
+from .get_token import GetToken
+from .passwordless import Passwordless
+from .revoke_token import RevokeToken
+from .social import Social
+from .users import Users
 
 __all__ = ("Database", "Delegated", "Enterprise", "GetToken", "Passwordless", "RevokeToken", "Social", "Users")

--- a/stubs/auth0-python/auth0/authentication/async_token_verifier.pyi
+++ b/stubs/auth0-python/auth0/authentication/async_token_verifier.pyi
@@ -1,10 +1,4 @@
-from .. import TokenValidationError as TokenValidationError
-from ..rest_async import AsyncRestClient as AsyncRestClient
-from .token_verifier import (
-    AsymmetricSignatureVerifier as AsymmetricSignatureVerifier,
-    JwksFetcher as JwksFetcher,
-    TokenVerifier as TokenVerifier,
-)
+from .token_verifier import AsymmetricSignatureVerifier, JwksFetcher, TokenVerifier
 
 class AsyncAsymmetricSignatureVerifier(AsymmetricSignatureVerifier):
     def __init__(self, jwks_url: str, algorithm: str = "RS256") -> None: ...

--- a/stubs/auth0-python/auth0/authentication/back_channel_login.pyi
+++ b/stubs/auth0-python/auth0/authentication/back_channel_login.pyi
@@ -1,4 +1,4 @@
-from .base import AuthenticationBase as AuthenticationBase
+from .base import AuthenticationBase
 
 class BackChannelLogin(AuthenticationBase):
     def back_channel_login(self, binding_message: str, login_hint: str, scope: str, **kwargs): ...

--- a/stubs/auth0-python/auth0/authentication/base.pyi
+++ b/stubs/auth0-python/auth0/authentication/base.pyi
@@ -1,10 +1,8 @@
 from _typeshed import Incomplete
 from typing import Final
 
-from auth0.rest import RestClient as RestClient, RestClientOptions as RestClientOptions
-from auth0.types import RequestData as RequestData
-
-from .client_authentication import add_client_authentication as add_client_authentication
+from auth0.rest import RestClient
+from auth0.types import RequestData
 
 UNKNOWN_ERROR: Final[str]
 

--- a/stubs/auth0-python/auth0/authentication/database.pyi
+++ b/stubs/auth0-python/auth0/authentication/database.pyi
@@ -1,6 +1,6 @@
 from _typeshed import Incomplete
 
-from .base import AuthenticationBase as AuthenticationBase
+from .base import AuthenticationBase
 
 class Database(AuthenticationBase):
     def signup(

--- a/stubs/auth0-python/auth0/authentication/delegated.pyi
+++ b/stubs/auth0-python/auth0/authentication/delegated.pyi
@@ -1,4 +1,4 @@
-from .base import AuthenticationBase as AuthenticationBase
+from .base import AuthenticationBase
 
 class Delegated(AuthenticationBase):
     def get_token(

--- a/stubs/auth0-python/auth0/authentication/enterprise.pyi
+++ b/stubs/auth0-python/auth0/authentication/enterprise.pyi
@@ -1,4 +1,4 @@
-from .base import AuthenticationBase as AuthenticationBase
+from .base import AuthenticationBase
 
 class Enterprise(AuthenticationBase):
     def saml_metadata(self): ...

--- a/stubs/auth0-python/auth0/authentication/get_token.pyi
+++ b/stubs/auth0-python/auth0/authentication/get_token.pyi
@@ -1,4 +1,4 @@
-from .base import AuthenticationBase as AuthenticationBase
+from .base import AuthenticationBase
 
 class GetToken(AuthenticationBase):
     def authorization_code(self, code: str, redirect_uri: str | None, grant_type: str = "authorization_code"): ...

--- a/stubs/auth0-python/auth0/authentication/passwordless.pyi
+++ b/stubs/auth0-python/auth0/authentication/passwordless.pyi
@@ -1,4 +1,4 @@
-from .base import AuthenticationBase as AuthenticationBase
+from .base import AuthenticationBase
 
 class Passwordless(AuthenticationBase):
     def email(self, email: str, send: str = "link", auth_params: dict[str, str] | None = None): ...

--- a/stubs/auth0-python/auth0/authentication/pushed_authorization_requests.pyi
+++ b/stubs/auth0-python/auth0/authentication/pushed_authorization_requests.pyi
@@ -1,4 +1,4 @@
-from .base import AuthenticationBase as AuthenticationBase
+from .base import AuthenticationBase
 
 class PushedAuthorizationRequests(AuthenticationBase):
     def pushed_authorization_request(self, response_type: str, redirect_uri: str, **kwargs): ...

--- a/stubs/auth0-python/auth0/authentication/revoke_token.pyi
+++ b/stubs/auth0-python/auth0/authentication/revoke_token.pyi
@@ -1,4 +1,4 @@
-from .base import AuthenticationBase as AuthenticationBase
+from .base import AuthenticationBase
 
 class RevokeToken(AuthenticationBase):
     def revoke_refresh_token(self, token: str): ...

--- a/stubs/auth0-python/auth0/authentication/social.pyi
+++ b/stubs/auth0-python/auth0/authentication/social.pyi
@@ -1,4 +1,4 @@
-from .base import AuthenticationBase as AuthenticationBase
+from .base import AuthenticationBase
 
 class Social(AuthenticationBase):
     def login(self, access_token: str, connection: str, scope: str = "openid"): ...

--- a/stubs/auth0-python/auth0/authentication/token_verifier.pyi
+++ b/stubs/auth0-python/auth0/authentication/token_verifier.pyi
@@ -1,8 +1,6 @@
 from _typeshed import Incomplete
 from typing import ClassVar
 
-from auth0.exceptions import TokenValidationError as TokenValidationError
-
 class SignatureVerifier:
     DISABLE_JWT_CHECKS: ClassVar[dict[str, bool]]
     def __init__(self, algorithm: str) -> None: ...

--- a/stubs/auth0-python/auth0/authentication/users.pyi
+++ b/stubs/auth0-python/auth0/authentication/users.pyi
@@ -1,7 +1,7 @@
 from _typeshed import Incomplete
 
-from auth0.rest import RestClient as RestClient, RestClientOptions as RestClientOptions
-from auth0.types import TimeoutType as TimeoutType
+from auth0.rest import RestClient
+from auth0.types import TimeoutType
 
 class Users:
     domain: str

--- a/stubs/auth0-python/auth0/management/__init__.pyi
+++ b/stubs/auth0-python/auth0/management/__init__.pyi
@@ -1,33 +1,33 @@
-from .actions import Actions as Actions
-from .attack_protection import AttackProtection as AttackProtection
-from .auth0 import Auth0 as Auth0
-from .blacklists import Blacklists as Blacklists
-from .branding import Branding as Branding
-from .client_credentials import ClientCredentials as ClientCredentials
-from .client_grants import ClientGrants as ClientGrants
-from .clients import Clients as Clients
-from .connections import Connections as Connections
-from .custom_domains import CustomDomains as CustomDomains
-from .device_credentials import DeviceCredentials as DeviceCredentials
-from .email_templates import EmailTemplates as EmailTemplates
-from .emails import Emails as Emails
-from .grants import Grants as Grants
-from .guardian import Guardian as Guardian
-from .hooks import Hooks as Hooks
-from .jobs import Jobs as Jobs
-from .log_streams import LogStreams as LogStreams
-from .logs import Logs as Logs
-from .organizations import Organizations as Organizations
-from .resource_servers import ResourceServers as ResourceServers
-from .roles import Roles as Roles
-from .rules import Rules as Rules
-from .rules_configs import RulesConfigs as RulesConfigs
-from .stats import Stats as Stats
-from .tenants import Tenants as Tenants
-from .tickets import Tickets as Tickets
-from .user_blocks import UserBlocks as UserBlocks
-from .users import Users as Users
-from .users_by_email import UsersByEmail as UsersByEmail
+from .actions import Actions
+from .attack_protection import AttackProtection
+from .auth0 import Auth0
+from .blacklists import Blacklists
+from .branding import Branding
+from .client_credentials import ClientCredentials
+from .client_grants import ClientGrants
+from .clients import Clients
+from .connections import Connections
+from .custom_domains import CustomDomains
+from .device_credentials import DeviceCredentials
+from .email_templates import EmailTemplates
+from .emails import Emails
+from .grants import Grants
+from .guardian import Guardian
+from .hooks import Hooks
+from .jobs import Jobs
+from .log_streams import LogStreams
+from .logs import Logs
+from .organizations import Organizations
+from .resource_servers import ResourceServers
+from .roles import Roles
+from .rules import Rules
+from .rules_configs import RulesConfigs
+from .stats import Stats
+from .tenants import Tenants
+from .tickets import Tickets
+from .user_blocks import UserBlocks
+from .users import Users
+from .users_by_email import UsersByEmail
 
 __all__ = (
     "Auth0",

--- a/stubs/auth0-python/auth0/management/actions.pyi
+++ b/stubs/auth0-python/auth0/management/actions.pyi
@@ -1,7 +1,7 @@
 from _typeshed import Incomplete
 
-from ..rest import RestClient as RestClient, RestClientOptions as RestClientOptions
-from ..types import TimeoutType as TimeoutType
+from ..rest import RestClientOptions
+from ..types import TimeoutType
 
 class Actions:
     domain: Incomplete

--- a/stubs/auth0-python/auth0/management/async_auth0.pyi
+++ b/stubs/auth0-python/auth0/management/async_auth0.pyi
@@ -1,10 +1,7 @@
 from types import TracebackType
 from typing_extensions import Self
 
-from auth0.rest import RestClientOptions as RestClientOptions
-
-from ..asyncify import asyncify as asyncify
-from .auth0 import Auth0 as Auth0
+from auth0.rest import RestClientOptions
 
 class AsyncAuth0:
     def __init__(self, domain: str, token: str, rest_options: RestClientOptions | None = None) -> None: ...

--- a/stubs/auth0-python/auth0/management/attack_protection.pyi
+++ b/stubs/auth0-python/auth0/management/attack_protection.pyi
@@ -1,7 +1,7 @@
 from _typeshed import Incomplete
 
-from ..rest import RestClient as RestClient, RestClientOptions as RestClientOptions
-from ..types import TimeoutType as TimeoutType
+from ..rest import RestClientOptions
+from ..types import TimeoutType
 
 class AttackProtection:
     domain: Incomplete

--- a/stubs/auth0-python/auth0/management/auth0.pyi
+++ b/stubs/auth0-python/auth0/management/auth0.pyi
@@ -1,67 +1,65 @@
-from _typeshed import Incomplete
+from auth0.rest import RestClientOptions
 
-from auth0.rest import RestClientOptions as RestClientOptions
-
-from .actions import Actions as Actions
-from .attack_protection import AttackProtection as AttackProtection
-from .blacklists import Blacklists as Blacklists
-from .branding import Branding as Branding
-from .client_credentials import ClientCredentials as ClientCredentials
-from .client_grants import ClientGrants as ClientGrants
-from .clients import Clients as Clients
-from .connections import Connections as Connections
-from .custom_domains import CustomDomains as CustomDomains
-from .device_credentials import DeviceCredentials as DeviceCredentials
-from .email_templates import EmailTemplates as EmailTemplates
-from .emails import Emails as Emails
-from .grants import Grants as Grants
-from .guardian import Guardian as Guardian
-from .hooks import Hooks as Hooks
-from .jobs import Jobs as Jobs
-from .log_streams import LogStreams as LogStreams
-from .logs import Logs as Logs
-from .organizations import Organizations as Organizations
-from .prompts import Prompts as Prompts
-from .resource_servers import ResourceServers as ResourceServers
-from .roles import Roles as Roles
-from .rules import Rules as Rules
-from .rules_configs import RulesConfigs as RulesConfigs
-from .stats import Stats as Stats
-from .tenants import Tenants as Tenants
-from .tickets import Tickets as Tickets
-from .user_blocks import UserBlocks as UserBlocks
-from .users import Users as Users
-from .users_by_email import UsersByEmail as UsersByEmail
+from .actions import Actions
+from .attack_protection import AttackProtection
+from .blacklists import Blacklists
+from .branding import Branding
+from .client_credentials import ClientCredentials
+from .client_grants import ClientGrants
+from .clients import Clients
+from .connections import Connections
+from .custom_domains import CustomDomains
+from .device_credentials import DeviceCredentials
+from .email_templates import EmailTemplates
+from .emails import Emails
+from .grants import Grants
+from .guardian import Guardian
+from .hooks import Hooks
+from .jobs import Jobs
+from .log_streams import LogStreams
+from .logs import Logs
+from .organizations import Organizations
+from .prompts import Prompts
+from .resource_servers import ResourceServers
+from .roles import Roles
+from .rules import Rules
+from .rules_configs import RulesConfigs
+from .stats import Stats
+from .tenants import Tenants
+from .tickets import Tickets
+from .user_blocks import UserBlocks
+from .users import Users
+from .users_by_email import UsersByEmail
 
 class Auth0:
-    actions: Incomplete
-    attack_protection: Incomplete
-    blacklists: Incomplete
-    branding: Incomplete
-    client_credentials: Incomplete
-    client_grants: Incomplete
-    clients: Incomplete
-    connections: Incomplete
-    custom_domains: Incomplete
-    device_credentials: Incomplete
-    email_templates: Incomplete
-    emails: Incomplete
-    grants: Incomplete
-    guardian: Incomplete
-    hooks: Incomplete
-    jobs: Incomplete
-    log_streams: Incomplete
-    logs: Incomplete
-    organizations: Incomplete
-    prompts: Incomplete
-    resource_servers: Incomplete
-    roles: Incomplete
-    rules_configs: Incomplete
-    rules: Incomplete
-    stats: Incomplete
-    tenants: Incomplete
-    tickets: Incomplete
-    user_blocks: Incomplete
-    users_by_email: Incomplete
-    users: Incomplete
+    actions: Actions
+    attack_protection: AttackProtection
+    blacklists: Blacklists
+    branding: Branding
+    client_credentials: ClientCredentials
+    client_grants: ClientGrants
+    clients: Clients
+    connections: Connections
+    custom_domains: CustomDomains
+    device_credentials: DeviceCredentials
+    email_templates: EmailTemplates
+    emails: Emails
+    grants: Grants
+    guardian: Guardian
+    hooks: Hooks
+    jobs: Jobs
+    log_streams: LogStreams
+    logs: Logs
+    organizations: Organizations
+    prompts: Prompts
+    resource_servers: ResourceServers
+    roles: Roles
+    rules_configs: RulesConfigs
+    rules: Rules
+    stats: Stats
+    tenants: Tenants
+    tickets: Tickets
+    user_blocks: UserBlocks
+    users_by_email: UsersByEmail
+    users: Users
     def __init__(self, domain: str, token: str, rest_options: RestClientOptions | None = None) -> None: ...

--- a/stubs/auth0-python/auth0/management/blacklists.pyi
+++ b/stubs/auth0-python/auth0/management/blacklists.pyi
@@ -1,7 +1,7 @@
 from _typeshed import Incomplete
 
-from ..rest import RestClient as RestClient, RestClientOptions as RestClientOptions
-from ..types import TimeoutType as TimeoutType
+from ..rest import RestClientOptions
+from ..types import TimeoutType
 
 class Blacklists:
     url: Incomplete

--- a/stubs/auth0-python/auth0/management/branding.pyi
+++ b/stubs/auth0-python/auth0/management/branding.pyi
@@ -1,7 +1,7 @@
 from _typeshed import Incomplete
 
-from ..rest import RestClient as RestClient, RestClientOptions as RestClientOptions
-from ..types import TimeoutType as TimeoutType
+from ..rest import RestClientOptions
+from ..types import TimeoutType
 
 class Branding:
     domain: Incomplete

--- a/stubs/auth0-python/auth0/management/client_credentials.pyi
+++ b/stubs/auth0-python/auth0/management/client_credentials.pyi
@@ -1,7 +1,7 @@
 from _typeshed import Incomplete
 
-from ..rest import RestClient as RestClient, RestClientOptions as RestClientOptions
-from ..types import TimeoutType as TimeoutType
+from ..rest import RestClientOptions
+from ..types import TimeoutType
 
 class ClientCredentials:
     domain: Incomplete

--- a/stubs/auth0-python/auth0/management/client_grants.pyi
+++ b/stubs/auth0-python/auth0/management/client_grants.pyi
@@ -1,7 +1,7 @@
 from _typeshed import Incomplete
 
-from ..rest import RestClient as RestClient, RestClientOptions as RestClientOptions
-from ..types import TimeoutType as TimeoutType
+from ..rest import RestClientOptions
+from ..types import TimeoutType
 
 class ClientGrants:
     domain: Incomplete

--- a/stubs/auth0-python/auth0/management/clients.pyi
+++ b/stubs/auth0-python/auth0/management/clients.pyi
@@ -1,7 +1,7 @@
 from _typeshed import Incomplete
 
-from ..rest import RestClient as RestClient, RestClientOptions as RestClientOptions
-from ..types import TimeoutType as TimeoutType
+from ..rest import RestClientOptions
+from ..types import TimeoutType
 
 class Clients:
     domain: Incomplete

--- a/stubs/auth0-python/auth0/management/connections.pyi
+++ b/stubs/auth0-python/auth0/management/connections.pyi
@@ -1,7 +1,7 @@
 from _typeshed import Incomplete
 
-from ..rest import RestClient as RestClient, RestClientOptions as RestClientOptions
-from ..types import TimeoutType as TimeoutType
+from ..rest import RestClientOptions
+from ..types import TimeoutType
 
 class Connections:
     domain: Incomplete

--- a/stubs/auth0-python/auth0/management/custom_domains.pyi
+++ b/stubs/auth0-python/auth0/management/custom_domains.pyi
@@ -1,7 +1,7 @@
 from _typeshed import Incomplete
 
-from ..rest import RestClient as RestClient, RestClientOptions as RestClientOptions
-from ..types import TimeoutType as TimeoutType
+from ..rest import RestClientOptions
+from ..types import TimeoutType
 
 class CustomDomains:
     domain: Incomplete

--- a/stubs/auth0-python/auth0/management/device_credentials.pyi
+++ b/stubs/auth0-python/auth0/management/device_credentials.pyi
@@ -1,7 +1,7 @@
 from _typeshed import Incomplete
 
-from ..rest import RestClient as RestClient, RestClientOptions as RestClientOptions
-from ..types import TimeoutType as TimeoutType
+from ..rest import RestClientOptions
+from ..types import TimeoutType
 
 class DeviceCredentials:
     domain: Incomplete

--- a/stubs/auth0-python/auth0/management/email_templates.pyi
+++ b/stubs/auth0-python/auth0/management/email_templates.pyi
@@ -1,7 +1,7 @@
 from _typeshed import Incomplete
 
-from ..rest import RestClient as RestClient, RestClientOptions as RestClientOptions
-from ..types import TimeoutType as TimeoutType
+from ..rest import RestClientOptions
+from ..types import TimeoutType
 
 class EmailTemplates:
     domain: Incomplete

--- a/stubs/auth0-python/auth0/management/emails.pyi
+++ b/stubs/auth0-python/auth0/management/emails.pyi
@@ -1,7 +1,7 @@
 from _typeshed import Incomplete
 
-from ..rest import RestClient as RestClient, RestClientOptions as RestClientOptions
-from ..types import TimeoutType as TimeoutType
+from ..rest import RestClientOptions
+from ..types import TimeoutType
 
 class Emails:
     domain: Incomplete

--- a/stubs/auth0-python/auth0/management/grants.pyi
+++ b/stubs/auth0-python/auth0/management/grants.pyi
@@ -1,7 +1,7 @@
 from _typeshed import Incomplete
 
-from ..rest import RestClient as RestClient, RestClientOptions as RestClientOptions
-from ..types import TimeoutType as TimeoutType
+from ..rest import RestClientOptions
+from ..types import TimeoutType
 
 class Grants:
     domain: Incomplete

--- a/stubs/auth0-python/auth0/management/guardian.pyi
+++ b/stubs/auth0-python/auth0/management/guardian.pyi
@@ -1,7 +1,7 @@
 from _typeshed import Incomplete
 
-from ..rest import RestClient as RestClient, RestClientOptions as RestClientOptions
-from ..types import TimeoutType as TimeoutType
+from ..rest import RestClientOptions
+from ..types import TimeoutType
 
 class Guardian:
     domain: Incomplete

--- a/stubs/auth0-python/auth0/management/hooks.pyi
+++ b/stubs/auth0-python/auth0/management/hooks.pyi
@@ -1,7 +1,7 @@
 from _typeshed import Incomplete
 
-from ..rest import RestClient as RestClient, RestClientOptions as RestClientOptions
-from ..types import TimeoutType as TimeoutType
+from ..rest import RestClientOptions
+from ..types import TimeoutType
 
 class Hooks:
     domain: Incomplete

--- a/stubs/auth0-python/auth0/management/jobs.pyi
+++ b/stubs/auth0-python/auth0/management/jobs.pyi
@@ -1,7 +1,7 @@
 from _typeshed import Incomplete
 
-from ..rest import RestClient as RestClient, RestClientOptions as RestClientOptions
-from ..types import TimeoutType as TimeoutType
+from ..rest import RestClientOptions
+from ..types import TimeoutType
 
 class Jobs:
     domain: Incomplete

--- a/stubs/auth0-python/auth0/management/log_streams.pyi
+++ b/stubs/auth0-python/auth0/management/log_streams.pyi
@@ -1,8 +1,8 @@
 from _typeshed import Incomplete
 from builtins import list as _list
 
-from ..rest import RestClient as RestClient, RestClientOptions as RestClientOptions
-from ..types import TimeoutType as TimeoutType
+from ..rest import RestClientOptions
+from ..types import TimeoutType
 
 class LogStreams:
     domain: Incomplete

--- a/stubs/auth0-python/auth0/management/logs.pyi
+++ b/stubs/auth0-python/auth0/management/logs.pyi
@@ -1,7 +1,7 @@
 from _typeshed import Incomplete
 
-from ..rest import RestClient as RestClient, RestClientOptions as RestClientOptions
-from ..types import TimeoutType as TimeoutType
+from ..rest import RestClientOptions
+from ..types import TimeoutType
 
 class Logs:
     domain: Incomplete

--- a/stubs/auth0-python/auth0/management/organizations.pyi
+++ b/stubs/auth0-python/auth0/management/organizations.pyi
@@ -1,7 +1,7 @@
 from _typeshed import Incomplete
 
-from ..rest import RestClient as RestClient, RestClientOptions as RestClientOptions
-from ..types import TimeoutType as TimeoutType
+from ..rest import RestClientOptions
+from ..types import TimeoutType
 
 class Organizations:
     domain: Incomplete

--- a/stubs/auth0-python/auth0/management/prompts.pyi
+++ b/stubs/auth0-python/auth0/management/prompts.pyi
@@ -1,7 +1,7 @@
 from _typeshed import Incomplete
 
-from ..rest import RestClient as RestClient, RestClientOptions as RestClientOptions
-from ..types import TimeoutType as TimeoutType
+from ..rest import RestClientOptions
+from ..types import TimeoutType
 
 class Prompts:
     domain: Incomplete

--- a/stubs/auth0-python/auth0/management/resource_servers.pyi
+++ b/stubs/auth0-python/auth0/management/resource_servers.pyi
@@ -1,7 +1,7 @@
 from _typeshed import Incomplete
 
-from ..rest import RestClient as RestClient, RestClientOptions as RestClientOptions
-from ..types import TimeoutType as TimeoutType
+from ..rest import RestClientOptions
+from ..types import TimeoutType
 
 class ResourceServers:
     domain: Incomplete

--- a/stubs/auth0-python/auth0/management/roles.pyi
+++ b/stubs/auth0-python/auth0/management/roles.pyi
@@ -1,8 +1,8 @@
 from _typeshed import Incomplete
 from builtins import list as _list
 
-from ..rest import RestClient as RestClient, RestClientOptions as RestClientOptions
-from ..types import TimeoutType as TimeoutType
+from ..rest import RestClientOptions
+from ..types import TimeoutType
 
 class Roles:
     domain: Incomplete

--- a/stubs/auth0-python/auth0/management/rules.pyi
+++ b/stubs/auth0-python/auth0/management/rules.pyi
@@ -1,7 +1,7 @@
 from _typeshed import Incomplete
 
-from ..rest import RestClient as RestClient, RestClientOptions as RestClientOptions
-from ..types import TimeoutType as TimeoutType
+from ..rest import RestClientOptions
+from ..types import TimeoutType
 
 class Rules:
     domain: Incomplete

--- a/stubs/auth0-python/auth0/management/rules_configs.pyi
+++ b/stubs/auth0-python/auth0/management/rules_configs.pyi
@@ -1,7 +1,7 @@
 from _typeshed import Incomplete
 
-from ..rest import RestClient as RestClient, RestClientOptions as RestClientOptions
-from ..types import TimeoutType as TimeoutType
+from ..rest import RestClientOptions
+from ..types import TimeoutType
 
 class RulesConfigs:
     domain: Incomplete

--- a/stubs/auth0-python/auth0/management/stats.pyi
+++ b/stubs/auth0-python/auth0/management/stats.pyi
@@ -1,7 +1,7 @@
 from _typeshed import Incomplete
 
-from ..rest import RestClient as RestClient, RestClientOptions as RestClientOptions
-from ..types import TimeoutType as TimeoutType
+from ..rest import RestClientOptions
+from ..types import TimeoutType
 
 class Stats:
     domain: Incomplete

--- a/stubs/auth0-python/auth0/management/tenants.pyi
+++ b/stubs/auth0-python/auth0/management/tenants.pyi
@@ -1,7 +1,7 @@
 from _typeshed import Incomplete
 
-from ..rest import RestClient as RestClient, RestClientOptions as RestClientOptions
-from ..types import TimeoutType as TimeoutType
+from ..rest import RestClientOptions
+from ..types import TimeoutType
 
 class Tenants:
     domain: Incomplete

--- a/stubs/auth0-python/auth0/management/tickets.pyi
+++ b/stubs/auth0-python/auth0/management/tickets.pyi
@@ -1,7 +1,7 @@
 from _typeshed import Incomplete
 
-from ..rest import RestClient as RestClient, RestClientOptions as RestClientOptions
-from ..types import TimeoutType as TimeoutType
+from ..rest import RestClientOptions
+from ..types import TimeoutType
 
 class Tickets:
     domain: Incomplete

--- a/stubs/auth0-python/auth0/management/user_blocks.pyi
+++ b/stubs/auth0-python/auth0/management/user_blocks.pyi
@@ -1,7 +1,7 @@
 from _typeshed import Incomplete
 
-from ..rest import RestClient as RestClient, RestClientOptions as RestClientOptions
-from ..types import TimeoutType as TimeoutType
+from ..rest import RestClientOptions
+from ..types import TimeoutType
 
 class UserBlocks:
     domain: Incomplete

--- a/stubs/auth0-python/auth0/management/users.pyi
+++ b/stubs/auth0-python/auth0/management/users.pyi
@@ -1,8 +1,8 @@
 from _typeshed import Incomplete
 from builtins import list as _list
 
-from ..rest import RestClient as RestClient, RestClientOptions as RestClientOptions
-from ..types import TimeoutType as TimeoutType
+from ..rest import RestClientOptions
+from ..types import TimeoutType
 
 class Users:
     domain: Incomplete

--- a/stubs/auth0-python/auth0/management/users_by_email.pyi
+++ b/stubs/auth0-python/auth0/management/users_by_email.pyi
@@ -1,7 +1,7 @@
 from _typeshed import Incomplete
 
-from ..rest import RestClient as RestClient, RestClientOptions as RestClientOptions
-from ..types import TimeoutType as TimeoutType
+from ..rest import RestClientOptions
+from ..types import TimeoutType
 
 class UsersByEmail:
     domain: Incomplete

--- a/stubs/auth0-python/auth0/rest.pyi
+++ b/stubs/auth0-python/auth0/rest.pyi
@@ -3,9 +3,8 @@ from collections.abc import Mapping
 from typing import Final
 
 import requests
-from auth0.exceptions import Auth0Error as Auth0Error, RateLimitError as RateLimitError
-from auth0.rest_async import RequestsResponse as RequestsResponse
-from auth0.types import RequestData as RequestData, TimeoutType as TimeoutType
+from auth0.rest_async import RequestsResponse
+from auth0.types import RequestData, TimeoutType
 
 UNKNOWN_ERROR: Final[str]
 

--- a/stubs/auth0-python/auth0/rest_async.pyi
+++ b/stubs/auth0-python/auth0/rest_async.pyi
@@ -1,15 +1,8 @@
 from _typeshed import Incomplete
 
-from auth0.exceptions import RateLimitError as RateLimitError
-from auth0.types import RequestData as RequestData
+from auth0.types import RequestData
 
-from .rest import (
-    EmptyResponse as EmptyResponse,
-    JsonResponse as JsonResponse,
-    PlainResponse as PlainResponse,
-    Response as Response,
-    RestClient as RestClient,
-)
+from .rest import RestClient
 
 class AsyncRestClient(RestClient):
     timeout: Incomplete


### PR DESCRIPTION
These are all leftovers from an initial generation using stubgen. I don't believe they are intended to be re-exported.