### PR TITLE
[requests] Add missing attributes and __init__ to JSONDecodeError stub

### DIFF
--- a/stubs/requests/requests/exceptions.pyi
+++ b/stubs/requests/requests/exceptions.pyi
@@ -14,7 +14,17 @@ class RequestException(OSError):
     ) -> None: ...
 
 class InvalidJSONError(RequestException): ...
-class JSONDecodeError(InvalidJSONError, CompatJSONDecodeError): ...
+
+class JSONDecodeError(InvalidJSONError, CompatJSONDecodeError):
+    # requests.JSONDecodeError.__init__ explicitly calls CompatJSONDecodeError.__init__(msg, doc, pos),
+    # so these attributes from json.JSONDecodeError are always present on instances.
+    # Re-declared here to help type checkers resolve them despite the complex MRO.
+    msg: str
+    doc: str
+    pos: int
+    lineno: int
+    colno: int
+    def __init__(self, msg: str, doc: str, pos: int) -> None: ...
 
 class HTTPError(RequestException):
     request: Request | PreparedRequest | Any


### PR DESCRIPTION
Fixes #15167

## Problem

`requests.exceptions.JSONDecodeError` inherits from both `InvalidJSONError` (which inherits from `RequestException`) and `json.JSONDecodeError`. When catching it in user code, accessing attributes like `exc.doc` causes a mypy error:

```
error: "JSONDecodeError" has no attribute "doc"  [attr-defined]
```

## Root Cause

The runtime `requests.JSONDecodeError.__init__` explicitly calls `CompatJSONDecodeError.__init__(self, *args)` first, which sets the `json.JSONDecodeError` instance attributes (`doc`, `pos`, `lineno`, `colno`, `msg`). However, due to the complex MRO (where `RequestException.__init__` appears before `json.JSONDecodeError` in the chain), type checkers may not correctly resolve these inherited attributes.

## Fix

Explicitly re-declare the `json.JSONDecodeError` attributes on `requests.JSONDecodeError` and add the correct `__init__` signature matching the runtime behavior (`msg: str, doc: str, pos: int`), consistent with how requests calls it:

```python
raise RequestsJSONDecodeError(e.msg, e.doc, e.pos)
```

**After this fix:**
```python
import requests
from requests.exceptions import JSONDecodeError

try:
    requests.get("https://www.google.com").json()
except JSONDecodeError as exc:
    d = exc.doc  # no longer a mypy error
    print("Failed to decode json. Got:", d[:10])
```