### PR TITLE
[stdlib] add `importlib.util._incompatible_extension_module_restrictions`

### DIFF
--- a/stdlib/importlib/util.pyi
+++ b/stdlib/importlib/util.pyi
@@ -50,7 +50,7 @@ if sys.version_info >= (3, 12):
     class _incompatible_extension_module_restrictions:
         def __init__(self, *, disable_check: bool) -> None: ...
         disable_check: bool
-        old: Literal[-1, 0]  # exists only while entered
+        old: Literal[-1, 0, 1]  # exists only while entered
         def __enter__(self) -> Self: ...
         def __exit__(
             self, exc_type: type[BaseException] | None, exc_val: BaseException | None, exc_tb: TracebackType | None


### PR DESCRIPTION
docs: https://docs.python.org/3/library/importlib.html#importlib.util._incompatible_extension_module_restrictions
source code: https://github.com/python/cpython/blob/86513f6c2ebdd1fb692c39b84786ea41d88c84fd/Lib/importlib/util.py#L118