### PR TITLE
[glob] Deprecate `glob0` and `glob1` functions

### DIFF
--- a/stdlib/glob.pyi
+++ b/stdlib/glob.pyi
@@ -2,14 +2,22 @@ import sys
 from _typeshed import StrOrBytesPath
 from collections.abc import Iterator, Sequence
 from typing import AnyStr
+from typing_extensions import deprecated
 
 __all__ = ["escape", "glob", "iglob"]
 
 if sys.version_info >= (3, 13):
     __all__ += ["translate"]
 
-def glob0(dirname: AnyStr, pattern: AnyStr) -> list[AnyStr]: ...
-def glob1(dirname: AnyStr, pattern: AnyStr) -> list[AnyStr]: ...
+if sys.version_info >= (3, 10):
+    @deprecated("Will be removed in Python 3.15; Use `glob.glob` and pass *root_dir* argument instead.")
+    def glob0(dirname: AnyStr, pattern: AnyStr) -> list[AnyStr]: ...
+    @deprecated("Will be removed in Python 3.15; Use `glob.glob` and pass *root_dir* argument instead.")
+    def glob1(dirname: AnyStr, pattern: AnyStr) -> list[AnyStr]: ...
+
+else:
+    def glob0(dirname: AnyStr, pattern: AnyStr) -> list[AnyStr]: ...
+    def glob1(dirname: AnyStr, pattern: AnyStr) -> list[AnyStr]: ...
 
 if sys.version_info >= (3, 11):
     def glob(

--- a/stdlib/glob.pyi
+++ b/stdlib/glob.pyi
@@ -9,7 +9,7 @@ __all__ = ["escape", "glob", "iglob"]
 if sys.version_info >= (3, 13):
     __all__ += ["translate"]
 
-if sys.version_info >= (3, 10):
+if sys.version_info >= (3, 13):
     @deprecated("Will be removed in Python 3.15; Use `glob.glob` and pass *root_dir* argument instead.")
     def glob0(dirname: AnyStr, pattern: AnyStr) -> list[AnyStr]: ...
     @deprecated("Will be removed in Python 3.15; Use `glob.glob` and pass *root_dir* argument instead.")

--- a/stdlib/glob.pyi
+++ b/stdlib/glob.pyi
@@ -9,7 +9,7 @@ __all__ = ["escape", "glob", "iglob"]
 if sys.version_info >= (3, 13):
     __all__ += ["translate"]
 
-if sys.version_info >= (3, 13):
+if sys.version_info >= (3, 10):
     @deprecated("Will be removed in Python 3.15; Use `glob.glob` and pass *root_dir* argument instead.")
     def glob0(dirname: AnyStr, pattern: AnyStr) -> list[AnyStr]: ...
     @deprecated("Will be removed in Python 3.15; Use `glob.glob` and pass *root_dir* argument instead.")


### PR DESCRIPTION
Source: https://github.com/python/cpython/pull/117371

Warning was added to runtime in 3.13. And I added a check for 3.10 since the *root_dir* argument appeared only in this version.