### PR TITLE
Support `initial` keyword for `functools.reduce` 3.14

### DIFF
--- a/stdlib/@tests/stubtest_allowlists/py314.txt
+++ b/stdlib/@tests/stubtest_allowlists/py314.txt
@@ -366,7 +366,8 @@ functools.__all__
 functools.Placeholder
 functools.WRAPPER_ASSIGNMENTS
 functools.partialmethod.__new__
-functools.reduce
+functools.partialmethod.__new__
+functools.partialmethod.__new__
 functools.update_wrapper
 functools.wraps
 gzip.GzipFile.readinto

--- a/stdlib/@tests/stubtest_allowlists/py314.txt
+++ b/stdlib/@tests/stubtest_allowlists/py314.txt
@@ -366,8 +366,6 @@ functools.__all__
 functools.Placeholder
 functools.WRAPPER_ASSIGNMENTS
 functools.partialmethod.__new__
-functools.partialmethod.__new__
-functools.partialmethod.__new__
 functools.update_wrapper
 functools.wraps
 gzip.GzipFile.readinto

--- a/stdlib/functools.pyi
+++ b/stdlib/functools.pyi
@@ -34,6 +34,7 @@ _RWrapper = TypeVar("_RWrapper")
 if sys.version_info >= (3, 14):
     @overload
     def reduce(function: Callable[[_T, _S], _T], sequence: Iterable[_S], /, initial: _T) -> _T: ...
+
 else:
     @overload
     def reduce(function: Callable[[_T, _S], _T], sequence: Iterable[_S], initial: _T, /) -> _T: ...

--- a/stdlib/functools.pyi
+++ b/stdlib/functools.pyi
@@ -31,8 +31,13 @@ _RWrapped = TypeVar("_RWrapped")
 _PWrapper = ParamSpec("_PWrapper")
 _RWrapper = TypeVar("_RWrapper")
 
-@overload
-def reduce(function: Callable[[_T, _S], _T], sequence: Iterable[_S], initial: _T, /) -> _T: ...
+if sys.version_info >= (3, 14):
+    @overload
+    def reduce(function: Callable[[_T, _S], _T], sequence: Iterable[_S], /, initial: _T) -> _T: ...
+else:
+    @overload
+    def reduce(function: Callable[[_T, _S], _T], sequence: Iterable[_S], initial: _T, /) -> _T: ...
+
 @overload
 def reduce(function: Callable[[_T, _T], _T], sequence: Iterable[_T], /) -> _T: ...
 


### PR DESCRIPTION
`initial` is supported as a keyword argument starting in 3.14.