### PR TITLE
[stdlib] Correct `IllegalMonthError`, `IllegalWeekdayError` type stubs

### DIFF
--- a/stdlib/calendar.pyi
+++ b/stdlib/calendar.pyi
@@ -56,10 +56,12 @@ if sys.version_info >= (3, 12):
 
 _LocaleType: TypeAlias = tuple[str | None, str | None]
 
-class IllegalMonthError(ValueError):
+class IllegalMonthError(ValueError, IndexError):
+    month: int
     def __init__(self, month: int) -> None: ...
 
 class IllegalWeekdayError(ValueError):
+    weekday: int
     def __init__(self, weekday: int) -> None: ...
 
 def isleap(year: int) -> bool: ...


### PR DESCRIPTION
src: https://github.com/python/cpython/blob/4cfa695c953e5dfdab99ade81cee960ddf4b106d/Lib/calendar.py#L30-L44
docs: https://docs.python.org/3/library/calendar.html#calendar.IllegalMonthError