### PR TITLE
networkx: Fix incompletes in connectivity/connectivity

### DIFF
--- a/stubs/networkx/networkx/algorithms/approximation/connectivity.pyi
+++ b/stubs/networkx/networkx/algorithms/approximation/connectivity.pyi
@@ -1,6 +1,7 @@
 from collections.abc import Callable, Iterable
 
-from networkx.classes.graph import Graph, DiGraph, _Node
+from networkx.classes.graph import Graph, _Node
+from networkx.classes.digraph import DiGraph
 from networkx.utils.backends import _dispatchable
 
 __all__ = [
@@ -51,7 +52,7 @@ def local_edge_connectivity(
     residual: DiGraph[_Node] | None = None,
     cutoff: int | float | None = None,
 ) -> int | float: ...
-@nx._dispatchable
+@_dispatchable
 def edge_connectivity(
     G: Graph[_Node],
     s: _Node,

--- a/stubs/networkx/networkx/algorithms/approximation/connectivity.pyi
+++ b/stubs/networkx/networkx/algorithms/approximation/connectivity.pyi
@@ -1,60 +1,16 @@
-from collections.abc import Callable, Iterable
+from _typeshed import Incomplete
+from collections.abc import Iterable
 
-from networkx.classes.digraph import DiGraph
 from networkx.classes.graph import Graph, _Node
 from networkx.utils.backends import _dispatchable
 
-__all__ = [
-    "average_node_connectivity",
-    "local_node_connectivity",
-    "node_connectivity",
-    "local_edge_connectivity",
-    "edge_connectivity",
-    "all_pairs_node_connectivity",
-]
+__all__ = ["local_node_connectivity", "node_connectivity", "all_pairs_node_connectivity"]
 
 @_dispatchable
-def local_node_connectivity(
-    G: Graph[_Node],
-    s: _Node,
-    t: _Node,
-    flow_func: Callable[[DiGraph[_Node], _Node, _Node], DiGraph[_Node]] | None = None,
-    auxiliary: DiGraph[_Node] | None = None,
-    residual: DiGraph[_Node] | None = None,
-    cutoff: int | float | None = None,
-) -> int | float: ...
+def local_node_connectivity(G: Graph[_Node], source: _Node, target: _Node, cutoff: int | None = None): ...
 @_dispatchable
-def node_connectivity(
-    G: Graph[_Node],
-    s: _Node | None = None,
-    t: _Node | None = None,
-    flow_func: Callable[[DiGraph[_Node], _Node, _Node], DiGraph[_Node]] | None = None,
-) -> int | float: ...
-@_dispatchable
-def average_node_connectivity(
-    G: Graph[_Node], flow_func: Callable[[DiGraph[_Node], _Node, _Node], DiGraph[_Node]] | None = None
-) -> float: ...
+def node_connectivity(G: Graph[_Node], s: _Node | None = None, t: _Node | None = None): ...
 @_dispatchable
 def all_pairs_node_connectivity(
-    G: Graph[_Node],
-    nbunch: Iterable[tuple[_Node, _Node]] | None = None,
-    flow_func: Callable[[DiGraph[_Node], _Node, _Node], DiGraph[_Node]] | None = None,
-) -> dict[_Node, dict[_Node, int | float]]: ...
-@_dispatchable
-def local_edge_connectivity(
-    G: Graph[_Node],
-    s: _Node,
-    t: _Node,
-    flow_func: Callable[[DiGraph[_Node], _Node, _Node], DiGraph[_Node]] | None = None,
-    auxiliary: DiGraph[_Node] | None = None,
-    residual: DiGraph[_Node] | None = None,
-    cutoff: int | float | None = None,
-) -> int | float: ...
-@_dispatchable
-def edge_connectivity(
-    G: Graph[_Node],
-    s: _Node,
-    t: _Node,
-    flow_func: Callable[[DiGraph[_Node], _Node, _Node], DiGraph[_Node]] | None = None,
-    cutoff: int | float | None = None,
-) -> int | float: ...
+    G: Graph[_Node], nbunch: Iterable[Incomplete] | None = None, cutoff: int | None = None
+) -> dict[Incomplete, dict[Incomplete, Incomplete]]: ...

--- a/stubs/networkx/networkx/algorithms/approximation/connectivity.pyi
+++ b/stubs/networkx/networkx/algorithms/approximation/connectivity.pyi
@@ -1,16 +1,61 @@
-from _typeshed import Incomplete
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 
-from networkx.classes.graph import Graph, _Node
+from networkx.classes.graph import Graph, DiGraph, _Node
 from networkx.utils.backends import _dispatchable
 
-__all__ = ["local_node_connectivity", "node_connectivity", "all_pairs_node_connectivity"]
+__all__ = [
+    "average_node_connectivity",
+    "local_node_connectivity",
+    "node_connectivity",
+    "local_edge_connectivity",
+    "edge_connectivity",
+    "all_pairs_node_connectivity",
+]
+
 
 @_dispatchable
-def local_node_connectivity(G: Graph[_Node], source: _Node, target: _Node, cutoff: int | None = None): ...
+def local_node_connectivity(
+    G: Graph[_Node],
+    s: _Node,
+    t: _Node,
+    flow_func: Callable[[DiGraph[_Node], _Node, _Node], DiGraph[_Node]] | None = None,
+    auxiliary: DiGraph[_Node] | None = None,
+    residual: DiGraph[_Node] | None = None,
+    cutoff: int | float | None = None,
+) -> int | float: ...
 @_dispatchable
-def node_connectivity(G: Graph[_Node], s: _Node | None = None, t: _Node | None = None): ...
+def node_connectivity(
+    G: Graph[_Node],
+    s: _Node | None = None,
+    t: _Node | None = None,
+    flow_func: Callable[[DiGraph[_Node], _Node, _Node], DiGraph[_Node]] | None = None,
+) -> int | float: ...
+@_dispatchable
+def average_node_connectivity(
+    G: Graph[_Node],
+    flow_func: Callable[[DiGraph[_Node], _Node, _Node], DiGraph[_Node]] | None = None,
+) -> float: ...
 @_dispatchable
 def all_pairs_node_connectivity(
-    G: Graph[_Node], nbunch: Iterable[Incomplete] | None = None, cutoff: int | None = None
-) -> dict[Incomplete, dict[Incomplete, Incomplete]]: ...
+    G: Graph[_Node],
+    nbunch: Iterable[tuple[_Node, _Node]] | None = None,
+    flow_func: Callable[[DiGraph[_Node], _Node, _Node], DiGraph[_Node]] | None = None,
+) -> dict[_Node, dict[_Node, int | float]]: ...
+@_dispatchable
+def local_edge_connectivity(
+    G: Graph[_Node],
+    s: _Node,
+    t: _Node,
+    flow_func: Callable[[DiGraph[_Node], _Node, _Node], DiGraph[_Node]] | None = None,
+    auxiliary: DiGraph[_Node] | None = None,
+    residual: DiGraph[_Node] | None = None,
+    cutoff: int | float | None = None,
+) -> int | float: ...
+@nx._dispatchable
+def edge_connectivity(
+    G: Graph[_Node],
+    s: _Node,
+    t: _Node,
+    flow_func: Callable[[DiGraph[_Node], _Node, _Node], DiGraph[_Node]] | None = None,
+    cutoff: int | float | None = None,
+) -> int | float: ...

