### PR TITLE
Support `requires_python` in `runtests.py`

### DIFF
--- a/lib/ts_utils/metadata.py
+++ b/lib/ts_utils/metadata.py
@@ -47,7 +47,7 @@ def _is_nested_dict(obj: object) -> TypeGuard[dict[str, dict[str, Any]]]:
 
 
 @functools.cache
-def _get_oldest_supported_python() -> str:
+def get_oldest_supported_python() -> str:
     with PYPROJECT_PATH.open("rb") as config:
         val = tomli.load(config)["tool"]["typeshed"]["oldest_supported_python"]
     assert type(val) is str
@@ -276,7 +276,7 @@ def read_metadata(distribution: str) -> StubMetadata:
     partial_stub: object = data.get("partial_stub", True)
     assert type(partial_stub) is bool
     requires_python_str: object = data.get("requires_python")
-    oldest_supported_python = _get_oldest_supported_python()
+    oldest_supported_python = get_oldest_supported_python()
     oldest_supported_python_specifier = Specifier(f">={oldest_supported_python}")
     if requires_python_str is None:
         requires_python = oldest_supported_python_specifier


### PR DESCRIPTION
Addresses the `runtests.py` part of https://github.com/python/typeshed/issues/14025

I tested by running:
`uv run .\tests\runtests.py --run-stubtest .\stubs\networkx\` (should default to 3.10)
`uv run .\tests\runtests.py --run-stubtest .\stubs\networkx\ --python-version=3.9` (should fail some tests)
`uv run .\tests\runtests.py --run-stubtest .\stubs\networkx\ --python-version=3.11` (should work on 3.11)

`uv run .\tests\runtests.py --run-stubtest .\stubs\setuptools\` (should default to 3.9)
`uv run .\tests\runtests.py --run-stubtest .\stubs\setuptools\ --python-version=3.11` (should work on 3.11)

`uv run .\tests\runtests.py --run-stubtest .\stdlib\typing.pyi` (should default to 3.9)

This also deduplicates a Python version in code