### PR TITLE
[stdlib] Add `method_calls` attribute to `NonCallableMock` class

### DIFF
--- a/stdlib/unittest/mock.pyi
+++ b/stdlib/unittest/mock.pyi
@@ -199,6 +199,7 @@ class NonCallableMock(Base, Any):
     call_count: int
     call_args: _Call | MaybeNone
     call_args_list: _CallList
+    method_calls: _CallList
     mock_calls: _CallList
     def _format_mock_call_signature(self, args: Any, kwargs: Any) -> str: ...
     def _call_matcher(self, _call: tuple[_Call, ...]) -> _Call: ...


### PR DESCRIPTION
docs: https://docs.python.org/3/library/unittest.mock.html#unittest.mock.Mock.method_calls
src: https://github.com/python/cpython/blob/4fe6e81d84eaaf145609fd4d9eca5ddc64463afd/Lib/unittest/mock.py#L262