### PR TITLE
correct grammatical error in CONTRIBUTING.md to "in their own right"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -311,7 +311,7 @@ def foo(x: Incomplete | None) -> list[Incomplete]: ...
 ### What to do when a project's documentation and implementation disagree
 
 Type stubs are meant to be external type annotations for a given
-library.  While they are useful documentation in its own merit, they
+library.  While they are useful documentation in their own right, they
 augment the project's concrete implementation, not the project's
 documentation.  Whenever you find them disagreeing, model the type
 information after the actual implementation and file an issue on the


### PR DESCRIPTION
The pronoun and its noun did not agree in grammatical number. Furthermore, the previous author seems to have started writing the idiomatic phrase "in its own right", and then gotten distracted and completed the clause by writing the end of the idiomatic phrase "on its own merits". The former better expresses the concept under discussion here (which could also be paraphrased as "themselves", "in-and-of-themselves", or "also", although less precisely), so I've gone with it.