### PR TITLE
Fix urllib3 dependency version to match the docker-py

### DIFF
--- a/stubs/docker/METADATA.toml
+++ b/stubs/docker/METADATA.toml
@@ -1,3 +1,3 @@
 version = "7.1.*"
 upstream_repository = "https://github.com/docker/docker-py"
-requires = ["types-requests", "urllib3>=2"]
+requires = ["types-requests", "urllib3>=1.26.0"]


### PR DESCRIPTION
Per https://github.com/docker/docker-py/blob/main/pyproject.toml#L34C6-L34C17, docker-py depends on urllib3 >= 1.26.0 and depending on >= 2 here can cause breakages due to version incompatibility in projects.