### PR TITLE
Style and formatting docs fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -344,20 +344,20 @@ the latest mypy (`pip install -r requirements-tests.txt`) before running the scr
 
 ### Supported type system features
 
-Since PEP 484 was accepted, there have been many other PEPs that added
-new features to the Python type system. In general, new features can
-be used in typeshed as soon as the PEP has been accepted and implemented
-and most type checkers support the new feature.
+Since [PEP 484](https://peps.python.org/pep-0484/) was accepted, there have been
+many other PEPs that added new features to the Python type system. In general,
+new features can be used in typeshed as soon as the PEP has been accepted and
+implemented and most type checkers support the new feature.
 
 Supported features include:
-- [PEP 544](https://peps.python.org/pep-0544/) (Protocol)
+- [PEP 544](https://peps.python.org/pep-0544/) (`Protocol`)
 - [PEP 585](https://peps.python.org/pep-0585/) (builtin generics)
-- [PEP 586](https://peps.python.org/pep-0586/) (Literal)
-- [PEP 591](https://peps.python.org/pep-0591/) (Final/@final)
-- [PEP 589](https://peps.python.org/pep-0589/) (TypedDict)
+- [PEP 586](https://peps.python.org/pep-0586/) (`Literal`)
+- [PEP 591](https://peps.python.org/pep-0591/) (`Final`/`@final`)
+- [PEP 589](https://peps.python.org/pep-0589/) (`TypedDict`)
 - [PEP 604](https://peps.python.org/pep-0604/) (`Foo | Bar` union syntax)
-- [PEP 612](https://peps.python.org/pep-0612/) (ParamSpec)
-- [PEP 647](https://peps.python.org/pep-0647/) (TypeGuard):
+- [PEP 612](https://peps.python.org/pep-0612/) (`ParamSpec`)
+- [PEP 647](https://peps.python.org/pep-0647/) (`TypeGuard`):
   see [#5406](https://github.com/python/typeshed/issues/5406)
 - [PEP 655](https://peps.python.org/pep-0655/) (`Required` and `NotRequired`)
 - [PEP 673](https://peps.python.org/pep-0673/) (`Self`)

--- a/tests/README.md
+++ b/tests/README.md
@@ -22,17 +22,17 @@ may require extra dependencies external to typeshed to be installed in your virt
 prior to running the test.
 You can list or install all of a stubs package's external dependencies using the following script:
 ```bash
-(.venv3)$ python tests/get_external_stub_requirements.py <third_party_stub>  # List external dependencies for <third_party_stub>
-(.venv3)$ python tests/get_external_stub_requirements.py <third_party_stub1> <third_party_stub2>  # List external dependencies for <third_party_stub1> and <third_party_stub2>
-(.venv3)$ python tests/get_external_stub_requirements.py  # List external dependencies for all third-party stubs in typeshed
-(.venv3)$ python scripts/install_all_third_party_dependencies.py  # Install external dependencies for all third-party stubs in typeshed
+(.venv)$ python tests/get_external_stub_requirements.py <third_party_stub>  # List external dependencies for <third_party_stub>
+(.venv)$ python tests/get_external_stub_requirements.py <third_party_stub1> <third_party_stub2>  # List external dependencies for <third_party_stub1> and <third_party_stub2>
+(.venv)$ python tests/get_external_stub_requirements.py  # List external dependencies for all third-party stubs in typeshed
+(.venv)$ python scripts/install_all_third_party_dependencies.py  # Install external dependencies for all third-party stubs in typeshed
 ```
 
 ## Run all tests for a specific stub
 
 Run using:
 ```bash
-(.venv3)$ python3 tests/runtests.py <stdlib-or-stubs>/<stub-to-test>
+(.venv)$ python3 tests/runtests.py <stdlib-or-stubs>/<stub-to-test>
 ```
 
 This script will run all tests below for a specific typeshed directory. If a
@@ -52,7 +52,7 @@ For more information, see the docs on [`stubtest_stdlib.py`](#stubtest_stdlibpy)
 
 Run using:
 ```bash
-(.venv3)$ python3 tests/mypy_test.py
+(.venv)$ python3 tests/mypy_test.py
 ```
 
 The test has two parts: running mypy on the stdlib stubs,
@@ -71,9 +71,9 @@ This test requires [Node.js](https://nodejs.org) to be installed. Although
 typeshed runs pyright in CI, it does not currently use this script. However,
 this script uses the same pyright version and configuration as the CI.
 ```bash
-(.venv3)$ python3 tests/pyright_test.py                                # Check all files
-(.venv3)$ python3 tests/pyright_test.py stdlib/sys.pyi                 # Check one file
-(.venv3)$ python3 tests/pyright_test.py -p pyrightconfig.stricter.json # Check with the stricter config.
+(.venv)$ python3 tests/pyright_test.py                                # Check all files
+(.venv)$ python3 tests/pyright_test.py stdlib/sys.pyi                 # Check one file
+(.venv)$ python3 tests/pyright_test.py -p pyrightconfig.stricter.json # Check with the stricter config.
 ```
 
 `pyrightconfig.stricter.json` is a stricter configuration that enables additional
@@ -103,7 +103,7 @@ $ python3 tests/check_typeshed_structure.py
 
 Run using
 ```bash
-(.venv3)$ python3 tests/stubtest_stdlib.py
+(.venv)$ python3 tests/stubtest_stdlib.py
 ```
 
 This test compares the stdlib stubs against the objects at runtime. Because of
@@ -138,7 +138,7 @@ stubtest on.
 
 Run using
 ```bash
-(.venv3)$ python3 tests/stubtest_third_party.py
+(.venv)$ python3 tests/stubtest_third_party.py
 ```
 
 Similar to `stubtest_stdlib.py`, but tests the third party stubs. By default,
@@ -146,13 +146,13 @@ it checks all third-party stubs, but you can provide the distributions to
 check on the command line:
 
 ```bash
-(.venv3)$ python3 tests/stubtest_third_party.py requests toml  # check stubs/requests and stubs/toml
+(.venv)$ python3 tests/stubtest_third_party.py requests toml  # check stubs/requests and stubs/toml
 ```
 
 If you have the runtime package installed in your local virtual environment, you can also run stubtest
 directly, with
 ```bash
-(.venv3)$ MYPYPATH=<path-to-module-stubs> python3 -m mypy.stubtest \
+(.venv)$ MYPYPATH=<path-to-module-stubs> python3 -m mypy.stubtest \
   --custom-typeshed-dir <path-to-typeshed> \
   <third-party-module>
 ```
@@ -203,7 +203,7 @@ configuration to properly validate Django-specific types during stubtest executi
 
 Run using
 ```bash
-(.venv3)$ python3 tests/typecheck_typeshed.py
+(.venv)$ python3 tests/typecheck_typeshed.py
 ```
 
 This is a small wrapper script that uses mypy to typecheck typeshed's own code in the

--- a/tests/REGRESSION.md
+++ b/tests/REGRESSION.md
@@ -99,8 +99,9 @@ rather than `.pyi` files)
 is that the test cases cannot always use modern syntax for type hints.
 While we can use `from __future__ import annotations` to enable the use of
 modern typing syntax wherever possible,
-type checkers may (correctly) emit errors if PEP 604 syntax or PEP 585 syntax
-is used in a runtime context on lower versions of Python. For example:
+type checkers may (correctly) emit errors if [PEP 604](https://peps.python.org/pep-0604/)
+syntax or [PEP 585](https://peps.python.org/pep-0585/) syntax is used
+in a runtime context on lower versions of Python. For example:
 
 ```python
 from __future__ import annotations


### PR DESCRIPTION
* Adds PEP links for more context
* Normalizes the virtualenv name from `.venv3` to `.venv` (the [documentation suggests](https://github.com/python/typeshed/blob/main/CONTRIBUTING.md#-or-create-a-local-development-environment) creating a `.venv` name, not `.venv3`so `venv3` is not used anywhere else)