### PR TITLE
[gdb] Make a Value's address have type Value | None

### DIFF
--- a/stubs/gdb/gdb/__init__.pyi
+++ b/stubs/gdb/gdb/__init__.pyi
@@ -76,7 +76,7 @@ _ValueOrInt: TypeAlias = Value | int
 
 @disjoint_base
 class Value:
-    address: Value
+    address: Value | None
     is_optimized_out: bool
     type: Type
     dynamic_type: Type


### PR DESCRIPTION
Which is consistent with the GDB documentation:

https://sourceware.org/gdb/current/onlinedocs/gdb.html/Values-From-Inferior.html#Values-From-Inferior:~:text=Variable%3A%20Value%2Eaddress

<img width="1414" height="106" alt="image" src="https://github.com/user-attachments/assets/58b253d8-846b-42fd-a9ba-4791e0b7865f" />

related: https://sourceware.org/bugzilla/show_bug.cgi?id=33860