### PR TITLE
psutil: remove empty tuple from `laddr`

### DIFF
--- a/stubs/psutil/psutil/_ntuples.pyi
+++ b/stubs/psutil/psutil/_ntuples.pyi
@@ -57,7 +57,7 @@ class sconn(NamedTuple):
     fd: int
     family: AddressFamily
     type: SocketKind
-    laddr: addr | tuple[()]
+    laddr: addr
     raddr: addr | tuple[()]
     status: str
     pid: int | None


### PR DESCRIPTION
remove empty tuple from `sconn.laddr`

The PR that introduced this https://github.com/python/typeshed/pull/6669 only showed results for `raddr`, not `laddr`

The documentation https://psutil.readthedocs.io/en/latest/#psutil.net_connections says that `raddr` can be the empty tuple. It does not say that `laddr` can be the empty tuple.

---

I don't know `psutil` that well. It would be nice if someone who knows it better can confirm.
(But if this isn't right, they should change their documentation.)