### PR TITLE
Update jsonschema stubs to track latest changes

### DIFF
--- a/stubs/jsonschema/jsonschema/protocols.pyi
+++ b/stubs/jsonschema/jsonschema/protocols.pyi
@@ -1,6 +1,6 @@
 from _typeshed import Incomplete
 from collections.abc import Iterator, Mapping, Sequence
-from typing import ClassVar, Protocol
+from typing import Any, ClassVar, Protocol
 from typing_extensions import TypeAlias
 
 import referencing.jsonschema
@@ -15,12 +15,14 @@ class Validator(Protocol):
     VALIDATORS: ClassVar[dict[Incomplete, Incomplete]]
     TYPE_CHECKER: ClassVar[TypeChecker]
     FORMAT_CHECKER: ClassVar[FormatChecker]
-    schema: dict[Incomplete, Incomplete] | bool
+    schema: referencing.jsonschema.Schema
     def __init__(
         self,
-        schema: dict[Incomplete, Incomplete] | bool,
-        registry: referencing.jsonschema.SchemaRegistry,
+        schema: Mapping[Incomplete, Incomplete] | bool,
+        resolver: Any = None,  # deprecated
         format_checker: FormatChecker | None = None,
+        *,
+        registry: referencing.jsonschema.SchemaRegistry = ...,
     ) -> None: ...
     @classmethod
     def check_schema(cls, schema: dict[Incomplete, Incomplete]) -> None: ...

--- a/stubs/jsonschema/jsonschema/validators.pyi
+++ b/stubs/jsonschema/jsonschema/validators.pyi
@@ -21,7 +21,7 @@ _ValidatorCallback: TypeAlias = Callable[[Any, Any, _JsonValue, _JsonObject], It
 # This class does not exist at runtime. Compatible classes are created at
 # runtime by create().
 @type_check_only
-class _Validator:
+class _Validator(Validator):
     VALIDATORS: ClassVar[dict[Incomplete, Incomplete]]
     META_SCHEMA: ClassVar[dict[Incomplete, Incomplete]]
     TYPE_CHECKER: ClassVar[Incomplete]
@@ -32,12 +32,11 @@ class _Validator:
     format_checker: FormatChecker | None
     def __init__(
         self,
-        schema: Schema,
-        resolver=None,
+        schema: Mapping[Incomplete, Incomplete] | bool,
+        resolver: Any = None,  # deprecated
         format_checker: FormatChecker | None = None,
         *,
         registry: SchemaRegistry = ...,
-        _resolver=None,
     ) -> None: ...
     @classmethod
     def check_schema(cls, schema: Schema, format_checker: FormatChecker | Unset = ...) -> None: ...


### PR DESCRIPTION
In python-jsonschema/jsonschema#1396 , the type signature for `Validator.__init__` is updated to better match the runtime signature. This backports the fix to typeshed, keeping the copies of this data in sync. python-jsonschema/jsonschema#1396 is, itself, a response to feedback on `jsonschema` about the changes in `typeshed` #14327.

In addition to the `__init__` fix, a couple of additional small changes are made, both in `jsonschema` and here in the stubs:

1. In `jsonschema`, the type for `create()` in `validators.py` was updated to be notated with `-> type[Validator]`. This was necessary for internal testing on types to correctly read that validator classes created by this factory implement the protocol.

2. Here, in order to better guarantee that the types align, the `_Validator` class (which does not exist in `jsonschema`, but is only defined here in the stubs) now inherits from `Validator`.

3. The init signature for `_Validator` is updated to match

4. `tests/mypy_test.py` flags the `schema` instance variable annotation as mismatching between `Validator` and `_Validator`. Review against the `jsonschema` source reveals that `_Validator` was closer to correct, so `Validator` is fixed to match.

Any further changes (e.g., elimination of `_Validator` or changing `create`'s return type annotation) are left as potential future work.
