### PR TITLE
`tensorflow`: add `Activation`, `GlobalAveragePooling2D` and `MaxPool2D` layers

### DIFF
--- a/stubs/tensorflow/tensorflow/keras/layers/__init__.pyi
+++ b/stubs/tensorflow/tensorflow/keras/layers/__init__.pyi
@@ -471,4 +471,20 @@ class GlobalAveragePooling2D(Layer[tf.Tensor, tf.Tensor]):
         name: str | None = None,
     ) -> None: ...
 
+class MaxPool2D(Layer[tf.Tensor, tf.Tensor]):
+    def __init__(
+        self,
+        pool_size: int | tuple[int, int] = (2, 2),
+        strides: int | tuple[int, int] | None = None,
+        padding: Literal["valid", "same"] = "valid",
+        data_format: Literal["channels_last", "channels_first"] | None = None,
+        *,
+        # **kwargs passed to Layer
+        activity_regularizer: _Regularizer = None,
+        trainable: bool = True,
+        dtype: _LayerDtype | None = None,
+        autocast: bool = True,
+        name: str | None = None,
+    ) -> None: ...
+
 def __getattr__(name: str): ...  # incomplete module


### PR DESCRIPTION
This PR adds the following layers:

- [Activation](https://www.tensorflow.org/api_docs/python/tf/keras/layers/Activation)
- [GlobalAveragePooling2D](https://www.tensorflow.org/api_docs/python/tf/keras/layers/GlobalAveragePooling2D)
- [MaxPool2D](https://www.tensorflow.org/api_docs/python/tf/keras/layers/MaxPool2D)

Since the layers already present are not inheriting from `Operation`, I did not add it here either.