### PR TITLE
Update nx_pylab.pyi: allow node_color to be a list of strings as well

### DIFF
--- a/stubs/networkx/networkx/drawing/nx_pylab.pyi
+++ b/stubs/networkx/networkx/drawing/nx_pylab.pyi
@@ -25,7 +25,7 @@ def draw_networkx_nodes(
     pos,
     nodelist: Collection[Incomplete] | None = None,
     node_size: Incomplete | int = 300,
-    node_color: str | list[str] = "#1f78b4",
+    node_color: str | Sequence[str] = "#1f78b4",
     node_shape: str = "o",
     alpha=None,
     cmap=None,

--- a/stubs/networkx/networkx/drawing/nx_pylab.pyi
+++ b/stubs/networkx/networkx/drawing/nx_pylab.pyi
@@ -1,5 +1,5 @@
 from _typeshed import Incomplete
-from collections.abc import Collection
+from collections.abc import Collection, Sequence
 
 __all__ = [
     "draw",

--- a/stubs/networkx/networkx/drawing/nx_pylab.pyi
+++ b/stubs/networkx/networkx/drawing/nx_pylab.pyi
@@ -26,7 +26,7 @@ def draw_networkx_nodes(
     pos,
     nodelist: Collection[Incomplete] | None = None,
     node_size: Incomplete | int = 300,
-    node_color: Union[str|list[str]] = "#1f78b4",
+    node_color: Union[str | list[str]] = "#1f78b4",
     node_shape: str = "o",
     alpha=None,
     cmap=None,

--- a/stubs/networkx/networkx/drawing/nx_pylab.pyi
+++ b/stubs/networkx/networkx/drawing/nx_pylab.pyi
@@ -1,5 +1,6 @@
 from _typeshed import Incomplete
 from collections.abc import Collection
+from typing import Union
 
 __all__ = [
     "draw",
@@ -25,7 +26,7 @@ def draw_networkx_nodes(
     pos,
     nodelist: Collection[Incomplete] | None = None,
     node_size: Incomplete | int = 300,
-    node_color: str = "#1f78b4",
+    node_color: Union[str|list[str]] = "#1f78b4",
     node_shape: str = "o",
     alpha=None,
     cmap=None,

--- a/stubs/networkx/networkx/drawing/nx_pylab.pyi
+++ b/stubs/networkx/networkx/drawing/nx_pylab.pyi
@@ -1,6 +1,5 @@
 from _typeshed import Incomplete
 from collections.abc import Collection
-from typing import Union
 
 __all__ = [
     "draw",
@@ -26,7 +25,7 @@ def draw_networkx_nodes(
     pos,
     nodelist: Collection[Incomplete] | None = None,
     node_size: Incomplete | int = 300,
-    node_color: Union[str | list[str]] = "#1f78b4",
+    node_color: str | list[str] = "#1f78b4",
     node_shape: str = "o",
     alpha=None,
     cmap=None,


### PR DESCRIPTION
As per the documentation https://networkx.org/documentation/latest/reference/generated/networkx.drawing.nx_pylab.draw_networkx_nodes.html#draw-networkx-nodes and program behavior.

Fun fact: I'm actually using version 2 of this library, 2 majors behind, and it accepts list[str] as well there as well!