### PR TITLE
Update `grpcio` stub to import `grpc.aio`

### DIFF
--- a/stubs/grpcio/grpc/__init__.pyi
+++ b/stubs/grpcio/grpc/__init__.pyi
@@ -1,11 +1,15 @@
 import abc
 import enum
+import sys
 import threading
 from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from concurrent import futures
 from types import ModuleType, TracebackType
 from typing import Any, Generic, NoReturn, Protocol, TypeVar, type_check_only
 from typing_extensions import Self, TypeAlias
+
+if sys.version_info >= (3, 6):
+    from . import aio as aio
 
 __version__: str
 

--- a/stubs/grpcio/grpc/__init__.pyi
+++ b/stubs/grpcio/grpc/__init__.pyi
@@ -1,15 +1,11 @@
 import abc
 import enum
-import sys
 import threading
 from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from concurrent import futures
 from types import ModuleType, TracebackType
 from typing import Any, Generic, NoReturn, Protocol, TypeVar, type_check_only
 from typing_extensions import Self, TypeAlias
-
-if sys.version_info >= (3, 6):
-    from grpc import aio
 
 __version__: str
 

--- a/stubs/grpcio/grpc/__init__.pyi
+++ b/stubs/grpcio/grpc/__init__.pyi
@@ -1,6 +1,5 @@
 import abc
 import enum
-import sys
 import threading
 from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from concurrent import futures
@@ -8,8 +7,7 @@ from types import ModuleType, TracebackType
 from typing import Any, Generic, NoReturn, Protocol, TypeVar, type_check_only
 from typing_extensions import Self, TypeAlias
 
-if sys.version_info >= (3, 6):
-    from . import aio as aio
+from . import aio as aio
 
 __version__: str
 

--- a/stubs/grpcio/grpc/__init__.pyi
+++ b/stubs/grpcio/grpc/__init__.pyi
@@ -1,11 +1,15 @@
 import abc
 import enum
+import sys
 import threading
 from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from concurrent import futures
 from types import ModuleType, TracebackType
 from typing import Any, Generic, NoReturn, Protocol, TypeVar, type_check_only
 from typing_extensions import Self, TypeAlias
+
+if sys.version_info >= (3, 6):
+    from grpc import aio
 
 __version__: str
 


### PR DESCRIPTION
Relevant part in `grpc/__init__.py`: https://github.com/grpc/grpc/blob/cadf3c8329377e93b1f5e2d6a43d91f7a4becc28/src/python/grpcio/grpc/__init__.py#L2344-L2348

It runs `from grpc import aio` inside `__init__.py` if the Python version is 3.6 or later. I bumped into this because after upgrading to Pyright 1.1.401, `grpc.aio` type checking & definition finding regressed.