### PR TITLE
[stdlib][tarfile] Fix `pax_headers` type annotation in tarfile.pyi

### DIFF
--- a/stdlib/tarfile.pyi
+++ b/stdlib/tarfile.pyi
@@ -127,7 +127,7 @@ class TarFile:
     encoding: str | None
     errors: str
     fileobject: type[ExFileObject]  # undocumented
-    pax_headers: Mapping[str, str] | None
+    pax_headers: Mapping[str, str]
     debug: int | None
     errorlevel: int | None
     offset: int  # undocumented


### PR DESCRIPTION
docs: https://docs.python.org/dev/library/tarfile.html#tarfile.TarFile.pax_headers
src: https://github.com/python/cpython/blob/e6bfe4d8869e046a91d091611d3c7b5dccdaf0d6/Lib/tarfile.py#L1775-L1778
```pycon
>>> import tarfile
>>> tarfile.TarFile("somefile", 'w').pax_headers
{}
>>> 
```