### PR TITLE
Fix stdlib/encodings: expose imported submodules

### DIFF
--- a/stdlib/encodings/__init__.pyi
+++ b/stdlib/encodings/__init__.pyi
@@ -1,4 +1,3 @@
-import codecs as codecs
 import sys
 from codecs import CodecInfo
 


### PR DESCRIPTION
mypy reports a false positive when accessing encodings.aliases.aliases:
```py
import encodings

def get(key: str) -> str:
    return encodings.aliases.aliases.get(key, key)

reveal_type(encodings.aliases.aliases)
```
This produces:
```
main.py:4: error: Returning Any from function declared to return "str"  [no-any-return]
main.py:6: note: Revealed type is "Any"
Found 1 error in 1 file (checked 1 source file)
```

The revealed type of encodings.aliases.aliases is Any, which causes the dict.get() call to return Any and triggers no-any-return.

At runtime, however, encodings imports certain submodules (including aliases) into its namespace:

```py
Python 3.12.3 (main, Jan 22 2026, 20:57:42) [GCC 13.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
Ctrl click to launch VS Code Native REPL
>>> import encodings
>>> dir(encodings)
['CodecRegistryError', '__builtins__', '__cached__', '__doc__', '__file__', '__loader__', '__name__', '__package__', '__path__', '__spec__', '_aliases', '_cache', '_import_tail', '_unknown', 'aliases', 'codecs', 'normalize_encoding', 'search_function', 'sys', 'utf_8']
>>> 
```

p.s. Actually, `utf_8` and `utf_8_sig` appear at runtime, while only `aliases` is explicitly imported in `__init__.py`
