### PR TITLE
psycopg2: Add types to RealDictCursor.execute

### DIFF
--- a/stubs/psycopg2/psycopg2/extras.pyi
+++ b/stubs/psycopg2/psycopg2/extras.pyi
@@ -15,6 +15,7 @@ from psycopg2._psycopg import (
     ReplicationConnection as _replicationConnection,
     ReplicationCursor as _replicationCursor,
     ReplicationMessage as ReplicationMessage,
+    _Vars,
     connection as _connection,
     cursor as _cursor,
     quote_ident as quote_ident,
@@ -29,6 +30,7 @@ from psycopg2._range import (
     RangeCaster as RangeCaster,
     register_range as register_range,
 )
+from psycopg2.sql import Composable
 
 _T_cur = TypeVar("_T_cur", bound=_cursor)
 
@@ -106,7 +108,7 @@ class RealDictConnection(_connection):
 class RealDictCursor(DictCursorBase):
     def __init__(self, *args, **kwargs) -> None: ...
     column_mapping: Any
-    def execute(self, query, vars=None): ...
+    def execute(self, query: str | bytes | Composable, vars: _Vars = None) -> None: ...
     def callproc(self, procname, vars=None): ...
     def fetchone(self) -> RealDictRow | None: ...  # type: ignore[override]
     def fetchmany(self, size: int | None = None) -> list[RealDictRow]: ...  # type: ignore[override]


### PR DESCRIPTION
To address that `RealDictCursor` is now failing as untyped under mypy strict mode
See https://github.com/python/typeshed/issues/14417 for deeper explanation and examples