### PR TITLE
Fix PEP 728 TypedDict.__closed__ annotation in typing_extensions

### DIFF
--- a/stdlib/typing_extensions.pyi
+++ b/stdlib/typing_extensions.pyi
@@ -239,7 +239,7 @@ class _TypedDict(Mapping[str, object], metaclass=abc.ABCMeta):
     __readonly_keys__: ClassVar[frozenset[str]]
     __mutable_keys__: ClassVar[frozenset[str]]
     # PEP 728
-    __closed__: ClassVar[bool]
+    __closed__: ClassVar[bool | None]
     __extra_items__: ClassVar[AnnotationForm]
     def copy(self) -> Self: ...
     # Using Never so that only calls using mypy plugin hook that specialize the signature


### PR DESCRIPTION
The default / implicit value for `TypedDict.__closed__` is `None`.
That's how it's implemented in both typing_extensions and https://github.com/python/cpython/pull/137933.

/CC @JelleZijlstra