### PR TITLE
Revert "Byestring removal for 3.14 (#12490)"

### DIFF
--- a/stdlib/@tests/stubtest_allowlists/common.txt
+++ b/stdlib/@tests/stubtest_allowlists/common.txt
@@ -181,6 +181,12 @@ _collections_abc.AsyncGenerator.__anext__
 _collections_abc.AsyncGenerator.aclose
 _collections_abc.AsyncIterator.__anext__
 
+# Pretend typing.ByteString is a Union, to better match its documented semantics.
+# As a side effect, this changes the definition of collections.abc.ByteString, which is okay,
+# because it's not an ABC that makes any sense and was deprecated in 3.12
+_collections_abc\.ByteString
+typing\.ByteString
+
 _collections_abc.Callable  # Typing-related weirdness
 _collections_abc.Mapping.get  # Adding None to the Union messed up mypy
 _collections_abc.Sequence.index  # Supporting None in end is not mandatory

--- a/stdlib/@tests/stubtest_allowlists/py310.txt
+++ b/stdlib/@tests/stubtest_allowlists/py310.txt
@@ -155,18 +155,11 @@ tkinter.tix.TkVersion
 # <= 3.13
 # =======
 
-# Pretend typing.ByteString is a Union, to better match its documented semantics.
-# As a side effect, this changes the definition of collections.abc.ByteString, which is okay,
-# because it's not an ABC that makes any sense and was deprecated in 3.12
-_collections_abc.ByteString
-
 ast.Ellipsis.__new__  # Implementation has *args, but shouldn't allow any
 
 _?hashlib.scrypt  # Raises TypeError if salt, n, r or p are None
 
 importlib.abc.Traversable.open  # Problematic protocol signature at runtime, see source code comments.
-
-typing\.ByteString
 
 # Will always raise. Not included to avoid type checkers inferring that
 # TypeAliasType instances are callable.

--- a/stdlib/@tests/stubtest_allowlists/py311.txt
+++ b/stdlib/@tests/stubtest_allowlists/py311.txt
@@ -121,18 +121,11 @@ tkinter.tix.TkVersion
 # <= 3.13
 # =======
 
-# Pretend typing.ByteString is a Union, to better match its documented semantics.
-# As a side effect, this changes the definition of collections.abc.ByteString, which is okay,
-# because it's not an ABC that makes any sense and was deprecated in 3.12
-_collections_abc.ByteString
-
 ast.Ellipsis.__new__  # Implementation has *args, but shouldn't allow any
 
 _?hashlib.scrypt  # Raises TypeError if salt, n, r or p are None
 
 importlib.abc.Traversable.open  # Problematic protocol signature at runtime, see source code comments.
-
-typing\.ByteString
 
 # Will always raise. Not included to avoid type checkers inferring that
 # TypeAliasType instances are callable.

--- a/stdlib/@tests/stubtest_allowlists/py312.txt
+++ b/stdlib/@tests/stubtest_allowlists/py312.txt
@@ -120,18 +120,11 @@ tkinter.tix.TkVersion
 # <= 3.13
 # =======
 
-# Pretend typing.ByteString is a Union, to better match its documented semantics.
-# As a side effect, this changes the definition of collections.abc.ByteString, which is okay,
-# because it's not an ABC that makes any sense and was deprecated in 3.12
-_collections_abc.ByteString
-
 ast.Ellipsis.__new__  # Implementation has *args, but shouldn't allow any
 
 _?hashlib.scrypt  # Raises TypeError if salt, n, r or p are None
 
 importlib.abc.Traversable.open  # Problematic protocol signature at runtime, see source code comments.
-
-typing\.ByteString
 
 # Will always raise. Not included to avoid type checkers inferring that
 # TypeAliasType instances are callable.

--- a/stdlib/@tests/stubtest_allowlists/py313.txt
+++ b/stdlib/@tests/stubtest_allowlists/py313.txt
@@ -81,18 +81,11 @@ typing(_extensions)?\.IO\.writelines
 # <= 3.13
 # =======
 
-# Pretend typing.ByteString is a Union, to better match its documented semantics.
-# As a side effect, this changes the definition of collections.abc.ByteString, which is okay,
-# because it's not an ABC that makes any sense and was deprecated in 3.12
-_collections_abc.ByteString
-
 ast.Ellipsis.__new__  # Implementation has *args, but shouldn't allow any
 
 _?hashlib.scrypt  # Raises TypeError if salt, n, r or p are None
 
 importlib.abc.Traversable.open  # Problematic protocol signature at runtime, see source code comments.
