### PR TITLE
Annotate `encoding` argument and return type of `io.text_encoding` as `TypeVar` with upper bound `str` in second overload

### DIFF
--- a/stdlib/_io.pyi
+++ b/stdlib/_io.pyi
@@ -9,7 +9,7 @@ from types import TracebackType
 from typing import IO, Any, BinaryIO, Final, Generic, Literal, Protocol, TextIO, TypeVar, overload, type_check_only
 from typing_extensions import Self, disjoint_base
 
-_T = TypeVar("_T")
+_S = TypeVar("_S", bound=str)
 
 if sys.version_info >= (3, 14):
     DEFAULT_BUFFER_SIZE: Final = 131072
@@ -298,4 +298,4 @@ if sys.version_info >= (3, 10):
     @overload
     def text_encoding(encoding: None, stacklevel: int = 2, /) -> Literal["locale", "utf-8"]: ...
     @overload
-    def text_encoding(encoding: _T, stacklevel: int = 2, /) -> _T: ...
+    def text_encoding(encoding: _S, stacklevel: int = 2, /) -> _S: ...


### PR DESCRIPTION
Closes #15662.