### PR TITLE
Add @disjoint_base to builtins.tuple

### DIFF
--- a/stdlib/@tests/stubtest_allowlists/common.txt
+++ b/stdlib/@tests/stubtest_allowlists/common.txt
@@ -10,7 +10,6 @@ importlib.abc.PathEntryFinder.find_spec  # Not defined on the actual class, but 
 tkinter.simpledialog.[A-Z_]+
 tkinter.simpledialog.TclVersion
 tkinter.simpledialog.TkVersion
-builtins.tuple  # should have @disjoint_base but hits pyright issue
 tarfile.TarInfo.__slots__  # it's a big dictionary at runtime and the dictionary values are a bit long
 
 

--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -1021,8 +1021,7 @@ class slice(Generic[_StartT_co, _StopT_co, _StepT_co]):
 
     def indices(self, len: SupportsIndex, /) -> tuple[int, int, int]: ...
 
-# Making this a disjoint_base upsets pyright
-# @disjoint_base
+@disjoint_base
 class tuple(Sequence[_T_co]):
     def __new__(cls, iterable: Iterable[_T_co] = ..., /) -> Self: ...
     def __len__(self) -> int: ...


### PR DESCRIPTION
Should be safe now that we've updated pyright.