### PR TITLE
`os.linesep` can only be `\n` or `\r\n`

### DIFF
--- a/stdlib/os/__init__.pyi
+++ b/stdlib/os/__init__.pyi
@@ -683,7 +683,7 @@ else:
 extsep: str
 pathsep: str
 defpath: str
-linesep: str
+linesep: Literal["\n", "\r\n"]
 devnull: str
 name: str
 


### PR DESCRIPTION
See:
- https://github.com/python/cpython/blob/5334732f9c8a44722e4b339f4bb837b5b0226991/Lib/os.py#L52-L54 for POSIX
- https://github.com/python/cpython/blob/5334732f9c8a44722e4b339f4bb837b5b0226991/Lib/os.py#L76-L78 on Windows