### PR TITLE
Pin Python 3.13 and Python 3.14 to patch versions to resolve stubtest stdlib failures on `main`

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -35,7 +35,8 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        # TODO: unpin the patch versions of Python 3.13/3.14 once stubtest failures are fixed
+        python-version: ["3.10", "3.11", "3.12", "3.13.12", "3.14.3"]
       fail-fast: false
 
     steps:

--- a/.github/workflows/stubtest_stdlib.yml
+++ b/.github/workflows/stubtest_stdlib.yml
@@ -31,7 +31,8 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        # TODO: unpin the patch versions of Python 3.13/3.14 once stubtest failures are fixed
+        python-version: ["3.10", "3.11", "3.12", "3.13.12", "3.14.3"]
       fail-fast: false
 
     steps:


### PR DESCRIPTION
3.13.13 and 3.14.4 were released last night, and are causing new stubtest failures on `main`, which is causing confusion on contributor PRs (e.g. https://github.com/python/typeshed/pull/15612#issuecomment-4205188206). Add a temporary pin here to get `main` green again.