### PR TITLE
[networkx] completed type annotation for `equivalence_classes`

### DIFF
--- a/stubs/networkx/networkx/algorithms/minors/contraction.pyi
+++ b/stubs/networkx/networkx/algorithms/minors/contraction.pyi
@@ -1,5 +1,5 @@
 from _typeshed import Incomplete
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 
 from networkx.classes.graph import Graph, _Node
 from networkx.utils.backends import _dispatchable
@@ -7,7 +7,7 @@ from networkx.utils.backends import _dispatchable
 __all__ = ["contracted_edge", "contracted_nodes", "equivalence_classes", "identified_nodes", "quotient_graph"]
 
 @_dispatchable
-def equivalence_classes(iterable, relation): ...
+def equivalence_classes(iterable: Iterable[_Node], relation: Callable[[_Node, _Node], bool]) -> set[frozenset[_Node]]: ...
 @_dispatchable
 def quotient_graph(
     G: Graph[_Node],


### PR DESCRIPTION
Annotation is largely in accordance with the documentation:

https://networkx.org/documentation/stable/reference/algorithms/generated/networkx.algorithms.minors.equivalence_classes.html

The only difference is that `iterable` is of type `Iterable` rather than `set|list|tuple`.

While the documentation does specify that it has to be one of those types, the code only uses the argument to iterate over it once.