### PR TITLE
[html5lib] Minimal pyright fix for HTMLParser.__init__

### DIFF
--- a/stubs/html5lib/html5lib/html5parser.pyi
+++ b/stubs/html5lib/html5lib/html5parser.pyi
@@ -4,6 +4,7 @@ from xml.etree.ElementTree import Element
 
 from ._inputstream import _InputStream
 from ._tokenizer import HTMLTokenizer
+from .treebuilders.base import TreeBuilder
 
 @overload
 def parse(
@@ -21,7 +22,13 @@ class HTMLParser:
     tree: Any
     errors: list[Incomplete]
     phases: Any
-    def __init__(self, tree=None, strict: bool = False, namespaceHTMLElements: bool = True, debug: bool = False) -> None: ...
+    def __init__(
+        self,
+        tree: str | type[TreeBuilder] | None = None,
+        strict: bool = False,
+        namespaceHTMLElements: bool = True,
+        debug: bool = False,
+    ) -> None: ...
     firstStartTag: bool
     log: Any
     compatMode: str


### PR DESCRIPTION
Recent removal of `Incomplete` (python/typeshed#14029) in `HTMLParser.__init__()` breaks `pyright` strict mode, so fill in minimal necessary argument type info as remedy.