### PR TITLE
Use uv action rather than install script

### DIFF
--- a/.github/workflows/meta_tests.yml
+++ b/.github/workflows/meta_tests.yml
@@ -39,7 +39,9 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.13"
-      - run: curl -LsSf https://astral.sh/uv/install.sh | sh
+      - uses: astral-sh/setup-uv@v6
+        with:
+          version-file: "requirements-tests.txt"
       - run: uv pip install -r requirements-tests.txt --system
       - run: python ./tests/typecheck_typeshed.py --platform=${{ matrix.platform }}
   pyright:
@@ -54,7 +56,9 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.13"
-      - run: curl -LsSf https://astral.sh/uv/install.sh | sh
+      - uses: astral-sh/setup-uv@v6
+        with:
+          version-file: "requirements-tests.txt"
       - run: uv pip install -r requirements-tests.txt --system
       - name: Run pyright on typeshed
         uses: jakebailey/pyright-action@v2
@@ -71,7 +75,9 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.13"
-      - run: curl -LsSf https://astral.sh/uv/install.sh | sh
+      - uses: astral-sh/setup-uv@v6
+        with:
+          version-file: "requirements-tests.txt"
       - name: Git config
         run: |
           git config --global user.name stubsabot

--- a/.github/workflows/stubsabot.yml
+++ b/.github/workflows/stubsabot.yml
@@ -27,7 +27,9 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.13"
-      - run: curl -LsSf https://astral.sh/uv/install.sh | sh
+      - uses: astral-sh/setup-uv@v6
+        with:
+          version-file: "requirements-tests.txt"
       - name: git config
         run: |
           git config --global user.name stubsabot

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,9 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.13"
-      - run: curl -LsSf https://astral.sh/uv/install.sh | sh
+      - uses: astral-sh/setup-uv@v6
+        with:
+          version-file: "requirements-tests.txt"
       - run: uv pip install -r requirements-tests.txt --system
       - run: python ./tests/check_typeshed_structure.py
 
@@ -48,7 +50,9 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - run: curl -LsSf https://astral.sh/uv/install.sh | sh
+      - uses: astral-sh/setup-uv@v6
+        with:
+          version-file: "requirements-tests.txt"
       - run: uv pip install -r requirements-tests.txt --system
       - name: Install required APT packages
         run: |
@@ -81,7 +85,9 @@ jobs:
           # Use py311 for now, as py312 seems to be around 30s slower in CI
           # TODO: figure out why that is (#11590)
           python-version: "3.11"
-      - run: curl -LsSf https://astral.sh/uv/install.sh | sh
+      - uses: astral-sh/setup-uv@v6
+        with:
+          version-file: "requirements-tests.txt"
       - run: uv pip install -r requirements-tests.txt --system
       - run: python ./tests/regr_test.py --all --verbosity QUIET
 


### PR DESCRIPTION
Follow-up to https://github.com/python/typeshed/pull/14082 now that that we can ensure a consistant and specific uv version (uv version changing mid-run used to make the post-action step fail due to cache issues)

According to https://github.com/astral-sh/setup-uv#enable-caching, caching with the action is enabled by default on GitHub-hosted runners, and the default `cache-dependency-glob` should take both our `requirements-tests.txt` and `pyproject.toml` into account: https://github.com/astral-sh/setup-uv#cache-dependency-glob. So there's no extra configuration needed.

Hopefully this should result in faster runs for the affected steps.
