### PR TITLE
[Authlib] Fix AsyncOAuth2Client missing async context manager methods.

### DIFF
--- a/stubs/Authlib/@tests/stubtest_allowlist.txt
+++ b/stubs/Authlib/@tests/stubtest_allowlist.txt
@@ -55,7 +55,6 @@ authlib.integrations.django_oauth2.*
 authlib.integrations.flask_client.*
 authlib.integrations.flask_oauth1.*
 authlib.integrations.flask_oauth2.*
-authlib.integrations.httpx_client.*
 authlib.integrations.requests_client.*
 authlib.integrations.sqla_oauth2.*
 authlib.integrations.starlette_client.*

--- a/stubs/Authlib/@tests/test_cases/check_integration_httpx_client_oauth2.py
+++ b/stubs/Authlib/@tests/test_cases/check_integration_httpx_client_oauth2.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from authlib.integrations.httpx_client import AsyncOAuth2Client
+
+
+# ================================================================================
+# Test for AsyncOAuth2Client contex manager being correctly inherited and present.
+# ================================================================================
+async def test_client_contex_manager() -> None:
+    async with AsyncOAuth2Client():
+        pass

--- a/stubs/Authlib/METADATA.toml
+++ b/stubs/Authlib/METADATA.toml
@@ -1,3 +1,6 @@
 version = "1.6.6"
 upstream_repository = "https://github.com/lepture/authlib"
-requires = ["cryptography"]
+requires = ["cryptography", "httpx"]
+
+[tool.stubtest]
+extras = ["httpx"]

--- a/stubs/Authlib/authlib/integrations/httpx_client/oauth2_client.pyi
+++ b/stubs/Authlib/authlib/integrations/httpx_client/oauth2_client.pyi
@@ -1,8 +1,10 @@
 from _typeshed import Incomplete
 from collections.abc import Generator
+from contextlib import _AsyncGeneratorContextManager
 from typing import NoReturn
-from typing_extensions import TypeAlias
+from typing_extensions import Self, TypeAlias
 
+import httpx
 from authlib.oauth2.auth import ClientAuth, TokenAuth
 from authlib.oauth2.client import OAuth2Client as _OAuth2Client
 
@@ -24,7 +26,7 @@ class OAuth2ClientAuth(ClientAuth):
     def auth_flow(self, request: _Request) -> Generator[_Request, _Response, None]: ...
 
 # Inherits from httpx.AsyncClient
-class AsyncOAuth2Client(_OAuth2Client):
+class AsyncOAuth2Client(_OAuth2Client, httpx.AsyncClient):
     SESSION_REQUEST_PARAMS: list[str]
     client_auth_class = OAuth2ClientAuth
     token_auth_class = OAuth2Auth
@@ -43,8 +45,11 @@ class AsyncOAuth2Client(_OAuth2Client):
         leeway=60,
         **kwargs,
     ) -> None: ...
+    async def __aenter__(self) -> Self: ...
     async def request(self, method, url, withhold_token: bool = False, auth=..., **kwargs): ...
-    async def stream(self, method, url, withhold_token: bool = False, auth=..., **kwargs) -> Generator[Incomplete]: ...
+    def stream(
+        self, method, url, withhold_token: bool = False, auth=..., **kwargs
+    ) -> _AsyncGeneratorContextManager[httpx.Response]: ...
     async def ensure_active_token(self, token): ...  # type: ignore[override]
 
 # Inherits from httpx.Client


### PR DESCRIPTION
After recent changes to `Authlib` integrations, `mypy` complains that `AsyncOAuth2Client` has no attribute `__aenter__` and `__aexit__` when used as an async context manager.

I've looked into it and found that `AsyncOAuth2Client` inherits these methods from `httpx.AsyncClient`, but this inheritance is not reflected in the stub file. I've tried to fix it and added a test.

I had some problems with pyright tests - I couldn't get it to work without explicitly adding the `__aenter__` method. I don't know why, as I haven't used pyright before. If this is a result of issues in my local environment (that's my suspicion due to other problems like unknown imports) and the explicit method is unnecessary, please let me know.