### PR TITLE
Add return type to tqdm_asyncio.gather

### DIFF
--- a/stubs/tqdm/tqdm/asyncio.pyi
+++ b/stubs/tqdm/tqdm/asyncio.pyi
@@ -81,7 +81,7 @@ class tqdm_asyncio(std_tqdm[_T]):
         nrows: int | None = ...,
         colour: str | None = ...,
         delay: float | None = ...,
-    ): ...
+    ) -> list[_T]: ...
     @overload
     def __init__(
         self,


### PR DESCRIPTION
The return type of `tqdm_asyncio.gather()` is currently missing.  
This PR adds it.

### Rationale:

`tqdm_asyncio.gather()` is a wrapper around `asyncio.gather`. [1]  
According to the typeshed definition, `asyncio.gather` returns `Future[list[_T]]`. [2]  
Therefore, `tqdm_asyncio.gather()` should return the same type but without `Future`, as it is an `async def` function.

[1]: https://github.com/tqdm/tqdm/blob/0ed5d7f18fa3153834cbac0aa57e8092b217cc16/tqdm/asyncio.py#L73
[2]: https://github.com/python/typeshed/blob/ef0ee2087c10e40d3132ce116091964058bf426d/stdlib/asyncio/tasks.pyi#L163