### PR TITLE
[django-filter] Broaden OrderingFilter fields parameter type

### DIFF
--- a/stubs/django-filter/django_filters/filters.pyi
+++ b/stubs/django-filter/django_filters/filters.pyi
@@ -303,7 +303,7 @@ class OrderingFilter(BaseCSVFilter, ChoiceFilter):
         field_name: str | None = None,
         lookup_expr: str | None = None,
         *,
-        fields: dict[str, str] | Iterable[tuple[str, str]] = ...,
+        fields: dict[str, str] | Iterable[str] | Iterable[tuple[str, str]] = ...,
         field_labels: dict[str, StrOrPromise] = ...,
         # Inherited from ChoiceFilter
         null_value: Any = ...,  # Null value can be any type (None, empty string, etc.)


### PR DESCRIPTION
The type annotation for the `fields` parameter in `OrderingFilter` was incomplete.

According to the documentation:
https://django-filter.readthedocs.io/en/stable/ref/filters.html#django_filters.filters.OrderingFilter
> `fields` is a mapping of {model field name: parameter name}. The parameter names are exposed in the choices and mask/alias the field names used in the `order_by()` call. Similar to field `choices`, fields accepts the ‘list of two-tuples’ syntax that retains order. **`fields` may also just be an iterable of strings. In this case, the field names simply double as the exposed parameter names.**

https://github.com/carltongibson/django-filter/blob/17ec565554bea4119ad74d2ffccdfb9740d9845b/django_filters/filters.py#L799-L800

### Notes

The incorrect type has been present since commit 893b9a760deb3be64d13c748318e95a752230961, affecting versions starting from `types-django-filter==25.1.0.20250815`.

If possible, guidance on how to submit a backport PR for an older stub version would be appreciated.
