### PR TITLE
[ibm-db] Mark constants as `Final`

### DIFF
--- a/stubs/ibm-db/ibm_db.pyi
+++ b/stubs/ibm-db/ibm_db.pyi
@@ -1,6 +1,7 @@
 from typing import Any, Final, final, overload
 from typing_extensions import Self
 
+__version__: Final[str]
 ATTR_CASE: Final = 3271982
 CASE_LOWER: Final = 1
 CASE_NATURAL: Final = 0


### PR DESCRIPTION
Also
* Add missing `__version__`
* Set literal values for a few constants. These all have hard-coded values and have been stable since being introduced. I sanity-checked the values using stubtest from mypy's master branch, which now checks `Final` values ([python/mypy#20858](https://github.com/python/mypy/pull/20858))
