### PR TITLE
croniter.pyi: `get_next` with a `ret_type` passed should return that type

### DIFF
--- a/stubs/croniter/croniter/croniter.pyi
+++ b/stubs/croniter/croniter/croniter.pyi
@@ -188,7 +188,7 @@ class croniter(Generic[_R_co]):
     @overload
     def get_next(
         self, ret_type: type[_R2_co], start_time: float | datetime.datetime | None = None, update_current: bool = True
-    ) -> _R_co: ...
+    ) -> _R2_co: ...
     @overload
     def get_next(
         self, ret_type: None = None, start_time: float | datetime.datetime | None = None, update_current: bool = True


### PR DESCRIPTION
I think this was maybe a typo?

Currently I am getting spurious errors from Pyright and I think it's due to this mismatch:
![Screenshot 2025-06-12 at 09 33 40](https://github.com/user-attachments/assets/c95fdf31-12ab-4b5e-beaa-7c8161e3d86a)
