### PR TITLE
Mitigate CI stall by excluding `materialize` from mypy_primer projects

### DIFF
--- a/.github/workflows/mypy_primer.yml
+++ b/.github/workflows/mypy_primer.yml
@@ -53,6 +53,7 @@ jobs:
             --custom-typeshed-repo typeshed_to_test \
             --new-typeshed $GITHUB_SHA --old-typeshed upstream_main \
             --num-shards 4 --shard-index ${{ matrix.shard-index }} \
+            --project-selector '^((?!materialize).)*$' \
             --debug \
             --output concise \
             | tee diff_${{ matrix.shard-index }}.txt


### PR DESCRIPTION
Stopgap for https://github.com/python/typeshed/pull/14716#issuecomment-3289636151