### PR TITLE
networkx Final and Literal from python-type-stubs

### DIFF
--- a/stubs/networkx/networkx/algorithms/approximation/traveling_salesman.pyi
+++ b/stubs/networkx/networkx/algorithms/approximation/traveling_salesman.pyi
@@ -1,6 +1,6 @@
 from _typeshed import Incomplete, SupportsLenAndGetItem
-from collections.abc import Callable, Mapping
-from typing import Any, TypeVar
+from collections.abc import Callable, Iterable, Mapping
+from typing import Any, Literal, TypeVar
 
 from networkx.classes.digraph import DiGraph
 from networkx.classes.graph import Graph, _Node
@@ -57,7 +57,7 @@ def simulated_annealing_tsp(
 @_dispatchable
 def threshold_accepting_tsp(
     G: Graph[_Node],
-    init_cycle,
+    init_cycle: Literal["greedy"] | Iterable[Incomplete],
     weight: str | None = "weight",
     source=None,
     threshold: int | None = 1,

--- a/stubs/networkx/networkx/algorithms/assortativity/connectivity.pyi
+++ b/stubs/networkx/networkx/algorithms/assortativity/connectivity.pyi
@@ -1,5 +1,6 @@
 from _typeshed import Incomplete
 from collections.abc import Iterable
+from typing import Literal
 
 from networkx.classes.graph import Graph, _Node
 from networkx.utils.backends import _dispatchable
@@ -8,5 +9,9 @@ __all__ = ["average_degree_connectivity"]
 
 @_dispatchable
 def average_degree_connectivity(
-    G: Graph[_Node], source="in+out", target="in+out", nodes: Iterable[Incomplete] | None = None, weight: str | None = None
+    G: Graph[_Node],
+    source: Literal["in+out", "out", "in"] = "in+out",
+    target: Literal["in+out", "out", "in"] = "in+out",
+    nodes: Iterable[Incomplete] | None = None,
+    weight: str | None = None,
 ) -> dict[Incomplete, int | float]: ...

--- a/stubs/networkx/networkx/readwrite/gexf.pyi
+++ b/stubs/networkx/networkx/readwrite/gexf.pyi
@@ -1,5 +1,6 @@
 from _typeshed import Incomplete
 from collections.abc import Generator
+from typing import Final, Literal
 
 from networkx.utils.backends import _dispatchable
 
@@ -17,7 +18,7 @@ class GEXF:
     xml_type: Incomplete
     python_type: Incomplete
     def construct_types(self) -> None: ...
-    convert_bool: Incomplete
+    convert_bool: Final[dict[Literal["true", "false", "True", "False", "0", 0, "1", 1], bool]]
     NS_GEXF: Incomplete
     NS_VIZ: Incomplete
     NS_XSI: Incomplete

--- a/stubs/networkx/networkx/readwrite/graphml.pyi
+++ b/stubs/networkx/networkx/readwrite/graphml.pyi
@@ -1,6 +1,6 @@
 from _typeshed import Incomplete
 from collections.abc import Generator
-from typing import Final
+from typing import Final, Literal
 
 from networkx.utils.backends import _dispatchable
 
@@ -49,7 +49,7 @@ class GraphML:
     xml_type: Incomplete
     python_type: Incomplete
     def construct_types(self) -> None: ...
-    convert_bool: Incomplete
+    convert_bool: Final[dict[Literal["true", "false", "0", 0, "1", 1], bool]]
     def get_xml_type(self, key): ...
 
 class GraphMLWriter(GraphML):


### PR DESCRIPTION
Extracted changes from https://github.com/python/typeshed/pull/14038 where `Final` and `Literal` would be added