### PR TITLE
Remove explicit target-version field for ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,6 @@ skip-magic-trailing-comma = true
 
 [tool.ruff]
 line-length = 130
-# Oldest supported Python version
-target-version = "py39"
 fix = true
 exclude = [
     # virtual environment


### PR DESCRIPTION
This is inferred from project.requires-python