### PR TITLE
bisect: Allow sequences without __len__ when `hi` is explicitly provided

### DIFF
--- a/stdlib/_bisect.pyi
+++ b/stdlib/_bisect.pyi
@@ -1,5 +1,5 @@
 import sys
-from _typeshed import SupportsLenAndGetItem, SupportsRichComparisonT
+from _typeshed import SupportsGetItem, SupportsLenAndGetItem, SupportsRichComparisonT
 from collections.abc import Callable, MutableSequence
 from typing import TypeVar, overload
 
@@ -17,11 +17,32 @@ if sys.version_info >= (3, 10):
     ) -> int: ...
     @overload
     def bisect_left(
+        a: SupportsGetItem[int, SupportsRichComparisonT], x: SupportsRichComparisonT, lo: int, hi: int, *, key: None = None
+    ) -> int: ...
+    @overload
+    def bisect_left(
+        a: SupportsGetItem[int, SupportsRichComparisonT], x: SupportsRichComparisonT, lo: int = 0, *, hi: int, key: None = None
+    ) -> int: ...
+    @overload
+    def bisect_left(
         a: SupportsLenAndGetItem[_T],
         x: SupportsRichComparisonT,
         lo: int = 0,
         hi: int | None = None,
         *,
+        key: Callable[[_T], SupportsRichComparisonT],
+    ) -> int: ...
+    @overload
+    def bisect_left(
+        a: SupportsGetItem[int, _T], x: SupportsRichComparisonT, lo: int, hi: int, *, key: Callable[[_T], SupportsRichComparisonT]
+    ) -> int: ...
+    @overload
+    def bisect_left(
+        a: SupportsGetItem[int, _T],
+        x: SupportsRichComparisonT,
+        lo: int = 0,
+        *,
+        hi: int,
         key: Callable[[_T], SupportsRichComparisonT],
     ) -> int: ...
     @overload
@@ -35,11 +56,32 @@ if sys.version_info >= (3, 10):
     ) -> int: ...
     @overload
     def bisect_right(
+        a: SupportsGetItem[int, SupportsRichComparisonT], x: SupportsRichComparisonT, lo: int, hi: int, *, key: None = None
+    ) -> int: ...
+    @overload
+    def bisect_right(
+        a: SupportsGetItem[int, SupportsRichComparisonT], x: SupportsRichComparisonT, lo: int = 0, *, hi: int, key: None = None
+    ) -> int: ...
+    @overload
+    def bisect_right(
         a: SupportsLenAndGetItem[_T],
         x: SupportsRichComparisonT,
         lo: int = 0,
         hi: int | None = None,
         *,
+        key: Callable[[_T], SupportsRichComparisonT],
+    ) -> int: ...
+    @overload
+    def bisect_right(
+        a: SupportsGetItem[int, _T], x: SupportsRichComparisonT, lo: int, hi: int, *, key: Callable[[_T], SupportsRichComparisonT]
+    ) -> int: ...
+    @overload
+    def bisect_right(
+        a: SupportsGetItem[int, _T],
+        x: SupportsRichComparisonT,
+        lo: int = 0,
+        *,
+        hi: int,
         key: Callable[[_T], SupportsRichComparisonT],
     ) -> int: ...
     @overload
@@ -70,11 +112,25 @@ if sys.version_info >= (3, 10):
     ) -> None: ...
 
 else:
+    @overload
     def bisect_left(
         a: SupportsLenAndGetItem[SupportsRichComparisonT], x: SupportsRichComparisonT, lo: int = 0, hi: int | None = None
     ) -> int: ...
+    @overload
+    def bisect_left(a: SupportsGetItem[int, SupportsRichComparisonT], x: SupportsRichComparisonT, lo: int, hi: int) -> int: ...
+    @overload
+    def bisect_left(
+        a: SupportsGetItem[int, SupportsRichComparisonT], x: SupportsRichComparisonT, lo: int = 0, *, hi: int
+    ) -> int: ...
+    @overload
     def bisect_right(
         a: SupportsLenAndGetItem[SupportsRichComparisonT], x: SupportsRichComparisonT, lo: int = 0, hi: int | None = None
+    ) -> int: ...
+    @overload
+    def bisect_right(a: SupportsGetItem[int, SupportsRichComparisonT], x: SupportsRichComparisonT, lo: int, hi: int) -> int: ...
+    @overload
+    def bisect_right(
+        a: SupportsGetItem[int, SupportsRichComparisonT], x: SupportsRichComparisonT, lo: int = 0, *, hi: int
     ) -> int: ...
     def insort_left(
         a: MutableSequence[SupportsRichComparisonT], x: SupportsRichComparisonT, lo: int = 0, hi: int | None = None


### PR DESCRIPTION
Fixes #15492 

Currently, the `bisect` module stubs strictly require the first argument `a` to implement `__len__` (via `SupportsLenAndGetItem` or similar sequence protocols). However, in the CPython source code, `len(a)` is **never** evaluated if the `hi` parameter is explicitly provided. 

This causes false-positive type errors when users pass custom lazy-evaluated sequences, database cursors, or virtual arrays that only support `__getitem__`, even when they properly define the upper bound `hi`.

This PR fixes this by introducing new overloads that fall back to `SupportsGetItem[int, T]` when `hi: int` is specified.