### PR TITLE
grpc `_CallIterator` is an iterator

### DIFF
--- a/stubs/grpcio/@tests/test_cases/check_grpc.py
+++ b/stubs/grpcio/@tests/test_cases/check_grpc.py
@@ -44,3 +44,4 @@ assert_type(call_details.timeout, Optional[float])
 call_iter = cast(grpc._CallIterator[str], None)
 for call in call_iter:
     assert_type(call, str)
+assert_type(next(call_iter), str)

--- a/stubs/grpcio/grpc/__init__.pyi
+++ b/stubs/grpcio/grpc/__init__.pyi
@@ -426,6 +426,7 @@ class UnaryUnaryClientInterceptor(abc.ABC, Generic[_TRequest, _TResponse]):
 @type_check_only
 class _CallIterator(Call, Generic[_TResponse], metaclass=abc.ABCMeta):
     def __iter__(self) -> Iterator[_TResponse]: ...
+    def __next__(self) -> _TResponse: ...
 
 class UnaryStreamClientInterceptor(abc.ABC, Generic[_TRequest, _TResponse]):
     @abc.abstractmethod


### PR DESCRIPTION
The internal typing concept `_CallIterator` is an iterator (and also an iterable).

The stub here is a bit simplified, under the hood the runtime code actually uses the fairly flexible / complex class `grpc._channel._MultiThreadedRendezvous` which kind of does a bit of everything.

Originally proposed in https://github.com/shabbyrobe/grpc-stubs/pull/53