### PR TITLE
`tensorflow`: add `tf.tile`

### DIFF
--- a/stubs/tensorflow/tensorflow/__init__.pyi
+++ b/stubs/tensorflow/tensorflow/__init__.pyi
@@ -26,6 +26,7 @@ from tensorflow._aliases import (
     AnyArray,
     DTypeLike,
     IntArray,
+    RaggedTensorLike,
     ScalarTensorCompatible,
     ShapeLike,
     Slice,
@@ -448,4 +449,5 @@ def transpose(
 def clip_by_value(
     t: Tensor | IndexedSlices, clip_value_min: TensorCompatible, clip_value_max: TensorCompatible, name: str | None = None
 ) -> Tensor: ...
+def tile(input: RaggedTensorLike, multiples: Tensor, name: str | None = None) -> Tensor: ...
 def __getattr__(name: str): ...  # incomplete module


### PR DESCRIPTION
[Documentation link](https://www.tensorflow.org/api_docs/python/tf/tile)

I searched for the implementation code, but did not find it. 
I found [this function](https://github.com/tensorflow/tensorflow/blob/5f41a3190a68bfd3059044c6b8abf28af0a32e25/tensorflow/python/ops/ragged/ragged_array_ops.py#L218), I don't know if that's the correct one, but I tested with a ragged tensor input and the code executed without issue.