### PR TITLE
Drop Windows 3.10 from stubtest testing matrix

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -36,6 +36,10 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        exclude:
+          # https://github.com/python/typeshed/issues/15694
+          - os: "windows-latest"
+            python-version: "3.10"
       fail-fast: false
 
     steps:

--- a/.github/workflows/stubtest_stdlib.yml
+++ b/.github/workflows/stubtest_stdlib.yml
@@ -32,6 +32,10 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        exclude:
+          # https://github.com/python/typeshed/issues/15694
+          - os: "windows-latest"
+            python-version: "3.10"
       fail-fast: false
 
     steps:


### PR DESCRIPTION
Due to Github flakiness