### PR TITLE
Use stricter pyright settings when testing `punq` in CI

### DIFF
--- a/pyrightconfig.stricter.json
+++ b/pyrightconfig.stricter.json
@@ -74,7 +74,6 @@
         "stubs/protobuf",
         "stubs/psutil/psutil/__init__.pyi",
         "stubs/psycopg2",
-        "stubs/punq",
         "stubs/pyasn1",
         "stubs/pycurl",
         "stubs/Pygments",


### PR DESCRIPTION
Fixes https://github.com/AlexWaygood/typeshed-stats/issues/424, fixes https://github.com/AlexWaygood/typeshed-stats/issues/423, fixes https://github.com/AlexWaygood/typeshed-stats/issues/422