### PR TITLE
Remind to remove library from pyrightconfig

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -463,8 +463,8 @@ steps:
 4. When a new version of the package was automatically uploaded to PyPI
    (which can take up to a day), open a PR to remove the stubs.
 
-Don't forget to make sure the library is not in the `pyrightconfig.strict.json` exclusion list.
-If feeling kindly, please update [mypy](https://github.com/python/mypy/blob/master/mypy/stubinfo.py)
+Don't forget to make sure the library is not in the [`pyrightconfig.stricter.json`](./pyrightconfig.stricter.json)
+exclusion list. If feeling kindly, please update [mypy](https://github.com/python/mypy/blob/master/mypy/stubinfo.py)
 for any stub obsoletions or removals.
 
 ### Marking PRs as "deferred"


### PR DESCRIPTION
motivation: people have forgotten this more than once. although I understand that it may be redundant, I don't think one sentence clutters up the instructions too much, and it will help to be more complete.