### PR TITLE
jsonschema: fix type of validator on errors

### DIFF
--- a/stubs/jsonschema/jsonschema/exceptions.pyi
+++ b/stubs/jsonschema/jsonschema/exceptions.pyi
@@ -6,7 +6,6 @@ from typing_extensions import Self, TypeAlias, deprecated
 
 from ._types import TypeChecker
 from ._utils import Unset
-from .protocols import Validator
 
 _RelevanceFuncType: TypeAlias = Callable[[ValidationError], SupportsRichComparison]
 


### PR DESCRIPTION
I noticed this while improving mypy's reachability analysis in https://github.com/python/mypy/pull/20660 (because the type of validator is wrong, mypy would think some code is unreachable)

Source: https://github.com/python-jsonschema/jsonschema/blob/c4f8b68cb0b826fcb770c28b5296dacfbca1367c/jsonschema/exceptions.py#L58 I also checked some downstream uses of it