### PR TITLE
Fix label links in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -447,7 +447,7 @@ If a package ships its own `py.typed` file, please follow these steps:
 
 1. Open an issue with the earliest month of removal in the subject.
 2. A maintainer will add the
-   ["stubs: removal" label](https://github.com/python/typeshed/labels/stubs%3A%20removal).
+   ["stubs: removal" label](https://github.com/python/typeshed/labels/%22stubs%3A%20removal%22).
 3. Open a PR that sets the `obsolete_since` field in the `METADATA.toml`
    file to the first version of the package that shipped `py.typed`.
 4. After at least six months, open a PR to remove the stubs.
@@ -457,7 +457,7 @@ steps:
 
 1. Open an issue explaining why the stubs should be removed.
 2. A maintainer will add the
-   ["stubs: removal" label](https://github.com/python/typeshed/labels/stubs%3A%20removal).
+   ["stubs: removal" label](https://github.com/python/typeshed/labels/%22stubs%3A%20removal%22).
 3. Open a PR that sets the `no_longer_updated` field in the `METADATA.toml`
    file to `true`.
 4. When a new version of the package was automatically uploaded to PyPI
@@ -468,7 +468,7 @@ for any stub obsoletions or removals.
 
 ### Marking PRs as "deferred"
 
-We sometimes use the ["status: deferred" label](https://github.com/python/typeshed/labels/status%3A%20deferred)
+We sometimes use the ["status: deferred" label](https://github.com/python/typeshed/labels/%22status%3A%20deferred%22)
 to mark PRs and issues that we'd like to accept, but that are blocked by some
 external factor. Blockers can include:
 


### PR DESCRIPTION
The label links in CONTRIBUTING.md take you to a search page with a broken label filter. For example:

[`https://github.com/python/typeshed/labels/stubs%3A%20removal`](https://github.com/python/typeshed/labels/stubs%3A%20removal)

It seems that GitHub is having issues with there being a space in the label name. What's weird is that this is the  exact URL that GitHub expects for rendered labels, e.g. https://github.com/python/typeshed/labels/stubs%3A%20removal.

Putting some quotes around the label name seems to make the links work. For example:

[`https://github.com/python/typeshed/labels/%22stubs%3A%20removal%22`](https://github.com/python/typeshed/labels/%22stubs%3A%20removal%22)

