### PR TITLE
don't require `IO` for `redirect_stdout`

### DIFF
--- a/stdlib/contextlib.pyi
+++ b/stdlib/contextlib.pyi
@@ -143,6 +143,7 @@ class suppress(AbstractContextManager[None, bool]):
 # This is trying to describe what is needed for (most?) uses
 # of `redirect_stdout` and `redirect_stderr`.
 # https://github.com/python/typeshed/issues/14903
+@type_check_only
 class _SupportsRedirect(Protocol):
     def write(self, s: str, /) -> int: ...
     def flush(self) -> None: ...


### PR DESCRIPTION
https://github.com/python/typeshed/issues/14903

This changes `redirect_stdout` and `redirect_stderr` to only require a `Protocol` with `write` and `flush`,
instead of requiring `typing.IO[str]`