### PR TITLE
Remove obsolete pyright setting "reportShadowedImports"

### DIFF
--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -28,8 +28,6 @@
     // No effect in stubs
     "reportMissingSuperCall": "none",
     "reportUninitializedInstanceVariable": "none",
-    // stdlib stubs trigger reportShadowedImports
-    "reportShadowedImports": "none",
     // Stubs are allowed to use private variables
     "reportPrivateUsage": "none",
     // Stubs don't need the actual modules to be installed

--- a/pyrightconfig.scripts_and_tests.json
+++ b/pyrightconfig.scripts_and_tests.json
@@ -14,7 +14,6 @@
     "reportImplicitStringConcatenation": "none",
     // Extra strict settings
     "reportMissingModuleSource": "error",
-    "reportShadowedImports": "error",
     "reportCallInDefaultInitializer": "error",
     "reportPropertyTypeMismatch": "error",
     "reportUninitializedInstanceVariable": "error",

--- a/pyrightconfig.stricter.json
+++ b/pyrightconfig.stricter.json
@@ -109,8 +109,6 @@
     // No effect in stubs
     "reportMissingSuperCall": "none",
     "reportUninitializedInstanceVariable": "none",
-    // stdlib stubs trigger reportShadowedImports
-    "reportShadowedImports": "none",
     // Stubs are allowed to use private variables
     "reportPrivateUsage": "none",
     // Stubs don't need the actual modules to be installed

--- a/pyrightconfig.testcases.json
+++ b/pyrightconfig.testcases.json
@@ -6,7 +6,6 @@
     ],
     "typeCheckingMode": "strict",
     // Extra strict settings
-    "reportShadowedImports": "error", // Don't accidentally name a file something that shadows stdlib
     "reportImplicitStringConcatenation": "error",
     "reportUninitializedInstanceVariable": "error",
     "reportUnnecessaryTypeIgnoreComment": "error",


### PR DESCRIPTION
Removed in 1.1.406: https://github.com/microsoft/pyright/releases/tag/1.1.406