### PR TITLE
[concurrent.futures.interpreter] Update to 3.14.0b4

### DIFF
--- a/stdlib/@tests/stubtest_allowlists/py314.txt
+++ b/stdlib/@tests/stubtest_allowlists/py314.txt
@@ -2,14 +2,6 @@
 # TODO: New errors in Python 3.14 that need to be fixed or moved below
 # ====================================================================
 
-concurrent.futures.InterpreterPoolExecutor.__init__
-concurrent.futures.InterpreterPoolExecutor.prepare_context
-concurrent.futures.interpreter.ExecutionFailed
-concurrent.futures.interpreter.InterpreterPoolExecutor.__init__
-concurrent.futures.interpreter.InterpreterPoolExecutor.prepare_context
-concurrent.futures.interpreter.WorkerContext.__init__
-concurrent.futures.interpreter.WorkerContext.prepare
-concurrent.futures.interpreter.do_call
 multiprocessing.managers.BaseListProxy.clear
 multiprocessing.managers.BaseListProxy.copy
 multiprocessing.managers.DictProxy.__ior__

--- a/stdlib/@tests/test_cases/check_concurrent_futures.py
+++ b/stdlib/@tests/test_cases/check_concurrent_futures.py
@@ -47,7 +47,7 @@ if sys.version_info >= (3, 14):
         with InterpreterPoolExecutor(initializer=_initializer, initargs=("x",)):  # type: ignore
             ...
 
-        context = InterpreterPoolExecutor.prepare_context(initializer=_initializer, initargs=(1,), shared={})
+        context = InterpreterPoolExecutor.prepare_context(initializer=_initializer, initargs=(1,))
         worker_context = context[0]()
         assert_type(worker_context, concurrent.futures.interpreter.WorkerContext)
         resolve_task = context[1]

