### PR TITLE
Put all mypy_test.py version parsing in mypy_test.py

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,11 +62,7 @@ jobs:
             sudo apt-get update -q && sudo apt-get install -qy $PACKAGES
           fi
       - name: Run mypy_test.py
-        run: |
-          # python-version can sometimes be pinned to a specific version or to "-dev", but
-          # mypy understands only X.Y version numbers.
-          MYPY_PY_VERSION=$(echo ${{ matrix.python-version }} | cut -d - -f 1 | cut -d . -f 1-2)
-          python ./tests/mypy_test.py --platform=${{ matrix.platform }} --python-version=${MYPY_PY_VERSION}
+        run: python ./tests/mypy_test.py --platform=${{ matrix.platform }} --python-version=${{ matrix.python-version }}
 
   regression-tests:
     name: "mypy: Run test cases"

--- a/tests/mypy_test.py
+++ b/tests/mypy_test.py
@@ -78,7 +78,7 @@ def remove_dev_suffix(version: str) -> str:
     """
     if version.endswith("-dev"):
         return version[: -len("-dev")]
-    return version
+    return ".".join(version.split(".")[:2])
 
 
 parser = argparse.ArgumentParser(


### PR DESCRIPTION
This makes it possible to run `python mypy_test.py --python-version=3.14.2`, which is useful if we need to pin Python to a specific micro version in CI.

Currently we already do some massaging of the `--python-version` flag inside `mypy_test.py` itself. I think it makes sense to put all of that inside `mypy_test.py` rather than doing some pre-cleaning of the version in the GitHub workflow before passing it to the script. This should help improve maintenance somewhat.

Relates to #14972.