### PR TITLE
networkx: fix link argument deprecation warning

### DIFF
--- a/stubs/networkx/networkx/readwrite/json_graph/node_link.pyi
+++ b/stubs/networkx/networkx/readwrite/json_graph/node_link.pyi
@@ -15,13 +15,13 @@ Use the `edges` keyword instead."""
 def node_link_data(
     G: Graph[_Node],
     *,
+    link: str | None,
     source: str = "source",
     target: str = "target",
     name: str = "id",
     key: str = "key",
     edges: str | None = None,
     nodes: str = "nodes",
-    link: str | None = None,
 ): ...
 @overload
 def node_link_data(


### PR DESCRIPTION
This PR ensures that the deprecation warning for the `link` argument is only emitted when the `link` argument is explicitly specified.

Before this fix, `nx.readwrite.node_link_data(G)` would emit a deprecation warning, even though the `link` argument was not specified.

With this fix, the same snippet no longer emits a deprecation warning, but `nx.readwrite.node_link_data(G, link="something")` _will_ emit a warning.
