### PR TITLE
Add TypeVars for the Iterators in select.select

### DIFF
--- a/stdlib/select.pyi
+++ b/stdlib/select.pyi
@@ -2,8 +2,8 @@ import sys
 from _typeshed import FileDescriptorLike
 from collections.abc import Iterable
 from types import TracebackType
-from typing import Any, ClassVar, Final, final
-from typing_extensions import Self
+from typing import Any, ClassVar, Final, TypeVar, final
+from typing_extensions import Never, Self
 
 if sys.platform != "win32":
     PIPE_BUF: Final[int]
@@ -31,9 +31,13 @@ if sys.platform != "win32":
         def unregister(self, fd: FileDescriptorLike, /) -> None: ...
         def poll(self, timeout: float | None = None, /) -> list[tuple[int, int]]: ...
 
+_R = TypeVar("_R", default=Never)
+_W = TypeVar("_W", default=Never)
+_X = TypeVar("_X", default=Never)
+
 def select(
-    rlist: Iterable[Any], wlist: Iterable[Any], xlist: Iterable[Any], timeout: float | None = None, /
-) -> tuple[list[Any], list[Any], list[Any]]: ...
+    rlist: Iterable[_R], wlist: Iterable[_W], xlist: Iterable[_X], timeout: float | None = None, /
+) -> tuple[list[_R], list[_W], list[_X]]: ...
 
 error = OSError
 


### PR DESCRIPTION
Back in 2017, #1080 added in  `TypeVar` to handle correctly indicating how the arguments for `select.select` were passed through to the return values. But unfortunately it caused issues for when an empty Iterator was provided for an argument, as `mypy` could not resolve the type, so it was reverted in #1097

But now, `TypeVar` has an optional `default` argument that is used to set a default when the type is not provided, and we have the `Never` type to indicate a case where there is an empty list. By combining the two , it is now possible to support more descriptive types. 