### PR TITLE
[yt-dlp] Check common code in extractor subpackage with stubtest

### DIFF
--- a/stubs/yt-dlp/@tests/stubtest_allowlist.txt
+++ b/stubs/yt-dlp/@tests/stubtest_allowlist.txt
@@ -1,5 +1,5 @@
 # Extractors will not be stubbed at this time.
-yt_dlp.extractor.*
+yt_dlp.extractor\.(?!__init__|common*).*
 # Postprocessors will not be stubbed at this time.
 yt_dlp.postprocessor.*
 # Won't be covered.

--- a/stubs/yt-dlp/yt_dlp/extractor/commonmistakes.pyi
+++ b/stubs/yt-dlp/yt_dlp/extractor/commonmistakes.pyi
@@ -1,10 +1,12 @@
+from typing import ClassVar
+
 from .common import InfoExtractor
 
 class CommonMistakesIE(InfoExtractor):
-    IE_DESC: bool
+    IE_DESC: ClassVar[bool]
 
 class UnicodeBOMIE(InfoExtractor):
-    IE_DESC: bool
+    IE_DESC: ClassVar[bool]
 
 class BlobIE(InfoExtractor):
-    IE_DESC: bool
+    IE_DESC: ClassVar[bool]

--- a/stubs/yt-dlp/yt_dlp/extractor/commonprotocols.pyi
+++ b/stubs/yt-dlp/yt_dlp/extractor/commonprotocols.pyi
@@ -1,10 +1,12 @@
+from typing import ClassVar
+
 from .common import InfoExtractor
 
 class RtmpIE(InfoExtractor):
-    IE_DESC: bool
+    IE_DESC: ClassVar[bool]
 
 class MmsIE(InfoExtractor):
-    IE_DESC: bool
+    IE_DESC: ClassVar[bool]
 
 class ViewSourceIE(InfoExtractor):
-    IE_DESC: bool
+    IE_DESC: ClassVar[bool]


### PR DESCRIPTION
Typeshed doesn't include stubs for the individual extractor modules, but we do stub a few modules with common code. This makes stubtest run for those modules and fixes few inconsistencies that have accumulated.