### PR TITLE
[stdlib] add `multiprocessing.synchronize.SemLock.locked`

### DIFF
--- a/stdlib/@tests/stubtest_allowlists/py314.txt
+++ b/stdlib/@tests/stubtest_allowlists/py314.txt
@@ -11,7 +11,6 @@ multiprocessing.managers._BaseDictProxy.__reversed__
 multiprocessing.managers._BaseDictProxy.__ror__
 multiprocessing.managers._BaseDictProxy.fromkeys
 multiprocessing.process.BaseProcess.interrupt
-multiprocessing.synchronize.SemLock.locked
 
 
 # =========================

--- a/stdlib/multiprocessing/synchronize.pyi
+++ b/stdlib/multiprocessing/synchronize.pyi
@@ -1,3 +1,4 @@
+import sys
 import threading
 from collections.abc import Callable
 from multiprocessing.context import BaseContext
@@ -45,6 +46,8 @@ class SemLock:
     # These methods are copied from the wrapped _multiprocessing.SemLock object
     def acquire(self, block: bool = True, timeout: float | None = None) -> bool: ...
     def release(self) -> None: ...
+    if sys.version_info >= (3, 14):
+        def locked(self) -> bool: ...
 
 class Lock(SemLock):
     def __init__(self, *, ctx: BaseContext) -> None: ...


### PR DESCRIPTION
docs: 
https://docs.python.org/3/library/multiprocessing.html#multiprocessing.Lock.locked
https://docs.python.org/3/library/multiprocessing.html#multiprocessing.RLock.locked
src:
https://github.com/python/cpython/blob/92972aea0f0e12dd21bfb8c466289a0c3b4c236e/Lib/multiprocessing/synchronize.py#L93-L94