### PR TITLE
[importlib] Deprecate ResourceReader

### DIFF
--- a/stdlib/importlib/resources/abc.pyi
+++ b/stdlib/importlib/resources/abc.pyi
@@ -4,8 +4,10 @@ from abc import ABCMeta, abstractmethod
 from collections.abc import Iterator
 from io import BufferedReader
 from typing import IO, Any, Literal, Protocol, overload, runtime_checkable
+from typing_extensions import deprecated
 
 if sys.version_info >= (3, 11):
+    @deprecated("Deprecated since Python 3.12. Use `importlib.resources.abc.TraversableResources` instead.")
     class ResourceReader(metaclass=ABCMeta):
         @abstractmethod
         def open_resource(self, resource: str) -> IO[bytes]: ...


### PR DESCRIPTION
Docs (`importlib.abc.ResourceReader`): https://docs.python.org/dev/library/importlib.html#importlib.abc.ResourceReader
Docs (`importlib.resources.abc.ResourceReader`): https://docs.python.org/dev/library/importlib.resources.abc.html#importlib.resources.abc.ResourceReader
(this class is reimported in typeshed, but both are deprecated. `TraversableResources` is available since 3.11)