### PR TITLE
[stdlib] Add a comment to the alias for the return type of `urllib.request.urlopen`

### DIFF
--- a/stdlib/urllib/request.pyi
+++ b/stdlib/urllib/request.pyi
@@ -49,7 +49,14 @@ if sys.version_info < (3, 14):
     __all__ += ["URLopener", "FancyURLopener"]
 
 _T = TypeVar("_T")
+
+# The actual type is `addinfourl | HTTPResponse`, but users would need to use `typing.cast` or `isinstance` to narrow the type,
+# so we use `Any` instead.
+# See
+# - https://github.com/python/typeshed/pull/15042
+# - https://github.com/python/typing/issues/566
 _UrlopenRet: TypeAlias = Any
+
 _DataType: TypeAlias = ReadableBuffer | SupportsRead[bytes] | Iterable[bytes] | None
 
 if sys.version_info >= (3, 13):


### PR DESCRIPTION
This PR originally changed the return type of `urllib.request.urlopen` to `urllib.response.addinfourl | http.client.HTTPResponse`, but on feedback from Sebastian, it was changed to simply comment explaining why `Any` is used.

For reference:

- https://github.com/python/typing/issues/566