### PR TITLE
[cffi] FFI.NULL is now CData

### DIFF
--- a/stubs/cffi/cffi/api.pyi
+++ b/stubs/cffi/cffi/api.pyi
@@ -19,7 +19,7 @@ class FFI:
 
     BVoidP: CType
     BCharA: CType
-    NULL: CType
+    NULL: CData
     errno: int
 
     def __init__(self, backend: types.ModuleType | None = None) -> None: ...


### PR DESCRIPTION
Seems like an oversight that it is not. CData is an instance after all. At very least I think it would fix the typecheking in my package.