### PR TITLE
[asyncio] Support IPv6 addr type in DatagramProtocol.datagram_received

### DIFF
--- a/stdlib/asyncio/protocols.pyi
+++ b/stdlib/asyncio/protocols.pyi
@@ -31,7 +31,8 @@ class DatagramProtocol(BaseProtocol):
     # Use tuple[str | Any, int] to not cause typechecking issues on most usual cases.
     # This could be improved by using tuple[AnyOf[str, int], int] if the AnyOf feature is accepted.
     # See https://github.com/python/typing/issues/566
-    def datagram_received(self, data: bytes, addr: tuple[str | Any, int]) -> None: ...
+    # For IPv6, addr is a 4-tuple: (host, port, flowinfo, scope_id).
+    def datagram_received(self, data: bytes, addr: tuple[str | Any, int] | tuple[str, int, int, int]) -> None: ...
     def error_received(self, exc: Exception) -> None: ...
 
 class SubprocessProtocol(BaseProtocol):


### PR DESCRIPTION
Fixes #15169

## Changes

`DatagramProtocol.datagram_received` currently types the `addr` parameter as `tuple[str | Any, int]` — a 2-tuple — which handles IPv4 (`(host, port)`) and unusual protocols like AF_NETLINK. However, when using **IPv6**, the addr is a **4-tuple** `(host, port, flowinfo, scope_id)`, i.e. `tuple[str, int, int, int]`.

This adds the IPv6 4-tuple to the union type so that datagram protocols using IPv6 can be properly type-checked without resorting to `Any` or ignoring the error.

**Before:**
```python
def datagram_received(self, data: bytes, addr: tuple[str | Any, int]) -> None: ...
```

**After:**
```python
def datagram_received(self, data: bytes, addr: tuple[str | Any, int] | tuple[str, int, int, int]) -> None: ...
```

This is consistent with how IPv6 addresses are represented elsewhere in typeshed — for example, `socket.getaddrinfo()` already uses `tuple[str, int, int, int]` for IPv6 in its return type.