### PR TITLE
Use more mypy_primer shards

### DIFF
--- a/.github/workflows/mypy_primer.yml
+++ b/.github/workflows/mypy_primer.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        shard-index: [0, 1, 2, 3]
+        shard-index: [0, 1, 2, 3, 4, 5]
       fail-fast: false
     steps:
       - uses: actions/checkout@v6
@@ -52,7 +52,7 @@ jobs:
             --new v${MYPY_VERSION} --old v${MYPY_VERSION} \
             --custom-typeshed-repo typeshed_to_test \
             --new-typeshed $GITHUB_SHA --old-typeshed upstream_main \
-            --num-shards 4 --shard-index ${{ matrix.shard-index }} \
+            --num-shards 6 --shard-index ${{ matrix.shard-index }} \
             --debug \
             --output concise \
             | tee diff_${{ matrix.shard-index }}.txt


### PR DESCRIPTION
The CI on pull requests seems to take about 6 minutes, and the slowest thing is mypy_primer. Everything else is done in about 4 minutes. If this PR works like I intend, it will shorten the total CI time to about 4 minutes.