### PR TITLE
TypeAliasType.__type_params__ can return forms from typing_extensions

### DIFF
--- a/stdlib/typing.pyi
+++ b/stdlib/typing.pyi
@@ -1133,28 +1133,23 @@ if sys.version_info >= (3, 10):
 def _type_repr(obj: object) -> str: ...
 
 if sys.version_info >= (3, 12):
+    _TypeParameter: typing_extensions.TypeAlias = (
+        TypeVar
+        | typing_extensions.TypeVar
+        | ParamSpec
+        | typing_extensions.ParamSpec
+        | TypeVarTuple
+        | typing_extensions.TypeVarTuple
+    )
+
     def override(method: _F, /) -> _F: ...
     @final
     class TypeAliasType:
-        def __new__(
-            cls,
-            name: str,
-            value: Any,
-            *,
-            type_params: tuple[
-                TypeVar
-                | typing_extensions.TypeVar
-                | ParamSpec
-                | typing_extensions.ParamSpec
-                | TypeVarTuple
-                | typing_extensions.TypeVarTuple,
-                ...,
-            ] = (),
-        ) -> Self: ...
+        def __new__(cls, name: str, value: Any, *, type_params: tuple[_TypeParameter, ...] = ()) -> Self: ...
         @property
         def __value__(self) -> Any: ...  # AnnotationForm
         @property
-        def __type_params__(self) -> tuple[TypeVar | ParamSpec | TypeVarTuple, ...]: ...
+        def __type_params__(self) -> tuple[_TypeParameter, ...]: ...
         @property
         def __parameters__(self) -> tuple[Any, ...]: ...  # AnnotationForm
         @property


### PR DESCRIPTION
Apply the change from https://github.com/python/typeshed/pull/14840 to the `__type_params__` property of `TypeAliasType` as well as to its constructor.