### PR TITLE
fix(token): Fix create_token_response body only accepting string inst…

### DIFF
--- a/stubs/oauthlib/oauthlib/oauth2/rfc6749/endpoints/token.pyi
+++ b/stubs/oauthlib/oauthlib/oauth2/rfc6749/endpoints/token.pyi
@@ -23,7 +23,7 @@ class TokenEndpoint(BaseEndpoint):
         self,
         uri: str,
         http_method: _HTTPMethod = "POST",
-        body: str | None = None,
+        body: str | dict[str, str] | list[tuple[str, str]] | None = None,
         headers: dict[str, str] | None = None,
         credentials=None,
         grant_type_for_scope=None,


### PR DESCRIPTION
…ead of various supported datatypes

For convenience, this is the code of create_token_response:

```ts
    @catch_errors_and_unavailability
    def create_token_response(self, uri, http_method='POST', body=None,
                              headers=None, credentials=None, grant_type_for_scope=None,
                              claims=None):
        """Extract grant_type and route to the designated handler."""
        request = Request(
            uri, http_method=http_method, body=body, headers=headers)
        self.validate_token_request(request)
   ...
```

And here is Request constructor from https://github.com/python/typeshed/blob/main/stubs/oauthlib/oauthlib/common.pyi#L62

```ts
class Request:
    ...
    def __init__(
        self,
        uri: str,
        http_method: _HTTPMethod = "GET",
        body: str | dict[str, str] | list[tuple[str, str]] | None = None,
        headers: Mapping[str, str] | None = None,
        encoding: str = "utf-8",
    ): ...

```