### PR TITLE
fix(m3u8): fix M3U8.program_date_time

### DIFF
--- a/stubs/m3u8/m3u8/model.pyi
+++ b/stubs/m3u8/m3u8/model.pyi
@@ -54,7 +54,7 @@ class M3U8:
     is_i_frames_only: bool | None
     target_duration: float | None
     media_sequence: int | None
-    program_date_time: str | None
+    program_date_time: dt.datetime | None
     is_independent_segments: bool | None
     version: str | None
     allow_cache: str | None


### PR DESCRIPTION
proof that this is actually datetime by lib design: 
https://github.com/globocom/m3u8/blob/bfbfd48fccf446471dde0731f68f23d6c8299301/tests/test_model.py#L63