### PR TITLE
Make `(Async)GeneratorType` type parameters consistent with `(Async)Generator` type parameters

### DIFF
--- a/stdlib/types.pyi
+++ b/stdlib/types.pyi
@@ -450,7 +450,7 @@ class AsyncGeneratorType(AsyncGenerator[_YieldT_co, _SendT_contra]):
     def aclose(self) -> Coroutine[Any, Any, None]: ...
     def __class_getitem__(cls, item: Any, /) -> GenericAlias: ...
 
-# Non-default variations to accommodate couroutines
+# Non-default variations to accommodate coroutines
 _SendT_nd_contra = TypeVar("_SendT_nd_contra", contravariant=True)
 _ReturnT_nd_co = TypeVar("_ReturnT_nd_co", covariant=True)
 

--- a/stdlib/typing.pyi
+++ b/stdlib/typing.pyi
@@ -577,7 +577,7 @@ class Awaitable(Protocol[_T_co]):
     @abstractmethod
     def __await__(self) -> Generator[Any, Any, _T_co]: ...
 
-# Non-default variations to accommodate couroutines, and `AwaitableGenerator` having a 4th type parameter.
+# Non-default variations to accommodate coroutines, and `AwaitableGenerator` having a 4th type parameter.
 _SendT_nd_contra = TypeVar("_SendT_nd_contra", contravariant=True)
 _ReturnT_nd_co = TypeVar("_ReturnT_nd_co", covariant=True)
 


### PR DESCRIPTION
Currently `typing.Generator` (a protocol) is generic over three type variables that have defaults, but `types.GeneratorType` (a concrete class) is generic over three type variables that do not have defaults. It seems like it probably makes more sense for them to be consistent? The vast majority of real-world `Generator`s are instances of `GeneratorType`