### PR TITLE
Use stricter pyright settings when checking `ephem` in CI

### DIFF
--- a/pyrightconfig.stricter.json
+++ b/pyrightconfig.stricter.json
@@ -34,7 +34,6 @@
         "stubs/defusedxml",
         "stubs/docker",
         "stubs/docutils",
-        "stubs/ephem",
         "stubs/Flask-SocketIO",
         "stubs/fpdf2",
         "stubs/gdb",


### PR DESCRIPTION
it's fully annotated