### PR TITLE
Better type return value of `json.detect_encoding`

### DIFF
--- a/stdlib/json/__init__.pyi
+++ b/stdlib/json/__init__.pyi
@@ -58,4 +58,6 @@ def load(
     object_pairs_hook: Callable[[list[tuple[Any, Any]]], Any] | None = None,
     **kwds: Any,
 ) -> Any: ...
-def detect_encoding(b: bytes | bytearray) -> Literal['utf-8', 'utf-8-sig', 'utf-16', 'utf-16-be', 'utf-16-le', 'utf-32', 'utf-32-be', 'utf-32-le']: ...  # undocumented
+def detect_encoding(
+    b: bytes | bytearray,
+) -> Literal["utf-8", "utf-8-sig", "utf-16", "utf-16-be", "utf-16-le", "utf-32", "utf-32-be", "utf-32-le"]: ...  # undocumented


### PR DESCRIPTION
It would be beneficial to annotate the return type of `json.detect_encoding` as the values that are actually possible, so that the user knows approximately what the function does just by looking at the stub. This would mean changing the signature from

```python
def detect_encoding(b: bytes | bytearray) -> str: ...  # undocumented
```

to

```python
def detect_encoding(b: bytes | bytearray) -> Literal['utf-8', 'utf-8-sig', 'utf-16', 'utf-16-be', 'utf-16-le', 'utf-32', 'utf-32-be', 'utf-32-le']: ...  # undocumented
```

.

See [the relevant source](https://github.com/python/cpython/blob/1f36a510a2a16e8ff15572f44090c7db43bb7935/Lib/json/__init__.py#L247).