### PR TITLE
Make `tkinter.Event` equivalent to `tkinter.Event[tkinter.Misc]`

### DIFF
--- a/stdlib/tkinter/__init__.pyi
+++ b/stdlib/tkinter/__init__.pyi
@@ -287,7 +287,7 @@ else:
 
 _W = TypeVar("_W", bound=Misc)
 # Events considered covariant because you should never assign to event.widget.
-_W_co = TypeVar("_W_co", covariant=True, bound=Misc)
+_W_co = TypeVar("_W_co", covariant=True, bound=Misc, default=Misc)
 
 class Event(Generic[_W_co]):
     serial: int


### PR DESCRIPTION
A `tkinter.Event` represents something happening in a widget. The event's `widget` field is basically the widget that caused it. The somewhat misleadingly named `Misc` class means "any widget".

When writing an event handler function, you can specify the type of `event.widget` by using e.g. `event: tkinter.Event[tkinter.Label]`. Before this PR, it is required with strict type checker settings, and you get `Any` if you don't use it. With this PR, it is assumed to be `Misc`. This is suitable for event handlers that don't use the `.widget` field.

For example:

```python
import tkinter

def handle_event(event: tkinter.Event) -> None:
    reveal_type(event.widget)
```

Mypy output before:

```
a.py:3: error: Missing type parameters for generic type "Event"  [type-arg]
a.py:4: note: Revealed type is "Any"
Found 1 error in 1 file (checked 1 source file)
```

Mypy ouput with this PR:

```
a.py:4: note: Revealed type is "tkinter.Misc"
Success: no issues found in 1 source file
```

The only reason why I didn't use `default=Misc` initially is that the `default` parameter didn't exist at the time.