### PR TITLE
Add --show-traceback to stubtest_third_party

### DIFF
--- a/tests/stubtest_third_party.py
+++ b/tests/stubtest_third_party.py
@@ -108,6 +108,7 @@ def run_stubtest(dist: Path, *, verbose: bool = False, ci_platforms_only: bool =
                 "mypy.stubtest",
                 "--mypy-config-file",
                 temp.name,
+                "--show-traceback",
                 # Use --custom-typeshed-dir in case we make linked changes to stdlib or _typeshed
                 "--custom-typeshed-dir",
                 str(dist.parent.parent),


### PR DESCRIPTION
I just had a fatal error testing latest mypy master. I need the traceback to properly report a bug. I figured always showing the traceback in case of fatal error may be beneficial.
This is already the case for `stubtest_stdlib`.
I see no documented adverse effect: https://mypy.readthedocs.io/en/stable/config_file.html#confval-show_traceback