### PR TITLE
Fix AiofilesContextManagerTempDir type argument

### DIFF
--- a/stubs/aiofiles/aiofiles/tempfile/__init__.pyi
+++ b/stubs/aiofiles/aiofiles/tempfile/__init__.pyi
@@ -318,6 +318,6 @@ def TemporaryDirectory(
 ) -> AiofilesContextManagerTempDir: ...
 
 class AiofilesContextManagerTempDir(AiofilesContextManager[str]):
-    async def __aenter__(self) -> str: ...  # type: ignore[override]
+    async def __aenter__(self) -> str: ...
 
 __all__ = ["NamedTemporaryFile", "TemporaryFile", "SpooledTemporaryFile", "TemporaryDirectory"]

--- a/stubs/aiofiles/aiofiles/tempfile/__init__.pyi
+++ b/stubs/aiofiles/aiofiles/tempfile/__init__.pyi
@@ -15,7 +15,6 @@ from typing import AnyStr, Literal, overload
 from ..base import AiofilesContextManager
 from ..threadpool.binary import AsyncBufferedIOBase, AsyncBufferedReader, AsyncFileIO
 from ..threadpool.text import AsyncTextIOWrapper
-from .temptypes import AsyncTemporaryDirectory
 
 # Text mode: always returns AsyncTextIOWrapper
 @overload

--- a/stubs/aiofiles/aiofiles/tempfile/__init__.pyi
+++ b/stubs/aiofiles/aiofiles/tempfile/__init__.pyi
@@ -318,7 +318,7 @@ def TemporaryDirectory(
     executor=None,
 ) -> AiofilesContextManagerTempDir: ...
 
-class AiofilesContextManagerTempDir(AiofilesContextManager[AsyncTemporaryDirectory]):
+class AiofilesContextManagerTempDir(AiofilesContextManager[str]):
     async def __aenter__(self) -> str: ...  # type: ignore[override]
 
 __all__ = ["NamedTemporaryFile", "TemporaryFile", "SpooledTemporaryFile", "TemporaryDirectory"]


### PR DESCRIPTION
When using `aiofiles.tempfile.TemporaryDirectory` with `AsyncExitStack` as shown below:

```python
import asyncio
from contextlib import AsyncExitStack
from typing import reveal_type

from aiofiles.tempfile import TemporaryDirectory


async def main() -> None:
    stack = AsyncExitStack()
    d = await stack.enter_async_context(TemporaryDirectory())
    reveal_type(d)
    await stack.aclose()


if __name__ == '__main__':
    asyncio.run(main())
```

Mypy reports `Revealed type is "aiofiles.tempfile.temptypes.AsyncTemporaryDirectory"`, but running the code shows: `Runtime type is 'str'`.

This PR fixes this mismatch.