### PR TITLE
[yt-dlp] Make _Params["paths"] a Mapping[str, str]

### DIFF
--- a/stubs/yt-dlp/yt_dlp/__init__.pyi
+++ b/stubs/yt-dlp/yt_dlp/__init__.pyi
@@ -105,7 +105,7 @@ class _Params(TypedDict, total=False):
     listformats: bool | None
     outtmpl: str | Mapping[str, str] | None
     outtmpl_na_placeholder: str | None
-    paths: str | None
+    paths: Mapping[str, str] | None
     restrictfilenames: bool | None
     windowsfilenames: bool | None
     ignoreerrors: bool | Literal["only_download"] | None

--- a/stubs/yt-dlp/yt_dlp/__init__.pyi
+++ b/stubs/yt-dlp/yt_dlp/__init__.pyi
@@ -105,7 +105,7 @@ class _Params(TypedDict, total=False):
     listformats: bool | None
     outtmpl: str | Mapping[str, str] | None
     outtmpl_na_placeholder: str | None
-    paths: Mapping[str, str] | None
+    paths: dict[str, str] | None
     restrictfilenames: bool | None
     windowsfilenames: bool | None
     ignoreerrors: bool | Literal["only_download"] | None


### PR DESCRIPTION
`paths` accepts a dict of output paths (keys: 'home', 'temp', and OUTTMPL_TYPES keys). Typing it as `Mapping[str, str] | None` matches runtime behavior and avoids false positives when passing a dict to YoutubeDL params.

`paths` key description in YoutubeDL.py: 
[Dictionary of output paths. The allowed keys are 'home', 'temp' and the keys of OUTTMPL_TYPES (in utils/_utils.py)](https://github.com/yt-dlp/yt-dlp/blob/a75399d89f90b249ccfda148987e10bc688e2f84/yt_dlp/YoutubeDL.py#L271)
It's also asserted to be a `dict` in `get_output_path`:
[assert isinstance(paths, dict), '"paths" parameter must be a dictionary'](https://github.com/yt-dlp/yt-dlp/blob/a75399d89f90b249ccfda148987e10bc688e2f84/yt_dlp/YoutubeDL.py#L1156)
