### PR TITLE
Add `CopyComPointer` to `stdlib/ctypes/__init__.pyi`.

### DIFF
--- a/stdlib/ctypes/__init__.pyi
+++ b/stdlib/ctypes/__init__.pyi
@@ -32,7 +32,7 @@ if sys.platform == "win32":
     from _ctypes import FormatError as FormatError, get_last_error as get_last_error, set_last_error as set_last_error
 
     if sys.version_info >= (3, 14):
-        from _ctypes import COMError as COMError
+        from _ctypes import COMError as COMError, CopyComPointer as CopyComPointer
 
 if sys.version_info >= (3, 11):
     from ctypes._endian import BigEndianUnion as BigEndianUnion, LittleEndianUnion as LittleEndianUnion


### PR DESCRIPTION
This is a follow-up to the version bridge for Python 3.14 added in https://github.com/python/typeshed/pull/14137 and my own contribution to cpython (https://github.com/python/cpython/pull/127275).

See also: https://docs.python.org/3.14/library/ctypes.html#ctypes.CopyComPointer