### PR TITLE
attempt to improve `sched.scheduler.enterabs`/`sched.scheduler.enter`

### DIFF
--- a/stdlib/sched.pyi
+++ b/stdlib/sched.pyi
@@ -1,9 +1,16 @@
 import sys
-from collections.abc import Callable
-from typing import Any, ClassVar, NamedTuple, type_check_only
-from typing_extensions import TypeAlias
+from collections.abc import Callable, Mapping
+from typing import Any, ClassVar, Generic, NamedTuple, TypeVar, overload, type_check_only
+from typing_extensions import Never, TypeAlias, TypeVarTuple, Unpack
 
 __all__ = ["scheduler"]
+
+_KwargValue = TypeVar("_KwargValue")
+_R = TypeVar("_R")
+_Args = TypeVarTuple("_Args")
+
+class _MyCallable(Generic[Unpack[_Args], _KwargValue, _R]):
+    def __call__(self, args: tuple[Unpack[_Args]], kwargs: Mapping[str, _KwargValue]) -> _R: ...
 
 _ActionCallback: TypeAlias = Callable[..., Any]
 
@@ -33,11 +40,41 @@ class scheduler:
     delayfunc: Callable[[float], object]
 
     def __init__(self, timefunc: Callable[[], float] = ..., delayfunc: Callable[[float], object] = ...) -> None: ...
+    @overload
     def enterabs(
-        self, time: float, priority: Any, action: _ActionCallback, argument: tuple[Any, ...] = (), kwargs: dict[str, Any] = ...
+        self,
+        time: float,
+        priority: Any,
+        action: Callable[[], object],
+        argument: tuple[()] = ...,
+        kwargs: Mapping[Never, Never] = ...,
     ) -> Event: ...
+    @overload
+    def enterabs(
+        self,
+        time: float,
+        priority: Any,
+        action: _MyCallable[Unpack[_Args], _KwargValue, object],
+        argument: tuple[Unpack[_Args]] = ...,
+        kwargs: Mapping[str, _KwargValue] = ...,
+    ) -> Event: ...
+    @overload
     def enter(
-        self, delay: float, priority: Any, action: _ActionCallback, argument: tuple[Any, ...] = (), kwargs: dict[str, Any] = ...
+        self,
+        delay: float,
+        priority: Any,
+        action: Callable[[], object],
+        argument: tuple[()] = ...,
+        kwargs: Mapping[Never, Never] = ...,
+    ) -> Event: ...
+    @overload
+    def enter(
+        self,
+        delay: float,
+        priority: Any,
+        action: _MyCallable[Unpack[_Args], _KwargValue, object],
+        argument: tuple[Unpack[_Args]] = ...,
+        kwargs: Mapping[str, _KwargValue] = ...,
     ) -> Event: ...
     def run(self, blocking: bool = True) -> float | None: ...
     def cancel(self, event: Event) -> None: ...


### PR DESCRIPTION
These changes **_are wrong_** and _**should not be merged**_. I'm hoping there might be a way to improve the type hints here (because I often get this wrong). Unfortunately, I'm not aware of one :(