### PR TITLE
Run stubtest with `--strict-type-check-only`

### DIFF
--- a/tests/stubtest_stdlib.py
+++ b/tests/stubtest_stdlib.py
@@ -28,6 +28,7 @@ def run_stubtest(typeshed_dir: Path) -> int:
         "mypy.stubtest",
         "--check-typeshed",
         "--show-traceback",
+        "--strict-type-check-only",
         "--custom-typeshed-dir",
         str(typeshed_dir),
         *allowlist_stubtest_arguments("stdlib"),

--- a/tests/stubtest_third_party.py
+++ b/tests/stubtest_third_party.py
@@ -109,6 +109,7 @@ def run_stubtest(dist: Path, *, verbose: bool = False, ci_platforms_only: bool =
                 "--mypy-config-file",
                 temp.name,
                 "--show-traceback",
+                "--strict-type-check-only",
                 # Use --custom-typeshed-dir in case we make linked changes to stdlib or _typeshed
                 "--custom-typeshed-dir",
                 str(dist.parent.parent),


### PR DESCRIPTION
New flag in mypy v1.20 (python/mypy#19574)

Enables checking for `@type_check_only` on private types.

