### PR TITLE
[httplib2] Update to 0.31.1

### DIFF
--- a/stubs/httplib2/METADATA.toml
+++ b/stubs/httplib2/METADATA.toml
@@ -1,2 +1,2 @@
-version = "0.31.*"
+version = "0.31.1"
 upstream_repository = "https://github.com/httplib2/httplib2"

--- a/stubs/httplib2/httplib2/auth.pyi
+++ b/stubs/httplib2/httplib2/auth.pyi
@@ -16,4 +16,3 @@ scheme: Incomplete
 challenge: Incomplete
 authentication_info: Incomplete
 www_authenticate: Incomplete
-downcaseTokens: Incomplete


### PR DESCRIPTION
Closes: #15276
Release: https://pypi.org/project/httplib2/0.31.1/
Diff: https://github.com/httplib2/httplib2/compare/v0.31.0...v0.31.1