### PR TITLE
Add attributes to urllib errors

### DIFF
--- a/stdlib/urllib/error.pyi
+++ b/stdlib/urllib/error.pyi
@@ -5,7 +5,9 @@ from urllib.response import addinfourl
 __all__ = ["URLError", "HTTPError", "ContentTooShortError"]
 
 class URLError(OSError):
+    args: tuple[str | BaseException, ...]
     reason: str | BaseException
+    filename: str
     def __init__(self, reason: str | BaseException, filename: str | None = None) -> None: ...
 
 class HTTPError(URLError, addinfourl):
@@ -16,6 +18,9 @@ class HTTPError(URLError, addinfourl):
     @property
     def reason(self) -> str: ...  # type: ignore[override]
     code: int
+    msg: str
+    hdrs: Message
+    fp: IO[bytes]
     def __init__(self, url: str, code: int, msg: str, hdrs: Message, fp: IO[bytes] | None) -> None: ...
 
 class ContentTooShortError(URLError):


### PR DESCRIPTION
I decided to add attributes because otherwise when accessing attributes my lsp server reports that they are type of `Any`