### PR TITLE
Make `filename`, `stream`, and `handlers` parameters of `logging.basicConfig` mutually-exclusive

### DIFF
--- a/stdlib/@tests/test_cases/check_logging.py
+++ b/stdlib/@tests/test_cases/check_logging.py
@@ -42,7 +42,13 @@ logging.basicConfig(filename="foo.log", filemode="w")
 logging.basicConfig(filename="foo.log", filemode="w", handlers=None)
 logging.basicConfig(stream=None)
 logging.basicConfig(stream=None, handlers=None)
-# 'filemode' is inert when 'filename' is not passed, but is accepted if 'handlers=None'.
-logging.basicConfig(filemode="w", stream=None)
 # dubious but accepted, has same meaning as 'stream=None'.
 logging.basicConfig(filename=None)
+# These are technically accepted at runtime, but are forbidden in the stubs to help
+# prevent user mistakes. Passing 'filemode' / 'encoding' / 'errors' does nothing
+# if 'filename' is not specified.
+logging.basicConfig(stream=None, filemode="w")  # type: ignore
+logging.basicConfig(stream=None, encoding="utf-8")  # type: ignore
+logging.basicConfig(stream=None, errors="strict")  # type: ignore
+logging.basicConfig(handlers=[], encoding="utf-8")  # type: ignore
+logging.basicConfig(handlers=[], errors="strict")  # type: ignore

--- a/stdlib/logging/__init__.pyi
+++ b/stdlib/logging/__init__.pyi
@@ -585,8 +585,6 @@ def basicConfig(
     level: _Level | None = None,
     handlers: Iterable[Handler],
     force: bool | None = False,
-    encoding: str | None = None,
-    errors: str | None = "backslashreplace",
 ) -> None: ...
 @overload  # handlers is None, filename is passed (but possibly None)
 def basicConfig(
@@ -605,7 +603,6 @@ def basicConfig(
 @overload  # handlers is None, filename is not passed
 def basicConfig(
     *,
-    filemode: str = "a",
     format: str = ...,  # default value depends on the value of `style`
     datefmt: str | None = None,
     style: _FormatStyle = "%",
@@ -613,8 +610,6 @@ def basicConfig(
     stream: SupportsWrite[str] | None = None,
     handlers: None = None,
     force: bool | None = False,
-    encoding: str | None = None,
-    errors: str | None = "backslashreplace",
 ) -> None: ...
 def shutdown(handlerList: Sequence[Any] = ...) -> None: ...  # handlerList is undocumented
 def setLoggerClass(klass: type[Logger]) -> None: ...


### PR DESCRIPTION
For reference:
```python
>>> logging.basicConfig(filename="foo.log", handlers=[])
Traceback (most recent call last):
  ...
ValueError: 'stream' or 'filename' should not be specified together with 'handlers'

>>> logging.basicConfig(filename="foo.log", stream=None)
Traceback (most recent call last):
  ...
ValueError: 'stream' and 'filename' should not be specified together

>>> logging.basicConfig(filename="foo.log", filemode="w")
>>> logging.basicConfig(handlers=[], filemode="w")
Traceback (most recent call last):
  ...
ValueError: Unrecognised argument(s): filemode
```
Source: https://github.com/python/cpython/blob/3.14/Lib/logging/__init__.py#L2005
Docs: https://docs.python.org/3/library/logging.html#logging.basicConfig