### PR TITLE
Fix missing names for `asyncio` in 3.14

### DIFF
--- a/stdlib/@tests/stubtest_allowlists/py314.txt
+++ b/stdlib/@tests/stubtest_allowlists/py314.txt
@@ -35,9 +35,6 @@ mmap.mmap.flush
 mmap.mmap.rfind
 multiprocessing.process.BaseProcess.__init__
 
-# Some names are exported via __getattr__ instead of __all__.
-asyncio.__all__
-
 # ====================================
 # Pre-existing errors from Python 3.13
 # ====================================

--- a/stdlib/@tests/stubtest_allowlists/py314.txt
+++ b/stdlib/@tests/stubtest_allowlists/py314.txt
@@ -35,6 +35,9 @@ mmap.mmap.flush
 mmap.mmap.rfind
 multiprocessing.process.BaseProcess.__init__
 
+# Some names are exported via __getattr__ instead of __all__.
+asyncio.__all__
+
 # ====================================
 # Pre-existing errors from Python 3.13
 # ====================================

--- a/stdlib/asyncio/__init__.pyi
+++ b/stdlib/asyncio/__init__.pyi
@@ -55,7 +55,6 @@ if sys.platform == "win32":
             "Server",  # from base_events
             "iscoroutinefunction",  # from coroutines
             "iscoroutine",  # from coroutines
-            "AbstractEventLoopPolicy",  # from events
             "AbstractEventLoop",  # from events
             "AbstractServer",  # from events
             "Handle",  # from events

--- a/stdlib/asyncio/__init__.pyi
+++ b/stdlib/asyncio/__init__.pyi
@@ -33,6 +33,20 @@ if sys.platform == "win32":
 else:
     from .unix_events import *
 
+if sys.version_info >= (3, 14):
+    from .events import _AbstractEventLoopPolicy as AbstractEventLoopPolicy
+
+if sys.platform == "win32":
+    if sys.version_info >= (3, 14):
+        from .windows_events import (
+            _DefaultEventLoopPolicy as DefaultEventLoopPolicy,
+            _WindowsProactorEventLoopPolicy as WindowsProactorEventLoopPolicy,
+            _WindowsSelectorEventLoopPolicy as WindowsSelectorEventLoopPolicy,
+        )
+else:
+    if sys.version_info >= (3, 14):
+        from .unix_events import _DefaultEventLoopPolicy as DefaultEventLoopPolicy
+
 if sys.platform == "win32":
     if sys.version_info >= (3, 14):
 
@@ -41,6 +55,7 @@ if sys.platform == "win32":
             "Server",  # from base_events
             "iscoroutinefunction",  # from coroutines
             "iscoroutine",  # from coroutines
+            "AbstractEventLoopPolicy",  # from events
             "AbstractEventLoop",  # from events
             "AbstractServer",  # from events
             "Handle",  # from events
@@ -131,8 +146,11 @@ if sys.platform == "win32":
             "SelectorEventLoop",  # from windows_events
             "ProactorEventLoop",  # from windows_events
             "IocpProactor",  # from windows_events
+            "DefaultEventLoopPolicy",  # from windows_events
             "_DefaultEventLoopPolicy",  # from windows_events
+            "WindowsSelectorEventLoopPolicy",  # from windows_events
             "_WindowsSelectorEventLoopPolicy",  # from windows_events
+            "WindowsProactorEventLoopPolicy",  # from windows_events
             "_WindowsProactorEventLoopPolicy",  # from windows_events
             "EventLoop",  # from windows_events
         )
@@ -514,6 +532,7 @@ else:
             "Server",  # from base_events
             "iscoroutinefunction",  # from coroutines
             "iscoroutine",  # from coroutines
+            "AbstractEventLoopPolicy",  # from events
             "AbstractEventLoop",  # from events
             "AbstractServer",  # from events
             "Handle",  # from events
@@ -604,6 +623,7 @@ else:
             "DatagramTransport",  # from transports
             "SubprocessTransport",  # from transports
             "SelectorEventLoop",  # from unix_events
+            "DefaultEventLoopPolicy",  # from unix_events
             "EventLoop",  # from unix_events
         )
     elif sys.version_info >= (3, 13):

--- a/stdlib/asyncio/__init__.pyi
+++ b/stdlib/asyncio/__init__.pyi
@@ -34,18 +34,22 @@ else:
     from .unix_events import *
 
 if sys.version_info >= (3, 14):
-    from .events import _AbstractEventLoopPolicy as AbstractEventLoopPolicy  # pyright: ignore[reportUnusedImport]
+    from .events import _AbstractEventLoopPolicy
+
+    AbstractEventLoopPolicy = _AbstractEventLoopPolicy
 
 if sys.platform == "win32":
     if sys.version_info >= (3, 14):
