### PR TITLE
[importlib] Deprecate debug_override parameter in cache_from_source

### DIFF
--- a/stdlib/_frozen_importlib_external.pyi
+++ b/stdlib/_frozen_importlib_external.pyi
@@ -9,7 +9,7 @@ from _typeshed.importlib import LoaderProtocol
 from collections.abc import Callable, Iterable, Iterator, Mapping, MutableSequence, Sequence
 from importlib.machinery import ModuleSpec
 from importlib.metadata import DistributionFinder, PathDistribution
-from typing import Any, Final, Literal
+from typing import Any, Final, Literal, overload
 from typing_extensions import Self, deprecated
 
 if sys.version_info >= (3, 10):
@@ -26,7 +26,13 @@ else:
 
 MAGIC_NUMBER: Final[bytes]
 
-def cache_from_source(path: StrPath, debug_override: bool | None = None, *, optimization: Any | None = None) -> str: ...
+@overload
+@deprecated(
+    "The `debug_override` parameter is deprecated since Python 3.5; will be removed in Python 3.15. Use `optimization` instead."
+)
+def cache_from_source(path: StrPath, debug_override: bool, *, optimization: None = None) -> str: ...
+@overload
+def cache_from_source(path: StrPath, debug_override: None = None, *, optimization: Any | None = None) -> str: ...
 def source_from_cache(path: StrPath) -> str: ...
 def decode_source(source_bytes: ReadableBuffer) -> str: ...
 def spec_from_file_location(


### PR DESCRIPTION
Docs: https://docs.python.org/3.14/library/importlib.html#importlib.util.cache_from_source
Source: https://github.com/python/cpython/blob/9f91278412e30ca3daaa427614176b2891bd230a/Lib/importlib/_bootstrap_external.py#L239