### PR TITLE
Add blocksize attribute to HTTPConnection class

### DIFF
--- a/stdlib/http/client.pyi
+++ b/stdlib/http/client.pyi
@@ -166,6 +166,7 @@ class HTTPResponse(io.BufferedIOBase, BinaryIO):  # type: ignore[misc]  # incomp
     def begin(self) -> None: ...
 
 class HTTPConnection:
+    blocksize: int
     auto_open: int  # undocumented
     debuglevel: int
     default_port: int  # undocumented


### PR DESCRIPTION
doc: https://docs.python.org/3/library/http.client.html#http.client.HTTPConnection.blocksize