### PR TITLE
python-dateutil: add overload to rrulestr

### DIFF
--- a/stubs/python-dateutil/@tests/test_cases/check_rrule.py
+++ b/stubs/python-dateutil/@tests/test_cases/check_rrule.py
@@ -1,0 +1,13 @@
+from typing import Union
+from typing_extensions import assert_type
+
+from dateutil.rrule import rrule, rruleset, rrulestr
+
+rs1 = rrulestr("", forceset=True)
+assert_type(rs1, rruleset)
+
+rs2 = rrulestr("", compatible=True)
+assert_type(rs2, rruleset)
+
+rs3 = rrulestr("")
+assert_type(rs3, Union[rrule, rruleset])

--- a/stubs/python-dateutil/dateutil/rrule.pyi
+++ b/stubs/python-dateutil/dateutil/rrule.pyi
@@ -1,7 +1,7 @@
 import datetime
 from _typeshed import Incomplete
 from collections.abc import Generator, Iterable, Iterator, Sequence
-from typing import Final, Literal
+from typing import Final, Literal, overload
 from typing_extensions import Self, TypeAlias
 
 from ._common import weekday as weekdaybase
@@ -174,6 +174,35 @@ class rruleset(rrulebase):
     def exdate(self, exdate) -> None: ...
 
 class _rrulestr:
+    @overload
+    def __call__(
+        self,
+        s: str,
+        *,
+        forceset: Literal[True],
+        dtstart: datetime.date | None = None,
+        cache: bool | None = None,
+        unfold: bool = False,
+        compatible: bool = False,
+        ignoretz: bool = False,
+        tzids=None,
+        tzinfos=None,
+    ) -> rruleset: ...
+    @overload
+    def __call__(
+        self,
+        s: str,
+        *,
+        compatible: Literal[True],
+        dtstart: datetime.date | None = None,
+        cache: bool | None = None,
+        unfold: bool = False,
+        forceset: bool = False,
+        ignoretz: bool = False,
+        tzids=None,
+        tzinfos=None,
+    ) -> rruleset: ...
+    @overload
     def __call__(
         self,
         s: str,


### PR DESCRIPTION
Resolves #14797 