### PR TITLE
Align type of aws_xra_sdk.core.xray_recorder stub with lib

### DIFF
--- a/stubs/aws-xray-sdk/aws_xray_sdk/core/__init__.pyi
+++ b/stubs/aws-xray-sdk/aws_xray_sdk/core/__init__.pyi
@@ -1,6 +1,7 @@
+from .async_recorder import AsyncAWSXRayRecorder as AsyncAWSXRayRecorder
 from .patcher import patch as patch, patch_all as patch_all
 from .recorder import AWSXRayRecorder as AWSXRayRecorder
 
-xray_recorder: AWSXRayRecorder
+xray_recorder: AsyncAWSXRayRecorder
 
 __all__ = ["patch", "patch_all", "xray_recorder", "AWSXRayRecorder"]


### PR DESCRIPTION
`aws_xra_sdk.core.xray_recorder` has unconditionally been an instance of `AsyncAWSXRayRecorder`, not `AWSXRayRecorder`, since `aws-xray-sdk==2.12.1`, see:

https://github.com/aws/aws-xray-sdk-python/commit/150f0ea3ea06447987b8b2b2e7c8b358b89b43e3