### PR TITLE
Deprecate `importlib` interfaces

### DIFF
--- a/stdlib/_frozen_importlib_external.pyi
+++ b/stdlib/_frozen_importlib_external.pyi
@@ -36,7 +36,10 @@ def spec_from_file_location(
     loader: LoaderProtocol | None = None,
     submodule_search_locations: list[str] | None = ...,
 ) -> importlib.machinery.ModuleSpec | None: ...
-
+@deprecated(
+    "Deprecated as of Python 3.6: Use site configuration instead. "
+    "Future versions of Python may not enable this finder by default."
+)
 class WindowsRegistryFinder(importlib.abc.MetaPathFinder):
     if sys.version_info < (3, 12):
         @classmethod

--- a/stdlib/importlib/abc.pyi
+++ b/stdlib/importlib/abc.pyi
@@ -8,6 +8,7 @@ from importlib import _bootstrap_external
 from importlib.machinery import ModuleSpec
 from io import BufferedReader
 from typing import IO, Any, Literal, Protocol, overload, runtime_checkable
+from typing_extensions import deprecated
 
 if sys.version_info >= (3, 11):
     __all__ = [
@@ -38,6 +39,7 @@ else:
 if sys.version_info < (3, 12):
     class Finder(metaclass=ABCMeta): ...
 
+@deprecated("Deprecated as of Python 3.7: Use importlib.resources.abc.TraversableResources instead.")
 class ResourceLoader(Loader):
     @abstractmethod
     def get_data(self, path: str) -> bytes: ...
@@ -58,6 +60,7 @@ class ExecutionLoader(InspectLoader):
     def get_filename(self, fullname: str) -> str: ...
 
 class SourceLoader(_bootstrap_external.SourceLoader, ResourceLoader, ExecutionLoader, metaclass=ABCMeta):  # type: ignore[misc]  # incompatible definitions of source_to_code in the base classes
+    @deprecated("Deprecated as of Python 3.3: Use importlib.resources.abc.SourceLoader.path_stats instead.")
     def path_mtime(self, path: str) -> float: ...
     def set_data(self, path: str, data: bytes) -> None: ...
     def get_source(self, fullname: str) -> str | None: ...


### PR DESCRIPTION
### 1. `importlib.machinery.WindowsRegistryFinder`
- Documentation: https://docs.python.org/dev/library/importlib.html#importlib.machinery.WindowsRegistryFinder
- Warning in code: https://github.com/python/cpython/blob/main/Lib/importlib/_bootstrap_external.py#L719-L723
### 2. `importlib.abc.ResourceLoader`
- Documentation: https://docs.python.org/dev/library/importlib.html#importlib.abc.ResourceLoader
- Warning in code: https://github.com/python/cpython/blob/main/Lib/importlib/abc.py#L74-L78
### 3. `importlib.abc.SourceLoader.path_mtime`
- Documentation: https://docs.python.org/dev/library/importlib.html#importlib.abc.SourceLoader.path_mtime
- Warning in code: https://github.com/python/cpython/blob/main/Lib/importlib/abc.py#L212-L214