### PR TITLE
docs: link to canonical PEP 561

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ you can install the type stubs using
 $ pip install types-html5lib types-requests
 ```
 
-These PyPI packages follow [PEP 561](https://peps.python.org/pep-0561/)
+These PyPI packages follow [the typing spec standards](https://typing.python.org/en/latest/spec/distributing.html)
 and are automatically released (up to once a day) by
 [typeshed internal machinery](https://github.com/typeshed-internal/stub_uploader).
 


### PR DESCRIPTION
Fixes the PEP 561 link in README to use the canonical HTTPS URL.