### PR TITLE
Minor fix for documentation link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ are important to the project's success.
       but [contact us](README.md#discussion) before starting significant work.
     * Create your stubs, considering [what to include](#what-to-include) and
       conforming to the [coding style](https://typing.readthedocs.io/en/latest/guides/writing_stubs.html#style-guide).
-4. Optionally [format and check your stubs](#code-formatting).
+4. Optionally [format and check your stubs](#stub-content-and-style).
 5. Optionally [run the tests](tests/README.md).
 6. [Submit your changes](#submitting-changes) by opening a pull request.
 7. Make sure that all tests in CI are passing.


### PR DESCRIPTION
While preparing to submit my first PR in this repo, I ran into a really minor documentation issue. I was asked to move the fix to a separate PR here: https://github.com/python/typeshed/pull/15168#discussion_r2649076955

It feels a little silly to have such a small PR, so if someone wants to just incorporate this into another documentation PR (if there are any pending), or hold off until there are other changes needed, feel free to do so and close this.