### PR TITLE
[stdlib] Make `http.cookies.Morsel` inherit a `TypedDict`

### DIFF
--- a/stdlib/http/cookies.pyi
+++ b/stdlib/http/cookies.pyi
@@ -32,7 +32,8 @@ if sys.version_info >= (3, 14):
         httponly: Any
         version: Any
         samesite: Any
-        partitioned: Any # New in version 3.14.
+        partitioned: Any  # New in version 3.14.
+
 else:
     @type_check_only
     class _MorselDictType(TypedDict):
@@ -45,7 +46,6 @@ else:
         httponly: Any
         version: Any
         samesite: Any
-
 
 class Morsel(_MorselDictType, Generic[_T]):
     @property


### PR DESCRIPTION
docs: https://docs.python.org/3/library/http.cookies.html#http.cookies.Morsel.expires
src: https://github.com/python/cpython/blob/77399436bfc87663f9058b749b6cb598bab273f9/Lib/http/cookies.py#L257-L268