### PR TITLE
[stdlib] Update asyncio.Runner.run to acccept Awaitable

### DIFF
--- a/stdlib/asyncio/runners.pyi
+++ b/stdlib/asyncio/runners.pyi
@@ -26,6 +26,7 @@ if sys.version_info >= (3, 11):
             def run(self, coro_or_future: Awaitable[_T], *, context: Context | None = None) -> _T: ...
         else:
             def run(self, coro: Coroutine[Any, Any, _T], *, context: Context | None = None) -> _T: ...
+
 if sys.version_info >= (3, 12):
     def run(
         main: Coroutine[Any, Any, _T], *, debug: bool | None = None, loop_factory: Callable[[], AbstractEventLoop] | None = None


### PR DESCRIPTION
As all Coroutine instances are also instances of Awaitable, we can just directly relax this type bound.

Issue: gh-120284
Link: https://github.com/python/cpython/commit/1229cb8c1412d37cf3206eab407f03e21d602cbd