### PR TITLE
Update default values for ast.ImportFrom initialization

### DIFF
--- a/stdlib/ast.pyi
+++ b/stdlib/ast.pyi
@@ -751,11 +751,8 @@ class ImportFrom(stmt):
     names: list[alias]
     level: int
     if sys.version_info >= (3, 13):
-        @overload
-        def __init__(self, module: str | None, names: list[alias], level: int, **kwargs: Unpack[_Attributes]) -> None: ...
-        @overload
         def __init__(
-            self, module: str | None = None, names: list[alias] = ..., *, level: int, **kwargs: Unpack[_Attributes]
+            self, module: str | None = None, names: list[alias] = ..., *, level: int | None = None, **kwargs: Unpack[_Attributes]
         ) -> None: ...
     else:
         @overload


### PR DESCRIPTION
```python
(.313) C:\clones\typeshed>py
Python 3.13.5 (tags/v3.13.5:6cb20a2, Jun 11 2025, 16:15:46) [MSC v.1943 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import ast
>>> yum = ast.ImportFrom('popeyes', [ast.alias('chicken')])
>>> ast.unparse(yum)
'from popeyes import chicken'
>>> print(yum.level)
None
```