### PR TITLE
Update `string.Template` to 3.14

### DIFF
--- a/stdlib/@tests/stubtest_allowlists/py314.txt
+++ b/stdlib/@tests/stubtest_allowlists/py314.txt
@@ -39,7 +39,6 @@ multiprocessing.managers._BaseDictProxy.__ror__
 multiprocessing.managers._BaseDictProxy.fromkeys
 multiprocessing.process.BaseProcess.interrupt
 multiprocessing.synchronize.SemLock.locked
-string.Template.flags
 tarfile.TarFile.zstopen
 tkinter.Event.__class_getitem__
 turtle.__all__

--- a/stdlib/string/__init__.pyi
+++ b/stdlib/string/__init__.pyi
@@ -32,12 +32,15 @@ whitespace: LiteralString
 
 def capwords(s: StrOrLiteralStr, sep: StrOrLiteralStr | None = None) -> StrOrLiteralStr: ...
 
-class Template(metaclass=type):
+class Template:
     template: str
     delimiter: ClassVar[str]
     idpattern: ClassVar[str]
     braceidpattern: ClassVar[str | None]
-    flags: ClassVar[RegexFlag]
+    if sys.version_info >= (3, 14):
+        flags: ClassVar[RegexFlag | None]
+    else:
+        flags: ClassVar[RegexFlag]
     pattern: ClassVar[Pattern[str]]
     def __init__(self, template: str) -> None: ...
     def substitute(self, mapping: Mapping[str, object] = {}, /, **kwds: object) -> str: ...


### PR DESCRIPTION
Source: https://github.com/python/cpython/commit/ee3657209b1464d66c89640e4db0dccdeec5b45c

```python
>>> import string
>>> assert string.Template.flags is None
```

But, it will be set to `re.IGNORECASE` on `__init_subclass__`.