### PR TITLE
Update `jsonschema.protocols.Validator.__init__`

### DIFF
--- a/stubs/jsonschema/jsonschema/protocols.pyi
+++ b/stubs/jsonschema/jsonschema/protocols.pyi
@@ -3,10 +3,10 @@ from collections.abc import Iterator, Mapping, Sequence
 from typing import ClassVar, Protocol
 from typing_extensions import TypeAlias
 
+import referencing.jsonschema
 from jsonschema._format import FormatChecker
 from jsonschema._types import TypeChecker
 from jsonschema.exceptions import ValidationError
-import referencing.jsonschema
 
 _JsonParameter: TypeAlias = str | int | float | bool | None | Mapping[str, _JsonParameter] | Sequence[_JsonParameter]
 

--- a/stubs/jsonschema/jsonschema/protocols.pyi
+++ b/stubs/jsonschema/jsonschema/protocols.pyi
@@ -6,7 +6,7 @@ from typing_extensions import TypeAlias
 from jsonschema._format import FormatChecker
 from jsonschema._types import TypeChecker
 from jsonschema.exceptions import ValidationError
-from jsonschema.validators import RefResolver
+import referencing.jsonschema
 
 _JsonParameter: TypeAlias = str | int | float | bool | None | Mapping[str, _JsonParameter] | Sequence[_JsonParameter]
 
@@ -19,7 +19,7 @@ class Validator(Protocol):
     def __init__(
         self,
         schema: dict[Incomplete, Incomplete] | bool,
-        resolver: RefResolver | None = None,
+        registry: referencing.jsonschema.SchemaRegistry,
         format_checker: FormatChecker | None = None,
     ) -> None: ...
     @classmethod


### PR DESCRIPTION
The signature of this protocol has changed in recent versions of `jsonschema`. Update to match.

---

Aside: There was a period (~1 year ago?) when I was actively working on `jsonschema` types with a plan to backport things from typeshed to `jsonschema`.
I got a bit bogged down and the work is unfinished, but I would ultimately like to help make that happen. In the meantime, I still want to keep these in sync. :)
