### PR TITLE
[ujson] Mark as obsolete since 5.11.0

### DIFF
--- a/stubs/ujson/METADATA.toml
+++ b/stubs/ujson/METADATA.toml
@@ -1,2 +1,3 @@
 version = "5.10.*"
 upstream_repository = "https://github.com/ultrajson/ultrajson"
+obsolete_since = "5.11.0" # Released 2025-08-20


### PR DESCRIPTION
ujson 5.11.0 (released 2025-08-20) includes type hints.

https://github.com/ultrajson/ultrajson/releases/tag/5.11.0

I spot checked that the wheels on PyPI do indeed contain the `ujson-stubs` directory and that the stubs are discovered as expected by mypy.
