### PR TITLE
fix(django-import-export): ForeignKeyWidget.__init__ argument types

### DIFF
--- a/stubs/django-import-export/import_export/widgets.pyi
+++ b/stubs/django-import-export/import_export/widgets.pyi
@@ -57,7 +57,7 @@ class JSONWidget(Widget): ...
 _ModelT = TypeVar("_ModelT", bound=Model)
 
 class ForeignKeyWidget(Widget, Generic[_ModelT]):
-    model: _ModelT
+    model: type[_ModelT]
     field: str
     key_is_id: bool
     use_natural_foreign_keys: bool


### PR DESCRIPTION
## Issue statement

In the stubs for django-import-export, the `model` argument of the `widgets.ForeignKeyWidget.__init__` method is incorrectly typed as `_ModelT`, which corresponds to a Django model _instance_, whereas the method actually expects the model itself, i.e. `type[_ModelT]`.

## MRE

```python
from django.db.models import CASCADE, CharField, ForeignKey, Model
from import_export.resources import ModelResource
from import_export.widgets import ForeignKeyWidget


class RelatedModel(Model):
    label = CharField()


class MyModel(Model):
    related = ForeignKey(RelatedModel, on_delete=CASCADE)


class MyModelResource(ModelResource[MyModel]):
    related = ForeignKeyWidget(RelatedModel, field="label")

    class Meta:
        model = MyModel
        fields = ("related",)
```

The above code corresponds to the django-import-export documentation [^1], and actually works. Yet:

```sh
$ mypy .
mre.py:15: error: Value of type variable "_ModelT" of "ForeignKeyWidget" cannot be "type[RelatedModel]"  [type-var]
Found 1 errors in 1 file (checked 1 source file)
```


[^1]: https://django-import-export.readthedocs.io/en/latest/api_widgets.html#import_export.widgets.ForeignKeyWidget