### PR TITLE
Revert "Mitigate CI stall by excluding `materialize` from mypy_primer projects"

### DIFF
--- a/.github/workflows/mypy_primer.yml
+++ b/.github/workflows/mypy_primer.yml
@@ -53,7 +53,6 @@ jobs:
             --custom-typeshed-repo typeshed_to_test \
             --new-typeshed $GITHUB_SHA --old-typeshed upstream_main \
             --num-shards 4 --shard-index ${{ matrix.shard-index }} \
-            --project-selector '^((?!materialize).)*$' \
             --debug \
             --output concise \
             | tee diff_${{ matrix.shard-index }}.txt


### PR DESCRIPTION
Reverts python/typeshed#14720

This shouldn't be needed anymore now that https://github.com/hauntsaninja/mypy_primer/pull/206 has been merged. Might as well revert it now before we forget