### PR TITLE
[protobuf] Add _loaded_options to FileDescriptor

### DIFF
--- a/stubs/protobuf/google/protobuf/descriptor.pyi
+++ b/stubs/protobuf/google/protobuf/descriptor.pyi
@@ -343,6 +343,7 @@ class FileDescriptor(DescriptorBase):
         create_key=None,
     ): ...
     _options: Any
+    _loaded_options: Any
     pool: DescriptorPool
     message_types_by_name: Mapping[str, Descriptor]
     name: str


### PR DESCRIPTION
protobuf renamed `_loaded_options` to `_options` in 6.x but continues to support the old name for compatibility with 5.x, which they explicitly still support (actually as this is about gencode, technically they still support back to 3.x)

https://protobuf.dev/support/version-support/

As it is still there in the latest version of protobuf, I guess the stub should reflect that

https://github.com/protocolbuffers/protobuf/blob/760418056a557866afc31860297b9034ef9ade1e/python/google/protobuf/descriptor.py#L140

Note, this came up because #15569 did a good job of updating type definitions throughout - but it means that previously the result of `AddSerializedFile` was `Any` and now it is `FileDescriptor`. This causes the latest version of typeshed to fail to typecheck 5.x gencode where previously it succeeded.