### PR TITLE
[stdlib] In `ssl`, import `_ssl.HAS_PHA`

### DIFF
--- a/stdlib/ssl.pyi
+++ b/stdlib/ssl.pyi
@@ -33,6 +33,9 @@ from typing_extensions import Never, Self, TypeAlias, deprecated
 if sys.version_info >= (3, 13):
     from _ssl import HAS_PSK as HAS_PSK
 
+if sys.version_info >= (3, 14):
+    from _ssl import HAS_PHA as HAS_PHA
+
 if sys.version_info < (3, 12):
     from _ssl import RAND_pseudo_bytes as RAND_pseudo_bytes
 


### PR DESCRIPTION
docs: https://docs.python.org/3/library/ssl.html#ssl.HAS_PHA
src: https://github.com/python/cpython/blob/37e2762ee12c2d7fc465938d7161a9a0640bd71f/Modules/_ssl.c#L7123-L7127