### PR TITLE
[pyasn1] Fix componentType to accept Asn1Type in SequenceOf

### DIFF
--- a/stubs/ldap3/ldap3/protocol/novell.pyi
+++ b/stubs/ldap3/ldap3/protocol/novell.pyi
@@ -41,7 +41,7 @@ class NmasSetUniversalPasswordResponseValue(Sequence):
     componentType: NamedTypes
 
 class ReplicaList(SequenceOf):
-    componentType: OctetString  # type: ignore[assignment]
+    componentType: OctetString
 
 class ReplicaInfoRequestValue(Sequence):
     tagSet: TagSet

--- a/stubs/ldap3/ldap3/protocol/rfc4511.pyi
+++ b/stubs/ldap3/ldap3/protocol/rfc4511.pyi
@@ -45,10 +45,10 @@ class AttributeValueAssertion(Sequence):
 class MatchingRuleId(LDAPString): ...
 
 class Vals(SetOf):
-    componentType: AttributeValue  # type: ignore[assignment]
+    componentType: AttributeValue
 
 class ValsAtLeast1(SetOf):
-    componentType: AttributeValue  # type: ignore[assignment]
+    componentType: AttributeValue
     subtypeSpec: ConstraintsIntersection
 
 class PartialAttribute(Sequence):
@@ -58,7 +58,7 @@ class Attribute(Sequence):
     componentType: NamedTypes
 
 class AttributeList(SequenceOf):
-    componentType: Attribute  # type: ignore[assignment]
+    componentType: Attribute
 
 class Simple(OctetString):
     tagSet: TagSet
@@ -97,7 +97,7 @@ class URI(LDAPString): ...
 
 class Referral(SequenceOf):
     tagSet: TagSet
-    componentType: URI  # type: ignore[assignment]
+    componentType: URI
 
 class ServerSaslCreds(OctetString):
     tagSet: TagSet
@@ -117,7 +117,7 @@ class Control(Sequence):
 
 class Controls(SequenceOf):
     tagSet: TagSet
-    componentType: Control  # type: ignore[assignment]
+    componentType: Control
 
 class Scope(Enumerated):
     namedValues: NamedValues
@@ -129,7 +129,7 @@ class TypesOnly(Boolean): ...
 class Selector(LDAPString): ...
 
 class AttributeSelection(SequenceOf):
-    componentType: Selector  # type: ignore[assignment]
+    componentType: Selector
 
 class MatchingRule(MatchingRuleId):
     tagSet: TagSet
@@ -161,7 +161,7 @@ class Substring(Choice):
 
 class Substrings(SequenceOf):
     subtypeSpec: ConstraintsIntersection
-    componentType: Substring  # type: ignore[assignment]
+    componentType: Substring
 
 class SubstringFilter(Sequence):
     tagSet: TagSet
@@ -170,12 +170,12 @@ class SubstringFilter(Sequence):
 class And(SetOf):
     tagSet: TagSet
     subtypeSpec: ConstraintsIntersection
-    componentType: Filter  # type: ignore[assignment]
+    componentType: Filter
 
 class Or(SetOf):
     tagSet: TagSet
     subtypeSpec: ConstraintsIntersection
-    componentType: Filter  # type: ignore[assignment]
+    componentType: Filter
 
 class Not(Choice): ...
 
@@ -201,7 +201,7 @@ class Filter(Choice):
     componentType: NamedTypes
 
 class PartialAttributeList(SequenceOf):
-    componentType: PartialAttribute  # type: ignore[assignment]
+    componentType: PartialAttribute
 
 class Operation(Enumerated):
     namedValues: NamedValues
@@ -210,7 +210,7 @@ class Change(Sequence):
     componentType: NamedTypes
 
 class Changes(SequenceOf):
-    componentType: Change  # type: ignore[assignment]
+    componentType: Change
 
 class DeleteOldRDN(Boolean): ...
 
@@ -256,7 +256,7 @@ class SearchRequest(Sequence):
 class SearchResultReference(SequenceOf):
     tagSet: TagSet
     subtypeSpec: ConstraintsIntersection
-    componentType: URI  # type: ignore[assignment]
+    componentType: URI
 
 class SearchResultEntry(Sequence):
     tagSet: TagSet

--- a/stubs/pyasn1/pyasn1/type/base.pyi
+++ b/stubs/pyasn1/pyasn1/type/base.pyi
@@ -126,7 +126,7 @@ AbstractSimpleAsn1Item = SimpleAsn1Type
 
 class ConstructedAsn1Type(Asn1Type):
     strictConstraints: bool
-    componentType: namedtype.NamedTypes | None
+    componentType: namedtype.NamedTypes | Asn1Type | None
     sizeSpec: constraint.ConstraintsIntersection
     def __init__(self, **kwargs) -> None: ...
     def __eq__(self, other): ...

--- a/stubs/pyasn1/pyasn1/type/univ.pyi
+++ b/stubs/pyasn1/pyasn1/type/univ.pyi
@@ -241,13 +241,13 @@ class Enumerated(Integer):
     namedValues: namedval.NamedValues
 
 class SequenceOfAndSetOfBase(base.ConstructedAsn1Type):
-    componentType: namedtype.NamedTypes | None
+    componentType: base.Asn1Type | None
     tagSet: TagSet
     subtypeSpec: constraint.ConstraintsIntersection
     def __init__(
         self,
         *args,
-        componentType: namedtype.NamedTypes | None = ...,
+        componentType: base.Asn1Type | None = ...,
         tagSet: TagSet = ...,
         subtypeSpec: constraint.ConstraintsIntersection = ...,
     ) -> None: ...


### PR DESCRIPTION
## PR Summary
The `componentType` attribute in `SequenceOfAndSetOfBase` was typed as `NamedTypes | None`, but `ASN.1 SEQUENCE OF / SET OF` constructs take a single `Asn1Type` (like `Integer()`), not `NamedTypes`. This caused false positives when subclassing `SequenceOf` with a component type, which is the standard usage shown in pyasn1's own documentation. The fix also removes the `# type: ignore[assignment]` that were added to ldap3 stubs.

Fixes #15369