### PR TITLE
Remove obsolete comments from turtle.pyi

### DIFF
--- a/stdlib/turtle.pyi
+++ b/stdlib/turtle.pyi
@@ -487,19 +487,8 @@ Pen = Turtle
 
 def write_docstringdict(filename: str = "turtle_docstringdict") -> None: ...
 
-# Note: it's somewhat unfortunate that we have to copy the function signatures.
-# It would be nice if we could partially reduce the redundancy by doing something
-# like the following:
-#
-#     _screen: Screen
-#     clear = _screen.clear
-#
-# However, it seems pytype does not support this type of syntax in pyi files.
-
 # Functions copied from TurtleScreenBase:
 
-# Note: mainloop() was always present in the global scope, but was added to
-# TurtleScreenBase in Python 3.0
 def mainloop() -> None: ...
 def textinput(title: str, prompt: str) -> str | None: ...
 def numinput(


### PR DESCRIPTION
While it would be possible to use the hack described in the comment
now that pytype support has been removed, that hack is a bit too
"magical" for stubs that are supposed to be fairly straight-forward
API descriptions. This would also introduce extra stub-only attributes
and would imply that e.g. `_Screen.setup()` and `setup()` refer to the
same object at runtime when they don't.