### PR TITLE
chore(jsonschema): exceptions._Error.context cannot be None

### DIFF
--- a/stubs/jsonschema/jsonschema/exceptions.pyi
+++ b/stubs/jsonschema/jsonschema/exceptions.pyi
@@ -19,7 +19,7 @@ class _Error(Exception):
     relative_path: deque[str | int]
     schema_path: deque[str | int]
     relative_schema_path: deque[str | int]
-    context: list[ValidationError] | None
+    context: list[ValidationError]
     cause: Exception | None
     validator: Validator | Unset
     validator_value: Any | Unset


### PR DESCRIPTION
The __init__() argument is defined as Sequence[ValidationError], and self.context is a list initialized from said argument.

See also the code, which does not allow passing `None` for `context`:
* https://github.com/python-jsonschema/jsonschema/blob/980a0c1fd95ed2e50b73161a8f7c8dd44169deca/jsonschema/exceptions.py#L61
* https://github.com/python-jsonschema/jsonschema/blob/980a0c1fd95ed2e50b73161a8f7c8dd44169deca/jsonschema/exceptions.py#L84
* https://github.com/python-jsonschema/jsonschema/blob/980a0c1fd95ed2e50b73161a8f7c8dd44169deca/jsonschema/exceptions.py#L93