### PR TITLE
[gunicorn] Update arbiter.pyi

### DIFF
--- a/stubs/gunicorn/gunicorn/arbiter.pyi
+++ b/stubs/gunicorn/gunicorn/arbiter.pyi
@@ -1,4 +1,3 @@
-import socket
 from types import FrameType
 from typing import ClassVar
 


### PR DESCRIPTION
`Arbiter.LISTENERS` is actually a list of `BaseSocket`. 

You can see this if you follow the calls from [`create_sockets` in Gunicorn](https://github.com/benoitc/gunicorn/blob/56b5ad87f8d72a674145c273ed8f547513c2b409/gunicorn/arbiter.py#L156). It's also correctly `BaseSocket` in the [Typeshed `sock.pyi` file](https://github.com/python/typeshed/blob/main/stubs/gunicorn/gunicorn/sock.pyi#L35).