### PR TITLE
[stubsabot] Support diff analysis for GitLab hosted projects

### DIFF
--- a/scripts/stubsabot.py
+++ b/scripts/stubsabot.py
@@ -360,7 +360,8 @@ async def get_host_repo_info(session: aiohttp.ClientSession, stub_info: StubMeta
     else:
         assert host == "gitlab"
         # https://docs.gitlab.com/api/tags/
-        info_url = f"https://gitlab.com/api/v4/projects/{url_path.replace('/', '%2F')}/repository/tags"
+        project_id = urllib.parse.quote(url_path, safe="")
+        info_url = f"https://gitlab.com/api/v4/projects/{project_id}/repository/tags"
         headers = None
     async with session.get(info_url, headers=headers) as response:
         if response.status == HTTPStatus.OK:
@@ -542,7 +543,7 @@ async def analyze_gitlab_diff(
     repo_path: str, distribution: str, old_tag: str, new_tag: str, *, session: aiohttp.ClientSession
 ) -> DiffAnalysis | None:
     # https://docs.gitlab.com/api/repositories/#compare-branches-tags-or-commits
-    project_id = repo_path.replace("/", "%2F")
+    project_id = urllib.parse.quote(repo_path, safe="")
     url = f"https://gitlab.com/api/v4/projects/{project_id}/repository/compare?from={old_tag}&to={new_tag}"
     async with session.get(url) as response:
         response.raise_for_status()


### PR DESCRIPTION
Currently, stubsabot only does diff analysis for GitHub hosted projects. Typeshed has a few third-party stubs whose upstream projects are hosted on GitLab. It would be nice if stubsabot could do diff analysis for those too (having a "diff" URL in the PR body is especially handy).

Apparently GitLab has a REST API that works pretty similarly to GitHub's. It also doesn't appear to require an access token (at least for the `/projects/:id` endpoint, which is all this would need to use). I took a stab at updating stubsabot to use this API in a way that mirrors the current GitHub API use. It turned out to be pretty straightforward. This makes stubsabot do roughly the same diff analysis for GitLab projects that it does for GitHub projects, including adding a convenient diff URL to the PR body.

I tested this locally by downgrading one of the GitLab stubs (python-crontab) and then running `python3 scripts/stubsabot.py --action-level local python-crontab`. It seems to be working well. This is the commit message was generated:

<details><summary>[stubsabot] Bump python-crontab to 3.3.*</summary>

> Release: https://pypi.org/pypi/python-crontab/3.3.0
> Homepage: https://gitlab.com/doctormo/python-crontab/
> Repository: https://gitlab.com/doctormo/python-crontab
> Typeshed stubs: https://github.com/python/typeshed/tree/main/stubs/python-crontab
> Diff: https://gitlab.com/doctormo/python-crontab/-/compare/v3.2.0...v3.3.0
> 
> Stubsabot analysis of the diff between the two releases:
>  - 0 public Python files have been added.
>  - 0 files included in typeshed's stubs have been deleted.
>  - 2 files included in typeshed's stubs have been modified or renamed: `cronlog.py`, `crontab.py`.
>  - Total lines of Python code added: 52.
>  - Total lines of Python code deleted: 40.
> 
> If stubtest fails for this PR:
> - Leave this PR open (as a reminder, and to prevent stubsabot from opening another PR)
> - Fix stubtest failures in another PR, then close this PR
> 
> Note that you will need to close and re-open the PR in order to trigger CI

</details>