### PR TITLE
[channels] Compatibility fixes for django-stubs 6.0.3

### DIFF
--- a/stubs/channels/METADATA.toml
+++ b/stubs/channels/METADATA.toml
@@ -1,6 +1,6 @@
 version = "4.3.*"
 upstream-repository = "https://github.com/django/channels"
-dependencies = ["django-stubs>=4.2", "asgiref"]
+dependencies = ["django-stubs>=6.0.3", "asgiref"]
 
 [tool.stubtest]
 mypy-plugins = ['mypy_django_plugin.main']

--- a/stubs/channels/channels/auth.pyi
+++ b/stubs/channels/channels/auth.pyi
@@ -1,4 +1,5 @@
 from _typeshed import Incomplete
+
 from asgiref.typing import ASGIReceiveCallable, ASGISendCallable
 from channels.middleware import BaseMiddleware
 from django.contrib.auth.backends import BaseBackend

--- a/stubs/channels/channels/auth.pyi
+++ b/stubs/channels/channels/auth.pyi
@@ -1,3 +1,4 @@
+from _typeshed import Incomplete
 from asgiref.typing import ASGIReceiveCallable, ASGISendCallable
 from channels.middleware import BaseMiddleware
 from django.contrib.auth.backends import BaseBackend
@@ -14,7 +15,7 @@ async def logout(scope: _ChannelScope) -> None: ...
 
 # Inherits AbstractBaseUser to improve autocomplete and show this is a lazy proxy for a user.
 # At runtime, it's just a LazyObject that wraps the actual user instance.
-class UserLazyObject(AbstractBaseUser, LazyObject): ...
+class UserLazyObject(AbstractBaseUser, LazyObject[Incomplete]): ...
 
 class AuthMiddleware(BaseMiddleware):
     def populate_scope(self, scope: _ChannelScope) -> None: ...

--- a/stubs/channels/channels/consumer.pyi
+++ b/stubs/channels/channels/consumer.pyi
@@ -1,3 +1,4 @@
+from _typeshed import Incomplete
 from collections.abc import Awaitable
 from typing import Any, ClassVar, Protocol, TypedDict, type_check_only
 
@@ -11,7 +12,7 @@ from django.utils.functional import LazyObject
 # We subclass both for type checking purposes to expose SessionBase attributes,
 # and suppress mypy's "misc" error with `# type: ignore[misc]`.
 @type_check_only
-class _LazySession(SessionBase, LazyObject):  # type: ignore[misc]
+class _LazySession(SessionBase, LazyObject[Incomplete]):  # type: ignore[misc]
     _wrapped: SessionBase
 
 @type_check_only


### PR DESCRIPTION
`LazyObject` is generic since django-stubs 6.0.3.

This fixes problems in unrelated PRs and preempts upcoming daily CI errors.