### PR TITLE
[CI] Move installing 3rd party pks into extra step

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -76,7 +76,7 @@ jobs:
             stubs/**/METADATA.toml
       - name: Install dependencies
         run: pip install -r requirements-tests.txt
-      - name: Run stubtest
+      - name: Install required system packages
         shell: bash
         run: |
           PACKAGES=$(python tests/get_stubtest_system_requirements.py)
@@ -86,8 +86,6 @@ jobs:
               printf "Installing APT packages:\n  $(echo $PACKAGES | sed 's/ /\n  /g')\n"
               sudo apt-get update -q && sudo apt-get install -qy $PACKAGES
             fi
-
-            PYTHON_EXECUTABLE="xvfb-run python"
           else
             if [ "${{ runner.os }}" = "macOS" ] && [ -n "$PACKAGES" ]; then
               printf "Installing Homebrew packages:\n  $(echo $PACKAGES | sed 's/ /\n  /g')\n"
@@ -98,7 +96,13 @@ jobs:
               printf "Installing Chocolatey packages:\n  $(echo $PACKAGES | sed 's/ /\n  /g')\n"
               choco install -y $PACKAGES
             fi
-
+          fi
+      - name: Run stubtest
+        shell: bash
+        run: |
+          if [ "${{ runner.os }}" = "Linux" ]; then
+            PYTHON_EXECUTABLE="xvfb-run python"
+          else
             PYTHON_EXECUTABLE="python"
           fi
 

--- a/.github/workflows/stubtest_third_party.yml
+++ b/.github/workflows/stubtest_third_party.yml
@@ -48,7 +48,7 @@ jobs:
             stubs/**/METADATA.toml
       - name: Install dependencies
         run: pip install -r requirements-tests.txt
-      - name: Run stubtest
+      - name: Determine changed stubs
         shell: bash
         run: |
           # This only runs stubtest on changed stubs, because it is much faster.
@@ -59,18 +59,17 @@ jobs:
             (while read stub; do [ -d "stubs/$stub" ] && echo "$stub" || true; done)
           }
           STUBS=$(find_stubs || echo '')
-
+          echo "Changed stubs: $STUBS"
+          echo "STUBS=$STUBS" >> $GITHUB_ENV
+      - name: Install required system packages
+        run: |
           if [ -n "$STUBS" ]; then
-            echo "Testing $STUBS..."
             PACKAGES=$(python tests/get_stubtest_system_requirements.py $STUBS)
-
             if [ "${{ runner.os }}" = "Linux" ]; then
               if [ -n "$PACKAGES" ]; then
                 printf "Installing APT packages:\n  $(echo $PACKAGES | sed 's/ /\n  /g')\n"
                 sudo apt-get update -q && sudo apt-get install -qy $PACKAGES
               fi
-
-              PYTHON_EXECUTABLE="xvfb-run python"
             else
               if [ "${{ runner.os }}" = "macOS" ] && [ -n "$PACKAGES" ]; then
                 printf "Installing Homebrew packages:\n  $(echo $PACKAGES | sed 's/ /\n  /g')\n"
@@ -81,7 +80,17 @@ jobs:
                 printf "Installing Chocolatey packages:\n  $(echo $PACKAGES | sed 's/ /\n  /g')\n"
                 choco install -y $PACKAGES
               fi
+            fi
+          fi
+      - name: Run stubtest
+        shell: bash
+        run: |
+          if [ -n "$STUBS" ]; then
+            echo "Testing $STUBS..."
 
+            if [ "${{ runner.os }}" = "Linux" ]; then
+              PYTHON_EXECUTABLE="xvfb-run python"
+            else
               PYTHON_EXECUTABLE="python"
             fi
 


### PR DESCRIPTION
This not only separates the concerns better, it also makes
the output clearer and allows for easier debugging
of long running CI tasks due to more granular timings.