### PR TITLE
Make numpy dependency from types-networkx optional

### DIFF
--- a/stubs/networkx/METADATA.toml
+++ b/stubs/networkx/METADATA.toml
@@ -1,7 +1,5 @@
 version = "3.5"
 upstream_repository = "https://github.com/networkx/networkx"
-# requires a version of numpy with a `py.typed` file
-requires = ["numpy>=1.20"]
 # Uses more recent dataclass kwargs
 requires_python = ">=3.10"
 


### PR DESCRIPTION
My attempt to fix https://github.com/python/typeshed/issues/14760