### PR TITLE
Match getaddrinfo() port types in create_connection()

### DIFF
--- a/stdlib/socket.pyi
+++ b/stdlib/socket.pyi
@@ -1427,7 +1427,7 @@ def getfqdn(name: str = "") -> str: ...
 
 if sys.version_info >= (3, 11):
     def create_connection(
-        address: tuple[str | None, int],
+        address: tuple[str | None, bytes | str | int | None],
         timeout: float | None = ...,
         source_address: _Address | None = None,
         *,


### PR DESCRIPTION
Inside `create_connection()` port is passed to `getaddrinfo()` so the types should match.