### PR TITLE
[pexpect] SpawnBase.delayafterread is allowed to be None

### DIFF
--- a/stubs/pexpect/pexpect/spawnbase.pyi
+++ b/stubs/pexpect/pexpect/spawnbase.pyi
@@ -57,7 +57,7 @@ class SpawnBase(Generic[AnyStr]):
     delaybeforesend: float | None
     delayafterclose: float
     delayafterterminate: float
-    delayafterread: float
+    delayafterread: float | None
     softspace: bool
     name: str
     closed: bool


### PR DESCRIPTION
See pexpect's source code:

https://github.com/pexpect/pexpect/blob/fc8f062518b40bd0862aae870cdedf5d9c0c7fc3/pexpect/spawnbase.py#L72

https://github.com/pexpect/pexpect/blob/fc8f062518b40bd0862aae870cdedf5d9c0c7fc3/pexpect/expect.py#L170

Closes #14727