--- a/stubs/networkx/networkx/algorithms/approximation/connectivity.pyi
+++ b/stubs/networkx/networkx/algorithms/approximation/connectivity.pyi
@@ -1,7 +1,7 @@
 from collections.abc import Callable, Iterable
 
-from networkx.classes.graph import Graph, _Node
 from networkx.classes.digraph import DiGraph
+from networkx.classes.graph import Graph, _Node
 from networkx.utils.backends import _dispatchable
 
 __all__ = [
@@ -12,7 +12,6 @@ __all__ = [
     "edge_connectivity",
     "all_pairs_node_connectivity",
 ]
-
 
 @_dispatchable
 def local_node_connectivity(
@@ -33,8 +32,7 @@ def node_connectivity(
 ) -> int | float: ...
 @_dispatchable
 def average_node_connectivity(
-    G: Graph[_Node],
-    flow_func: Callable[[DiGraph[_Node], _Node, _Node], DiGraph[_Node]] | None = None,
+    G: Graph[_Node], flow_func: Callable[[DiGraph[_Node], _Node, _Node], DiGraph[_Node]] | None = None
 ) -> float: ...
 @_dispatchable
 def all_pairs_node_connectivity(

--- a/stubs/networkx/networkx/algorithms/connectivity/connectivity.pyi
+++ b/stubs/networkx/networkx/algorithms/connectivity/connectivity.pyi
@@ -1,5 +1,6 @@
 from collections.abc import Callable, Iterable
 
+from networkx.algorithms.flow import edmonds_karp
 from networkx.classes.digraph import DiGraph
 from networkx.classes.graph import Graph, _Node
 from networkx.utils.backends import _dispatchable

--- a/stubs/networkx/networkx/algorithms/connectivity/connectivity.pyi
+++ b/stubs/networkx/networkx/algorithms/connectivity/connectivity.pyi
@@ -53,8 +53,8 @@ def local_edge_connectivity(
 @_dispatchable
 def edge_connectivity(
     G: Graph[_Node],
-    s: _Node,
-    t: _Node,
+    s: _Node | None = None,
+    t: _Node | None = None,
     flow_func: Callable[[DiGraph[_Node], _Node, _Node], DiGraph[_Node]] | None = None,
     cutoff: float | None = None,
 ) -> float: ...

--- a/stubs/networkx/networkx/algorithms/connectivity/connectivity.pyi
+++ b/stubs/networkx/networkx/algorithms/connectivity/connectivity.pyi
@@ -12,6 +12,7 @@ __all__ = [
     "edge_connectivity",
     "all_pairs_node_connectivity",
 ]
+default_flow_func = edmonds_karp
 
 @_dispatchable
 def local_node_connectivity(

--- a/stubs/networkx/networkx/algorithms/connectivity/connectivity.pyi
+++ b/stubs/networkx/networkx/algorithms/connectivity/connectivity.pyi
@@ -21,15 +21,15 @@ def local_node_connectivity(
     flow_func: Callable[[DiGraph[_Node], _Node, _Node], DiGraph[_Node]] | None = None,
     auxiliary: DiGraph[_Node] | None = None,
     residual: DiGraph[_Node] | None = None,
-    cutoff: int | float | None = None,
-) -> int | float: ...
+    cutoff: float | None = None,
+) -> float: ...
 @_dispatchable
 def node_connectivity(
     G: Graph[_Node],
     s: _Node | None = None,
     t: _Node | None = None,
     flow_func: Callable[[DiGraph[_Node], _Node, _Node], DiGraph[_Node]] | None = None,
-) -> int | float: ...
+) -> float: ...
 @_dispatchable
 def average_node_connectivity(
     G: Graph[_Node], flow_func: Callable[[DiGraph[_Node], _Node, _Node], DiGraph[_Node]] | None = None
@@ -39,7 +39,7 @@ def all_pairs_node_connectivity(
     G: Graph[_Node],
     nbunch: Iterable[tuple[_Node, _Node]] | None = None,
     flow_func: Callable[[DiGraph[_Node], _Node, _Node], DiGraph[_Node]] | None = None,
-) -> dict[_Node, dict[_Node, int | float]]: ...
+) -> dict[_Node, dict[_Node, float]]: ...
 @_dispatchable
 def local_edge_connectivity(
     G: Graph[_Node],
@@ -48,13 +48,13 @@ def local_edge_connectivity(
     flow_func: Callable[[DiGraph[_Node], _Node, _Node], DiGraph[_Node]] | None = None,
     auxiliary: DiGraph[_Node] | None = None,
     residual: DiGraph[_Node] | None = None,
-    cutoff: int | float | None = None,
-) -> int | float: ...
+    cutoff: float | None = None,
+) -> float: ...
 @_dispatchable
 def edge_connectivity(
     G: Graph[_Node],
     s: _Node,
     t: _Node,
     flow_func: Callable[[DiGraph[_Node], _Node, _Node], DiGraph[_Node]] | None = None,
-    cutoff: int | float | None = None,
-) -> int | float: ...
+    cutoff: float | None = None,
+) -> float: ...

--- a/stubs/networkx/networkx/algorithms/connectivity/connectivity.pyi
+++ b/stubs/networkx/networkx/algorithms/connectivity/connectivity.pyi
@@ -1,7 +1,5 @@
-from _typeshed import Incomplete
 from collections.abc import Callable, Iterable
 
-from networkx.algorithms.flow import edmonds_karp
 from networkx.classes.digraph import DiGraph
 from networkx.classes.graph import Graph, _Node
 from networkx.utils.backends import _dispatchable
@@ -14,43 +12,49 @@ __all__ = [
     "edge_connectivity",
     "all_pairs_node_connectivity",
 ]
-default_flow_func = edmonds_karp
 
 @_dispatchable
 def local_node_connectivity(
     G: Graph[_Node],
     s: _Node,
     t: _Node,
-    flow_func: Callable[..., Incomplete] | None = None,
+    flow_func: Callable[[DiGraph[_Node], _Node, _Node], DiGraph[_Node]] | None = None,
     auxiliary: DiGraph[_Node] | None = None,
     residual: DiGraph[_Node] | None = None,
-    cutoff: float | None = None,
-): ...
+    cutoff: int | float | None = None,
+) -> int | float: ...
 @_dispatchable
 def node_connectivity(
-    G: Graph[_Node], s: _Node | None = None, t: _Node | None = None, flow_func: Callable[..., Incomplete] | None = None
-): ...
+    G: Graph[_Node],
+    s: _Node | None = None,
+    t: _Node | None = None,
+    flow_func: Callable[[DiGraph[_Node], _Node, _Node], DiGraph[_Node]] | None = None,
+) -> int | float: ...
 @_dispatchable
