### PR TITLE
Use stricter pyright settings when testing `channels`

### DIFF
--- a/pyrightconfig.stricter.json
+++ b/pyrightconfig.stricter.json
@@ -31,7 +31,6 @@
         "stubs/boltons",
         "stubs/braintree",
         "stubs/cffi",
-        "stubs/channels",
         "stubs/dateparser",
         "stubs/defusedxml",
         "stubs/docker",


### PR DESCRIPTION
Fixes https://github.com/AlexWaygood/typeshed-stats/issues/351