### PR TITLE
[dateparser] Update to `~=1.2.2`

### DIFF
--- a/stubs/dateparser/METADATA.toml
+++ b/stubs/dateparser/METADATA.toml
@@ -1,4 +1,4 @@
-version = "1.2.*"
+version = "~=1.2.2"
 upstream_repository = "https://github.com/scrapinghub/dateparser"
 
 [tool.stubtest]

--- a/stubs/dateparser/dateparser/search/search.pyi
+++ b/stubs/dateparser/dateparser/search/search.pyi
@@ -1,3 +1,4 @@
+from collections.abc import Collection
 from typing import Any
 
 from ..date import _DetectLanguagesFunction
@@ -33,3 +34,4 @@ class DateSearchWithDetection:
     def search_dates(
         self, text, languages=None, settings=None, detect_languages_function: _DetectLanguagesFunction | None = None
     ): ...
+    def preprocess_text(self, text: str, languages: Collection[str]) -> str: ...

--- a/stubs/dateparser/dateparser/timezone_parser.pyi
+++ b/stubs/dateparser/dateparser/timezone_parser.pyi
@@ -1,6 +1,8 @@
+import pathlib
 import re
 from collections.abc import Generator
 from datetime import datetime, timedelta, tzinfo
+from typing import Final
 
 class StaticTzInfo(tzinfo):
     def __init__(self, name: str, offset: timedelta) -> None: ...
@@ -17,3 +19,6 @@ def build_tz_offsets(search_regex_parts: list[str]) -> Generator[tuple[str, dict
 def get_local_tz_offset() -> timedelta: ...
 
 local_tz_offset: timedelta
+
+CACHE_PATH: Final[pathlib.Path]
+current_hash: int | None


### PR DESCRIPTION
Closes #14345

For reference: https://github.com/scrapinghub/dateparser/compare/v1.2.1...v1.2.2