### PR TITLE
[requests] requests.exceptions.JSONDecodeError inherits from json.JSONDecodeError

### DIFF
--- a/stubs/requests/requests/exceptions.pyi
+++ b/stubs/requests/requests/exceptions.pyi
@@ -1,3 +1,4 @@
+from json import JSONDecodeError as CompatJSONDecodeError
 from typing import Any
 
 from urllib3.exceptions import HTTPError as BaseHTTPError
@@ -13,7 +14,7 @@ class RequestException(OSError):
     ) -> None: ...
 
 class InvalidJSONError(RequestException): ...
-class JSONDecodeError(InvalidJSONError): ...
+class JSONDecodeError(InvalidJSONError, CompatJSONDecodeError): ...
 
 class HTTPError(RequestException):
     request: Request | PreparedRequest | Any


### PR DESCRIPTION
Addresses: https://github.com/python/typeshed/issues/15167

Technically, it inherits from either `json.JSONDecodeError` or `simplejson.errors.JSONDecodeError`, but the latter is compatible: https://github.com/simplejson/simplejson/blob/master/simplejson/errors.py#L41-L47

I've included a test that fails prior to the changes to `stubs/requests/requests/exceptions.pyi` but passes now.