### PR TITLE
Fix ImportError for get_oldest_supported_python in runtests.py (#14381)

### DIFF
--- a/lib/ts_utils/metadata.py
+++ b/lib/ts_utils/metadata.py
@@ -26,6 +26,7 @@ __all__ = [
     "PackageDependencies",
     "StubMetadata",
     "StubtestSettings",
+    "get_oldest_supported_python",
     "get_recursive_requirements",
     "read_dependencies",
     "read_metadata",


### PR DESCRIPTION
Adds get_oldest_supported_python to `__all__` in metadata.py to allow explicit import in runtests.py and avoid ImportError. Fixes #14381.