### PR TITLE
[gunicorn] Fully remove eventlet support

### DIFF
--- a/stubs/gunicorn/METADATA.toml
+++ b/stubs/gunicorn/METADATA.toml
@@ -7,7 +7,6 @@ supported-platforms = ["linux", "darwin"]
 ci-platforms = ["linux", "darwin"]
 stubtest-dependencies = [
     "gevent>=1.4.0",
-    "eventlet>=0.24.1,!=0.36.0",
     "tornado>=0.2",
     "setproctitle",
     "PasteDeploy",

--- a/stubs/gunicorn/gunicorn/workers/__init__.pyi
+++ b/stubs/gunicorn/gunicorn/workers/__init__.pyi
@@ -3,7 +3,6 @@ from typing import TypedDict, type_check_only
 @type_check_only
 class _SupportedWorkers(TypedDict):
     sync: str
-    eventlet: str  # deprecated: will be removed in 26.0
     gevent: str
     gevent_wsgi: str
     gevent_pywsgi: str


### PR DESCRIPTION
Looks like we already don't need this in the `stubtest-dependencies` list anymore.
Source: https://github.com/benoitc/gunicorn/pull/3623/