### PR TITLE
Fully typed setuptools setup method

### DIFF
--- a/stubs/setuptools/setuptools/__init__.pyi
+++ b/stubs/setuptools/setuptools/__init__.pyi
@@ -159,7 +159,7 @@ def setup(
     # kwargs used directly in distutils.core.setup
     distclass: type[_DistributionT] = Distribution,  # type: ignore[assignment] # noqa: Y011
     # Custom Distributions could accept more params
-    **attrs: object,
+    **attrs: Any,
 ) -> _DistributionT: ...
 
 class Command(_Command):


### PR DESCRIPTION
Pulled directly from https://github.com/pypa/setuptools/pull/5021/files . But with an extra effort to try and use a dict-like protocol instead of a `dict` as parameter.

setuptools contributions have been stalling in the past year, thought I'd be done with it sooner. So I'm adding these here to for more parameters autocomplete and more flexible parameter types.