### PR TITLE
[dateparser] Fix return type of `search_dates`

### DIFF
--- a/stubs/dateparser/dateparser/search/__init__.pyi
+++ b/stubs/dateparser/dateparser/search/__init__.pyi
@@ -13,7 +13,7 @@ def search_dates(
     settings: Settings | dict[str, Any] | None,
     add_detected_language: Literal[True],
     detect_languages_function: _DetectLanguagesFunction | None = None,
-) -> list[tuple[str, datetime, str]]: ...
+) -> list[tuple[str, datetime, str]] | None: ...
 @overload
 def search_dates(
     text: str,
@@ -21,4 +21,4 @@ def search_dates(
     settings: Settings | dict[str, Any] | None = None,
     add_detected_language: Literal[False] = False,
     detect_languages_function: _DetectLanguagesFunction | None = None,
-) -> list[tuple[str, datetime]]: ...
+) -> list[tuple[str, datetime]] | None: ...


### PR DESCRIPTION
dateparser.search.search_dates will return None if no parseable date could be found in the `text` argument.

This is explained in the original docstring as well.

Closes #15538.

I'm unsure if I have to edit a changelog for this or something in that regard.