### PR TITLE
[gdb] Update ThreadExitedEvent parent class for 17.0 (#14729)

### DIFF
--- a/stubs/gdb/gdb/__init__.pyi
+++ b/stubs/gdb/gdb/__init__.pyi
@@ -960,7 +960,7 @@ class ExitedEvent(Event):
     exit_code: int
     inferior: Inferior
 
-class ThreadExitedEvent(Event): ...
+class ThreadExitedEvent(ThreadEvent): ...
 
 class StopEvent(ThreadEvent):
     details: dict[str, object]


### PR DESCRIPTION
Even though the parent thread for `ThreadExitedEvent` won't change from `Event` to `ThreadEvent` until 17.0 is released, this actually makes type checking work better in practice for all released versions that support `ThreadExitedEvent` because at run time `ThreadExitedEvent` has the lone attribute, `inferior_thread`, that it would have inherited from `ThreadEvent`.

Fixes #14729 

Upstream GDB issue:
* https://sourceware.org/bugzilla/show_bug.cgi?id=33444