### PR TITLE
[requests] Add `requests.compat.JSONDecodeError`

### DIFF
--- a/stubs/requests/requests/compat.pyi
+++ b/stubs/requests/requests/compat.pyi
@@ -1,5 +1,8 @@
 from builtins import bytes as bytes, str as str
 from collections import OrderedDict as OrderedDict
+
+# If simplejson is installed, JSONDecodeError is actually imported from there.
+from json import JSONDecodeError as JSONDecodeError
 from typing import Literal
 from typing_extensions import TypeAlias
 from urllib.parse import (

--- a/stubs/requests/requests/exceptions.pyi
+++ b/stubs/requests/requests/exceptions.pyi
@@ -1,8 +1,8 @@
-from json import JSONDecodeError as CompatJSONDecodeError
 from typing import Any
 
 from urllib3.exceptions import HTTPError as BaseHTTPError
 
+from .compat import JSONDecodeError as CompatJSONDecodeError
 from .models import Request, Response
 from .sessions import PreparedRequest
 


### PR DESCRIPTION
Also add a comment that `JSONDecodeError` may be imported from `simplejson` if that is installed.