### PR TITLE
Deprecate `TarInfo.tarfile` attribute

### DIFF
--- a/stdlib/tarfile.pyi
+++ b/stdlib/tarfile.pyi
@@ -7,7 +7,7 @@ from collections.abc import Callable, Iterable, Iterator, Mapping
 from gzip import _ReadableFileobj as _GzipReadableFileobj, _WritableFileobj as _GzipWritableFileobj
 from types import TracebackType
 from typing import IO, ClassVar, Literal, Protocol, overload
-from typing_extensions import Self, TypeAlias
+from typing_extensions import Self, TypeAlias, deprecated
 
 __all__ = [
     "TarFile",
@@ -622,7 +622,6 @@ class TarInfo:
     offset: int
     offset_data: int
     sparse: bytes | None
-    tarfile: TarFile | None
     mode: int
     type: bytes
     linkname: str
@@ -632,6 +631,16 @@ class TarInfo:
     gname: str
     pax_headers: Mapping[str, str]
     def __init__(self, name: str = "") -> None: ...
+    if sys.version_info >= (3, 13):
+        @property
+        @deprecated("Deprecated in Python 3.13; Removal scheduled for Python 3.16")
+        def tarfile(self) -> TarFile | None: ...
+        @tarfile.setter
+        @deprecated("Deprecated in Python 3.13; removal scheduled for Python 3.16")
+        def tarfile(self) -> None: ...
+    else:
+        tarfile: TarFile | None
+
     @classmethod
     def frombuf(cls, buf: bytes | bytearray, encoding: str, errors: str) -> Self: ...
     @classmethod

--- a/stdlib/tarfile.pyi
+++ b/stdlib/tarfile.pyi
@@ -633,7 +633,7 @@ class TarInfo:
     def __init__(self, name: str = "") -> None: ...
     if sys.version_info >= (3, 13):
         @property
-        @deprecated("Deprecated in Python 3.13; Removal scheduled for Python 3.16")
+        @deprecated("Deprecated in Python 3.13; removal scheduled for Python 3.16")
         def tarfile(self) -> TarFile | None: ...
         @tarfile.setter
         @deprecated("Deprecated in Python 3.13; removal scheduled for Python 3.16")


### PR DESCRIPTION
Source: https://github.com/python/cpython/pull/115257