### PR TITLE
Update some tarfile.TarFile class attributes to be non-optional

### DIFF
--- a/stdlib/tarfile.pyi
+++ b/stdlib/tarfile.pyi
@@ -119,16 +119,16 @@ class TarFile:
     OPEN_METH: ClassVar[Mapping[str, str]]
     name: StrOrBytesPath | None
     mode: Literal["r", "a", "w", "x"]
-    fileobj: _Fileobj | None
-    format: _TarFormat | None
+    fileobj: _Fileobj
+    format: _TarFormat
     tarinfo: type[TarInfo]
-    dereference: bool | None
-    ignore_zeros: bool | None
-    encoding: str | None
+    dereference: bool
+    ignore_zeros: bool
+    encoding: str
     errors: str
     fileobject: type[ExFileObject]  # undocumented
     pax_headers: Mapping[str, str]
-    debug: int | None
+    debug: int
     errorlevel: int
     offset: int  # undocumented
     extraction_filter: _FilterFunction | None


### PR DESCRIPTION
#### Summary
The following `tarfile.TarFile` attributes are changed to non-optional:
```
    debug: int
    dereference: bool
    encoding: str
    fileobj: _Fileobj
    format: _TarFormat
    ignore_zeros: bool
```

#### References
- `fileobj` is set unconditionally in the constructor and never cleared:
   - Tip of main when writing this PR: https://github.com/python/cpython/blob/93b27e7f6d185efd5163d04fcdae8436ebf69144/Lib/tarfile.py#L1743-L1758
   - 3.14: https://github.com/python/cpython/blob/360214e25742181c1970fb7cc12e8707638233d2/Lib/tarfile.py#L1744-L1759
   - 3.13: https://github.com/python/cpython/blob/cc1f81bb4577235c99e9a8e6671834c18cc8b304/Lib/tarfile.py#L1733-L1748
   - 3.12: https://github.com/python/cpython/blob/276b9f2ea2da29313619eacfc677e6e907a67889/Lib/tarfile.py#L1712-L1727
   - 3.11: https://github.com/python/cpython/blob/11a1e4e07924089c5fd9987306fa9dbdc78ef56a/Lib/tarfile.py#L1711-L1726
   - 3.10: https://github.com/python/cpython/blob/e3109d6267cb78b534ca22681230dfb06f4c127c/Lib/tarfile.py#L1710-L1725

- `debug`, `dereference`, `encoding`, `format`, `ignore_zeros` are all set as class level attributes, and only overwritten as instance attributes if the user passes a non-`None` override.
  - Setting of class attributes:
    - Tip of main when writing this PR: https://github.com/python/cpython/blob/93b27e7f6d185efd5163d04fcdae8436ebf69144/Lib/tarfile.py#L1701-L1723
    - 3.14: https://github.com/python/cpython/blob/360214e25742181c1970fb7cc12e8707638233d2/Lib/tarfile.py#L1702-L1724
    - 3.13: https://github.com/python/cpython/blob/cc1f81bb4577235c99e9a8e6671834c18cc8b304/Lib/tarfile.py#L1691-L1713
    - 3.12: https://github.com/python/cpython/blob/276b9f2ea2da29313619eacfc677e6e907a67889/Lib/tarfile.py#L1670-L1692
    - 3.11: https://github.com/python/cpython/blob/11a1e4e07924089c5fd9987306fa9dbdc78ef56a/Lib/tarfile.py#L1669-L1691
    - 3.10: https://github.com/python/cpython/blob/e3109d6267cb78b534ca22681230dfb06f4c127c/Lib/tarfile.py#L1668-L1690

  - Overwriting with constructor parameters:
    - Tip of main when writing this PR: https://github.com/python/cpython/blob/93b27e7f6d185efd5163d04fcdae8436ebf69144/Lib/tarfile.py#L1762-L1783
    - 3.14: https://github.com/python/cpython/blob/360214e25742181c1970fb7cc12e8707638233d2/Lib/tarfile.py#L1763-L1784
    - 3.13: https://github.com/python/cpython/blob/cc1f81bb4577235c99e9a8e6671834c18cc8b304/Lib/tarfile.py#L1752-L1773
    - 3.12: https://github.com/python/cpython/blob/276b9f2ea2da29313619eacfc677e6e907a67889/Lib/tarfile.py#L1729-L1750
    - 3.11: https://github.com/python/cpython/blob/11a1e4e07924089c5fd9987306fa9dbdc78ef56a/Lib/tarfile.py#L1728-L1749
    - 3.10: https://github.com/python/cpython/blob/e3109d6267cb78b534ca22681230dfb06f4c127c/Lib/tarfile.py#L1727-L1748
  

Note:
This is my first PR on this project so I'm not sure about the expectations, let me know if I need to check additional versions supported by typeshed or if the PR should be split up somehow.