### PR TITLE
Add `@type_check_only` to stub-only private classes in stdlib, round 2

### DIFF
--- a/stdlib/importlib/metadata/__init__.pyi
+++ b/stdlib/importlib/metadata/__init__.pyi
@@ -10,7 +10,7 @@ from importlib.abc import MetaPathFinder
 from os import PathLike
 from pathlib import Path
 from re import Pattern
-from typing import Any, ClassVar, Generic, NamedTuple, TypeVar, overload
+from typing import Any, ClassVar, Generic, NamedTuple, TypeVar, overload, type_check_only
 from typing_extensions import Self, TypeAlias, deprecated, disjoint_base
 
 _T = TypeVar("_T")
@@ -54,6 +54,7 @@ elif sys.version_info >= (3, 11):
 
     _EntryPointBase = DeprecatedTuple
 else:
+    @type_check_only
     class _EntryPointBase(NamedTuple):
         name: str
         value: str

--- a/stdlib/statistics.pyi
+++ b/stdlib/statistics.pyi
@@ -3,7 +3,7 @@ from _typeshed import SupportsRichComparisonT
 from collections.abc import Callable, Hashable, Iterable, Sequence, Sized
 from decimal import Decimal
 from fractions import Fraction
-from typing import Literal, NamedTuple, Protocol, SupportsFloat, SupportsIndex, TypeVar
+from typing import Literal, NamedTuple, Protocol, SupportsFloat, SupportsIndex, TypeVar, type_check_only
 from typing_extensions import Self, TypeAlias
 
 __all__ = [
@@ -44,7 +44,9 @@ _Seed: TypeAlias = int | float | str | bytes | bytearray  # noqa: Y041
 # Used in linear_regression
 _T_co = TypeVar("_T_co", covariant=True)
 
+@type_check_only
 class _SizedIterable(Iterable[_T_co], Sized, Protocol[_T_co]): ...
+
 class StatisticsError(ValueError): ...
 
 if sys.version_info >= (3, 11):

--- a/stdlib/tkinter/ttk.pyi
+++ b/stdlib/tkinter/ttk.pyi
@@ -57,6 +57,7 @@ _VsapiStatespec: TypeAlias = tuple[Unpack[tuple[str, ...]], int]
 _P = ParamSpec("_P")
 _T = TypeVar("_T")
 
+@type_check_only
 class _Layout(TypedDict, total=False):
     side: Literal["left", "right", "top", "bottom"]
     sticky: str  # consists of letters 'n', 's', 'w', 'e', may contain repeats, may be empty
@@ -68,6 +69,7 @@ class _Layout(TypedDict, total=False):
 _LayoutSpec: TypeAlias = list[tuple[str, _Layout | None]]
 
 # Keep these in sync with the appropriate methods in Style
+@type_check_only
 class _ElementCreateImageKwargs(TypedDict, total=False):
     border: _Padding
     height: float | str
@@ -82,12 +84,15 @@ _ElementCreateArgsCrossPlatform: TypeAlias = (
     | tuple[Literal["from"], str]  # (fromelement is optional)
 )
 if sys.platform == "win32" and sys.version_info >= (3, 13):
+    @type_check_only
     class _ElementCreateVsapiKwargsPadding(TypedDict, total=False):
         padding: _Padding
 
+    @type_check_only
     class _ElementCreateVsapiKwargsMargin(TypedDict, total=False):
         padding: _Padding
 
+    @type_check_only
     class _ElementCreateVsapiKwargsSize(TypedDict):
         width: float | str
         height: float | str


### PR DESCRIPTION
New hits from python/mypy#19574:
```text
error: importlib.metadata._EntryPointBase is not present at runtime. Maybe mark it as "@type_check_only"?
error: statistics._SizedIterable is not present at runtime. Maybe mark it as "@type_check_only"?
error: tkinter.ttk._ElementCreateImageKwargs is not present at runtime. Maybe mark it as "@type_check_only"?
error: tkinter.ttk._ElementCreateVsapiKwargsMargin is not present at runtime. Maybe mark it as "@type_check_only"?
error: tkinter.ttk._ElementCreateVsapiKwargsPadding is not present at runtime. Maybe mark it as "@type_check_only"?
error: tkinter.ttk._ElementCreateVsapiKwargsSize is not present at runtime. Maybe mark it as "@type_check_only"?
error: tkinter.ttk._Layout is not present at runtime. Maybe mark it as "@type_check_only"?
```
Introduced in #14348, #15249, and one missed due to https://github.com/python/mypy/pull/19574/commits/565e42fe808c2e6e0e8ec9728f7a63555d586236