### PR TITLE
[pysftp] Pin `paramiko~=3.0` when running stubtest

### DIFF
--- a/stubs/pysftp/METADATA.toml
+++ b/stubs/pysftp/METADATA.toml
@@ -1,3 +1,6 @@
 version = "0.2.*"
 upstream_repository = "https://bitbucket.org/dundeemt/pysftp"
 requires = ["types-paramiko"]
+
+[tool.stubtest]
+stubtest_requirements = ["paramiko~=3.0"]


### PR DESCRIPTION
Fixes #14525