### PR TITLE
Add missing `_optimize` parameter to `importlib.machinery.SourceFileLoader` method.

### DIFF
--- a/stdlib/_frozen_importlib_external.pyi
+++ b/stdlib/_frozen_importlib_external.pyi
@@ -127,7 +127,8 @@ class SourceFileLoader(importlib.abc.FileLoader, FileLoader, importlib.abc.Sourc
         path: ReadableBuffer | StrPath = "<string>",
         *,
         _optimize: int = -1,
-    ) -> types.CodeType: ...
+    ) -> types.CodeType: # type: ignore[override]  # incompatible with InspectLoader.source_to_code
+        ...
 
 class SourcelessFileLoader(importlib.abc.FileLoader, FileLoader, _LoaderBasics):
     def get_code(self, fullname: str) -> types.CodeType | None: ...

--- a/stdlib/_frozen_importlib_external.pyi
+++ b/stdlib/_frozen_importlib_external.pyi
@@ -121,13 +121,13 @@ class FileLoader:
 class SourceFileLoader(importlib.abc.FileLoader, FileLoader, importlib.abc.SourceLoader, SourceLoader):  # type: ignore[misc]  # incompatible method arguments in base classes
     def set_data(self, path: str, data: ReadableBuffer, *, _mode: int = 0o666) -> None: ...
     def path_stats(self, path: str) -> Mapping[str, Any]: ...
-    def source_to_code(
+    def source_to_code(  # type: ignore[override]  # incompatible with InspectLoader.source_to_code
         self,
         data: ReadableBuffer | str | _ast.Module | _ast.Expression | _ast.Interactive,
         path: ReadableBuffer | StrPath = "<string>",
         *,
         _optimize: int = -1,
-    ) -> types.CodeType: # type: ignore[override]  # incompatible with InspectLoader.source_to_code
+    ) -> types.CodeType:
         ...
 
 class SourcelessFileLoader(importlib.abc.FileLoader, FileLoader, _LoaderBasics):

--- a/stdlib/_frozen_importlib_external.pyi
+++ b/stdlib/_frozen_importlib_external.pyi
@@ -121,6 +121,13 @@ class FileLoader:
 class SourceFileLoader(importlib.abc.FileLoader, FileLoader, importlib.abc.SourceLoader, SourceLoader):  # type: ignore[misc]  # incompatible method arguments in base classes
     def set_data(self, path: str, data: ReadableBuffer, *, _mode: int = 0o666) -> None: ...
     def path_stats(self, path: str) -> Mapping[str, Any]: ...
+    def source_to_code(
+        self,
+        data: ReadableBuffer | str | _ast.Module | _ast.Expression | _ast.Interactive,
+        path: ReadableBuffer | StrPath = "<string>",
+        *,
+        _optimize: int = -1,
+    ) -> types.CodeType: ...
 
 class SourcelessFileLoader(importlib.abc.FileLoader, FileLoader, _LoaderBasics):
     def get_code(self, fullname: str) -> types.CodeType | None: ...

--- a/stdlib/_frozen_importlib_external.pyi
+++ b/stdlib/_frozen_importlib_external.pyi
@@ -127,8 +127,7 @@ class SourceFileLoader(importlib.abc.FileLoader, FileLoader, importlib.abc.Sourc
         path: ReadableBuffer | StrPath,
         *,
         _optimize: int = -1,
-    ) -> types.CodeType:
-        ...
+    ) -> types.CodeType: ...
 
 class SourcelessFileLoader(importlib.abc.FileLoader, FileLoader, _LoaderBasics):
     def get_code(self, fullname: str) -> types.CodeType | None: ...

--- a/stdlib/_frozen_importlib_external.pyi
+++ b/stdlib/_frozen_importlib_external.pyi
@@ -124,7 +124,7 @@ class SourceFileLoader(importlib.abc.FileLoader, FileLoader, importlib.abc.Sourc
     def source_to_code(  # type: ignore[override]  # incompatible with InspectLoader.source_to_code
         self,
         data: ReadableBuffer | str | _ast.Module | _ast.Expression | _ast.Interactive,
-        path: ReadableBuffer | StrPath = "<string>",
+        path: ReadableBuffer | StrPath,
         *,
         _optimize: int = -1,
     ) -> types.CodeType:


### PR DESCRIPTION
This has been present since before Python 3.9, I think.