### PR TITLE
[docker-py] Add `exec_start` overload

### DIFF
--- a/stubs/docker/docker/api/exec_api.pyi
+++ b/stubs/docker/docker/api/exec_api.pyi
@@ -72,7 +72,7 @@ class ExecApiMixin:
         stream: Literal[True],
         socket: Literal[False],
         demux: Literal[False],
-    ) -> CancellableStream[str]: ...
+    ) -> CancellableStream[bytes]: ...
     @overload
     def exec_start(
         self,
@@ -83,7 +83,7 @@ class ExecApiMixin:
         stream: Literal[True],
         socket: Literal[False] = False,
         demux: Literal[False] = False,
-    ) -> CancellableStream[str]: ...
+    ) -> CancellableStream[bytes]: ...
     @overload
     def exec_start(
         self,
@@ -114,7 +114,7 @@ class ExecApiMixin:
         stream: Literal[False] = False,
         socket: Literal[False] = False,
         demux: Literal[False] = False,
-    ) -> str: ...
+    ) -> bytes: ...
     @overload
     def exec_start(
         self,
@@ -129,7 +129,8 @@ class ExecApiMixin:
         | SocketIO
         | _BufferedReaderStream
         | SSHSocket
-        | CancellableStream[str]
+        | CancellableStream[bytes]
         | CancellableStream[tuple[str | None, str | None]]
         | tuple[str | None, str | None]
+        | bytes
     ): ...


### PR DESCRIPTION
This new overload is needed for a wrapping function like:
```py
def my_function(
    obj: ExecApiMixin,
    exec_id: str,
    detach: bool = False,
    tty: bool = False,
    stream: bool = False,
    socket: bool = False,
    demux: bool = False,
) -> None:
    obj.exec_start(exec_id, detach, tty, stream, socket, demux)
```

If this new overload is not present, `mypy` will give the following error:
```
No overload variant of "exec_start" of "ExecApiMixin" matches argument types "str", "bool", "bool", "bool", "bool", "bool"
``` 

Besides, return type when `stream=True` (`False` for the rest) is `CancellableStream[bytes]` instead of `CancellableStream[str]` and `bytes` instead of `str` if everything is `False`.