### PR TITLE
don't ignore UP038 in ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,8 +175,6 @@ ignore = [
     "TD003", # Missing issue link for this TODO
     # Mostly from scripts and tests, it's ok to have messages passed directly to exceptions
     "TRY003", # Avoid specifying long messages outside the exception class
-    # Slower and more verbose https://github.com/astral-sh/ruff/issues/7871
-    "UP038", # Use `X | Y` in `isinstance` call instead of `(X, Y)`
     "PLC0205", # Sometimes __slots__ really is a string at runtime
     ###
     # False-positives, but already checked by type-checkers


### PR DESCRIPTION
it was removed, this has no effect

when running pre-commit with verbose I saw this:

```console
Run ruff on stubs, tests and scripts.....................................Passed
- hook id: ruff
- duration: 0.12s

warning: The following rules have been removed and ignoring them has no effect:
    - UP038

All checks passed!
warning: The following rules have been removed and ignoring them has no effect:
    - UP038

All checks passed!
```