### PR TITLE
Add explicit definition for __repr__ and __str__ in BaseException

### DIFF
--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -2058,6 +2058,10 @@ class BaseException:
     def __new__(cls, *args: Any, **kwds: Any) -> Self: ...
     def __setstate__(self, state: dict[str, Any] | None, /) -> None: ...
     def with_traceback(self, tb: TracebackType | None, /) -> Self: ...
+    # Necessary for security-focused static analyzers (e.g, pysa)
+    # See https://github.com/python/typeshed/pull/14900
+    def __str__(self) -> str: ...  # noqa: Y029
+    def __repr__(self) -> str: ...  # noqa: Y029
     if sys.version_info >= (3, 11):
         # only present after add_note() is called
         __notes__: list[str]


### PR DESCRIPTION
Taint analysis tools such as Pysa might want to mark `BaseException.__str__` and `BaseException.__repr__` as a source and check if it flows to a sink (such as a logging call). Leaking exception messages is usually a security risk.

However, since those methods are inherited from `object`, marking those as sources does not work.
This can be easily fixed by making the definition explicit, which this PR does.

I agree this is not optimal, but the alternatives are limited:
* Adding support for marking inherited methods as a source in those tools (i.e Pysa) would require a month of work
* Using our own typeshed fork would lead to a maintenance cost, as well as user frustration when our fork inevitably gets out of date