### PR TITLE
Update windows install instructions for windows

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,9 +77,9 @@ Note that some tests require extra setup steps to install the required dependenc
   Run the following commands from a Windows terminal to install all requirements:
 
   ```powershell
-  > python -m venv .venv
+  > py -m venv .venv
   > .venv\Scripts\activate
-  (.venv) > pip install -U pip
+  (.venv) > python -m pip install -U pip
   (.venv) > pip install -r requirements-tests.txt
   ```
 


### PR DESCRIPTION
Use the `py` launcher and don't use the `pip` shortcut for upgrading pip itself. The latter is a required change since `pip install -U pip` is blocked by `pip` because it can't function correctly (`pip` can't replace the `pip.exe` wrapper while it is running). The former is more of a style change to get inline with the common suggestions for windows users to not have global `python` executables visible.