### PR TITLE
[stubsabot] Bump protobuf to ~=6.31.1

### DIFF
--- a/stubs/protobuf/METADATA.toml
+++ b/stubs/protobuf/METADATA.toml
@@ -1,6 +1,6 @@
 # Using an exact number in the specifier for scripts/sync_protobuf/google_protobuf.py
 # When updating, also re-run the script
-version = "~=6.30.2"
+version = "~=6.31.1"
 upstream_repository = "https://github.com/protocolbuffers/protobuf"
 extra_description = "Partially generated using [mypy-protobuf==3.6.0](https://github.com/nipunn1313/mypy-protobuf/tree/v3.6.0) and libprotoc 29.0 on [protobuf v30.2](https://github.com/protocolbuffers/protobuf/releases/tag/v30.2) (python `protobuf==6.30.2`)."
 partial_stub = true


### PR DESCRIPTION
Release: https://pypi.org/pypi/protobuf/6.31.1
Homepage: https://developers.google.com/protocol-buffers/
Repository: https://github.com/protocolbuffers/protobuf
Typeshed stubs: https://github.com/python/typeshed/tree/main/stubs/protobuf

If stubtest fails for this PR:
- Leave this PR open (as a reminder, and to prevent stubsabot from opening another PR)
- Fix stubtest failures in another PR, then close this PR

Note that you will need to close and re-open the PR in order to trigger CI
