### PR TITLE
[libsass] Mark as no longer updated

### DIFF
--- a/stubs/libsass/METADATA.toml
+++ b/stubs/libsass/METADATA.toml
@@ -1,7 +1,8 @@
 version = "0.23.*"
 requires = ["types-setuptools"]
 upstream_repository = "https://github.com/sass/libsass-python"
+no_longer_updated = true
 
 [tool.stubtest]
 # The runtime package has an undeclared dependency on setuptools
-stubtest_requirements = ["setuptools"]
+stubtest_requirements = ["setuptools<82"]


### PR DESCRIPTION
Fix stubtest setuptools dependency

Part of #15410

Closes #15409
