### PR TITLE
Add merge_extra attribute to LoggerAdapter

### DIFF
--- a/stdlib/logging/__init__.pyi
+++ b/stdlib/logging/__init__.pyi
@@ -373,6 +373,9 @@ class LoggerAdapter(Generic[_L]):
     else:
         extra: Mapping[str, object]
 
+    if sys.version_info >= (3, 13):
+        merge_extra: bool
+
     def process(self, msg: Any, kwargs: MutableMapping[str, Any]) -> tuple[Any, MutableMapping[str, Any]]: ...
     def debug(
         self,


### PR DESCRIPTION
This was added in python 3.13 and the typeshed already defines the argument but does not include the public attribute in the stub of LoggerAdapter class.

In my usecase I am overriding process and would like to be able to make use of the `merge_extra` attribute there. 