### PR TITLE
Use stricter pyright settings for `xmltodict`

### DIFF
--- a/pyrightconfig.stricter.json
+++ b/pyrightconfig.stricter.json
@@ -93,7 +93,6 @@
         "stubs/tqdm",
         "stubs/vobject",
         "stubs/workalendar",
-        "stubs/xmltodict",
     ],
     "typeCheckingMode": "strict",
     // TODO: Complete incomplete stubs


### PR DESCRIPTION
It's fully annotated following https://github.com/python/typeshed/pull/14695.

Fixes https://github.com/AlexWaygood/typeshed-stats/issues/365, fixes https://github.com/AlexWaygood/typeshed-stats/issues/366, fixes https://github.com/AlexWaygood/typeshed-stats/issues/367, fixes https://github.com/AlexWaygood/typeshed-stats/issues/368