-        from .windows_events import (
-            _DefaultEventLoopPolicy as DefaultEventLoopPolicy,  # pyright: ignore[reportUnusedImport]
-            _WindowsProactorEventLoopPolicy as WindowsProactorEventLoopPolicy,  # pyright: ignore[reportUnusedImport]
-            _WindowsSelectorEventLoopPolicy as WindowsSelectorEventLoopPolicy,  # pyright: ignore[reportUnusedImport]
-        )
+        from .windows_events import _DefaultEventLoopPolicy, _WindowsProactorEventLoopPolicy, _WindowsSelectorEventLoopPolicy
+
+        DefaultEventLoopPolicy = _DefaultEventLoopPolicy
+        WindowsProactorEventLoopPolicy = _WindowsProactorEventLoopPolicy
+        WindowsSelectorEventLoopPolicy = _WindowsSelectorEventLoopPolicy
 else:
     if sys.version_info >= (3, 14):
-        from .unix_events import _DefaultEventLoopPolicy as DefaultEventLoopPolicy  # pyright: ignore[reportUnusedImport]
+        from .unix_events import _DefaultEventLoopPolicy
+
+        DefaultEventLoopPolicy = _DefaultEventLoopPolicy
 
 if sys.platform == "win32":
     if sys.version_info >= (3, 14):

--- a/stdlib/asyncio/__init__.pyi
+++ b/stdlib/asyncio/__init__.pyi
@@ -146,11 +146,8 @@ if sys.platform == "win32":
             "SelectorEventLoop",  # from windows_events
             "ProactorEventLoop",  # from windows_events
             "IocpProactor",  # from windows_events
-            "DefaultEventLoopPolicy",  # from windows_events
             "_DefaultEventLoopPolicy",  # from windows_events
-            "WindowsSelectorEventLoopPolicy",  # from windows_events
             "_WindowsSelectorEventLoopPolicy",  # from windows_events
-            "WindowsProactorEventLoopPolicy",  # from windows_events
             "_WindowsProactorEventLoopPolicy",  # from windows_events
             "EventLoop",  # from windows_events
         )
@@ -532,7 +529,6 @@ else:
             "Server",  # from base_events
             "iscoroutinefunction",  # from coroutines
             "iscoroutine",  # from coroutines
-            "AbstractEventLoopPolicy",  # from events
             "AbstractEventLoop",  # from events
             "AbstractServer",  # from events
             "Handle",  # from events
@@ -623,7 +619,6 @@ else:
             "DatagramTransport",  # from transports
             "SubprocessTransport",  # from transports
             "SelectorEventLoop",  # from unix_events
-            "DefaultEventLoopPolicy",  # from unix_events
             "EventLoop",  # from unix_events
         )
     elif sys.version_info >= (3, 13):

--- a/stdlib/asyncio/__init__.pyi
+++ b/stdlib/asyncio/__init__.pyi
@@ -34,18 +34,18 @@ else:
     from .unix_events import *
 
 if sys.version_info >= (3, 14):
-    from .events import _AbstractEventLoopPolicy as AbstractEventLoopPolicy
+    from .events import _AbstractEventLoopPolicy as AbstractEventLoopPolicy  # pyright: ignore[reportUnusedImport]
 
 if sys.platform == "win32":
     if sys.version_info >= (3, 14):
         from .windows_events import (
-            _DefaultEventLoopPolicy as DefaultEventLoopPolicy,
-            _WindowsProactorEventLoopPolicy as WindowsProactorEventLoopPolicy,
-            _WindowsSelectorEventLoopPolicy as WindowsSelectorEventLoopPolicy,
+            _DefaultEventLoopPolicy as DefaultEventLoopPolicy,  # pyright: ignore[reportUnusedImport]
+            _WindowsProactorEventLoopPolicy as WindowsProactorEventLoopPolicy,  # pyright: ignore[reportUnusedImport]
+            _WindowsSelectorEventLoopPolicy as WindowsSelectorEventLoopPolicy,  # pyright: ignore[reportUnusedImport]
         )
 else:
     if sys.version_info >= (3, 14):
-        from .unix_events import _DefaultEventLoopPolicy as DefaultEventLoopPolicy
+        from .unix_events import _DefaultEventLoopPolicy as DefaultEventLoopPolicy  # pyright: ignore[reportUnusedImport]
 
 if sys.platform == "win32":
     if sys.version_info >= (3, 14):


### PR DESCRIPTION
`AbstractEventLoopPolicy`, `DefaultEventLoopPolicy`, `WindowsSelectorEventLoopPolicyc` and `WindowsProactorEventLoopPolicy` are exported by `asyncio` via `__getattr__` in 3.14, but are missing from the stubs.

https://github.com/python/cpython/blob/3.14/Lib/asyncio/__init__.py

The names were removed in #14128.