### PR TITLE
[yt-dlp] Make _Params["playlist_items"] a str

### DIFF
--- a/stubs/yt-dlp/yt_dlp/__init__.pyi
+++ b/stubs/yt-dlp/yt_dlp/__init__.pyi
@@ -210,7 +210,7 @@ class _Params(TypedDict, total=False):
     download_ranges: Callable[[Any, YoutubeDL], Iterator[_DownloadRange]] | None
     force_keyframes_at_cuts: bool | None
     list_thumbnails: str | None
-    playlist_items: Collection[int] | None
+    playlist_items: str | None
     match_filter: NotRequired[Callable[[Mapping[str, Any], bool], str | None] | Callable[[Mapping[str, Any]], str | None] | None]
     color: _Color | None
     ffmpeg_location: str | None


### PR DESCRIPTION
The `playlist_items` is always passed to `PlaylistEntries.parse_playlist_items` which expects a string input.