### PR TITLE
Mark stub-only types with runtime aliases as `@type_check_only` in stdlib

### DIFF
--- a/stdlib/asyncio/events.pyi
+++ b/stdlib/asyncio/events.pyi
@@ -602,16 +602,25 @@ class AbstractEventLoop:
     @abstractmethod
     async def shutdown_default_executor(self) -> None: ...
 
-@type_check_only
-class _AbstractEventLoopPolicy:
-    @abstractmethod
-    def get_event_loop(self) -> AbstractEventLoop: ...
-    @abstractmethod
-    def set_event_loop(self, loop: AbstractEventLoop | None) -> None: ...
-    @abstractmethod
-    def new_event_loop(self) -> AbstractEventLoop: ...
-    # Child processes handling (Unix only).
-    if sys.version_info < (3, 14):
+if sys.version_info >= (3, 14):
+    class _AbstractEventLoopPolicy:
+        @abstractmethod
+        def get_event_loop(self) -> AbstractEventLoop: ...
+        @abstractmethod
+        def set_event_loop(self, loop: AbstractEventLoop | None) -> None: ...
+        @abstractmethod
+        def new_event_loop(self) -> AbstractEventLoop: ...
+
+else:
+    @type_check_only
+    class _AbstractEventLoopPolicy:
+        @abstractmethod
+        def get_event_loop(self) -> AbstractEventLoop: ...
+        @abstractmethod
+        def set_event_loop(self, loop: AbstractEventLoop | None) -> None: ...
+        @abstractmethod
+        def new_event_loop(self) -> AbstractEventLoop: ...
+        # Child processes handling (Unix only).
         if sys.version_info >= (3, 12):
             @abstractmethod
             @deprecated("Deprecated since Python 3.12; removed in Python 3.14.")
@@ -625,7 +634,6 @@ class _AbstractEventLoopPolicy:
             @abstractmethod
             def set_child_watcher(self, watcher: AbstractChildWatcher) -> None: ...
 
-if sys.version_info < (3, 14):
     AbstractEventLoopPolicy = _AbstractEventLoopPolicy
 
 if sys.version_info >= (3, 14):

--- a/stdlib/asyncio/events.pyi
+++ b/stdlib/asyncio/events.pyi
@@ -602,9 +602,7 @@ class AbstractEventLoop:
     @abstractmethod
     async def shutdown_default_executor(self) -> None: ...
 
-# This class does not exist at runtime, but stubtest complains if it's marked as
-# @type_check_only because it has an alias that does exist at runtime. See mypy#19568.
-# @type_check_only
+@type_check_only
 class _AbstractEventLoopPolicy:
     @abstractmethod
     def get_event_loop(self) -> AbstractEventLoop: ...

--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -1363,10 +1363,8 @@ class property:
     def __set__(self, instance: Any, value: Any, /) -> None: ...
     def __delete__(self, instance: Any, /) -> None: ...
 
-# This class does not exist at runtime, but stubtest complains if it's marked as
-# @type_check_only because it has an alias that does exist at runtime. See mypy#19568.
-# @type_check_only
 @final
+@type_check_only
 class _NotImplementedType(Any):
     __call__: None
 


### PR DESCRIPTION
Subtest no longer complains when these types are marked `@type_check_only` since python/mypy#19568