### PR TITLE
Pin `Jetson.GPIO` to 2.1.11

### DIFF
--- a/stubs/Jetson.GPIO/METADATA.toml
+++ b/stubs/Jetson.GPIO/METADATA.toml
@@ -1,2 +1,2 @@
-version = "~=2.1.11"
+version = "2.1.11"
 upstream_repository = "https://github.com/NVIDIA/jetson-gpio"


### PR DESCRIPTION
fixes https://github.com/python/typeshed/issues/14810