### PR TITLE
[docutils] Extend applicable types to _ContentModelCategory

### DIFF
--- a/stubs/docutils/@tests/stubtest_allowlist.txt
+++ b/stubs/docutils/@tests/stubtest_allowlist.txt
@@ -36,9 +36,3 @@ docutils.readers.TYPE_CHECKING
 docutils.utils.TYPE_CHECKING
 docutils.writers.TYPE_CHECKING
 docutils.writers._html_base.TYPE_CHECKING
-
-# FIXME: new stubtest errors from mypy v1.18.1 that need to be looked at more closely.
-# See https://github.com/python/typeshed/pull/14699
-docutils\.nodes\.\w+\.content_model
-docutils.parsers.docutils_xml.Unknown.content_model
-docutils.transforms.universal.SmartQuotes.nodes_to_skip

--- a/stubs/docutils/docutils/nodes.pyi
+++ b/stubs/docutils/docutils/nodes.pyi
@@ -12,7 +12,8 @@ from docutils.transforms import Transform, Transformer
 from docutils.utils import Reporter
 
 _N = TypeVar("_N", bound=Node)
-_ContentModelCategory: TypeAlias = type[Element] | tuple[type[Element], ...]
+_ElementLikeType: TypeAlias = type[Element | Text | Body | Bibliographic | Inline]
+_ContentModelCategory: TypeAlias = _ElementLikeType | tuple[_ElementLikeType, ...]
 _ContentModelQuantifier: TypeAlias = Literal[".", "?", "+", "*"]
 _ContentModelItem: TypeAlias = tuple[_ContentModelCategory, _ContentModelQuantifier]
 _ContentModelTuple: TypeAlias = tuple[_ContentModelItem, ...]

--- a/stubs/docutils/docutils/transforms/universal.pyi
+++ b/stubs/docutils/docutils/transforms/universal.pyi
@@ -43,7 +43,7 @@ class StripClassesAndElements(Transform):
 
 class SmartQuotes(Transform):
     default_priority: ClassVar[int]
-    nodes_to_skip: ClassVar[tuple[type[nodes.Node], ...]]
+    nodes_to_skip: ClassVar[tuple[type[nodes.Node | nodes.Special], ...]]
     literal_nodes: ClassVar[tuple[type[nodes.Node | nodes.Body], ...]]
     smartquotes_action: ClassVar[str]
     unsupported_languages: set[str]


### PR DESCRIPTION
Since these type aliases were taken from source codes, it would be a good idea to report this to `docutils` core team