### PR TITLE
Fix docker mount source type

### DIFF
--- a/stubs/docker/docker/types/services.pyi
+++ b/stubs/docker/docker/types/services.pyi
@@ -61,7 +61,7 @@ class Mount(dict[str, Incomplete]):
     def __init__(
         self,
         target: str,
-        source: str,
+        source: str | None,
         type: Literal["bind", "volume", "tmpfs", "npipe"] = "volume",
         read_only: bool = False,
         consistency: Literal["default", "consistent", "cached", "delegated"] | None = None,


### PR DESCRIPTION
The source of a mount can be None e.g. if the type is tmpfs. The parse_mount_string also sets source=None in some cases