### PR TITLE
[select] `devpoll` is `@final`

### DIFF
--- a/stdlib/select.pyi
+++ b/stdlib/select.pyi
@@ -159,6 +159,7 @@ if sys.platform == "linux":
 
 if sys.platform != "linux" and sys.platform != "darwin" and sys.platform != "win32":
     # Solaris only
+    @final
     class devpoll:
         def close(self) -> None: ...
         closed: bool


### PR DESCRIPTION
It is defined as:

```c
static PyType_Spec devpoll_Type_spec = {
    "select.devpoll",
    sizeof(devpollObject),
    0,
    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_DISALLOW_INSTANTIATION,
    devpoll_Type_slots
};
```

Since it does not have `Py_TPFLAGS_BASETYPE` it can't have child classes