### PR TITLE
[stdlib][tarfile] Change errorlevel type from `int | None` to `int`

### DIFF
--- a/stdlib/tarfile.pyi
+++ b/stdlib/tarfile.pyi
@@ -129,7 +129,7 @@ class TarFile:
     fileobject: type[ExFileObject]  # undocumented
     pax_headers: Mapping[str, str] | None
     debug: int | None
-    errorlevel: int | None
+    errorlevel: int
     offset: int  # undocumented
     extraction_filter: _FilterFunction | None
     if sys.version_info >= (3, 13):


### PR DESCRIPTION
Docs: https://docs.python.org/dev/library/tarfile.html#tarfile.TarFile.errorlevel
src: https://github.com/python/cpython/blob/e6bfe4d8869e046a91d091611d3c7b5dccdaf0d6/Lib/tarfile.py#L1709
```pycon
>>> import tarfile
>>> tarfile.TarFile("somefile", 'w').errorlevel
1
>>> ```