### PR TITLE
`tensorflow`: add `tf.keras.metrics.MeanSquaredError`

### DIFF
--- a/stubs/tensorflow/tensorflow/keras/metrics.pyi
+++ b/stubs/tensorflow/tensorflow/keras/metrics.pyi
@@ -109,6 +109,9 @@ class SparseTopKCategoricalAccuracy(MeanMetricWrapper):
         self, k: int = 5, name: str | None = "sparse_top_k_categorical_accuracy", dtype: DTypeLike | None = None
     ) -> None: ...
 
+class MeanSquaredError(MeanMetricWrapper):
+    def __init__(self, name: str | None = "mean_squared_error", dtype: DTypeLike | None = None) -> None: ...
+
 # TODO: Actually tensorflow.python.keras.utils.metrics_utils.Reduction, but that module
 # is currently missing from the stub.
 @type_check_only


### PR DESCRIPTION
[Documentation link](https://www.tensorflow.org/api_docs/python/tf/keras/metrics/MeanSquaredError)
[Implementation link](https://github.com/keras-team/keras/tree/v3.3.3/keras/src/metrics/regression_metrics.py#L16-L44)