### PR TITLE
fix pyscreeze.locateCenterOnScreen

### DIFF
--- a/stubs/PyScreeze/pyscreeze/__init__.pyi
+++ b/stubs/PyScreeze/pyscreeze/__init__.pyi
@@ -140,7 +140,7 @@ def locateCenterOnScreen(
 def locateCenterOnScreen(
     image: str | Image.Image,
     *,
-    minSearchTime: float,
+    minSearchTime: float = 0,
     grayscale: bool | None = None,
     limit: Unused = 1,
     region: tuple[int, int, int, int] | None = None,

--- a/stubs/PyScreeze/pyscreeze/__init__.pyi
+++ b/stubs/PyScreeze/pyscreeze/__init__.pyi
@@ -127,7 +127,7 @@ def locateAllOnScreen(
 def locateCenterOnScreen(
     image: str | Image.Image | _MatLike,
     *,
-    minSearchTime: float,
+    minSearchTime: float = 0,
     grayscale: bool | None = None,
     limit: Unused = 1,
     region: tuple[int, int, int, int] | None = None,


### PR DESCRIPTION
Give parameter `minSearchTime` a default value of 0 in function `pyscreeze.locateCenterOnScreen`. This should be okay because in the actual library, `locateCenterOnScreen` just delegates all of its parameters to `locateOnScreen`, and the type definition here for `locateOnScreen` gives `minSearchTime` a default value of 0.

Fixes #13851 