### PR TITLE
Fix type of data return by `boltons.strutils.int_ranges_from_int_list`

### DIFF
--- a/stubs/boltons/boltons/strutils.pyi
+++ b/stubs/boltons/boltons/strutils.pyi
@@ -53,9 +53,7 @@ def format_int_list(int_list: list[int], delim: str = ",", range_delim: str = "-
 def complement_int_list(
     range_string: str, range_start: int = 0, range_end: int | None = None, delim: str = ",", range_delim: str = "-"
 ) -> str: ...
-def int_ranges_from_int_list(
-    range_string: str, delim: str = ",", range_delim: str = "-"
-) -> tuple[tuple[int, int], ...]: ...
+def int_ranges_from_int_list(range_string: str, delim: str = ",", range_delim: str = "-") -> tuple[tuple[int, int], ...]: ...
 
 class MultiReplace:
     group_map: dict[str, str]


### PR DESCRIPTION
`int_ranges_from_int_list()` returns a tuple of tuple of 2 integers, instead of just a tuple of 2 integers, as currently implemented.

See [original `int_ranges_from_int_list()` implementation](https://github.com/mahmoud/boltons/blob/0c88f25323de3ff85bcca844b9ce6cd171a80392/boltons/strutils.py#L1090-L1122).

This is an error that was introduced in: https://github.com/python/typeshed/commit/0deaca4862bab2bf0b5a339d8e4dbe1bfb962b64#diff-3d7d3ce708d009363d313560098b48067359fbf813eda929a2451183efbb9f22R53
