### PR TITLE
Update `uuid` for 3.14, other minor improvements

### DIFF
--- a/stdlib/@tests/stubtest_allowlists/py314.txt
+++ b/stdlib/@tests/stubtest_allowlists/py314.txt
@@ -625,11 +625,6 @@ urllib.request.pathname2url
 urllib.request.url2pathname
 urllib.request.url2pathname
 urllib.request.url2pathname
-uuid.MAX
-uuid.NIL
-uuid.uuid6
-uuid.uuid7
-uuid.uuid8
 wsgiref.types.ErrorStream.__annotate_func__
 wsgiref.types.ErrorStream.__annotations_cache__
 wsgiref.types.FileWrapper.__annotate_func__

--- a/stdlib/uuid.pyi
+++ b/stdlib/uuid.pyi
@@ -1,7 +1,8 @@
 import builtins
 import sys
 from enum import Enum
-from typing_extensions import TypeAlias
+from typing import Final
+from typing_extensions import LiteralString, TypeAlias
 
 _FieldsType: TypeAlias = tuple[int, int, int, int, int, int]
 
@@ -67,6 +68,11 @@ class UUID:
 def getnode() -> int: ...
 def uuid1(node: int | None = None, clock_seq: int | None = None) -> UUID: ...
 
+if sys.version_info >= (3, 14):
+    def uuid6(node: int | None = None, clock_seq: int | None = None) -> UUID: ...
+    def uuid7() -> UUID: ...
+    def uuid8(a: int | None = None, b: int | None = None, c: int | None = None) -> UUID: ...
+
 if sys.version_info >= (3, 12):
     def uuid3(namespace: UUID, name: str | bytes) -> UUID: ...
 
@@ -81,14 +87,18 @@ if sys.version_info >= (3, 12):
 else:
     def uuid5(namespace: UUID, name: str) -> UUID: ...
 
-NAMESPACE_DNS: UUID
-NAMESPACE_URL: UUID
-NAMESPACE_OID: UUID
-NAMESPACE_X500: UUID
-RESERVED_NCS: str
-RFC_4122: str
-RESERVED_MICROSOFT: str
-RESERVED_FUTURE: str
+if sys.version_info >= (3, 14):
+    NIL: Final[UUID]
+    MAX: Final[UUID]
+
+NAMESPACE_DNS: Final[UUID]
+NAMESPACE_URL: Final[UUID]
+NAMESPACE_OID: Final[UUID]
+NAMESPACE_X500: Final[UUID]
+RESERVED_NCS: Final[LiteralString]
+RFC_4122: Final[LiteralString]
+RESERVED_MICROSOFT: Final[LiteralString]
+RESERVED_FUTURE: Final[LiteralString]
 
 if sys.version_info >= (3, 12):
     def main() -> None: ...


### PR DESCRIPTION
- Add [uuid.uuid6()](https://docs.python.org/3.14/library/uuid.html#uuid.uuid6), [uuid.uuid7()](https://docs.python.org/3.14/library/uuid.html#uuid.uuid7), and [uuid.uuid8()](https://docs.python.org/3.14/library/uuid.html#uuid.uuid8), along with [uuid.NIL](https://docs.python.org/3.14/library/uuid.html#uuid.NIL) and [uuid.MAX](https://docs.python.org/3.14/library/uuid.html#uuid.MAX).
- Ensure we're consistently using Final across constants (https://github.com/python/typeshed/issues/12311)
- Several constants are strings known at init time, it's more appropriate to use `LiteralString` for these.