### PR TITLE
Add deprecation for ` check_home` arg of `sysconfig.is_python_build`

### DIFF
--- a/stdlib/sysconfig.pyi
+++ b/stdlib/sysconfig.pyi
@@ -43,10 +43,7 @@ if sys.version_info >= (3, 12):
     @overload
     def is_python_build() -> bool: ...
     @overload
-    @deprecated(
-        "The check_home argument of sysconfig.is_python_build is deprecated and its value is ignored. "
-        "It will be removed in Python 3.15."
-    )
+    @deprecated("The `check_home` parameter is deprecated since Python 3.12; removed in Python 3.15.")
     def is_python_build(check_home: object = None) -> bool: ...
 
 elif sys.version_info >= (3, 11):


### PR DESCRIPTION
Reflect deprecation as seen in https://github.com/python/cpython/pull/129102/