### PR TITLE
[geopandas] Unblock CI

### DIFF
--- a/stubs/geopandas/METADATA.toml
+++ b/stubs/geopandas/METADATA.toml
@@ -1,6 +1,6 @@
 version = "1.0.1"
 # Requires a version of numpy with a `py.typed` file
-requires = ["numpy>=1.20", "pandas-stubs", "types-shapely", "pyproj"]
+requires = ["numpy>=1.20", "pandas-stubs<2.2.3.250527", "types-shapely", "pyproj"]
 upstream_repository = "https://github.com/geopandas/geopandas"
 
 [tool.stubtest]


### PR DESCRIPTION
New release of `pandas-stubs` made our `geopandas` stubs incompatible: https://pypi.org/project/pandas-stubs/2.2.3.250527/

My plan is to unblock the CI for now and figure out what is wrong later.
Refs #14177 