### PR TITLE
networkx: Update approximation/connectivity.pyi

### DIFF
--- a/stubs/networkx/networkx/algorithms/approximation/connectivity.pyi
+++ b/stubs/networkx/networkx/algorithms/approximation/connectivity.pyi
@@ -6,13 +6,9 @@ from networkx.utils.backends import _dispatchable
 __all__ = ["local_node_connectivity", "node_connectivity", "all_pairs_node_connectivity"]
 
 @_dispatchable
-def local_node_connectivity(
-    G: Graph[_Node], source: _Node, target: _Node, cutoff: float | None = None
-) -> float: ...
+def local_node_connectivity(G: Graph[_Node], source: _Node, target: _Node, cutoff: float | None = None) -> float: ...
 @_dispatchable
-def node_connectivity(
-    G: Graph[_Node], s: _Node | None = None, t: _Node | None = None
-) -> float: ...
+def node_connectivity(G: Graph[_Node], s: _Node | None = None, t: _Node | None = None) -> float: ...
 @_dispatchable
 def all_pairs_node_connectivity(
     G: Graph[_Node], nbunch: Iterable[_Node] | None = None, cutoff: float | None = None


### PR DESCRIPTION
Fixes the `Incomplete`s, adds return types, and changes some `int`s to floats. Despite the documentation saying "Integer", the code actually uses floats.
```py
if cutoff is None:
    cutoff = float("inf")
```
Based on https://networkx.org/documentation/stable/_modules/networkx/algorithms/approximation/connectivity.html