### PR TITLE
Allow docutils.readers.standalone.Reader.document to be a docutils.no…

### DIFF
--- a/stubs/docutils/docutils/readers/standalone.pyi
+++ b/stubs/docutils/docutils/readers/standalone.pyi
@@ -1,11 +1,11 @@
 from typing import ClassVar, Final, TypeVar
 
-from docutils import readers
+from docutils import nodes, readers
 
 __docformat__: Final = "reStructuredText"
 
 _S = TypeVar("_S", bound=str | bytes)
 
 class Reader(readers.Reader[_S]):
-    document: None  # type: ignore[assignment]
+    document: nodes.document | None  # type: ignore[assignment]
     config_section_dependencies: ClassVar[tuple[str, ...]]


### PR DESCRIPTION
…des.document

The use of this in docutils is not trivial but in testing I changed `document` to a property and created a setter and found that https://github.com/docutils/docutils/blob/9f04802532e77542c8edf6b7f4bf78bab141cf6e/docutils/docutils/readers/__init__.py#L103 was setting this as a `nodes.document`.
Intuitively it likely is not always None, as well :)

I am making this change because Sphinx sets this to a `nodes.document` - see https://github.com/sphinx-doc/sphinx/pull/13634.