-
-typing\.ByteString
 
 # Will always raise. Not included to avoid type checkers inferring that
 # TypeAliasType instances are callable.

--- a/stdlib/@tests/stubtest_allowlists/py39.txt
+++ b/stdlib/@tests/stubtest_allowlists/py39.txt
@@ -18,7 +18,7 @@ collections.AsyncGenerator.__anext__  # async at runtime, deliberately not in th
 collections.AsyncGenerator.aclose  # async at runtime, deliberately not in the stub, see #7491
 collections.AsyncGenerator.asend  # async at runtime, deliberately not in the stub, see #7491. Pos-only differences also.
 collections.AsyncIterator.__anext__  # async at runtime, deliberately not in the stub, see #7491
-collections.ByteString  # see comments in py3_common.txt
+collections.ByteString  # see comments in common.txt
 collections.Callable
 collections.Mapping.get  # Adding None to the Union messed up mypy
 collections.Sequence.index  # Supporting None in end is not mandatory
@@ -104,18 +104,11 @@ tkinter.tix.TkVersion
 # <= 3.13
 # =======
 
-# Pretend typing.ByteString is a Union, to better match its documented semantics.
-# As a side effect, this changes the definition of collections.abc.ByteString, which is okay,
-# because it's not an ABC that makes any sense and was deprecated in 3.12
-_collections_abc.ByteString
-
 ast.Ellipsis.__new__  # Implementation has *args, but shouldn't allow any
 
 _?hashlib.scrypt  # Raises TypeError if salt, n, r or p are None
 
 importlib.abc.Traversable.open  # Problematic protocol signature at runtime, see source code comments.
-
-typing\.ByteString
 
 # Will always raise. Not included to avoid type checkers inferring that
 # TypeAliasType instances are callable.

--- a/stdlib/_collections_abc.pyi
+++ b/stdlib/_collections_abc.pyi
@@ -1,12 +1,13 @@
 import sys
 from abc import abstractmethod
 from types import MappingProxyType
-from typing import (  # noqa: Y022,Y038,UP035
+from typing import (  # noqa: Y022,Y038,UP035,Y057
     AbstractSet as Set,
     AsyncGenerator as AsyncGenerator,
     AsyncIterable as AsyncIterable,
     AsyncIterator as AsyncIterator,
     Awaitable as Awaitable,
+    ByteString as ByteString,
     Callable as Callable,
     ClassVar,
     Collection as Collection,
@@ -59,12 +60,8 @@ __all__ = [
     "ValuesView",
     "Sequence",
     "MutableSequence",
+    "ByteString",
 ]
-if sys.version_info < (3, 14):
-    from typing import ByteString as ByteString  # noqa: Y057,UP035
-
-    __all__ += ["ByteString"]
-
 if sys.version_info >= (3, 12):
     __all__ += ["Buffer"]
 

--- a/stdlib/typing.pyi
+++ b/stdlib/typing.pyi
@@ -41,6 +41,7 @@ __all__ = [
     "AsyncIterator",
     "Awaitable",
     "BinaryIO",
+    "ByteString",
     "Callable",
     "ChainMap",
     "ClassVar",
@@ -108,9 +109,6 @@ __all__ = [
     "overload",
     "runtime_checkable",
 ]
-
-if sys.version_info < (3, 14):
-    __all__ += ["ByteString"]
 
 if sys.version_info >= (3, 14):
     __all__ += ["evaluate_forward_ref"]

--- a/stdlib/typing.pyi
+++ b/stdlib/typing.pyi
@@ -923,8 +923,7 @@ class TextIO(IO[str]):
     @abstractmethod
     def __enter__(self) -> TextIO: ...
 
-if sys.version_info < (3, 14):
-    ByteString: typing_extensions.TypeAlias = bytes | bytearray | memoryview
+ByteString: typing_extensions.TypeAlias = bytes | bytearray | memoryview
 
 # Functions
 


### PR DESCRIPTION
This reverts commit 8a7f09e3511f3a1d04281c60167b8dcc3b78938b.

`ByteString` was added back to Python 3.14 at the last minute, since several users reported that the deprecation warnings had not been prominent enough prior to its removal. It is still scheduled to be removed, but its removal has been postponed to 3.17.

Helps with https://github.com/python/typeshed/issues/14741