### PR TITLE
[requests] Allow "connect" timeout to be `None` in timeout configuration tuple

### DIFF
--- a/stubs/requests/requests/sessions.pyi
+++ b/stubs/requests/requests/sessions.pyi
@@ -102,7 +102,7 @@ _Params: TypeAlias = (
 )
 _TextMapping: TypeAlias = MutableMapping[str, str]
 _HeadersUpdateMapping: TypeAlias = Mapping[str, str | bytes | None]
-_Timeout: TypeAlias = float | tuple[float, float] | tuple[float, None]
+_Timeout: TypeAlias = float | tuple[float | None, float | None]
 _Verify: TypeAlias = bool | str
 
 @type_check_only


### PR DESCRIPTION
Individual values of the timeout configuration tuple (connect timeout, read timeout) can be set to `None`, making the timeout indefinite.

Previously, only the `read` timeout could be set to `None`.