### PR TITLE
Update `ast.alias` _attributes for Python 3.9

### DIFF
--- a/stdlib/ast.pyi
+++ b/stdlib/ast.pyi
@@ -1429,15 +1429,19 @@ class keyword(AST):
         def __replace__(self, *, arg: str | None = ..., value: expr = ..., **kwargs: Unpack[_Attributes]) -> Self: ...
 
 class alias(AST):
-    lineno: int
-    col_offset: int
-    end_lineno: int | None
-    end_col_offset: int | None
-    if sys.version_info >= (3, 10):
-        __match_args__ = ("name", "asname")
     name: str
     asname: str | None
-    def __init__(self, name: str, asname: str | None = None, **kwargs: Unpack[_Attributes]) -> None: ...
+    if sys.version_info >= (3, 10):
+        lineno: int
+        col_offset: int
+        end_lineno: int | None
+        end_col_offset: int | None
+    if sys.version_info >= (3, 10):
+        __match_args__ = ("name", "asname")
+    if sys.version_info >= (3, 10):
+        def __init__(self, name: str, asname: str | None = None, **kwargs: Unpack[_Attributes]) -> None: ...
+    else:
+        def __init__(self, name: str, asname: str | None = None) -> None: ...
 
     if sys.version_info >= (3, 14):
         def __replace__(self, *, name: str = ..., asname: str | None = ..., **kwargs: Unpack[_Attributes]) -> Self: ...


### PR DESCRIPTION
Adjust the `ast.alias` class to correctly reflect the absence of `lineno`, `col_offset`, `end_lineno`, and `end_col_offset` attributes in Python 3.9, aligning it with the actual behavior observed in the interpreter.

Fixes #14102