### PR TITLE
Remove typing_extensions recommendation for 3.10 constructs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -366,10 +366,6 @@ Features from the `typing` module that are not present in all
 supported Python versions must be imported from `typing_extensions`
 instead in typeshed stubs. This currently affects:
 
-- `TypeAlias` (new in Python 3.10)
-- `Concatenate` (new in Python 3.10)
-- `ParamSpec` (new in Python 3.10)
-- `TypeGuard` (new in Python 3.10)
 - `Self` (new in Python 3.11)
 - `Never` (new in Python 3.11)
 - `LiteralString` (new in Python 3.11)


### PR DESCRIPTION
Fixes #15719. Since 3.9 is EOL, typing features new in 3.10 can now just be (and, in this repo, are) imported from `typing`.