### PR TITLE
networkx: Add all_simple_path target typing in allsimple_paths.pyi

### DIFF
--- a/stubs/networkx/networkx/algorithms/simple_paths.pyi
+++ b/stubs/networkx/networkx/algorithms/simple_paths.pyi
@@ -1,5 +1,5 @@
 from _typeshed import Incomplete, SupportsGetItem
-from collections.abc import Callable, Collection, Generator
+from collections.abc import Callable, Collection, Generator, Iterable
 from typing import Any
 
 from networkx.classes.graph import Graph, _Node
@@ -10,10 +10,10 @@ __all__ = ["all_simple_paths", "is_simple_path", "shortest_simple_paths", "all_s
 @_dispatchable
 def is_simple_path(G: Graph[_Node], nodes: Collection[Incomplete]) -> bool: ...
 @_dispatchable
-def all_simple_paths(G: Graph[_Node], source: _Node, target, cutoff: int | None = None) -> Generator[list[_Node], None, None]: ...
+def all_simple_paths(G: Graph[_Node], source: _Node, target: _Node | Iterable[_Node], cutoff: int | None = None) -> Generator[list[_Node], None, None]: ...
 @_dispatchable
 def all_simple_edge_paths(
-    G: Graph[_Node], source: _Node, target, cutoff: int | None = None
+    G: Graph[_Node], source: _Node, target: _Node | Iterable[_Node], cutoff: int | None = None
 ) -> Generator[list[_Node] | list[tuple[_Node, _Node]], None, list[_Node] | None]: ...
 @_dispatchable
 def shortest_simple_paths(


### PR DESCRIPTION
Adds typing for the target argument of all_simple_paths and all_simple_edge_paths, which per the documentation take either a single node or an iterable of nodes.

[all_simple_paths](https://networkx.org/documentation/stable/reference/algorithms/generated/networkx.algorithms.simple_paths.all_simple_paths.html#networkx.algorithms.simple_paths.all_simple_paths):
> target: *nodes*
> Single node or iterable of nodes at which to end path


[all_simple_edge_paths](https://networkx.org/documentation/stable/reference/algorithms/generated/networkx.algorithms.simple_paths.all_simple_edge_paths.html#networkx.algorithms.simple_paths.all_simple_edge_paths)
> target: *nodes*
> Single node or iterable of nodes at which to end path