### PR TITLE
Make `copy.replace` more strongly typed

### DIFF
--- a/stdlib/@tests/stubtest_allowlists/py313.txt
+++ b/stdlib/@tests/stubtest_allowlists/py313.txt
@@ -1,7 +1,8 @@
 # =========================
 # New errors in Python 3.13
 # =========================
-
+# No way to express keyword-only ParamSpec
+copy.replace
 # ====================================
 # Pre-existing errors from Python 3.12
 # ====================================

--- a/stdlib/@tests/stubtest_allowlists/py314.txt
+++ b/stdlib/@tests/stubtest_allowlists/py314.txt
@@ -35,6 +35,8 @@ multiprocessing.process.BaseProcess.__init__
 # Pre-existing errors from Python 3.13
 # ====================================
 
+# No way to express keyword-only ParamSpec
+copy.replace
 
 # =======
 # >= 3.12

--- a/stdlib/@tests/stubtest_allowlists/py315.txt
+++ b/stdlib/@tests/stubtest_allowlists/py315.txt
@@ -175,6 +175,8 @@ types.MappingProxyType.get
 
 typing_extensions.Protocol  # Super-special typing primitive
 
+copy.replace  # Cannot have keyword-only ParamSpec
+
 
 # =============================================================
 # Allowlist entries that cannot or should not be fixed; >= 3.12

--- a/stdlib/@tests/test_cases/check_copy.py
+++ b/stdlib/@tests/test_cases/check_copy.py
@@ -10,7 +10,7 @@ class ReplaceableClass:
     def __init__(self, val: int) -> None:
         self.val = val
 
-    def __replace__(self, val: int) -> Self:
+    def __replace__(self, /, *, val: int) -> Self:
         cpy = copy.copy(self)
         cpy.val = val
         return cpy
@@ -29,11 +29,11 @@ class Box(Generic[_T_co]):
     def __init__(self, value: _T_co, /) -> None:
         self.value = value
 
-    def __replace__(self, value: str) -> Box[str]:
+    def __replace__(self, /, *, value: str) -> Box[str]:
         return Box(value)
 
 
 if sys.version_info >= (3, 13):
     box1: Box[int] = Box(42)
-    box2 = copy.replace(box1, val="spam")
+    box2 = copy.replace(box1, value="spam")
     assert_type(box2, Box[str])

--- a/stdlib/copy.pyi
+++ b/stdlib/copy.pyi
@@ -24,9 +24,7 @@ if sys.version_info >= (3, 13):
     __all__ += ["replace"]
 
     def replace(
-        obj: _SupportsReplace[_P, _RT_co], /,
-        *_: _P.args,  # does not accept positional arguments at runtime
-        **changes: _P.kwargs,
+        obj: _SupportsReplace[_P, _RT_co], /, *_: _P.args, **changes: _P.kwargs  # does not accept positional arguments at runtime
     ) -> _RT_co: ...
 
 class Error(Exception): ...

--- a/stdlib/copy.pyi
+++ b/stdlib/copy.pyi
@@ -1,15 +1,17 @@
 import sys
 from typing import Any, Protocol, TypeVar, type_check_only
+from typing_extensions import ParamSpec
 
 __all__ = ["Error", "copy", "deepcopy"]
 
 _T = TypeVar("_T")
 _RT_co = TypeVar("_RT_co", covariant=True)
+_P = ParamSpec("_P")
 
 @type_check_only
-class _SupportsReplace(Protocol[_RT_co]):
+class _SupportsReplace(Protocol[_P, _RT_co]):
     # In reality doesn't support args, but there's no great way to express this.
-    def __replace__(self, /, *_: Any, **changes: Any) -> _RT_co: ...
+    def __replace__(self, /, *_: _P.args, **changes: _P.kwargs) -> _RT_co: ...
 
 # None in CPython but non-None in Jython
 PyStringMap: Any
@@ -20,8 +22,12 @@ def copy(x: _T) -> _T: ...
 
 if sys.version_info >= (3, 13):
     __all__ += ["replace"]
-    # The types accepted by `**changes` match those of `obj.__replace__`.
-    def replace(obj: _SupportsReplace[_RT_co], /, **changes: Any) -> _RT_co: ...
+
+    def replace(
+        obj: _SupportsReplace[_P, _RT_co], /,
+        *_: _P.args,  # does not accept positional arguments at runtime
+        **changes: _P.kwargs,
+    ) -> _RT_co: ...
 
 class Error(Exception): ...
 


