### PR TITLE
Mention rerunning sync_protobuf scripts

### DIFF
--- a/stubs/protobuf/METADATA.toml
+++ b/stubs/protobuf/METADATA.toml
@@ -1,4 +1,5 @@
 # Using an exact number in the specifier for scripts/sync_protobuf/google_protobuf.py
+# When updating, also re-run the script
 version = "~=5.29.1"
 upstream_repository = "https://github.com/protocolbuffers/protobuf"
 extra_description = "Partially generated using [mypy-protobuf==3.6.0](https://github.com/nipunn1313/mypy-protobuf/tree/v3.6.0) and libprotoc 28.1 on [protobuf v29.1](https://github.com/protocolbuffers/protobuf/releases/tag/v29.1) (python `protobuf==5.29.1`)."

--- a/stubs/s2clientprotocol/METADATA.toml
+++ b/stubs/s2clientprotocol/METADATA.toml
@@ -1,5 +1,6 @@
 # Whenever you update version here, PACKAGE_VERSION should be updated
 # in scripts/sync_protobuf/s2clientprotocol.py and vice-versa.
+# When updating, also re-run the script
 version = "5.*"
 upstream_repository = "https://github.com/Blizzard/s2client-proto"
 requires = ["types-protobuf"]

--- a/stubs/tensorflow/METADATA.toml
+++ b/stubs/tensorflow/METADATA.toml
@@ -1,4 +1,5 @@
 # Using an exact number in the specifier for scripts/sync_protobuf/tensorflow.py
+# When updating, also re-run the script
 version = "~=2.18.0"
 upstream_repository = "https://github.com/tensorflow/tensorflow"
 # requires a version of numpy with a `py.typed` file


### PR DESCRIPTION
This should make it more obvious than a manual action needs to be taken (https://github.com/python/typeshed/pull/13922/files#r2072228873)

`pre-commit.ci` isn't an option to automate this as it requires internet access at runtime.