### PR TITLE
[stdlib] Allow FileHandler.stream to be None

### DIFF
--- a/stdlib/@tests/test_cases/check_logging.py
+++ b/stdlib/@tests/test_cases/check_logging.py
@@ -1,12 +1,10 @@
 from __future__ import annotations
 
-import io
 import logging
 import logging.handlers
 import multiprocessing
 import queue
-from typing import Any, Union
-from typing_extensions import assert_type
+from typing import Any
 
 # This pattern comes from the logging docs, and should therefore pass a type checker
 # See https://docs.python.org/3/library/logging.html#logrecord-objects
@@ -30,7 +28,3 @@ logging.handlers.QueueHandler(multiprocessing.Queue())
 logging.handlers.QueueListener(queue.Queue())
 logging.handlers.QueueListener(queue.SimpleQueue())
 logging.handlers.QueueListener(multiprocessing.Queue())
-
-# FileHandler.stream can be None when delay=True or after close()
-fh = logging.FileHandler("test.log", delay=True)
-assert_type(fh.stream, Union[io.TextIOWrapper, None])


### PR DESCRIPTION
## Summary                                           
- Override `FileHandler.stream` type to `TextIOWrapper | None` to reflect CPython's actual behavior                                                                                                              
- `FileHandler` sets `self.stream = None` in two code paths:                                                                                                                                                   
  - [`delay=True` in `__init__`](https://github.com/python/cpython/blob/25e99b375d959d2a2eb78d25f592a68455532c9a/Lib/logging/__init__.py#L1214)                                                                  
  - [after `close()`](https://github.com/python/cpython/blob/25e99b375d959d2a2eb78d25f592a68455532c9a/Lib/logging/__init__.py#L1229)                                                                             
- Added `assert_type` test for the new type in `check_logging.py`                                                                                                                                                
