### PR TITLE
[channels] Relax django-stubs dependency

### DIFF
--- a/stubs/channels/@tests/stubtest_allowlist.txt
+++ b/stubs/channels/@tests/stubtest_allowlist.txt
@@ -4,6 +4,7 @@ channels.auth.UserLazyObject
 # these one need to be exclude due to mypy error: * is not present at runtime
 channels.auth.UserLazyObject.DoesNotExist
 channels.auth.UserLazyObject.MultipleObjectsReturned
+channels.auth.UserLazyObject.NotUpdated
 channels.auth.UserLazyObject@AnnotatedWith
 
 # database_sync_to_async is implemented as a class instance but stubbed as a function

--- a/stubs/channels/METADATA.toml
+++ b/stubs/channels/METADATA.toml
@@ -1,6 +1,6 @@
 version = "4.3.*"
 upstream_repository = "https://github.com/django/channels"
-requires = ["django-stubs>=4.2,<5.3", "asgiref"]
+requires = ["django-stubs>=4.2", "asgiref"]
 
 [tool.stubtest]
 mypy_plugins = ['mypy_django_plugin.main']


### PR DESCRIPTION
Hello. This is my first contribution to typeshed — happy to receive any feedback!

Relaxes the `django-stubs` version constraint in the `channels` stub to align with the `django` dependency declared on the `channels` package..

Fixes #15523