### PR TITLE
Add comment indicating default value of `format` parameter in `typing.get_type_hints()`

### DIFF
--- a/stdlib/typing.pyi
+++ b/stdlib/typing.pyi
@@ -952,7 +952,7 @@ if sys.version_info >= (3, 14):
         localns: Mapping[str, Any] | None = None,
         include_extras: bool = False,
         *,
-        format: Format = Format.VALUE,
+        format: Format | None = None,  # Default: Format.VALUE
     ) -> dict[str, Any]: ...  # AnnotationForm
 
 else:


### PR DESCRIPTION
The runtime definition only has a default of `None` to lazily import `annotationlib`: https://github.com/python/cpython/blob/66e1399311c17684c6e26f5d9d9603fbd0717d0d/Lib/typing.py#L2365-L2367.

While providing `None` explicitly is technically valid, it's best to have the value present in the stub so that users can easily know the default value.