### PR TITLE
Make `socketpair` not support `type: SocketType`

### DIFF
--- a/stdlib/socket.pyi
+++ b/stdlib/socket.pyi
@@ -1409,7 +1409,7 @@ if sys.platform == "win32":
 
 else:
     def socketpair(
-        family: int | AddressFamily | None = None, type: SocketType | int = ..., proto: int = 0
+        family: int | AddressFamily | None = None, type: SocketKind | int = ..., proto: int = 0
     ) -> tuple[socket, socket]: ...
 
 class SocketIO(RawIOBase):


### PR DESCRIPTION
More specifically, sync `socketpair`'s `type` parameter with `socket.__init__` and `fromfd`. (Adding `SocketKind` into the union is not necessary, but it probably makes for a clearer signature in an IDE.)

Closes #15283.