### PR TITLE
[python-dateutil] dateutil.parser.parse(fuzzy_with_tokens=True) returns a tuple

### DIFF
--- a/stubs/python-dateutil/dateutil/parser/_parser.pyi
+++ b/stubs/python-dateutil/dateutil/parser/_parser.pyi
@@ -88,7 +88,7 @@ class parser:
         dayfirst: bool | None = ...,
         yearfirst: bool | None = ...,
         fuzzy: bool = ...,
-        fuzzy_with_tokens: Literal[False] = ...,
+        fuzzy_with_tokens: Literal[False] = False,
     ) -> datetime: ...
     @overload
     def parse(
@@ -101,7 +101,7 @@ class parser:
         dayfirst: bool | None = ...,
         yearfirst: bool | None = ...,
         fuzzy: bool = ...,
-        fuzzy_with_tokens: Literal[True] = ...,
+        fuzzy_with_tokens: Literal[True],
     ) -> tuple[datetime, tuple[str, ...]]: ...
 
 DEFAULTPARSER: parser
@@ -115,7 +115,7 @@ def parse(
     yearfirst: bool | None = ...,
     ignoretz: bool = ...,
     fuzzy: bool = ...,
-    fuzzy_with_tokens: Literal[False] = ...,
+    fuzzy_with_tokens: Literal[False] = False,
     default: datetime | None = ...,
     tzinfos: _TzInfos | None = ...,
 ) -> datetime: ...
@@ -128,7 +128,7 @@ def parse(
     yearfirst: bool | None = ...,
     ignoretz: bool = ...,
     fuzzy: bool = ...,
-    fuzzy_with_tokens: Literal[True] = ...,
+    fuzzy_with_tokens: Literal[True],
     default: datetime | None = ...,
     tzinfos: _TzInfos | None = ...,
 ) -> tuple[datetime, tuple[str, ...]]: ...


### PR DESCRIPTION
@overload the parse function at module and class level, separate return type for fuzzy_with_tokens: Literal[True] and Literal[False].

Note, not entirely sure this syntax is perfect. mypy is happy locally, but that doesn't check against the upstream library behaviour. Could use a second pair of eyes.

Closes issue https://github.com/python/typeshed/issues/15473

ref:

https://github.com/dateutil/dateutil/blob/e081f6725fbb49cae6eedab7010f517e8490859b/src/dateutil/parser/_parser.py#L702

https://github.com/dateutil/dateutil/blob/e081f6725fbb49cae6eedab7010f517e8490859b/src/dateutil/parser/_parser.py#L871