### PR TITLE
prefer newer "tomllib" over "tomli" backport

### DIFF
--- a/lib/ts_utils/metadata.py
+++ b/lib/ts_utils/metadata.py
@@ -15,9 +15,9 @@ from pathlib import Path
 from typing import Annotated, Any, Final, NamedTuple, final
 from typing_extensions import TypeGuard
 
-try:
+if sys.version_info >= (3, 11):
     import tomllib
-except ImportError:
+else:
     import tomli as tomllib
 
 import tomlkit

--- a/lib/ts_utils/metadata.py
+++ b/lib/ts_utils/metadata.py
@@ -15,7 +15,11 @@ from pathlib import Path
 from typing import Annotated, Any, Final, NamedTuple, final
 from typing_extensions import TypeGuard
 
-import tomli
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib
+
 import tomlkit
 from packaging.requirements import Requirement
 from packaging.specifiers import Specifier
@@ -52,7 +56,7 @@ def _is_nested_dict(obj: object) -> TypeGuard[dict[str, dict[str, Any]]]:
 @functools.cache
 def get_oldest_supported_python() -> str:
     with PYPROJECT_PATH.open("rb") as config:
-        val = tomli.load(config)["tool"]["typeshed"]["oldest_supported_python"]
+        val = tomllib.load(config)["tool"]["typeshed"]["oldest_supported_python"]
     assert type(val) is str
     return val
 
@@ -92,7 +96,7 @@ class StubtestSettings:
 def read_stubtest_settings(distribution: str) -> StubtestSettings:
     """Return an object describing the stubtest settings for a single stubs distribution."""
     with metadata_path(distribution).open("rb") as f:
-        data: dict[str, object] = tomli.load(f).get("tool", {}).get("stubtest", {})
+        data: dict[str, object] = tomllib.load(f).get("tool", {}).get("stubtest", {})
 
     skip: object = data.get("skip", False)
     apt_dependencies: object = data.get("apt_dependencies", [])

--- a/lib/ts_utils/metadata.py
+++ b/lib/ts_utils/metadata.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import datetime
 import functools
 import re
+import sys
 import urllib.parse
 from collections.abc import Mapping
 from dataclasses import dataclass

--- a/lib/ts_utils/mypy.py
+++ b/lib/ts_utils/mypy.py
@@ -4,7 +4,10 @@ from collections.abc import Generator, Iterable
 from contextlib import contextmanager
 from typing import Any, NamedTuple
 
-import tomli
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib
 
 from ts_utils.metadata import StubtestSettings, metadata_path
 from ts_utils.utils import NamedTemporaryFile, TemporaryFileWrapper
@@ -26,7 +29,7 @@ class MypyDistConf(NamedTuple):
 
 def mypy_configuration_from_distribution(distribution: str) -> list[MypyDistConf]:
     with metadata_path(distribution).open("rb") as f:
-        data = tomli.load(f)
+        data = tomllib.load(f)
 
     # TODO: This could be added to ts_utils.metadata
     mypy_tests_conf: dict[str, dict[str, Any]] = data.get("mypy-tests", {})

--- a/lib/ts_utils/mypy.py
+++ b/lib/ts_utils/mypy.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from collections.abc import Generator, Iterable
 from contextlib import contextmanager
 from typing import Any, NamedTuple

--- a/lib/ts_utils/mypy.py
+++ b/lib/ts_utils/mypy.py
@@ -4,9 +4,9 @@ from collections.abc import Generator, Iterable
 from contextlib import contextmanager
 from typing import Any, NamedTuple
 
-try:
+if sys.version_info >= (3, 11):
     import tomllib
-except ImportError:
+else:
     import tomli as tomllib
 
 from ts_utils.metadata import StubtestSettings, metadata_path

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -19,7 +19,7 @@ ruff==0.12.2
 # TODO (2025-05-07): Dependency libcst doesn't support Python 3.14 yet.
 stubdefaulter==0.1.0; python_version < "3.14"
 termcolor>=2.3
-tomli==2.2.1
+tomli==2.2.1; python_version < "3.11"
 tomlkit==0.13.3
 typing_extensions>=4.14.0rc1
 uv==0.7.19

--- a/scripts/stubsabot.py
+++ b/scripts/stubsabot.py
@@ -25,9 +25,9 @@ from pathlib import Path
 from typing import Annotated, Any, ClassVar, NamedTuple, TypeVar
 from typing_extensions import Self, TypeAlias
 
-try:
+if sys.version_info >= (3, 11):
     import tomllib
-except ImportError:
+else:
     import tomli as tomllib
 
 import aiohttp

--- a/scripts/stubsabot.py
+++ b/scripts/stubsabot.py
@@ -25,9 +25,13 @@ from pathlib import Path
 from typing import Annotated, Any, ClassVar, NamedTuple, TypeVar
 from typing_extensions import Self, TypeAlias
 
+try:
+   import tomllib
+except ImportError:
+   import tomli as tomllib
+
 import aiohttp
 import packaging.version
-import tomli
 import tomlkit
 from packaging.specifiers import Specifier
 from termcolor import colored
@@ -536,7 +540,7 @@ def parse_no_longer_updated_from_archive(source: zipfile.ZipFile | tarfile.TarFi
             return False
 
     with file as f:
-        toml_data: dict[str, object] = tomli.load(f)
+        toml_data: dict[str, object] = tomllib.load(f)
 
     no_longer_updated = toml_data.get("no_longer_updated", False)
     assert type(no_longer_updated) is bool

--- a/scripts/stubsabot.py
+++ b/scripts/stubsabot.py
@@ -26,9 +26,9 @@ from typing import Annotated, Any, ClassVar, NamedTuple, TypeVar
 from typing_extensions import Self, TypeAlias
 
 try:
-   import tomllib
+    import tomllib
 except ImportError:
-   import tomli as tomllib
+    import tomli as tomllib
 
 import aiohttp
 import packaging.version


### PR DESCRIPTION
Hi,

From Pyhon3.11, `tomli` was merged into the Python standard library as `tomllib`

https://wiki.debian.org/Python/Backports