### PR TITLE
openpyxl: tag attr can be callable

### DIFF
--- a/stubs/openpyxl/openpyxl/xml/_functions_overloads.pyi
+++ b/stubs/openpyxl/openpyxl/xml/_functions_overloads.pyi
@@ -1,7 +1,7 @@
 # This file does not exist at runtime. It is a helper file to overload imported functions in openpyxl.xml.functions
 
-from _typeshed import Incomplete, ReadableBuffer
-from collections.abc import Iterable, Iterator, Mapping, Sequence
+from _typeshed import Incomplete, ReadableBuffer, Unused
+from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from typing import Any, Protocol, TypeVar, overload
 from typing_extensions import TypeAlias
 from xml.etree.ElementTree import Element, ElementTree, QName, XMLParser, _FileRead
@@ -18,7 +18,8 @@ _T_co = TypeVar("_T_co", covariant=True)
 # lxml.etree._Element
 # xml.etree.Element
 class _HasTag(Protocol):
-    tag: str
+    # See openpyxl.xml.functions.localname for when tag can be callable
+    tag: str | Callable[..., Unused]
 
 class _HasGet(Protocol[_T_co]):
     def get(self, value: str, /) -> _T_co | None: ...
@@ -56,11 +57,11 @@ _lxml_ElementTree: TypeAlias = ElementTree  # noqa: Y042
 # from lxml.etree import QName
 _lxml_QName: TypeAlias = QName  # noqa: Y042
 
-# from xml.etree import fromstring
+# from xml.etree.ElementTree import SubElement
 @overload
 def SubElement(parent: _ParentElement[_T], tag: str, attrib: dict[str, str] = ..., **extra: str) -> _T: ...
 
-# from lxml.etree import fromstring
+# from lxml.etree import SubElement
 @overload
 def SubElement(
     _parent: _lxml_Element,  # This would be preferable as a protocol, but it's a C-Extension


### PR DESCRIPTION
As noticed in https://github.com/python/typeshed/pull/11841#issuecomment-2926286794

> The `tag` can actually be a `str` OR a callable.
> The only place the `tag` attribute isn't for a comparison (equal, contains, itemgetter, ...) is: https://foss.heptapod.net/openpyxl/openpyxl/-/blob/700cafe4928c9c5e7ffc998f5d911e475ac8c37f/openpyxl/descriptors/serialisable.py#L76
> And that's after being passed through the `localname` function [where it simply checks if it's a callable]: https://foss.heptapod.net/openpyxl/openpyxl/-/blob/700cafe4928c9c5e7ffc998f5d911e475ac8c37f/openpyxl/xml/functions.py#L77-81