### PR TITLE
Fully annotate `yt-dlp`

### DIFF
--- a/stubs/yt-dlp/yt_dlp/networking/common.pyi
+++ b/stubs/yt-dlp/yt_dlp/networking/common.pyi
@@ -1,6 +1,7 @@
 import abc
 import enum
 import io
+from _typeshed import Unused
 from collections.abc import Callable, Iterable, Mapping
 from email.message import Message
 from logging import Logger
@@ -57,7 +58,7 @@ class RequestHandler(abc.ABC, metaclass=abc.ABCMeta):
         client_cert: dict[str, str | None] | None = None,
         verify: bool = True,
         legacy_ssl_support: bool = False,
-        **_,
+        **_: Unused,
     ) -> None: ...
     def validate(self, request: Request) -> None: ...
     def send(self, request: Request) -> Response: ...


### PR DESCRIPTION
The fact that this parameter wasn't annotated was tripping up an internal assertion in typeshed-stats: typeshed-stats thought that pyright shoudl probably be complaining about this stubs package, because we have the strictest pyright settings enabled for this project in CI but there are still unannotated parameters in the package. Possibly I should adjust the logic in typeshed-stats so that the assertion doesn't trigger if the parameter name is `_`, but it also seems preferable to fully annotate stubs packages where possible. In this case it seems fairly clear that any additional keyword arguments passed to `__init__` are just discarded: https://github.com/yt-dlp/yt-dlp/blob/23c658b9cbe34a151f8f921ab1320bb5d4e40a4d/yt_dlp/networking/common.py#L223-L250

Fixes https://github.com/AlexWaygood/typeshed-stats/issues/352