### PR TITLE
_csv.pyi argument fixes

### DIFF
--- a/stdlib/_csv.pyi
+++ b/stdlib/_csv.pyi
@@ -122,7 +122,7 @@ def reader(
 def register_dialect(
     name: str,
     /,
-    dialect: type[Dialect | csv.Dialect] = ...,
+    dialect: type[Dialect | csv.Dialect] | str = "excel",
     *,
     delimiter: str = ",",
     quotechar: str | None = '"',


### PR DESCRIPTION
These were discovered by the release of Python 3.13.8 and will cause failures in our daily tests.