### PR TITLE
Add secrets.DEFAULT_ENTROPY

### DIFF
--- a/stdlib/secrets.pyi
+++ b/stdlib/secrets.pyi
@@ -1,11 +1,13 @@
 from _typeshed import SupportsLenAndGetItem
 from hmac import compare_digest as compare_digest
 from random import SystemRandom as SystemRandom
-from typing import TypeVar
+from typing import Final, TypeVar
 
 __all__ = ["choice", "randbelow", "randbits", "SystemRandom", "token_bytes", "token_hex", "token_urlsafe", "compare_digest"]
 
 _T = TypeVar("_T")
+
+DEFAULT_ENTROPY: Final[int]
 
 def randbelow(exclusive_upper_bound: int) -> int: ...
 def randbits(k: int) -> int: ...


### PR DESCRIPTION
`secrets.DEFAULT_ENTROPY` is not documented (despite [a completed issue requesting documentation](https://github.com/python/cpython/issues/78134)) or included in `__all__`, but still very useful because it allows requesting a random value with at least as much entropy as Python recommends. 