### PR TITLE
statistics: relax linear_regression input types

### DIFF
--- a/stdlib/statistics.pyi
+++ b/stdlib/statistics.pyi
@@ -1,9 +1,9 @@
 import sys
 from _typeshed import SupportsRichComparisonT
-from collections.abc import Callable, Hashable, Iterable, Sequence
+from collections.abc import Callable, Hashable, Iterable, Sequence, Sized
 from decimal import Decimal
 from fractions import Fraction
-from typing import Literal, NamedTuple, SupportsFloat, SupportsIndex, TypeVar
+from typing import Literal, NamedTuple, Protocol, SupportsFloat, SupportsIndex, TypeVar
 from typing_extensions import Self, TypeAlias
 
 __all__ = [
@@ -41,6 +41,10 @@ _HashableT = TypeVar("_HashableT", bound=Hashable)
 # Used in NormalDist.samples and kde_random
 _Seed: TypeAlias = int | float | str | bytes | bytearray  # noqa: Y041
 
+# Used in linear_regression
+_T_co = TypeVar("_T_co", covariant=True)
+
+class _SizedIterable(Iterable[_T_co], Sized, Protocol[_T_co]): ...
 class StatisticsError(ValueError): ...
 
 if sys.version_info >= (3, 11):
@@ -129,11 +133,13 @@ if sys.version_info >= (3, 10):
 
 if sys.version_info >= (3, 11):
     def linear_regression(
-        regressor: Sequence[_Number], dependent_variable: Sequence[_Number], /, *, proportional: bool = False
+        regressor: _SizedIterable[_Number], dependent_variable: _SizedIterable[_Number], /, *, proportional: bool = False
     ) -> LinearRegression: ...
 
 elif sys.version_info >= (3, 10):
-    def linear_regression(regressor: Sequence[_Number], dependent_variable: Sequence[_Number], /) -> LinearRegression: ...
+    def linear_regression(
+        regressor: _SizedIterable[_Number], dependent_variable: _SizedIterable[_Number], /
+    ) -> LinearRegression: ...
 
 if sys.version_info >= (3, 13):
     _Kernel: TypeAlias = Literal[


### PR DESCRIPTION
only `len()` and iteration are needed at runtime, this is accepted now
```py
>>> import statistics
>>> d = {1: 10, 2: 20}
>>> statistics.linear_regression(d.keys(), d.values())
LinearRegression(slope=10.0, intercept=0.0)
```