### PR TITLE
Use consistent definition of NotImplementedType

### DIFF
--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -2044,8 +2044,7 @@ else:
 
     @final
     @type_check_only
-    class _NotImplementedType(Any):
-        __call__: None
+    class _NotImplementedType(Any): ...
 
     NotImplemented: _NotImplementedType
 


### PR DESCRIPTION
See discussion on https://github.com/python/typeshed/pull/14966

This makes the definition match types.NotImplementedType