### PR TITLE
Update dataclasses for 3.14

### DIFF
--- a/stdlib/@tests/stubtest_allowlists/py314.txt
+++ b/stdlib/@tests/stubtest_allowlists/py314.txt
@@ -99,10 +99,6 @@ ctypes.wintypes.HDROP
 ctypes.wintypes.HFILE
 ctypes.wintypes.HRESULT
 ctypes.wintypes.HSZ
-dataclasses.Field.__init__
-dataclasses.Field.doc
-dataclasses.field
-dataclasses.make_dataclass
 decimal.Decimal.from_number
 decimal.IEEE_CONTEXT_MAX_BITS
 dis.Instruction.make

--- a/stdlib/@tests/test_cases/check_dataclasses.py
+++ b/stdlib/@tests/test_cases/check_dataclasses.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import dataclasses as dc
 from typing import TYPE_CHECKING, Any, Dict, FrozenSet, Tuple, Type, Union
 from typing_extensions import Annotated, assert_type
+import sys
 
 if TYPE_CHECKING:
     from _typeshed import DataclassInstance
@@ -99,3 +100,39 @@ D = dc.make_dataclass(
 # in case a type checker decides to add some special-casing for
 # `make_dataclass` in the future)
 assert_type(D.__mro__, Tuple[type, ...])
+
+
+
+if sys.version_info >= (3, 14):
+
+    def custom_dataclass[T](cls: type[T], /, *,
+        init: bool = True,
+        repr: bool = True,
+        eq: bool = True,
+        order: bool = False,
+        unsafe_hash: bool = False,
+        frozen: bool = False,
+        match_args: bool = True,
+        kw_only: bool = False,
+        slots: bool = False,
+        weakref_slot: bool = False,
+    ) -> type[T]:
+        custom_dc = dc.dataclass(
+            cls,
+            init=init,
+            repr=repr,
+            eq=eq,
+            order=order,
+            unsafe_hash=unsafe_hash,
+            frozen=frozen,
+            match_args=match_args,
+            kw_only=kw_only,
+            slots=slots,
+            weakref_slot=weakref_slot,
+        )
+        return custom_dc
+
+    dc.make_dataclass(
+        "D", [("a", Union[int, None]), "y", ("z", Annotated[FrozenSet[bytes], "metadata"], dc.field(default=frozenset({b"foo"})))],
+        decorator=custom_dataclass,
+    )

--- a/stdlib/@tests/test_cases/check_dataclasses.py
+++ b/stdlib/@tests/test_cases/check_dataclasses.py
@@ -102,7 +102,7 @@ D = dc.make_dataclass(
 assert_type(D.__mro__, Tuple[type, ...])
 
 
-if sys.version_info >= (3, 14):
+if sys.version_info >= (3, 13):
 
     def custom_dataclass[T](
         cls: type[T],
@@ -119,8 +119,7 @@ if sys.version_info >= (3, 14):
         slots: bool = False,
         weakref_slot: bool = False,
     ) -> type[T]:
-        custom_dc = dc.dataclass(
-            cls,
+        custom_dc_maker = dc.dataclass(
             init=init,
             repr=repr,
             eq=eq,
@@ -132,7 +131,7 @@ if sys.version_info >= (3, 14):
             slots=slots,
             weakref_slot=weakref_slot,
         )
-        return custom_dc
+        return custom_dc_maker(cls)
 
     dc.make_dataclass(
         "D",

--- a/stdlib/@tests/test_cases/check_dataclasses.py
+++ b/stdlib/@tests/test_cases/check_dataclasses.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import dataclasses as dc
+import sys
 from typing import TYPE_CHECKING, Any, Dict, FrozenSet, Tuple, Type, Union
 from typing_extensions import Annotated, assert_type
-import sys
 
 if TYPE_CHECKING:
     from _typeshed import DataclassInstance
@@ -102,10 +102,12 @@ D = dc.make_dataclass(
 assert_type(D.__mro__, Tuple[type, ...])
 
 
-
 if sys.version_info >= (3, 14):
 
-    def custom_dataclass[T](cls: type[T], /, *,
+    def custom_dataclass[T](
+        cls: type[T],
+        /,
+        *,
         init: bool = True,
         repr: bool = True,
         eq: bool = True,
@@ -133,6 +135,7 @@ if sys.version_info >= (3, 14):
         return custom_dc
 
     dc.make_dataclass(
-        "D", [("a", Union[int, None]), "y", ("z", Annotated[FrozenSet[bytes], "metadata"], dc.field(default=frozenset({b"foo"})))],
+        "D",
+        [("a", Union[int, None]), "y", ("z", Annotated[FrozenSet[bytes], "metadata"], dc.field(default=frozenset({b"foo"})))],
         decorator=custom_dataclass,
     )

--- a/stdlib/@tests/test_cases/check_dataclasses.py
+++ b/stdlib/@tests/test_cases/check_dataclasses.py
@@ -103,9 +103,12 @@ assert_type(D.__mro__, Tuple[type, ...])
 
 
 if sys.version_info >= (3, 14):
+    from typing import TypeVar
 
-    def custom_dataclass[T](
-        cls: type[T],
+    _T = TypeVar("_T")
+
+    def custom_dataclass(
+        cls: type[_T],
         /,
         *,
         init: bool = True,
@@ -118,7 +121,7 @@ if sys.version_info >= (3, 14):
         kw_only: bool = False,
         slots: bool = False,
         weakref_slot: bool = False,
-    ) -> type[T]:
+    ) -> type[_T]:
         custom_dc_maker = dc.dataclass(
             init=init,
             repr=repr,

--- a/stdlib/@tests/test_cases/check_dataclasses.py
+++ b/stdlib/@tests/test_cases/check_dataclasses.py
@@ -102,7 +102,7 @@ D = dc.make_dataclass(
 assert_type(D.__mro__, Tuple[type, ...])
 
 
-if sys.version_info >= (3, 13):
+if sys.version_info >= (3, 14):
 
     def custom_dataclass[T](
         cls: type[T],

--- a/stdlib/dataclasses.pyi
+++ b/stdlib/dataclasses.pyi
@@ -79,21 +79,6 @@ def dataclass(cls: type[_T], /) -> type[_T]: ...
 if sys.version_info >= (3, 11):
     @overload
     def dataclass(
-        cls: type[_T],
-        *,
-        init: bool = True,
-        repr: bool = True,
-        eq: bool = True,
-        order: bool = False,
-        unsafe_hash: bool = False,
-        frozen: bool = False,
-        match_args: bool = True,
-        kw_only: bool = False,
-        slots: bool = False,
-        weakref_slot: bool = False,
-    ) -> type[_T]: ...
-    @overload
-    def dataclass(
         *,
         init: bool = True,
         repr: bool = True,

--- a/stdlib/dataclasses.pyi
+++ b/stdlib/dataclasses.pyi
@@ -152,9 +152,14 @@ class Field(Generic[_T]):
     init: bool
     compare: bool
     metadata: types.MappingProxyType[Any, Any]
-    doc: str | None
+
     if sys.version_info >= (3, 14):
+        doc: str | None
+
+    if sys.version_info >= (3, 10):
         kw_only: bool | Literal[_MISSING_TYPE.MISSING]
+
+    if sys.version_info >= (3, 14):
         def __init__(
             self,
             default: _T,

--- a/stdlib/dataclasses.pyi
+++ b/stdlib/dataclasses.pyi
@@ -31,7 +31,6 @@ if sys.version_info >= (3, 10):
 
 _DataclassT = TypeVar("_DataclassT", bound=DataclassInstance)
 
-
 @type_check_only
 class _DataclassFactory(Protocol):
     def __call__(
@@ -50,7 +49,6 @@ class _DataclassFactory(Protocol):
         slots: bool = False,
         weakref_slot: bool = False,
     ) -> type[_T]: ...
-
 
 # define _MISSING_TYPE as an enum within the type stubs,
 # even though that is not really its type at runtime
@@ -94,8 +92,6 @@ if sys.version_info >= (3, 11):
         slots: bool = False,
         weakref_slot: bool = False,
     ) -> type[_T]: ...
-
-
     @overload
     def dataclass(
         *,

--- a/stdlib/dataclasses.pyi
+++ b/stdlib/dataclasses.pyi
@@ -5,8 +5,8 @@ from _typeshed import DataclassInstance
 from builtins import type as Type  # alias to avoid name clashes with fields named "type"
 from collections.abc import Callable, Iterable, Mapping
 from types import GenericAlias
-from typing import Any, Generic, Literal, Protocol, TypeVar, overload
-from typing_extensions import Never, TypeIs, type_check_only
+from typing import Any, Generic, Literal, Protocol, TypeVar, overload, type_check_only
+from typing_extensions import Never, TypeIs
 
 _T = TypeVar("_T")
 _T_co = TypeVar("_T_co", covariant=True)


### PR DESCRIPTION
Make dataclass updates for 3.14, supporting `doc` on `dataclasses.Field` and `decorator` on `make_dataclass`.