### PR TITLE
Fix annotations of shapely.constructive.make_valid

### DIFF
--- a/stubs/shapely/shapely/constructive.pyi
+++ b/stubs/shapely/shapely/constructive.pyi
@@ -1,6 +1,5 @@
 from collections.abc import Sequence
 from typing import Any, Literal, SupportsIndex, overload
-from typing_extensions import TypeAlias
 
 from ._enum import ParamEnum
 from ._typing import ArrayLike, ArrayLikeSeq, GeoArray, OptGeoArrayLike, OptGeoArrayLikeSeq, OptGeoT
@@ -42,8 +41,6 @@ __all__ = [
     "snap",
     "voronoi_polygons",
 ]
-
-_Method: TypeAlias = Literal["linework", "structure"]
 
 class BufferCapStyle(ParamEnum):
     round = 1
@@ -269,25 +266,35 @@ def build_area(geometry: None, **kwargs) -> None: ...
 def build_area(geometry: Geometry | None, **kwargs) -> BaseGeometry | None: ...
 @overload
 def build_area(geometry: OptGeoArrayLikeSeq, **kwargs) -> GeoArray: ...
+
+# make_valid with `method="linework"` only accepts `keep_collapsed=True`
 @overload
-def make_valid(geometry: Geometry, *, method: _Method = "linework", keep_collapsed: bool = True, **kwargs) -> BaseGeometry: ...
+def make_valid(
+    geometry: Geometry, *, method: Literal["linework"] = "linework", keep_collapsed: Literal[True] = True, **kwargs
+) -> BaseGeometry: ...
 @overload
-def make_valid(geometry: None, *, method: _Method = "linework", keep_collapsed: bool = True, **kwargs) -> None: ...
+def make_valid(geometry: Geometry, *, method: Literal["structure"], keep_collapsed: bool = True, **kwargs) -> BaseGeometry: ...
+@overload
+def make_valid(
+    geometry: None, *, method: Literal["linework"] = "linework", keep_collapsed: Literal[True] = True, **kwargs
+) -> None: ...
+@overload
+def make_valid(geometry: None, *, method: Literal["structure"], keep_collapsed: bool = True, **kwargs) -> None: ...
+@overload
+def make_valid(
+    geometry: Geometry | None, *, method: Literal["linework"] = "linework", keep_collapsed: Literal[True] = True, **kwargs
+) -> BaseGeometry | None: ...
 @overload
 def make_valid(
     geometry: Geometry | None, *, method: Literal["structure"], keep_collapsed: bool = True, **kwargs
 ) -> BaseGeometry | None: ...
 @overload
 def make_valid(
-    geometry: Geometry | None, *, method: Literal["linework"], keep_collapsed: Literal[True], **kwargs
-) -> BaseGeometry | None: ...
-@overload
-def make_valid(
-    geometry: OptGeoArrayLikeSeq, *, method: Literal["structure"], keep_collapsed: bool = True, **kwargs
+    geometry: OptGeoArrayLikeSeq, *, method: Literal["linework"] = "linework", keep_collapsed: Literal[True] = True, **kwargs
 ) -> GeoArray: ...
 @overload
 def make_valid(
-    geometry: OptGeoArrayLikeSeq, *, method: Literal["linework"], keep_collapsed: Literal[True], **kwargs
+    geometry: OptGeoArrayLikeSeq, *, method: Literal["structure"], keep_collapsed: bool = True, **kwargs
 ) -> GeoArray: ...
 @overload
 def minimum_clearance_line(geometry: Point, **kwargs) -> Point: ...

--- a/stubs/shapely/shapely/constructive.pyi
+++ b/stubs/shapely/shapely/constructive.pyi
@@ -273,25 +273,25 @@ def make_valid(
     geometry: Geometry, *, method: Literal["linework"] = "linework", keep_collapsed: Literal[True] = True, **kwargs
 ) -> BaseGeometry: ...
 @overload
-def make_valid(geometry: Geometry, *, method: Literal["structure"], keep_collapsed: bool = True, **kwargs) -> BaseGeometry: ...
-@overload
 def make_valid(
     geometry: None, *, method: Literal["linework"] = "linework", keep_collapsed: Literal[True] = True, **kwargs
 ) -> None: ...
-@overload
-def make_valid(geometry: None, *, method: Literal["structure"], keep_collapsed: bool = True, **kwargs) -> None: ...
 @overload
 def make_valid(
     geometry: Geometry | None, *, method: Literal["linework"] = "linework", keep_collapsed: Literal[True] = True, **kwargs
 ) -> BaseGeometry | None: ...
 @overload
 def make_valid(
-    geometry: Geometry | None, *, method: Literal["structure"], keep_collapsed: bool = True, **kwargs
-) -> BaseGeometry | None: ...
-@overload
-def make_valid(
     geometry: OptGeoArrayLikeSeq, *, method: Literal["linework"] = "linework", keep_collapsed: Literal[True] = True, **kwargs
 ) -> GeoArray: ...
+@overload
+def make_valid(geometry: Geometry, *, method: Literal["structure"], keep_collapsed: bool = True, **kwargs) -> BaseGeometry: ...
+@overload
+def make_valid(geometry: None, *, method: Literal["structure"], keep_collapsed: bool = True, **kwargs) -> None: ...
+@overload
+def make_valid(
+    geometry: Geometry | None, *, method: Literal["structure"], keep_collapsed: bool = True, **kwargs
+) -> BaseGeometry | None: ...
 @overload
 def make_valid(
     geometry: OptGeoArrayLikeSeq, *, method: Literal["structure"], keep_collapsed: bool = True, **kwargs


### PR DESCRIPTION
Fixes a regression in #13847 where some overloads were missing default values for new optional keyword arguments.

Implementation: https://github.com/shapely/shapely/blob/88309764d16846be5108a0aa236757ad97b1ba9c/shapely/constructive.py#L680-L765