--- a/stdlib/_interpreters.pyi
+++ b/stdlib/_interpreters.pyi
@@ -34,8 +34,8 @@ def exec(
 def call(
     id: SupportsIndex,
     callable: Callable[..., _R],
-    args: tuple[object, ...] | None = None,
-    kwargs: dict[str, object] | None = None,
+    args: tuple[Any, ...] | None = None,
+    kwargs: dict[str, Any] | None = None,
     *,
     restrict: bool = False,
 ) -> tuple[_R, types.SimpleNamespace]: ...

--- a/stdlib/concurrent/futures/interpreter.pyi
+++ b/stdlib/concurrent/futures/interpreter.pyi
@@ -1,10 +1,14 @@
 import sys
-from collections.abc import Callable, Mapping
+from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
+from queue import Queue
 from typing import Literal, Protocol, overload, type_check_only
 from typing_extensions import ParamSpec, Self, TypeAlias, TypeVar, TypeVarTuple, Unpack
 
 _Task: TypeAlias = tuple[bytes, Literal["function", "script"]]
+_Ts = TypeVarTuple("_Ts")
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
 
 @type_check_only
 class _TaskFunc(Protocol):
@@ -13,62 +17,41 @@ class _TaskFunc(Protocol):
     @overload
     def __call__(self, fn: str) -> tuple[bytes, Literal["script"]]: ...
 
-_Ts = TypeVarTuple("_Ts")
-_P = ParamSpec("_P")
-_R = TypeVar("_R")
-
-# A `type.simplenamespace` with `__name__` attribute.
-@type_check_only
-class _HasName(Protocol):
-    __name__: str
-
-# `_interpreters.exec` technically gives us a simple namespace.
-@type_check_only
-class _ExcInfo(Protocol):
-    formatted: str
-    msg: str
-    type: _HasName
-
 if sys.version_info >= (3, 14):
     from concurrent.futures.thread import BrokenThreadPool, WorkerContext as ThreadWorkerContext
+    from concurrent.interpreters import Interpreter
 
-    from _interpreters import InterpreterError
-
-    class ExecutionFailed(InterpreterError):
-        def __init__(self, excinfo: _ExcInfo) -> None: ...  #  type: ignore[override]
+    def do_call(results: Queue, func: Callable[_P, _R], args: tuple[_P.args], kwargs: dict[str, _P.kwargs]) -> _R: ...
 
     class WorkerContext(ThreadWorkerContext):
-        # Parent class doesn't have `shared` argument,
-        @overload  #  type: ignore[override]
+        interp: Interpreter | None
+        results: Queue | None
+        @overload
         @classmethod
         def prepare(
-            cls, initializer: Callable[[Unpack[_Ts]], object], initargs: tuple[Unpack[_Ts]], shared: Mapping[str, object]
+            cls, initializer: Callable[[Unpack[_Ts]], object], initargs: tuple[Unpack[_Ts]]
         ) -> tuple[Callable[[], Self], _TaskFunc]: ...
-        @overload  #  type: ignore[override]
+        @overload
         @classmethod
-        def prepare(
-            cls, initializer: Callable[[], object], initargs: tuple[()], shared: Mapping[str, object]
-        ) -> tuple[Callable[[], Self], _TaskFunc]: ...
-        def __init__(
-            self, initdata: tuple[bytes, Literal["function", "script"]], shared: Mapping[str, object] | None = None
-        ) -> None: ...  #  type: ignore[override]
+        def prepare(cls, initializer: Callable[[], object], initargs: tuple[()]) -> tuple[Callable[[], Self], _TaskFunc]: ...
+        def __init__(self, initdata: _Task) -> None: ...
         def __del__(self) -> None: ...
-        def run(self, task: _Task) -> None: ...  #  type: ignore[override]
+        def run(self, task: _Task) -> None: ...  # type: ignore[override]
 
     class BrokenInterpreterPool(BrokenThreadPool): ...
 
     class InterpreterPoolExecutor(ThreadPoolExecutor):
         BROKEN: type[BrokenInterpreterPool]
 
-        @overload  #  type: ignore[override]
+        @overload
         @classmethod
         def prepare_context(
-            cls, initializer: Callable[[], object], initargs: tuple[()], shared: Mapping[str, object]
+            cls, initializer: Callable[[], object], initargs: tuple[()]
         ) -> tuple[Callable[[], WorkerContext], _TaskFunc]: ...
-        @overload  #  type: ignore[override]
+        @overload
         @classmethod
         def prepare_context(
-            cls, initializer: Callable[[Unpack[_Ts]], object], initargs: tuple[Unpack[_Ts]], shared: Mapping[str, object]
+            cls, initializer: Callable[[Unpack[_Ts]], object], initargs: tuple[Unpack[_Ts]]
         ) -> tuple[Callable[[], WorkerContext], _TaskFunc]: ...
         @overload
         def __init__(
@@ -77,7 +60,6 @@ if sys.version_info >= (3, 14):
             thread_name_prefix: str = "",
             initializer: Callable[[], object] | None = None,
             initargs: tuple[()] = (),
-            shared: Mapping[str, object] | None = None,
         ) -> None: ...
         @overload
         def __init__(
@@ -87,7 +69,6 @@ if sys.version_info >= (3, 14):
             *,
             initializer: Callable[[Unpack[_Ts]], object],
             initargs: tuple[Unpack[_Ts]],
-            shared: Mapping[str, object] | None = None,
         ) -> None: ...
         @overload
         def __init__(
@@ -96,5 +77,4 @@ if sys.version_info >= (3, 14):
             thread_name_prefix: str,
             initializer: Callable[[Unpack[_Ts]], object],
             initargs: tuple[Unpack[_Ts]],
-            shared: Mapping[str, object] | None = None,
         ) -> None: ...

--- a/stdlib/concurrent/futures/interpreter.pyi
+++ b/stdlib/concurrent/futures/interpreter.pyi
@@ -21,12 +21,12 @@ if sys.version_info >= (3, 14):
     from concurrent.futures.thread import BrokenThreadPool, WorkerContext as ThreadWorkerContext
     from concurrent.interpreters import Interpreter
 
-    def do_call(results: Queue, func: Callable[_P, _R], args: tuple[_P.args], kwargs: dict[str, _P.kwargs]) -> _R: ...
+    def do_call(results: Queue, func: Callable[_P, _R], args: _P.args, kwargs: _P.kwargs) -> _R: ...
 
     class WorkerContext(ThreadWorkerContext):
         interp: Interpreter | None
         results: Queue | None
-        @overload
+        @overload  # type: ignore[override]
         @classmethod
         def prepare(
             cls, initializer: Callable[[Unpack[_Ts]], object], initargs: tuple[Unpack[_Ts]]
@@ -43,7 +43,7 @@ if sys.version_info >= (3, 14):
     class InterpreterPoolExecutor(ThreadPoolExecutor):
         BROKEN: type[BrokenInterpreterPool]
 
-        @overload
+        @overload  # type: ignore[override]
         @classmethod
         def prepare_context(
             cls, initializer: Callable[[], object], initargs: tuple[()]

--- a/stdlib/concurrent/futures/interpreter.pyi
+++ b/stdlib/concurrent/futures/interpreter.pyi
@@ -1,8 +1,7 @@
 import sys
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
-from queue import Queue
-from typing import Literal, Protocol, overload, type_check_only
+from typing import Any, Literal, Protocol, overload, type_check_only
 from typing_extensions import ParamSpec, Self, TypeAlias, TypeVar, TypeVarTuple, Unpack
 
 _Task: TypeAlias = tuple[bytes, Literal["function", "script"]]
@@ -19,15 +18,13 @@ class _TaskFunc(Protocol):
 
 if sys.version_info >= (3, 14):
     from concurrent.futures.thread import BrokenThreadPool, WorkerContext as ThreadWorkerContext
-    from concurrent.interpreters import Interpreter
+    from concurrent.interpreters import Interpreter, Queue
 
-    def do_call(
-        results: Queue[BaseException | None], func: Callable[..., _R], args: tuple[object, ...], kwargs: dict[str, object]
-    ) -> _R: ...
+    def do_call(results: Queue, func: Callable[..., _R], args: tuple[Any, ...], kwargs: dict[str, Any]) -> _R: ...
 
     class WorkerContext(ThreadWorkerContext):
         interp: Interpreter | None
-        results: Queue[BaseException | None] | None
+        results: Queue | None
         @overload  # type: ignore[override]
         @classmethod
         def prepare(

--- a/stdlib/concurrent/futures/interpreter.pyi
+++ b/stdlib/concurrent/futures/interpreter.pyi
@@ -21,7 +21,7 @@ if sys.version_info >= (3, 14):
     from concurrent.futures.thread import BrokenThreadPool, WorkerContext as ThreadWorkerContext
     from concurrent.interpreters import Interpreter
 
-    def do_call(results: Queue, func: Callable[_P, _R], args: _P.args, kwargs: _P.kwargs) -> _R: ...
+    def do_call(results: Queue, func: Callable[..., _R], args: tuple[object, ...], kwargs: dict[str, object]) -> _R: ...
 
     class WorkerContext(ThreadWorkerContext):
         interp: Interpreter | None

--- a/stdlib/concurrent/futures/interpreter.pyi
+++ b/stdlib/concurrent/futures/interpreter.pyi
@@ -21,11 +21,13 @@ if sys.version_info >= (3, 14):
     from concurrent.futures.thread import BrokenThreadPool, WorkerContext as ThreadWorkerContext
     from concurrent.interpreters import Interpreter
 
-    def do_call(results: Queue, func: Callable[..., _R], args: tuple[object, ...], kwargs: dict[str, object]) -> _R: ...
+    def do_call(
+        results: Queue[BaseException | None], func: Callable[..., _R], args: tuple[object, ...], kwargs: dict[str, object]
+    ) -> _R: ...
 
     class WorkerContext(ThreadWorkerContext):
         interp: Interpreter | None
-        results: Queue | None
+        results: Queue[BaseException | None] | None
         @overload  # type: ignore[override]
         @classmethod
         def prepare(


### PR DESCRIPTION
Source: https://github.com/python/cpython/pull/133957

* Add `do_call` function
* Add `interp`, `results` attributes to `WorkerContext`
* Remove `ExecutionFailed`
* Remove `shared` argument from methods