### PR TITLE
Update outdated upstream_repository fields

### DIFF
--- a/stubs/Authlib/METADATA.toml
+++ b/stubs/Authlib/METADATA.toml
@@ -1,3 +1,3 @@
 version = "1.6.6"
-upstream_repository = "https://github.com/lepture/authlib"
+upstream_repository = "https://github.com/authlib/authlib"
 requires = ["cryptography"]

--- a/stubs/Deprecated/METADATA.toml
+++ b/stubs/Deprecated/METADATA.toml
@@ -1,3 +1,3 @@
 version = "~=1.3.1"
-upstream_repository = "https://github.com/tantale/deprecated"
+upstream_repository = "https://github.com/laurent-laporte-pro/deprecated"
 requires = []

--- a/stubs/fpdf2/METADATA.toml
+++ b/stubs/fpdf2/METADATA.toml
@@ -1,5 +1,5 @@
 version = "2.8.4"
-upstream_repository = "https://github.com/PyFPDF/fpdf2"
+upstream_repository = "https://github.com/py-pdf/fpdf2"
 requires = ["Pillow>=10.3.0"]
 
 [tool.stubtest]

--- a/stubs/netaddr/METADATA.toml
+++ b/stubs/netaddr/METADATA.toml
@@ -1,2 +1,2 @@
 version = "1.3.*"
-upstream_repository = "https://github.com/drkjam/netaddr"
+upstream_repository = "https://github.com/netaddr/netaddr"

--- a/stubs/ttkthemes/METADATA.toml
+++ b/stubs/ttkthemes/METADATA.toml
@@ -1,2 +1,2 @@
 version = "3.3.*"
-upstream_repository = "https://github.com/RedFantom/ttkthemes"
+upstream_repository = "https://github.com/TkinterEP/ttkthemes"

--- a/stubs/www-authenticate/METADATA.toml
+++ b/stubs/www-authenticate/METADATA.toml
@@ -1,2 +1,2 @@
 version = "0.9.*"
-upstream_repository = "https://github.com/alexsdutton/www-authenticate"
+upstream_repository = "https://github.com/alexdutton/www-authenticate"


### PR DESCRIPTION
I think this can be automated using stubsabot (or maybe there are more suitable places), but I don't know how others will rate the idea of ​​automating this process.