### PR TITLE
stdlib: Fix type for unittest.TestProgram module attribute

### DIFF
--- a/stdlib/unittest/main.pyi
+++ b/stdlib/unittest/main.pyi
@@ -18,7 +18,7 @@ class _TestRunner(Protocol):
 # not really documented
 class TestProgram:
     result: unittest.result.TestResult
-    module: None | str | ModuleType
+    module: ModuleType | None
     verbosity: int
     failfast: bool | None
     catchbreak: bool | None
@@ -30,7 +30,7 @@ class TestProgram:
         durations: unittest.result._DurationsType | None
         def __init__(
             self,
-            module: None | str | ModuleType = "__main__",
+            module: ModuleType | str | None = "__main__",
             defaultTest: str | Iterable[str] | None = None,
             argv: list[str] | None = None,
             testRunner: type[_TestRunner] | _TestRunner | None = None,


### PR DESCRIPTION
This was typed as being a module, string or None. However, while `TestProgram` accepts a string value for the module parameter, this will always be resolved to a module before being stored [1]. The attribute should therefore be either a module or None.

[1] https://github.com/python/cpython/blob/v3.9.0/Lib/unittest/main.py#L69-L72
