### PR TITLE
[select] Deprecate flags parameter for epoll

### DIFF
--- a/stdlib/select.pyi
+++ b/stdlib/select.pyi
@@ -2,8 +2,8 @@ import sys
 from _typeshed import FileDescriptorLike
 from collections.abc import Iterable
 from types import TracebackType
-from typing import Any, ClassVar, Final, TypeVar, final
-from typing_extensions import Never, Self
+from typing import Any, ClassVar, Final, TypeVar, final, overload
+from typing_extensions import Never, Self, deprecated
 
 if sys.platform != "win32":
     PIPE_BUF: Final[int]
@@ -52,13 +52,7 @@ if sys.platform != "linux" and sys.platform != "win32":
         ident: int
         udata: Any
         def __init__(
-            self,
-            ident: FileDescriptorLike,
-            filter: int = ...,
-            flags: int = ...,
-            fflags: int = ...,
-            data: Any = ...,
-            udata: Any = ...,
+            self, ident: FileDescriptorLike, filter: int = ..., flags: int = ..., fflags: int = 0, data: Any = 0, udata: Any = 0
         ) -> None: ...
         __hash__: ClassVar[None]  # type: ignore[assignment]
 
@@ -118,12 +112,19 @@ if sys.platform != "linux" and sys.platform != "win32":
 if sys.platform == "linux":
     @final
     class epoll:
-        def __new__(self, sizehint: int = ..., flags: int = ...) -> Self: ...
+        @overload
+        def __new__(self, sizehint: int = -1) -> Self: ...
+        @overload
+        @deprecated(
+            "The `flags` parameter is deprecated since Python 3.4. "
+            "Use `os.set_inheritable()` to make the file descriptor inheritable."
+        )
+        def __new__(self, sizehint: int = -1, flags: int = 0) -> Self: ...
         def __enter__(self) -> Self: ...
         def __exit__(
             self,
             exc_type: type[BaseException] | None = None,
-            exc_value: BaseException | None = ...,
+            exc_value: BaseException | None = None,
             exc_tb: TracebackType | None = None,
             /,
         ) -> None: ...
@@ -164,4 +165,4 @@ if sys.platform != "linux" and sys.platform != "darwin" and sys.platform != "win
         def register(self, fd: FileDescriptorLike, eventmask: int = ...) -> None: ...
         def modify(self, fd: FileDescriptorLike, eventmask: int = ...) -> None: ...
         def unregister(self, fd: FileDescriptorLike) -> None: ...
-        def poll(self, timeout: float | None = ...) -> list[tuple[int, int]]: ...
+        def poll(self, timeout: float | None = None) -> list[tuple[int, int]]: ...


### PR DESCRIPTION
- Deprecte `flags` param for `epoll`: https://docs.python.org/dev/library/select.html#select.epoll
- Add default values:
  * `select.kevent` - https://github.com/python/cpython/blob/8cfd7b4ecf9c01ca2bea57fe640250f716cb6ee3/Modules/selectmodule.c#L1775
  * `select.epoll.__new__` - https://github.com/python/cpython/blob/8cfd7b4ecf9c01ca2bea57fe640250f716cb6ee3/Modules/selectmodule.c#L1355
  * `select.epoll.__exit__` - https://github.com/python/cpython/blob/8cfd7b4ecf9c01ca2bea57fe640250f716cb6ee3/Modules/selectmodule.c#L1706
  * `select.devpoll.poll` - https://github.com/python/cpython/blob/8cfd7b4ecf9c01ca2bea57fe640250f716cb6ee3/Modules/selectmodule.c#L943