### PR TITLE
[geopandas] Fix CI tests in some circumstances

### DIFF
--- a/stubs/geopandas/METADATA.toml
+++ b/stubs/geopandas/METADATA.toml
@@ -2,3 +2,8 @@ version = "1.0.1"
 # Requires a version of numpy with a `py.typed` file
 requires = ["numpy>=1.20", "pandas-stubs", "types-shapely", "pyproj"]
 upstream_repository = "https://github.com/geopandas/geopandas"
+
+[tool.stubtest]
+# libproj-dev and proj-bin are required to build pyproj if wheels for the
+# target Python version are not available.
+apt_dependencies = ["libproj-dev", "proj-bin"]


### PR DESCRIPTION
Add "libproj-dev" and "proj-bin" to apt_dependencies.
These packages are necessary to build the
pyproj dependency
if a pre-built wheel is not available.