### PR TITLE
Visualization of the typeshed codebase

### DIFF
--- a/.codeboarding/GeneralUtils.md
+++ b/.codeboarding/GeneralUtils.md
@@ -1,0 +1,72 @@
+```mermaid
+graph LR
+    Requirement_Parsing["Requirement Parsing"]
+    Stdlib_Version_Parsing["Stdlib Version Parsing"]
+    Test_Case_Management["Test Case Management"]
+    Stubtest_Allowlist_Management["Stubtest Allowlist Management"]
+    Path_Utilities["Path Utilities"]
+    Test_Case_Management -- "uses" --> Path_Utilities
+    Stubtest_Allowlist_Management -- "uses" --> Path_Utilities
+```
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+## Component Details
+
+This graph illustrates the internal structure and interactions within the `GeneralUtils` subsystem of the typeshed project. It highlights how different sub-components handle tasks such as parsing requirements and standard library versions, managing test case directories, and generating stubtest allowlists, all while leveraging common path utility functions.
+
+### Requirement Parsing
+This component is responsible for parsing and managing project requirements, specifically focusing on extracting mypy requirements from the `requirements-tests.txt` file.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/utils.py#L106-L107" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.utils:get_mypy_req` (106:107)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/utils.py#L97-L103" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.utils:parse_requirements` (97:103)</a>
+
+
+### Stdlib Version Parsing
+This component handles the parsing of the `stdlib/VERSIONS` file to determine supported Python versions for different modules.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/utils.py#L122-L136" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.utils:parse_stdlib_versions_file` (122:136)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/utils.py#L34-L35" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.utils:strip_comments` (34:35)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/utils.py#L147-L150" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.utils._parse_version` (147:150)</a>
+
+
+### Test Case Management
+This component manages the identification and retrieval of test case directories for both standard library and third-party distributions.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/utils.py#L167-L175" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.utils:distribution_info` (167:175)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/utils.py#L178-L186" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.utils:get_all_testcase_directories` (178:186)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/paths.py#L32-L33" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.paths:test_cases_path` (32:33)</a>
+
+
+### Stubtest Allowlist Management
+This component is responsible for generating and managing allowlist arguments for the stubtest tool. It determines the appropriate allowlist files based on the distribution name, platform, and Python version.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/utils.py#L247-L253" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.utils:allowlist_stubtest_arguments` (247:253)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/utils.py#L189-L201" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.utils.allowlists` (189:201)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/paths.py#L36-L40" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.paths:allowlists_path` (36:40)</a>
+
+
+### Path Utilities
+This component provides utility functions for constructing various file paths within the typeshed project.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/paths.py#L32-L33" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.paths:test_cases_path` (32:33)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/paths.py#L36-L40" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.paths:allowlists_path` (36:40)</a>
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/MetadataManager.md
+++ b/.codeboarding/MetadataManager.md
@@ -1,0 +1,93 @@
+```mermaid
+graph LR
+    Metadata_Core["Metadata Core"]
+    Dependency_Resolution["Dependency Resolution"]
+    Stub_Requirements_API["Stub Requirements API"]
+    MyPy_Integration["MyPy Integration"]
+    Path_Utilities["Path Utilities"]
+    Metadata_Core -- "locates files using" --> Path_Utilities
+    Dependency_Resolution -- "reads metadata from" --> Metadata_Core
+    Stub_Requirements_API -- "retrieves external requirements from" --> Dependency_Resolution
+    Stub_Requirements_API -- "accesses stubtest settings from" --> Metadata_Core
+    MyPy_Integration -- "configures using metadata from" --> Metadata_Core
+```
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+## Component Details
+
+This graph illustrates the architecture of the `MetadataManager` subsystem, which is central to handling typeshed stub metadata. It encompasses functionalities for reading, updating, and parsing metadata, managing stubtest settings, resolving dependencies, generating MyPy configurations, and providing essential path utilities. The core purpose is to ensure accurate and consistent management of stub information and its related configurations within the typeshed project.
+
+### Metadata Core
+Manages all aspects of stub metadata, including reading, updating, and parsing dependencies from METADATA.toml files. It defines data structures for stub metadata and stubtest settings, and provides utilities for mapping PyPI names to Typeshed names and recursively gathering requirements.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/metadata.py#L57-L59" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.metadata:metadata_path` (57:59)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/metadata.py#L64-L85" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.metadata.StubtestSettings` (64:85)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/metadata.py#L81-L85" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.metadata.StubtestSettings:system_requirements_for_platform` (81:85)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/metadata.py#L89-L139" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.metadata:read_stubtest_settings` (89:139)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/metadata.py#L144-L165" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.metadata.StubMetadata` (144:165)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/metadata.py#L206-L316" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.metadata:read_metadata` (206:316)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/metadata.py#L319-L333" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.metadata:update_metadata` (319:333)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/metadata.py#L336-L338" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.metadata:parse_requires` (336:338)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/metadata.py#L50-L54" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.metadata:get_oldest_supported_python` (50:54)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/metadata.py#L41-L42" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.metadata:_is_list_of_strings` (41:42)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/metadata.py#L45-L46" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.metadata:_is_nested_dict` (45:46)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/metadata.py#L201-L202" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.metadata.NoSuchStubError` (201:202)</a>
+
+
+### Dependency Resolution
+Responsible for resolving and managing dependencies between typeshed stubs. It includes functions for reading direct and recursive dependencies, and mapping PyPI package names to typeshed stub names.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/metadata.py#L352-L375" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.metadata:read_dependencies` (352:375)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/metadata.py#L379-L397" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.metadata:get_recursive_requirements` (379:397)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/metadata.py#L347-L348" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.metadata:get_pypi_name_to_typeshed_name_mapping` (347:348)</a>
+
+
+### Stub Requirements API
+Provides an API for retrieving external stub requirements and system-specific requirements for stub testing. It leverages the metadata and dependency resolution components to gather the necessary information.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/requirements.py#L14-L18" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.requirements:get_external_stub_requirements` (14:18)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/requirements.py#L21-L28" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.requirements:get_stubtest_system_requirements` (21:28)</a>
+
+
+### MyPy Integration
+Handles the generation and validation of MyPy configuration files based on typeshed distribution metadata, ensuring compatibility and correctness for type checking.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/mypy.py#L27-L49" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.mypy:mypy_configuration_from_distribution` (27:49)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/mypy.py#L36-L46" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.mypy:mypy_configuration_from_distribution.validate_configuration` (36:46)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/mypy.py#L53-L77" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.mypy:temporary_mypy_config_file` (53:77)</a>
+
+
+### Path Utilities
+Provides utility functions for resolving file paths, specifically for distribution paths within typeshed, which are crucial for locating metadata files.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/paths.py#L20-L22" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.paths:distribution_path` (20:22)</a>
+- `typeshed.lib.ts_utils.paths:STUBS_PATH` (full file reference)
+- `typeshed.lib.ts_utils.paths:PYPROJECT_PATH` (full file reference)
+- `typeshed.lib.ts_utils.paths:STDLIB_PATH` (full file reference)
+- `typeshed.lib.ts_utils.paths:REQUIREMENTS_PATH` (full file reference)
+- `typeshed.lib.ts_utils.paths:GITIGNORE_PATH` (full file reference)
+- `typeshed.lib.ts_utils.paths:TESTS_DIR` (full file reference)
+- `typeshed.lib.ts_utils.paths:TEST_CASES_DIR` (full file reference)
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/paths.py#L25-L29" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.paths:tests_path` (25:29)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/paths.py#L32-L33" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.paths:test_cases_path` (32:33)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/paths.py#L36-L40" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.paths:allowlists_path` (36:40)</a>
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/MypyConfiguration.md
+++ b/.codeboarding/MypyConfiguration.md
@@ -1,0 +1,36 @@
+```mermaid
+graph LR
+    Mypy_Configuration_Generator["Mypy Configuration Generator"]
+    Distribution_Metadata_Accessor["Distribution Metadata Accessor"]
+    Mypy_Configuration_Generator -- "utilizes" --> Distribution_Metadata_Accessor
+```
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+## Component Details
+
+This system is designed to generate and validate Mypy configurations for Python distributions. Its primary function involves accessing distribution-specific metadata to locate relevant configuration files, processing this information, and then constructing a structured Mypy configuration. It also supports the creation of temporary Mypy configuration files to facilitate static analysis.
+
+### Mypy Configuration Generator
+This component is responsible for generating Mypy configurations from distribution metadata. It orchestrates the retrieval of metadata paths, loading of TOML data, and validation of configuration sections, ultimately providing a structured representation of Mypy settings. It also handles the creation of temporary Mypy configuration files.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/mypy.py#L27-L49" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.mypy:mypy_configuration_from_distribution` (27:49)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/mypy.py#L13-L15" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.mypy.MypyDistConf` (13:15)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/mypy.py#L53-L77" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.mypy.temporary_mypy_config_file` (53:77)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/mypy.py#L36-L46" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.mypy.mypy_configuration_from_distribution.validate_configuration` (36:46)</a>
+
+
+### Distribution Metadata Accessor
+This component provides an interface for accessing distribution metadata, specifically for obtaining the file path where configuration details are stored, enabling the Mypy configuration process to locate its source data.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/metadata.py#L57-L59" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.metadata.metadata_path` (57:59)</a>
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/PathResolver.md
+++ b/.codeboarding/PathResolver.md
@@ -1,0 +1,83 @@
+```mermaid
+graph LR
+    PathResolver["PathResolver"]
+    MetadataHandler["MetadataHandler"]
+    TestUtilities["TestUtilities"]
+    MetadataHandler -- "uses" --> PathResolver
+    TestUtilities -- "uses" --> PathResolver
+```
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+## Component Details
+
+This graph describes the core utility components of the typeshed project. The `PathResolver` component is responsible for defining and resolving various file and directory paths within the project structure. The `MetadataHandler` component manages the reading, parsing, and updating of `METADATA.toml` files, providing structured access to configuration details. The `TestUtilities` component offers general utilities for testing and project management, including virtual environment management and parsing configuration files. The `MetadataHandler` and `TestUtilities` components both depend on `PathResolver` for their path resolution needs, indicating a foundational role for `PathResolver` in the system's file operations.
+
+### PathResolver
+Provides utility functions for resolving various file and directory paths within the typeshed project structure, including paths for distributions, tests, and allowlists. It also defines core path constants.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/paths.py#L9-L9" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.paths:TS_BASE_PATH` (9:9)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/paths.py#L10-L10" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.paths:STDLIB_PATH` (10:10)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/paths.py#L11-L11" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.paths:STUBS_PATH` (11:11)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/paths.py#L13-L13" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.paths:PYPROJECT_PATH` (13:13)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/paths.py#L14-L14" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.paths:REQUIREMENTS_PATH` (14:14)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/paths.py#L15-L15" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.paths:GITIGNORE_PATH` (15:15)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/paths.py#L17-L17" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.paths:TESTS_DIR` (17:17)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/paths.py#L18-L18" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.paths:TEST_CASES_DIR` (18:18)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/paths.py#L20-L22" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.paths:distribution_path` (20:22)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/paths.py#L25-L29" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.paths:tests_path` (25:29)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/paths.py#L32-L33" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.paths:test_cases_path` (32:33)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/paths.py#L36-L40" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.paths:allowlists_path` (36:40)</a>
+
+
+### MetadataHandler
+Manages the reading, parsing, and updating of METADATA.toml files, including stub metadata, stubtest settings, and package dependencies. It provides structured access to configuration details for typeshed distributions.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/metadata.py#L57-L59" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.metadata:metadata_path` (57:59)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/metadata.py#L64-L85" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.metadata:StubtestSettings` (64:85)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/metadata.py#L89-L139" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.metadata:read_stubtest_settings` (89:139)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/metadata.py#L144-L165" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.metadata:StubMetadata` (144:165)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/metadata.py#L206-L316" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.metadata:read_metadata` (206:316)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/metadata.py#L319-L333" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.metadata:update_metadata` (319:333)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/metadata.py#L336-L338" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.metadata:parse_requires` (336:338)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/metadata.py#L341-L343" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.metadata:PackageDependencies` (341:343)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/metadata.py#L347-L348" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.metadata:get_pypi_name_to_typeshed_name_mapping` (347:348)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/metadata.py#L352-L375" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.metadata:read_dependencies` (352:375)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/metadata.py#L379-L397" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.metadata:get_recursive_requirements` (379:397)</a>
+
+
+### TestUtilities
+Provides a collection of general utilities for testing and project management within typeshed, including printing functions, virtual environment management, parsing requirements and version files, and generating stubtest-related arguments. It depends on PathResolver for path resolution.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/utils.py#L43-L46" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.utils:print_command` (43:46)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/utils.py#L49-L50" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.utils:print_info` (49:50)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/utils.py#L53-L58" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.utils:print_error` (53:58)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/utils.py#L61-L62" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.utils:print_success_msg` (61:62)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/utils.py#L65-L72" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.utils:print_divider` (65:72)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/utils.py#L75-L76" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.utils:print_time` (75:76)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/utils.py#L85-L88" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.utils:venv_python` (85:88)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/utils.py#L97-L103" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.utils:parse_requirements` (97:103)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/utils.py#L106-L107" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.utils:get_mypy_req` (106:107)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/utils.py#L122-L136" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.utils:parse_stdlib_versions_file` (122:136)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/utils.py#L139-L144" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.utils:supported_versions_for_module` (139:144)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/utils.py#L158-L164" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.utils:DistributionTests` (158:164)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/utils.py#L167-L175" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.utils:distribution_info` (167:175)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/utils.py#L178-L186" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.utils:get_all_testcase_directories` (178:186)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/utils.py#L189-L201" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.utils:allowlists` (189:201)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/utils.py#L180-L189" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.utils:NamedTemporaryFile` (180:189)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/utils.py#L230-L232" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.utils:get_gitignore_spec` (230:232)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/utils.py#L235-L239" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.utils:spec_matches_path` (235:239)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/utils.py#L247-L253" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.utils:allowlist_stubtest_arguments` (247:253)</a>
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/RequirementHandler.md
+++ b/.codeboarding/RequirementHandler.md
@@ -1,0 +1,36 @@
+```mermaid
+graph LR
+    RequirementHandler["RequirementHandler"]
+    MetadataReader["MetadataReader"]
+    RequirementHandler -- "retrieves data from" --> MetadataReader
+```
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+## Component Details
+
+This graph illustrates the interaction between the `RequirementHandler` and `MetadataReader` components. The `RequirementHandler` is responsible for gathering various stub requirements, while the `MetadataReader` provides the necessary metadata by parsing METADATA.toml files. The main flow involves the `RequirementHandler` querying the `MetadataReader` to obtain dependency and stubtest setting information, which it then processes to fulfill its purpose of handling external stub and system-specific requirements for stub testing.
+
+### RequirementHandler
+Handles the retrieval and processing of external stub requirements and system-specific requirements for stub testing.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/requirements.py#L14-L18" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.requirements:get_external_stub_requirements` (14:18)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/requirements.py#L21-L28" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.requirements:get_stubtest_system_requirements` (21:28)</a>
+
+
+### MetadataReader
+Responsible for reading, parsing, and validating METADATA.toml files. It provides structured access to stub metadata, stubtest settings, and package dependencies.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/metadata.py#L352-L375" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.metadata:read_dependencies` (352:375)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/metadata.py#L89-L139" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.metadata:read_stubtest_settings` (89:139)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/metadata.py#L81-L85" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.metadata.StubtestSettings:system_requirements_for_platform` (81:85)</a>
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/on_boarding.md
+++ b/.codeboarding/on_boarding.md
@@ -1,0 +1,97 @@
+```mermaid
+graph LR
+    MetadataManager["MetadataManager"]
+    PathResolver["PathResolver"]
+    RequirementHandler["RequirementHandler"]
+    MypyConfiguration["MypyConfiguration"]
+    GeneralUtils["GeneralUtils"]
+    RequirementHandler -- "retrieves stub and system requirements from" --> MetadataManager
+    MypyConfiguration -- "configures Mypy based on metadata from" --> MetadataManager
+    MetadataManager -- "locates metadata files using" --> PathResolver
+    GeneralUtils -- "accesses project paths using" --> PathResolver
+    RequirementHandler -- "uses paths for requirements processing from" --> PathResolver
+    MypyConfiguration -- "validates configurations using" --> GeneralUtils
+    click MetadataManager href "https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/typeshed/MetadataManager.md" "Details"
+    click PathResolver href "https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/typeshed/PathResolver.md" "Details"
+    click RequirementHandler href "https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/typeshed/RequirementHandler.md" "Details"
+    click MypyConfiguration href "https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/typeshed/MypyConfiguration.md" "Details"
+    click GeneralUtils href "https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/typeshed/GeneralUtils.md" "Details"
+```
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+## Component Details
+
+This architecture analysis of `typeshed` reveals a well-structured system primarily focused on managing Python type stubs. The core functionality revolves around metadata handling, path resolution, requirement processing, and Mypy configuration. The `MetadataManager` acts as a central hub for all stub-related metadata, relying on `PathResolver` for file location. `RequirementHandler` and `MypyConfiguration` interact with the `MetadataManager` to retrieve necessary information for dependency management and type checking, respectively. `GeneralUtils` provides a suite of common utilities that support various operations across these components, ensuring efficient and accurate processing of type stubs.
+
+### MetadataManager
+Manages all aspects of stub metadata, including reading, updating, and parsing dependencies from METADATA.toml files. It defines data structures for stub metadata and stubtest settings, and provides utilities for mapping PyPI names to Typeshed names and recursively gathering requirements.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/metadata.py#L57-L59" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.metadata:metadata_path` (57:59)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/metadata.py#L64-L85" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.metadata.StubtestSettings` (64:85)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/metadata.py#L81-L85" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.metadata.StubtestSettings:system_requirements_for_platform` (81:85)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/metadata.py#L89-L139" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.metadata:read_stubtest_settings` (89:139)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/metadata.py#L144-L165" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.metadata.StubMetadata` (144:165)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/metadata.py#L206-L316" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.metadata:read_metadata` (206:316)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/metadata.py#L319-L333" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.metadata:update_metadata` (319:333)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/metadata.py#L336-L338" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.metadata:parse_requires` (336:338)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/metadata.py#L347-L348" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.metadata:get_pypi_name_to_typeshed_name_mapping` (347:348)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/metadata.py#L352-L375" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.metadata:read_dependencies` (352:375)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/metadata.py#L379-L397" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.metadata:get_recursive_requirements` (379:397)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/metadata.py#L201-L202" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.metadata.NoSuchStubError` (201:202)</a>
+
+
+### PathResolver
+Provides utility functions for resolving various file and directory paths within the typeshed project structure, including paths for distributions, tests, and allowlists.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/paths.py#L20-L22" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.paths:distribution_path` (20:22)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/paths.py#L25-L29" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.paths:tests_path` (25:29)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/paths.py#L32-L33" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.paths:test_cases_path` (32:33)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/paths.py#L36-L40" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.paths:allowlists_path` (36:40)</a>
+
+
+### RequirementHandler
+Handles the retrieval and processing of external stub requirements and system-specific requirements for stub testing, interacting with the MetadataManager to obtain dependency information.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/requirements.py#L14-L18" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.requirements:get_external_stub_requirements` (14:18)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/requirements.py#L21-L28" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.requirements:get_stubtest_system_requirements` (21:28)</a>
+
+
+### MypyConfiguration
+Responsible for generating and validating Mypy configurations based on distribution information, ensuring Mypy can correctly analyze stub files.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/mypy.py#L27-L49" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.mypy:mypy_configuration_from_distribution` (27:49)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/mypy.py#L36-L46" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.mypy.mypy_configuration_from_distribution.validate_configuration` (36:46)</a>
+
+
+### GeneralUtils
+Provides a collection of miscellaneous utility functions supporting various operations across the typeshed project, including parsing versions, handling distribution information, and managing test case directories and allowlists.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/utils.py#L106-L107" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.utils:get_mypy_req` (106:107)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/utils.py#L122-L136" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.utils:parse_stdlib_versions_file` (122:136)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/utils.py#L167-L175" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.utils:distribution_info` (167:175)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/utils.py#L178-L186" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.utils:get_all_testcase_directories` (178:186)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/utils.py#L247-L253" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.utils:allowlist_stubtest_arguments` (247:253)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/utils.py#L97-L103" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.utils:parse_requirements` (97:103)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/utils.py#L34-L35" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.utils:strip_comments` (34:35)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/utils.py#L147-L150" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.utils._parse_version` (147:150)</a>
+- <a href="https://github.com/python/typeshed/blob/master/lib/ts_utils/utils.py#L189-L201" target="_blank" rel="noopener noreferrer">`typeshed.lib.ts_utils.utils.allowlists` (189:201)</a>
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)


### PR DESCRIPTION
Added high-level diagrams representing the typeshed codebase.

You can see how they render in GitHub here: https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/typeshed/on_boarding.md

The idea of these diagrams is to help new contributors get up-to-speed with the existing codebase. We think here visuals are crucial as they give you enough context to concentrate on the interesting to you component. We also believe that such documents require a lot of effort from the maintainers so we are looking into creating github action which generates them, the generation is using both static analysis and LLMs.

Any feedback is more than welcome! I usually open discussions, but it seems like they are not enabled for this repo so I decide to open directly a PR.

Full disclosure: we're trying to turn this into a startup, but we're still in a very early stage and figuring out what will actually be useful for people.