### PR TITLE
Fix wrong types for xlrd.(Cell.value|Sheet.get_rows)

### DIFF
--- a/stubs/xlrd/xlrd/sheet.pyi
+++ b/stubs/xlrd/xlrd/sheet.pyi
@@ -46,7 +46,7 @@ class Cell(BaseObject):
     ctype: Literal[0, 1, 2, 3, 4, 5, 6]
     value: str | float
     xf_index: int | None
-    def __init__(self, ctype: int, value: str, xf_index: int | None = None) -> None: ...
+    def __init__(self, ctype: Literal[0, 1, 2, 3, 4, 5, 6], value: str, xf_index: int | None = None) -> None: ...
 
 empty_cell: Final[Cell]
 


### PR DESCRIPTION
Per:
- [xlrd.sheet.Sheet.get_rows() documentation](https://xlrd.readthedocs.io/en/latest/api.html#xlrd.sheet.Sheet.get_rows) - Returns a **generator** for iterating through each row.
- [type table for xlrd.sheet.Cell](https://xlrd.readthedocs.io/en/latest/api.html#xlrd.sheet.Cell)
    - depending on `ctype`, `value` is either a string, `float`, or `int`
    - `ctype` is an integer between 0 and 6
