### PR TITLE
[CI] Run daily tests on pull requests in forks

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -30,7 +30,7 @@ env:
 jobs:
   stubtest-stdlib:
     name: "stubtest: stdlib"
-    if: ${{ github.repository == 'python/typeshed' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.repository == 'python/typeshed' || github.event_name != 'schedule' }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -58,7 +58,7 @@ jobs:
 
   stubtest-third-party:
     name: "stubtest: third party"
-    if: ${{ github.repository == 'python/typeshed' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.repository == 'python/typeshed' || github.event_name != 'schedule' }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -110,7 +110,7 @@ jobs:
 
   stub-uploader:
     name: stub_uploader tests
-    if: ${{ github.repository == 'python/typeshed' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.repository == 'python/typeshed' || github.event_name != 'schedule' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout typeshed


### PR DESCRIPTION
We currently run the daily tests for PRs that touch `requirements-tests.txt`, but only in the  main `python/typeshed` repo. This makes these tests also run when opening PRs in forks. This is useful for e.g. experimenting with different mypy versions in the CI.