### PR DESCRIPTION
The current stub for `copy.replace` accepts arbitrary keyword arguments. We can use `ParamSpec` to link the signature of `obj.__replace__` to the supplied keyword arguments.

This allows passing positional arguments to `copy.replace`, but I think it's fine, given that `__replace__` isn't supposed to contain positional arguments in the signature anyway ([docs for `object.__replace__`](https://docs.python.org/3.13/library/copy.html#object.__replace__))

Demo of the proposed stub for `copy.replace` in the [pyright playground](https://pyright-play.net/?pythonVersion=3.14&strict=true&code=GYJw9gtgBAJghgFzgYwDZwM4YKYagSwgAcwQFZEV0sAoUSKBATyPwDsBzA408gBXAIwyMKho1CJMlBFEm4gALwkaTBgAU9AF7Y2AXgAqIAK7YAlDVVYoAMRP4EALhpQobOBGyOoGBCBdQqGCc3gBGYKLioXDu7lB6tvYI6gBEAEIxmSkANFBGphYg2ABu2HCoAPrMRNjq0bFwAHQVFUVE6MjYLWauAMRQ6gBUue6e3r4g8VCNM7lBIVDholMzjT0AtAB8icYO4lZ4FQDKxkRSCBgAStjtKNgA2oODfLkGALrqAmBCIqhmzq5XDBsMAoC02h0uhV1DhUMBcgB6XKDOAgDgYbx8Rqo9HIwYAawA7jiMVAsUSSRttgYAYC6atxMDQRC7hVigAmR7PV4fMChABW3mOp3OVxukPuLzyb2RJMx2LRGDxFMV8pV6KpeVpRQQxhAbCgfP5zVa4tZ0JRiuVxMVFho-WMGHYXAQAAtsDI9UU2ORZExGizOj5daEaAAPKZ%2BgNmzp1TLuEYebB6FIAQTOqGwKR6dNzdP6bDAUGwIHAIFymGLYZqyAQ2BgNCYkbAcmjt1j9Uyic8KfT7Szc2CHD0NnKOBzBaLJbLFbw2Gr2Fr9ZoWmbrcDtU7CagEHwWGdegALOyc3mz1BJ8XS6RcqFjOQMK6wMZUDBFtgaIS1-6N3GGt3kzTDMB0CIcjxPXNL2nG9FnvHwnxfN9Qg-e0oEdZ0fGMDgOFwOs32QV0Yhw8Mpg3Nl2T-Ls3CTXtgOzc88yg69yygSt5xrPDG1ImMug5Sjt1GQC%2B0zHJQM4Ecx3MPo3CnZjZyrDjl1XBIyL4rc4FyXd93E49TwY-MrzLbxCygIhUSTOtJkEt8tKdTh5PYxdOK-FSePI-iNOonsgP7UT5mHXTIMM0hvEJcBOEYFhsAchclwbIA):
```py
from dataclasses import dataclass
from typing import Protocol

import copy

@dataclass(frozen=True)
class Fruit:
  name: str
  long: bool

banana = Fruit("Banana", True)
reveal_type(banana.__replace__)  # (*, name: str = ..., long: bool = ...) -> Fruit

class _SupportsReplace[**P, T](Protocol):
    def __replace__(self, /, *args: P.args, **kwargs: P.kwargs) -> T:
        ...

def replace_v2[**P, T](obj: _SupportsReplace[P, T], *args: P.args, **kwargs: P.kwargs) -> T:
  return obj.__replace__(*args, **kwargs)

# using the current copy.replace stub
x = copy.replace(banana, name="Apple")              # no error, as expected
y = copy.replace(banana, name="Apple", long=False)  # no error, as expected
z = copy.replace(banana, missing=42)                # no error, but should be
w = copy.replace(banana, name="Apple", long=42)     # no error, but should be

# using suggested change
x = replace_v2(banana, name="Apple")              # no error, as expected
y = replace_v2(banana, name="Apple", long=False)  # no error, as expected
z = replace_v2(banana, missing=42)                # error: no parameter named missing, as expected
w = replace_v2(banana, name="Apple", long=42)     # error: wrong type, as expected

```