### PR TITLE
[django-filter] fix return type for MultipleChoiceFilter.get_filter_predicate

### DIFF
--- a/stubs/django-filter/django_filters/filters.pyi
+++ b/stubs/django-filter/django_filters/filters.pyi
@@ -2,7 +2,7 @@ from collections.abc import Callable, Iterable
 from typing import Any
 
 from django import forms
-from django.db.models import Q, QuerySet
+from django.db.models import QuerySet
 from django.forms import Field
 from django_stubs_ext import StrOrPromise
 


### PR DESCRIPTION
@intgr @huynguyengl99 @srittau 

``MultipleChoiceFilter.get_filter_predicate`` is type hinted to return a Q object, but [the implementation](https://github.com/carltongibson/django-filter/blob/31b297ca2414218052476ba458c4d1eedc0a0f99/django_filters/filters.py#L276-L283) returns a dictionary that maps strings to any predicate value - [which is then used in the code to create Q objects](https://github.com/carltongibson/django-filter/blob/31b297ca2414218052476ba458c4d1eedc0a0f99/django_filters/filters.py#L265-L269). This PR fixes the descrepancy.