### PR TITLE
Fix stdlib stubtest flakes

### DIFF
--- a/stdlib/@tests/stubtest_allowlists/darwin-py313.txt
+++ b/stdlib/@tests/stubtest_allowlists/darwin-py313.txt
@@ -3,3 +3,10 @@
 # =======
 
 (mmap.MAP_32BIT)?  # Exists locally on MacOS but not on GitHub
+
+# ================
+# Unclear problems
+# ================
+
+# Added in 3.11.1, flagged by stubtest on Python < 3.14 for unknown reasons
+errno.ENOTCAPABLE

--- a/stdlib/@tests/stubtest_allowlists/linux-py39.txt
+++ b/stdlib/@tests/stubtest_allowlists/linux-py39.txt
@@ -6,11 +6,11 @@
 # while being inspected by stubtest. Fixed in Python 3.10.
 select.epoll.register
 
-# According to stubtest, these are not present at runtime, starting with
-# Python 3.9.24. Which is not true.
-_frozen_importlib_external.PathFinder.find_distributions
-importlib._bootstrap_external.PathFinder.find_distributions
-importlib.machinery.PathFinder.find_distributions
+# According to stubtest, these are sometimes not present at runtime, starting
+# with Python 3.9.24. Which is not true.
+(_frozen_importlib_external.PathFinder.find_distributions)?
+(importlib._bootstrap_external.PathFinder.find_distributions)?
+(importlib.machinery.PathFinder.find_distributions)?
 
 
 # =============================================================


### PR DESCRIPTION
See https://github.com/python/typeshed/issues/14870#issuecomment-3407510519. `find_distributions` seems to sometimes be available in CI, and sometimes not. Use the "trick" of a regular expression that makes the allowlist entry option (as described in https://github.com/python/mypy/pull/20007/files, which will be published as part of the official stubtest docs after mypy cuts its next release).

Meanwhile, the GitHub build of Python 3.13.9 (just released) on macOS doesn't appear to have `errno.ENOTCAPABLE` on it. We already ignore this stubtest error on macOS on other Python versions; let's just do the same here:

https://github.com/python/typeshed/blob/d1197127052745650f685d416488b9f44e0c0cc8/stdlib/%40tests/stubtest_allowlists/darwin-py311.txt#L42-L47

https://github.com/python/typeshed/blob/d1197127052745650f685d416488b9f44e0c0cc8/stdlib/%40tests/stubtest_allowlists/darwin-py312.txt#L30-L35