### PR TITLE
Use contravariant type variable rather than `object` in `Container`

### DIFF
--- a/stdlib/typing.pyi
+++ b/stdlib/typing.pyi
@@ -403,7 +403,6 @@ _S = TypeVar("_S")
 _KT = TypeVar("_KT")  # Key type.
 _VT = TypeVar("_VT")  # Value type.
 _T_co = TypeVar("_T_co", covariant=True)  # Any type covariant containers.
-_T_contra = TypeVar("_T_contra", contravariant=True, default=Any)  # Any type contravariant containers.
 _KT_co = TypeVar("_KT_co", covariant=True)  # Key type covariant containers.
 _VT_co = TypeVar("_VT_co", covariant=True)  # Value type covariant containers.
 _TC = TypeVar("_TC", bound=type[object])
@@ -641,10 +640,13 @@ class AsyncGenerator(AsyncIterator[_YieldT_co], Protocol[_YieldT_co, _SendT_cont
     ) -> Coroutine[Any, Any, _YieldT_co]: ...
     def aclose(self) -> Coroutine[Any, Any, None]: ...
 
+_ContainerT_contra = TypeVar("_ContainerT_contra", contravariant=True, default=Any)
+
 @runtime_checkable
-class Container(Protocol[_T_contra]):
+class Container(Protocol[_ContainerT_contra]):
+    # This is generic more on vibes than anything else
     @abstractmethod
-    def __contains__(self, x: _T_contra, /) -> bool: ...
+    def __contains__(self, x: _ContainerT_contra, /) -> bool: ...
 
 @runtime_checkable
 class Collection(Iterable[_T_co], Container[Any], Protocol[_T_co]):


### PR DESCRIPTION
Fixes https://github.com/python/typeshed/issues/15307

See Also: #15319

This PR changes the generic type of `collections.abc.Container` from `covariant` to `contravariant` and lets the `key` be of this type rather than `object`.

The current definition [forces a lot ofpeople to resort to `type: ignore[override]`](https://github.com/search?q=%2Fdef+__contains__%5C%28self%2C+%5Cw%2B%3A+%5Cw%2B%5C%29+-%3E+%5Cw%2B%3A%5Cx20%2B%5C%23+type%3A+ignore%2F+language%3APython+&type=code).


## Potential Backward Compatibility issue

The way I modified the class, if someone uses something like

```python
class MyClass[T](Iterable[T], Container[T]): ...
```

This change will make their class invariant, where it was covariant before.
Inside `collections.abc.Collection` I addressed this issue by changing `Container[_T_co]` to `Container[Any]`.

There weren't any other cases in the whole stubs where a type variable was fed into `Container`, so I believe the breakage in real world code will be extremely limited (as the user also would have have to use PEP 695 style syntax)
