### PR TITLE
grpcio: improve server interceptor typing

### DIFF
--- a/stubs/grpcio/@tests/test_cases/check_aio.py
+++ b/stubs/grpcio/@tests/test_cases/check_aio.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import cast
 from typing_extensions import assert_type
 
 import grpc.aio
@@ -9,7 +9,7 @@ import grpc.aio
 client_interceptors: list[grpc.aio.ClientInterceptor] = []
 grpc.aio.insecure_channel("target", interceptors=client_interceptors)
 
-server_interceptors: list[grpc.aio.ServerInterceptor[Any, Any]] = []
+server_interceptors: list[grpc.aio.ServerInterceptor] = []
 grpc.aio.server(interceptors=server_interceptors)
 
 

--- a/stubs/grpcio/@tests/test_cases/check_handler_inheritance.py
+++ b/stubs/grpcio/@tests/test_cases/check_handler_inheritance.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import cast
+from typing import Any, cast
 from typing_extensions import assert_type
 
 import grpc
@@ -19,11 +19,11 @@ def unary_unary_call(rq: Request, ctx: grpc.ServicerContext) -> Response:
     return Response()
 
 
-class ServiceHandler(grpc.ServiceRpcHandler[Request, Response]):
+class ServiceHandler(grpc.ServiceRpcHandler):
     def service_name(self) -> str:
         return "hello"
 
-    def service(self, handler_call_details: grpc.HandlerCallDetails) -> grpc.RpcMethodHandler[Request, Response] | None:
+    def service(self, handler_call_details: grpc.HandlerCallDetails) -> grpc.RpcMethodHandler[Any, Any] | None:
         rpc = grpc.RpcMethodHandler[Request, Response]()
         rpc.unary_unary = unary_unary_call
         return rpc

--- a/stubs/grpcio/@tests/test_cases/check_server_interceptor.py
+++ b/stubs/grpcio/@tests/test_cases/check_server_interceptor.py
@@ -1,22 +1,35 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from concurrent.futures.thread import ThreadPoolExecutor
+from typing import Awaitable, TypeVar
 
 import grpc
+import grpc.aio
+
+RequestT = TypeVar("RequestT")
+ResponseT = TypeVar("ResponseT")
 
 
-class Request:
-    pass
-
-
-class Response:
-    pass
-
-
-class NoopInterceptor(grpc.ServerInterceptor[Request, Response]):
+class NoopInterceptor(grpc.ServerInterceptor):
     def intercept_service(
         self,
-        continuation: Callable[[grpc.HandlerCallDetails], grpc.RpcMethodHandler[Request, Response] | None],
+        continuation: Callable[[grpc.HandlerCallDetails], grpc.RpcMethodHandler[RequestT, ResponseT] | None],
         handler_call_details: grpc.HandlerCallDetails,
-    ) -> grpc.RpcMethodHandler[Request, Response] | None:
+    ) -> grpc.RpcMethodHandler[RequestT, ResponseT] | None:
         return continuation(handler_call_details)
+
+
+grpc.server(interceptors=[NoopInterceptor()], thread_pool=ThreadPoolExecutor())
+
+
+class NoopAioInterceptor(grpc.aio.ServerInterceptor):
+    async def intercept_service(
+        self,
+        continuation: Callable[[grpc.HandlerCallDetails], Awaitable[grpc.RpcMethodHandler[RequestT, ResponseT]]],
+        handler_call_details: grpc.HandlerCallDetails,
+    ) -> grpc.RpcMethodHandler[RequestT, ResponseT]:
+        return await continuation(handler_call_details)
+
+
+grpc.aio.server(interceptors=[NoopAioInterceptor()])

--- a/stubs/grpcio/grpc/aio/__init__.pyi
+++ b/stubs/grpcio/grpc/aio/__init__.pyi
@@ -65,8 +65,8 @@ def secure_channel(
 
 def server(
     migration_thread_pool: futures.Executor | None = None,
-    handlers: Sequence[GenericRpcHandler[Any, Any]] | None = None,
-    interceptors: Sequence[ServerInterceptor[Any, Any]] | None = None,
+    handlers: Sequence[GenericRpcHandler] | None = None,
+    interceptors: Sequence[ServerInterceptor] | None = None,
     options: _Options | None = None,
     maximum_concurrent_rpcs: int | None = None,
     compression: Compression | None = None,
@@ -125,7 +125,7 @@ class Channel(abc.ABC):
 
 class Server(metaclass=abc.ABCMeta):
     @abc.abstractmethod
-    def add_generic_rpc_handlers(self, generic_rpc_handlers: Iterable[GenericRpcHandler[Any, Any]]) -> None: ...
+    def add_generic_rpc_handlers(self, generic_rpc_handlers: Iterable[GenericRpcHandler]) -> None: ...
 
     # Returns an integer port on which server will accept RPC requests.
     @abc.abstractmethod
@@ -355,7 +355,8 @@ class StreamStreamClientInterceptor(Generic[_TRequest, _TResponse], metaclass=ab
 
 # Server-Side Interceptor:
 
-class ServerInterceptor(Generic[_TRequest, _TResponse], metaclass=abc.ABCMeta):
+class ServerInterceptor(metaclass=abc.ABCMeta):
+    # This method (not the class) is generic over _TRequest and _TResponse.
     @abc.abstractmethod
     async def intercept_service(
         self,


### PR DESCRIPTION
`ServerInterceptor` and `GenericRpcHandler` should not be generic over request/response themselves, but rather should have generic methods:

* `ServerInterceptor`: a given instance of this should be able to intercept any call, and so should have a generic method over all request/continuation types rather than the instance being specialized itself
* `GenericRpcHandler` (and `ServiceRpcHandler`): this is "An implementation of arbitrarily many RPC methods" and has a `service` method that takes a parameter describing the method to handle, but that parameter dictates the request/response types. The instance of the `GenericRpcHandler` itself does not know about the request/response types. In theory this could be described using dependent types, but since this is Python the best we can do is have the `service` method return a type with `Any`s and allow the caller to cast later

Related: #14641