### PR TITLE
Rewrite `operator` Library with More Specific Annotations

### DIFF
--- a/.github/workflows/mypy_primer.yml
+++ b/.github/workflows/mypy_primer.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        shard-index: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        shard-index: [0, 1, 2, 3]
       fail-fast: false
     steps:
       - uses: actions/checkout@v6
@@ -52,7 +52,7 @@ jobs:
             --new v${MYPY_VERSION} --old v${MYPY_VERSION} \
             --custom-typeshed-repo typeshed_to_test \
             --new-typeshed $GITHUB_SHA --old-typeshed upstream_main \
-            --num-shards 10 --shard-index ${{ matrix.shard-index }} \
+            --num-shards 4 --shard-index ${{ matrix.shard-index }} \
             --debug \
             --output concise \
             | tee diff_${{ matrix.shard-index }}.txt


### PR DESCRIPTION
More detailed `operator` annotations could be very useful (see #6448).
For example,
```python
def polynomial_derivative(coefficients: Sequence[float]) -> list[float] / list[str]:
    """Compute the first derivative of a polynomial.
    f(x)  =  x³ -4x² -17x + 60
    f'(x) = 3x² -8x  -17
    """
    # polynomial_derivative([1, -4, -17, 60]) -> [3, -8, -17]
    n = len(coefficients)
    powers = reversed(range(1, n))
    return list(map(operator.mul, coefficients, powers))
```
This used to type check with either return type, but should only work with `list[float]` now.
Otherwise, the `operator` library is mostly type using `binop(a: Any, b: Any, /) -> Any`.