### PR TITLE
[wtforms] fix SelectField.choices

### DIFF
--- a/stubs/WTForms/wtforms/fields/choices.pyi
+++ b/stubs/WTForms/wtforms/fields/choices.pyi
@@ -46,7 +46,7 @@ class SelectFieldBase(Field):
 
 class SelectField(SelectFieldBase):
     coerce: Callable[[Any], Any]
-    choices: Sequence[_Choice] | _GroupedChoices
+    choices: Sequence[_Choice] | _GroupedChoices | None
     validate_choice: bool
     def __init__(
         self,


### PR DESCRIPTION
`list` is invariant, so .choices can't be assigned to after initialisation (without fully typing as _Choice). Doing so is suggested in the documentation:

https://wtforms.readthedocs.io/en/3.2.x/fields/#wtforms.fields.SelectField