### PR TITLE
gevent: Removes remaining uses of `Incomplete`

### DIFF
--- a/stubs/gevent/gevent/_util.pyi
+++ b/stubs/gevent/gevent/_util.pyi
@@ -1,5 +1,4 @@
-from _typeshed import Incomplete
-from collections.abc import Callable, MutableMapping, Sequence
+from collections.abc import Callable, Iterable, MutableMapping, Sequence
 from types import ModuleType
 from typing import Any, Generic, TypeVar, overload
 from typing_extensions import Self
@@ -13,7 +12,7 @@ def update_wrapper(wrapper: _T, wrapped: object, assigned: Sequence[str] = ..., 
 def copy_globals(
     source: ModuleType,
     globs: MutableMapping[str, Any],
-    only_names: Incomplete | None = None,
+    only_names: Iterable[str] | None = None,
     ignore_missing_names: bool = False,
     names_to_ignore: Sequence[str] = ...,
     dunder_names_to_keep: Sequence[str] = ...,

--- a/stubs/gevent/gevent/os.pyi
+++ b/stubs/gevent/gevent/os.pyi
@@ -1,8 +1,10 @@
 import os
 import sys
-from _typeshed import FileDescriptor, Incomplete, ReadableBuffer
+from _typeshed import FileDescriptor, ReadableBuffer
 from collections.abc import Callable
 from typing import Literal
+
+from gevent._types import _ChildWatcher, _Loop
 
 def tp_read(fd: FileDescriptor, n: int) -> bytes: ...
 def tp_write(fd: FileDescriptor, buf: ReadableBuffer) -> int: ...
@@ -17,11 +19,14 @@ if sys.platform != "win32":
     def forkpty_gevent() -> tuple[int, int]: ...
     waitpid = os.waitpid
     def fork_and_watch(
-        callback: Incomplete | None = None, loop: Incomplete | None = None, ref: bool = False, fork: Callable[[], int] = ...
+        callback: Callable[[_ChildWatcher], object] | None = None,
+        loop: _Loop | None = None,
+        ref: bool = False,
+        fork: Callable[[], int] = ...,
     ) -> int: ...
     def forkpty_and_watch(
-        callback: Incomplete | None = None,
-        loop: Incomplete | None = None,
+        callback: Callable[[_ChildWatcher], object] | None = None,
+        loop: _Loop | None = None,
         ref: bool = False,
         forkpty: Callable[[], tuple[int, int]] = ...,
     ) -> tuple[int, int]: ...


### PR DESCRIPTION
As suggested in #14063 I'm opening a separate PR for replacing the remaining uses of `Incomplete` in gevent with the correct type hints.