### PR TITLE
docs: update PEP 561 link to HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ you can install the type stubs using
 $ pip install types-html5lib types-requests
 ```
 
-These PyPI packages follow [PEP 561](https://peps.python.org/pep-0561/)
+These PyPI packages follow [PEP 561](https://typing.python.org/en/latest/spec/distributing.html)
 and are automatically released (up to once a day) by
 [typeshed internal machinery](https://github.com/typeshed-internal/stub_uploader).
 


### PR DESCRIPTION
Update PEP 561 reference to use canonical HTTPS URL (https://peps.python.org/pep-0561/).

Security best practice - all python.org links should use HTTPS.