### PR TITLE
Change whis type to support tuple

### DIFF
--- a/stubs/seaborn/seaborn/categorical.pyi
+++ b/stubs/seaborn/seaborn/categorical.pyi
@@ -27,7 +27,7 @@ def boxplot(
     dodge: bool | Literal["auto"] = "auto",
     width: float = 0.8,
     gap: float = 0,
-    whis: float = 1.5,
+    whis: float | tuple[float, float] = 1.5,
     linecolor: ColorType = "auto",
     linewidth: float | None = None,
     fliersize: float | None = None,


### PR DESCRIPTION
The seaborn boxplot whis argument for whisker plots supports a mode where the value is a tuple. https://seaborn.pydata.org/generated/seaborn.boxplot.html

> **whisfloat or pair of floats**
> Paramater that controls whisker length. If scalar, whiskers are drawn to the farthest datapoint within whis * IQR from the nearest hinge. If a tuple, it is interpreted as percentiles that whiskers represent.