### PR TITLE
Use stricter pyright settings for `gunicorn`

### DIFF
--- a/pyrightconfig.stricter.json
+++ b/pyrightconfig.stricter.json
@@ -44,7 +44,6 @@
         "stubs/grpcio-reflection/grpc_reflection/v1alpha",
         "stubs/grpcio-status/grpc_status",
         "stubs/grpcio/grpc/__init__.pyi",
-        "stubs/gunicorn",
         "stubs/hdbcli/hdbcli/dbapi.pyi",
         "stubs/html5lib",
         "stubs/httplib2",


### PR DESCRIPTION
It's fully annotated. Fixes https://github.com/AlexWaygood/typeshed-stats/issues/369