### PR TITLE
Fix value of `pickle.DEFAULT_PROTOCOL` for Python <3.14

### DIFF
--- a/stdlib/pickle.pyi
+++ b/stdlib/pickle.pyi
@@ -1,3 +1,4 @@
+import sys
 from _pickle import (
     PickleError as PickleError,
     Pickler as Pickler,
@@ -103,7 +104,10 @@ __all__ = [
 ]
 
 HIGHEST_PROTOCOL: Final = 5
-DEFAULT_PROTOCOL: Final = 5
+if sys.version_info >= (3, 14):
+    DEFAULT_PROTOCOL: Final = 5
+else:
+    DEFAULT_PROTOCOL: Final = 4
 
 bytes_types: tuple[type[Any], ...]  # undocumented
 


### PR DESCRIPTION
A fixed `Final` value was added in #14577, but the runtime value varies between versions.

For reference:
```shell
$ uv run --python 3.14 python3 -c 'import pickle; print(pickle.DEFAULT_PROTOCOL)'
5
$ uv run --python 3.13 python3 -c 'import pickle; print(pickle.DEFAULT_PROTOCOL)'
4
```
docs: https://docs.python.org/3/library/pickle.html#pickle.DEFAULT_PROTOCOL
source: https://github.com/python/cpython/blame/main/Lib/pickle.py#L69

