### PR TITLE
[stdlib] Deprecate keyfile, certfile and check_hostname parameters

### DIFF
--- a/stdlib/ftplib.pyi
+++ b/stdlib/ftplib.pyi
@@ -127,10 +127,12 @@ class FTP_TLS(FTP):
             user: str = "",
             passwd: str = "",
             acct: str = "",
-            *,
+            keyfile: None = None,
+            certfile: None = None,
             context: SSLContext | None = None,
             timeout: float | None = ...,
             source_address: tuple[str, int] | None = None,
+            *,
             encoding: str = "utf-8",
         ) -> None: ...
         @overload
@@ -146,7 +148,7 @@ class FTP_TLS(FTP):
             acct: str = "",
             keyfile: StrOrBytesPath | None = None,
             certfile: StrOrBytesPath | None = None,
-            context: SSLContext | None = None,
+            context: None = None,
             timeout: float | None = ...,
             source_address: tuple[str, int] | None = None,
             *,

--- a/stdlib/http/client.pyi
+++ b/stdlib/http/client.pyi
@@ -228,10 +228,13 @@ class HTTPSConnection(HTTPConnection):
             self,
             host: str,
             port: int | None = None,
-            *,
+            key_file: None = None,
+            cert_file: None = None,
             timeout: float | None = ...,
             source_address: tuple[str, int] | None = None,
+            *,
             context: ssl.SSLContext | None = None,
+            check_hostname: None = None,
             blocksize: int = 8192,
         ) -> None: ...
         @overload

--- a/stdlib/imaplib.pyi
+++ b/stdlib/imaplib.pyi
@@ -127,7 +127,13 @@ class IMAP4_SSL(IMAP4):
     else:
         @overload
         def __init__(
-            self, host: str = "", port: int = 993, *, ssl_context: SSLContext | None = None, timeout: float | None = None
+            self,
+            host: str = "",
+            port: int = 993,
+            keyfile: None = None,
+            certfile: None = None,
+            ssl_context: SSLContext | None = None,
+            timeout: float | None = None,
         ) -> None: ...
         @overload
         @deprecated(
@@ -140,7 +146,7 @@ class IMAP4_SSL(IMAP4):
             port: int = 993,
             keyfile: StrOrBytesPath | None = None,
             certfile: StrOrBytesPath | None = None,
-            ssl_context: SSLContext | None = None,
+            ssl_context: None = None,
             timeout: float | None = None,
         ) -> None: ...
         keyfile: StrOrBytesPath | None

--- a/stdlib/poplib.pyi
+++ b/stdlib/poplib.pyi
@@ -61,7 +61,13 @@ class POP3_SSL(POP3):
     else:
         @overload
         def __init__(
-            self, host: str, port: int = 995, *, timeout: float = ..., context: ssl.SSLContext | None = None
+            self,
+            host: str,
+            port: int = 995,
+            keyfile: None = None,
+            certfile: None = None,
+            timeout: float = ...,
+            context: ssl.SSLContext | None = None,
         ) -> None: ...
         @overload
         @deprecated(
@@ -75,7 +81,7 @@ class POP3_SSL(POP3):
             keyfile: StrOrBytesPath | None = None,
             certfile: StrOrBytesPath | None = None,
             timeout: float = ...,
-            context: ssl.SSLContext | None = None,
+            context: None = None,
         ) -> None: ...
         keyfile: StrOrBytesPath | None
         certfile: StrOrBytesPath | None

--- a/stdlib/smtplib.pyi
+++ b/stdlib/smtplib.pyi
@@ -132,14 +132,14 @@ class SMTP:
         def starttls(self, *, context: SSLContext | None = None) -> _Reply: ...
     else:
         @overload
-        def starttls(self, *, context: SSLContext | None = None) -> _Reply: ...
+        def starttls(self, keyfile: None = None, certfile: None = None, context: SSLContext | None = None) -> _Reply: ...
         @overload
         @deprecated(
             "The `keyfile`, `certfile` parameters are deprecated since Python 3.6; "
             "removed in Python 3.12. Use `context` parameter instead."
         )
         def starttls(
-            self, keyfile: StrOrBytesPath | None = None, certfile: StrOrBytesPath | None = None, context: SSLContext | None = None
+            self, keyfile: StrOrBytesPath | None = None, certfile: StrOrBytesPath | None = None, context: None = None
         ) -> _Reply: ...
 
     def sendmail(
@@ -181,7 +181,8 @@ class SMTP_SSL(SMTP):
             host: str = "",
             port: int = 0,
             local_hostname: str | None = None,
-            *,
+            keyfile: None = None,
+            certfile: None = None,
             timeout: float = ...,
             source_address: _SourceAddress | None = None,
             context: SSLContext | None = None,
@@ -200,7 +201,7 @@ class SMTP_SSL(SMTP):
             certfile: StrOrBytesPath | None = None,
             timeout: float = ...,
             source_address: _SourceAddress | None = None,
-            context: SSLContext | None = None,
+            context: None = None,
         ) -> None: ...
         keyfile: StrOrBytesPath | None
         certfile: StrOrBytesPath | None


### PR DESCRIPTION
Source: https://github.com/python/cpython/pull/94173
\+ Use `StrOrBytesPath` for them