-def average_node_connectivity(G: Graph[_Node], flow_func: Callable[..., Incomplete] | None = None) -> float: ...
+def average_node_connectivity(
+    G: Graph[_Node], flow_func: Callable[[DiGraph[_Node], _Node, _Node], DiGraph[_Node]] | None = None
+) -> float: ...
 @_dispatchable
 def all_pairs_node_connectivity(
-    G: Graph[_Node], nbunch: Iterable[Incomplete] | None = None, flow_func: Callable[..., Incomplete] | None = None
-) -> dict[Incomplete, dict[Incomplete, Incomplete]]: ...
+    G: Graph[_Node],
+    nbunch: Iterable[tuple[_Node, _Node]] | None = None,
+    flow_func: Callable[[DiGraph[_Node], _Node, _Node], DiGraph[_Node]] | None = None,
+) -> dict[_Node, dict[_Node, int | float]]: ...
 @_dispatchable
 def local_edge_connectivity(
     G: Graph[_Node],
     s: _Node,
     t: _Node,
-    flow_func: Callable[..., Incomplete] | None = None,
+    flow_func: Callable[[DiGraph[_Node], _Node, _Node], DiGraph[_Node]] | None = None,
     auxiliary: DiGraph[_Node] | None = None,
     residual: DiGraph[_Node] | None = None,
-    cutoff: float | None = None,
-): ...
+    cutoff: int | float | None = None,
+) -> int | float: ...
 @_dispatchable
 def edge_connectivity(
     G: Graph[_Node],
-    s: _Node | None = None,
-    t: _Node | None = None,
-    flow_func: Callable[..., Incomplete] | None = None,
-    cutoff: float | None = None,
-): ...
+    s: _Node,
+    t: _Node,
+    flow_func: Callable[[DiGraph[_Node], _Node, _Node], DiGraph[_Node]] | None = None,
+    cutoff: int | float | None = None,
+) -> int | float: ...


### PR DESCRIPTION
Adds type hints to previously incomplete items in `algorithms/connectivity/connectivity.pyi`. Changes were done referencing https://networkx.org/documentation/stable/_modules/networkx/algorithms/connectivity/connectivity.html