### PR TITLE
`tensorflow`: add missing re-export

### DIFF
--- a/stubs/tensorflow/tensorflow/__init__.pyi
+++ b/stubs/tensorflow/tensorflow/__init__.pyi
@@ -18,6 +18,7 @@ from tensorflow import (
     io as io,
     keras as keras,
     math as math,
+    random as random,
     types as types,
 )
 from tensorflow._aliases import (


### PR DESCRIPTION
Without the re-export, the module's stubs are not detected by the type checker (or at least not by pyright).