### PR TITLE
Add default value for `expression` parameter of `string.templatelib.Interpolation`

### DIFF
--- a/stdlib/string/templatelib.pyi
+++ b/stdlib/string/templatelib.pyi
@@ -26,6 +26,6 @@ class Interpolation:
     __match_args__ = ("value", "expression", "conversion", "format_spec")
 
     def __new__(
-        cls, value: Any, expression: str, conversion: Literal["a", "r", "s"] | None = None, format_spec: str = ""
+        cls, value: Any, expression: str = "", conversion: Literal["a", "r", "s"] | None = None, format_spec: str = ""
     ) -> Interpolation: ...
     def __class_getitem__(cls, item: Any, /) -> GenericAlias: ...


### PR DESCRIPTION
For reference: https://github.com/python/cpython/pull/136441
```python
Python 3.14.0b4+ (heads/3.14:33f561d, Jul 12 2025, 09:45:01) [GCC 11.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import string.templatelib
>>> string.templatelib.Interpolation(123)
Interpolation(123, '', None, '')
```