### PR TITLE
Refine the `copy._SupportsReplace.__replace__` signature

### DIFF
--- a/stdlib/copy.pyi
+++ b/stdlib/copy.pyi
@@ -9,8 +9,8 @@ _SR = TypeVar("_SR", bound=_SupportsReplace)
 
 @type_check_only
 class _SupportsReplace(Protocol):
-    # In reality doesn't support args, but there's no other great way to express this.
-    def __replace__(self, *args: Any, **kwargs: Any) -> Self: ...
+    # Usually there are *some* kwargs, but there's no great way to express this.
+    def __replace__(self, /) -> Self: ...
 
 # None in CPython but non-None in Jython
 PyStringMap: Any


### PR DESCRIPTION
The (non-existent) `*args: Any` and `**kwargs: Any` can be avoided by relying on the LSP and removing them altogether, making it a bit less incorrect :)