### PR TITLE
[curses] Revert Final for LINES and COLS

### DIFF
--- a/stdlib/curses/__init__.pyi
+++ b/stdlib/curses/__init__.pyi
@@ -14,8 +14,9 @@ _T = TypeVar("_T")
 _P = ParamSpec("_P")
 
 # available after calling `curses.initscr()`
-LINES: Final[int]
-COLS: Final[int]
+# not `Final` as it can change during the terminal resize:
+LINES: int
+COLS: int
 
 # available after calling `curses.start_color()`
 COLORS: Final[int]


### PR DESCRIPTION
If the values ​​can be changed in one runtime, for example during a terminal resize, then this doesn't really fit the concept of `Final`, although I honestly haven't found an exact definition in [PEP](https://peps.python.org/pep-0591) when changing value of object is no longer permissible for `Final` (Is it normal to have different values ​​for different builds, python runtimes, subinterpreters, or other?)

Docs: https://docs.python.org/dev/library/curses.html#curses.COLORS
Inspired by https://github.com/python/typeshed/pull/14613#discussion_r2363939613