### PR TITLE
[geopandas] Add lz4 and zstd compression to to_parquet

### DIFF
--- a/stubs/geopandas/geopandas/geodataframe.pyi
+++ b/stubs/geopandas/geopandas/geodataframe.pyi
@@ -221,7 +221,7 @@ class GeoDataFrame(GeoPandasBase, pd.DataFrame):  # type: ignore[misc]
         self,
         path: str | os.PathLike[str] | SupportsWrite[Incomplete],
         index: bool | None = None,
-        compression: Literal["snappy", "gzip", "brotli"] | None = "snappy",
+        compression: Literal["snappy", "gzip", "brotli", "lz4", "zstd"] | None = "snappy",
         geometry_encoding: _GeomEncoding = "WKB",
         write_covering_bbox: bool = False,
         schema_version: str | None = None,


### PR DESCRIPTION
Adds `lz4` and `zstd` to the `compression` parameter of `GeoDataFrame.to_parquet`.

Added in geopandas 1.1.0:
- https://github.com/geopandas/geopandas/pull/3399
- https://geopandas.org/en/stable/docs/reference/api/geopandas.GeoDataFrame.to_parquet.html