### PR TITLE
[cachetools] Add `@type_check_only` to stub-only private classes

### DIFF
--- a/stubs/cachetools/cachetools/__init__.pyi
+++ b/stubs/cachetools/cachetools/__init__.pyi
@@ -2,7 +2,7 @@ from _typeshed import IdentityFunction, Unused
 from collections.abc import Callable, Iterator, MutableMapping, Sequence
 from contextlib import AbstractContextManager
 from threading import Condition
-from typing import Any, Generic, Literal, NamedTuple, TypeVar, overload
+from typing import Any, Generic, Literal, NamedTuple, TypeVar, overload, type_check_only
 from typing_extensions import Self, deprecated
 
 __all__ = ("Cache", "FIFOCache", "LFUCache", "LRUCache", "RRCache", "TLRUCache", "TTLCache", "cached", "cachedmethod")
@@ -106,10 +106,12 @@ class _CacheInfo(NamedTuple):
     maxsize: int | None
     currsize: int
 
+@type_check_only
 class _cached_wrapper(Generic[_R]):
     __wrapped__: Callable[..., _R]
     def __call__(self, /, *args: Any, **kwargs: Any) -> _R: ...
 
+@type_check_only
 class _cached_wrapper_info(_cached_wrapper[_R]):
     def cache_info(self) -> _CacheInfo: ...
     def cache_clear(self) -> None: ...

--- a/stubs/cachetools/cachetools/func.pyi
+++ b/stubs/cachetools/cachetools/func.pyi
@@ -1,17 +1,14 @@
 from collections.abc import Callable, Sequence
-from typing import Any, Final, Generic, NamedTuple, TypeVar, overload
+from typing import Any, Final, Generic, TypeVar, overload, type_check_only
+
+from . import _CacheInfo
 
 __all__: Final = ("fifo_cache", "lfu_cache", "lru_cache", "rr_cache", "ttl_cache")
 
 _T = TypeVar("_T")
 _R = TypeVar("_R")
 
-class _CacheInfo(NamedTuple):
-    hits: int
-    misses: int
-    maxsize: int | None
-    currsize: int
-
+@type_check_only
 class _cachetools_cache_wrapper(Generic[_R]):
     __wrapped__: Callable[..., _R]
     def __call__(self, /, *args: Any, **kwargs: Any) -> _R: ...


### PR DESCRIPTION
New hits from python/mypy#19574, introduced in #14770

Also unify duplicated `_CacheInfo` definitions (the `func` submodule uses the [definition from `__init__.py`](https://github.com/tkem/cachetools/blob/5dce86fc5c9c565c6e9c912e2be5d6abb9586a1d/src/cachetools/__init__.py#L714) at runtime)