### PR TITLE
re-export _csv Reader and Writer in csv.pyi

### DIFF
--- a/stdlib/csv.pyi
+++ b/stdlib/csv.pyi
@@ -20,7 +20,7 @@ from _csv import (
 if sys.version_info >= (3, 12):
     from _csv import QUOTE_NOTNULL as QUOTE_NOTNULL, QUOTE_STRINGS as QUOTE_STRINGS
 if sys.version_info >= (3, 10):
-    from _csv import Reader, Writer
+    from _csv import Reader as Reader, Writer as Writer
 else:
     from _csv import _reader as Reader, _writer as Writer
 


### PR DESCRIPTION
Fixes: #14108

Question:

I would like to include `Reader, Writer  in `__all__` but I am not sure if and how it should be done.

Option 1) Include it in `__all__` for all versions, however it is only present at runtime for 3.10+
Option 2) 
```python
if sys.version_info >= (3, 10):
   __all__ += ["Reader", "Writer"]
```