### PR TITLE
Change 'self' to 'cls' in mmap.__new__ method

### DIFF
--- a/stdlib/mmap.pyi
+++ b/stdlib/mmap.pyi
@@ -34,7 +34,7 @@ PAGESIZE: Final[int]
 @disjoint_base
 class mmap:
     if sys.platform == "win32":
-        def __new__(self, fileno: int, length: int, tagname: str | None = None, access: int = 0, offset: int = 0) -> Self: ...
+        def __new__(cls, fileno: int, length: int, tagname: str | None = None, access: int = 0, offset: int = 0) -> Self: ...
     else:
         if sys.version_info >= (3, 13):
             def __new__(


### PR DESCRIPTION
In `stdlib/mmap.pyi`, under [the definition of the mmap constructor for windows](https://github.com/python/typeshed/blob/14968e64c6425a6d03f783e002a68bb4709cd36f/stdlib/mmap.pyi#L37), the __new__ method is incorrectly annotated with `self` as the first parameter, where it should be `cls` as per convention. Since this is trivially fixable, I have not opened an issue.