### PR TITLE
Fix type of `format_spec` attribute of `ast.Interpolation`

### DIFF
--- a/stdlib/ast.pyi
+++ b/stdlib/ast.pyi
@@ -1062,13 +1062,13 @@ if sys.version_info >= (3, 14):
         value: expr
         str: builtins.str
         conversion: int
-        format_spec: builtins.str | None = None
+        format_spec: expr | None = None
         def __init__(
             self,
             value: expr = ...,
             str: builtins.str = ...,
             conversion: int = ...,
-            format_spec: builtins.str | None = ...,
+            format_spec: expr | None = ...,
             **kwargs: Unpack[_Attributes],
         ) -> None: ...
         def __replace__(
@@ -1077,7 +1077,7 @@ if sys.version_info >= (3, 14):
             value: expr = ...,
             str: builtins.str = ...,
             conversion: int = ...,
-            format_spec: builtins.str | None = ...,
+            format_spec: expr | None = ...,
             **kwargs: Unpack[_Attributes],
         ) -> Self: ...
 


### PR DESCRIPTION
For reference:
```python
>>> ast.parse('t"{1}"').body[0].value.values[0].format_spec is None
True

>>> ast.parse('t"{1:}"').body[0].value.values[0].format_spec
JoinedStr(values=[])

>>> ast.parse('t"{1:2}"').body[0].value.values[0].format_spec
JoinedStr(values=[Constant(value='2', kind=None)])
```
https://docs.python.org/3.14/library/ast.html#ast.FormattedValue#:~:text=Interpolation(,)