### PR TITLE
`stdlib/unittest/mock.pyi`: Improve `_Call` types

### DIFF
--- a/stdlib/unittest/mock.pyi
+++ b/stdlib/unittest/mock.pyi
@@ -1,4 +1,5 @@
 import sys
+from _typeshed import MaybeNone
 from collections.abc import Awaitable, Callable, Coroutine, Iterable, Mapping, Sequence
 from contextlib import _GeneratorContextManager
 from types import TracebackType
@@ -159,7 +160,7 @@ class NonCallableMock(Base, Any):
     side_effect: Any
     called: bool
     call_count: int
-    call_args: _Call | None
+    call_args: _Call | MaybeNone
     call_args_list: _CallList
     mock_calls: _CallList
     def _format_mock_call_signature(self, args: Any, kwargs: Any) -> str: ...

--- a/stdlib/unittest/mock.pyi
+++ b/stdlib/unittest/mock.pyi
@@ -69,16 +69,13 @@ _CallValue: TypeAlias = str | tuple[Any, ...] | Mapping[str, Any] | _ArgsKwargs 
 
 class _Call(tuple[Any, ...]):
     def __new__(
-        cls, value: _CallValue = (), name: str | None = "", parent: Any | None = None, two: bool = False, from_kall: bool = True
+        cls, value: _CallValue = (), name: str | None = "", parent: _Call | None = None, two: bool = False, from_kall: bool = True
     ) -> Self: ...
-    name: Any
-    parent: Any
-    from_kall: Any
     def __init__(
         self,
         value: _CallValue = (),
         name: str | None = None,
-        parent: Any | None = None,
+        parent: _Call | None = None,
         two: bool = False,
         from_kall: bool = True,
     ) -> None: ...
@@ -162,7 +159,7 @@ class NonCallableMock(Base, Any):
     side_effect: Any
     called: bool
     call_count: int
-    call_args: Any
+    call_args: _Call | None
     call_args_list: _CallList
     mock_calls: _CallList
     def _format_mock_call_signature(self, args: Any, kwargs: Any) -> str: ...


### PR DESCRIPTION
This fixes a number of issues related to `_Call` in `stdlib/unittest/mock.pyi`:

- `_Call.__new__()`, `_Call.__init__()`: The `parent` argument should be another `_Call` or `None`.
- `_Call.name` doesn't exist.
- `_Call.parent` doesn't exist.
- `_Call.from_kall` doesn't exist.
- [`NonCallableMock.call_args`][0] should be a `_Call` or `None`.

[0]: https://docs.python.org/3/library/unittest.mock.html#unittest.mock.Mock.call_args