### PR TITLE
Remove flake8 F821 checks for stubs

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,6 @@
 [flake8]
 # Y: Flake8 is only used to run flake8-pyi, everything else is in Ruff
-# F821: Typeshed is a testing ground for flake8-pyi, which monkeypatches F821
-select = Y, F821
+select = Y
 # Ignore rules normally excluded by default
 extend-ignore = Y090,Y091
 per-file-ignores =


### PR DESCRIPTION
F821 is only checked as a test for the F821 monkeypatch functionality in flake8-pyi, but that will be removed.

Cf. PyCQA/flake8-pyi#522. Needed to unblock renovate updates, see #14357.