### PR TITLE
Fix docker exec types

### DIFF
--- a/stubs/docker/docker/api/exec_api.pyi
+++ b/stubs/docker/docker/api/exec_api.pyi
@@ -130,7 +130,7 @@ class ExecApiMixin:
         | _BufferedReaderStream
         | SSHSocket
         | CancellableStream[bytes]
-        | CancellableStream[tuple[str | None, str | None]]
-        | tuple[str | None, str | None]
+        | CancellableStream[tuple[bytes | None, bytes | None]]
+        | tuple[bytes | None, bytes | None]
         | bytes
     ): ...


### PR DESCRIPTION
The return types of docker `exec_start` are always bytes to my experiments

```py
from __future__ import annotations

from docker import APIClient

client = APIClient()

container_id = client.create_container("python:3.12", command="sleep 10")
client.start(container_id)

try:
    exec_id = client.exec_create(container_id, "echo hello")
    res = client.exec_start(exec_id)
    print(type(res))

    exec_id = client.exec_create(container_id, "echo hello")
    res = client.exec_start(exec_id, stream=True)
    print(type(next(res)))

    exec_id = client.exec_create(container_id, "echo hello")
    res = client.exec_start(exec_id, socket=True)
    print(type(next(res)))

    exec_id = client.exec_create(container_id, "echo hello")
    res = client.exec_start(exec_id, demux=True)
    print(type(res[0]))

    exec_id = client.exec_create(container_id, "echo hello")
    res = client.exec_start(exec_id, demux=True, stream=True)
    print(type(next(res)[0]))
finally:
    client.stop(container_id)
```

Output:
```
<class 'bytes'>
<class 'bytes'>
<class 'bytes'>
<class 'bytes'>
<class 'bytes'>
```