### PR TITLE
[select] Mark `select.poll` as `@final`

### DIFF
--- a/stdlib/select.pyi
+++ b/stdlib/select.pyi
@@ -24,6 +24,7 @@ if sys.platform != "win32":
 
     # This is actually a function that returns an instance of a class.
     # The class is not accessible directly, and also calls itself select.poll.
+    @final
     class poll:
         # default value is select.POLLIN | select.POLLPRI | select.POLLOUT
         def register(self, fd: FileDescriptorLike, eventmask: int = 7, /) -> None: ...


### PR DESCRIPTION
See:

```python
>>> import select
>>> t = type(select.poll())
>>> t
<class 'select.poll'>
>>> class a(t): ...
... 
Traceback (most recent call last):
  File "<python-input-11>", line 1, in <module>
    class a(t): ...
TypeError: type 'select.poll' is not an acceptable base type
```