### PR TITLE
Make Future's type var default to Any

### DIFF
--- a/stdlib/_asyncio.pyi
+++ b/stdlib/_asyncio.pyi
@@ -6,7 +6,7 @@ from types import FrameType, GenericAlias
 from typing import Any, Literal, TextIO, TypeVar
 from typing_extensions import Self, TypeAlias
 
-_T = TypeVar("_T")
+_T = TypeVar("_T", default=Any)
 _T_co = TypeVar("_T_co", covariant=True)
 _TaskYieldType: TypeAlias = Future[object] | None
 


### PR DESCRIPTION
This makes it possible to write `Future` instead of `Future[Any]` to annotate something as accepting any `Future`. This reduces visual clutter and avoids the need to comment on each `Future[Any]` per our documentation policy. It also allows us to distinguish between the "any Future allowed" case (bare `Future`) and the "a Future with a value we can't express" case (`Future[Any]`). This mirrors the annotations for `type`.