### PR TITLE
[gunicorn] Revert * to patch version

### DIFF
--- a/stubs/gunicorn/@tests/stubtest_allowlist.txt
+++ b/stubs/gunicorn/@tests/stubtest_allowlist.txt
@@ -3,3 +3,7 @@ gunicorn._types
 
 # .pyi file doesn't exist
 gunicorn.__main__
+
+# Internal API stuff:
+gunicorn.config.Config.forwarded_allow_networks
+gunicorn.config.Config.proxy_allow_networks

--- a/stubs/gunicorn/METADATA.toml
+++ b/stubs/gunicorn/METADATA.toml
@@ -1,4 +1,4 @@
-version = "24.1.0"
+version = "24.1.*"
 upstream_repository = "https://github.com/benoitc/gunicorn"
 requires = ["types-gevent"]
 


### PR DESCRIPTION
Diff: https://github.com/benoitc/gunicorn/compare/24.1.0...24.1.1

Apparently I was hasty in calling these new methods "public api changes" (in https://github.com/python/typeshed/pull/15323#issue-3853066823), since judging by the [docstrings](https://github.com/benoitc/gunicorn/blob/bbae34b951c27495bd0d91bafa353b55001d8116/gunicorn/config.py#L180), these are methods for internal use.