### PR TITLE
Remove values from unstable `opcode` constants

### DIFF
--- a/stdlib/opcode.pyi
+++ b/stdlib/opcode.pyi
@@ -41,7 +41,7 @@ if sys.version_info >= (3, 13):
 opname: Final[list[str]]
 
 opmap: Final[dict[str, int]]
-HAVE_ARGUMENT: Final = 43
-EXTENDED_ARG: Final = 69
+HAVE_ARGUMENT: Final[int]
+EXTENDED_ARG: Final[int]
 
 def stack_effect(opcode: int, oparg: int | None = None, /, *, jump: bool | None = None) -> int: ...


### PR DESCRIPTION
These constants vary unpredictably between major versions.

For reference:
```shell
$ for v in 3.12 3.13 3.14; do
      uv run --python $v python3 -c "import opcode; print(f'$v: {opcode.HAVE_ARGUMENT=} {opcode.EXTENDED_ARG=}')" 
  done
3.12: opcode.HAVE_ARGUMENT=90 opcode.EXTENDED_ARG=144
3.13: opcode.HAVE_ARGUMENT=44 opcode.EXTENDED_ARG=71
3.14: opcode.HAVE_ARGUMENT=43 opcode.EXTENDED_ARG=69
```
Current values were added in #14577.