### PR TITLE
remove pytype workaround

### DIFF
--- a/stdlib/xml/etree/ElementTree.pyi
+++ b/stdlib/xml/etree/ElementTree.pyi
@@ -78,9 +78,8 @@ def canonicalize(
 ) -> None: ...
 
 # The tag for Element can be set to the Comment or ProcessingInstruction
-# functions defined in this module. _ElementCallable could be a recursive
-# type, but defining it that way uncovered a bug in pytype.
-_ElementCallable: TypeAlias = Callable[..., Element[Any]]
+# functions defined in this module.
+_ElementCallable: TypeAlias = Callable[..., Element[_ElementCallable]]
 _CallableElement: TypeAlias = Element[_ElementCallable]
 
 _Tag = TypeVar("_Tag", default=str, bound=str | _ElementCallable)


### PR DESCRIPTION
I originally made this alias recursive, but it was blocked by https://github.com/google/pytype/issues/1858. Now it can be recursive?