### PR TITLE
builtins: remove `object.__annotations__`

### DIFF
--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -107,7 +107,6 @@ class object:
     __doc__: str | None
     __dict__: dict[str, Any]
     __module__: str
-    __annotations__: dict[str, Any]
     @property
     def __class__(self) -> type[Self]: ...
     @__class__.setter


### PR DESCRIPTION
Not all objects have annotations, so I think this shouldn't exist.
We already have `__annotations__` attributes explicitly set on the
objects that do have them (e.g., functions, classes, and modules).

Not sure what the fallout of this is going to be; it might not be worth changing.