### PR TITLE
[Authlib] Fix JsonWebKey.import_key typing

### DIFF
--- a/stubs/Authlib/authlib/jose/rfc7517/jwk.pyi
+++ b/stubs/Authlib/authlib/jose/rfc7517/jwk.pyi
@@ -1,5 +1,6 @@
-from _typeshed import Incomplete
-from collections.abc import Collection, Mapping
+from _typeshed import Incomplete, ReadableBuffer
+from collections.abc import Collection, Iterable, Mapping
+from typing import SupportsBytes, SupportsIndex
 
 from authlib.jose.rfc7517 import Key, KeySet
 
@@ -8,6 +9,10 @@ class JsonWebKey:
     @classmethod
     def generate_key(cls, kty, crv_or_size, options=None, is_private: bool = False): ...
     @classmethod
-    def import_key(cls, raw: Mapping[str, object], options: Mapping[str, object] | None = None) -> Key: ...
+    def import_key(
+        cls,
+        raw: str | bytes | float | Iterable[SupportsIndex] | SupportsIndex | SupportsBytes | ReadableBuffer | Mapping[str, object],
+        options: Mapping[str, object] | None = None
+    ) -> Key: ...
     @classmethod
     def import_key_set(cls, raw: str | Collection[str] | dict[str, object]) -> KeySet: ...

--- a/stubs/Authlib/authlib/jose/rfc7517/jwk.pyi
+++ b/stubs/Authlib/authlib/jose/rfc7517/jwk.pyi
@@ -11,8 +11,10 @@ class JsonWebKey:
     @classmethod
     def import_key(
         cls,
-        raw: str | bytes | float | Iterable[SupportsIndex] | SupportsIndex | SupportsBytes | ReadableBuffer | Mapping[str, object],
-        options: Mapping[str, object] | None = None
+        raw: (
+            str | bytes | float | Iterable[SupportsIndex] | SupportsIndex | SupportsBytes | ReadableBuffer | Mapping[str, object]
+        ),
+        options: Mapping[str, object] | None = None,
     ) -> Key: ...
     @classmethod
     def import_key_set(cls, raw: str | Collection[str] | dict[str, object]) -> KeySet: ...


### PR DESCRIPTION
`import_key`'s `raw` accepts everything that `load_pem_key` accepts. The function annotation even says `Import a Key from bytes, string, PEM or dict` yet it currently only supports `dict` type.

https://github.com/authlib/authlib/blob/a0b76fac3fa114d7759af2010546bfc332364b63/authlib/jose/rfc7517/jwk.py#L25-L41

Since the value of `raw` is passed down to `load_pem_key`, it should accept everything that function supports, which is defined in https://github.com/python/typeshed/blob/346d4bdf38c24712f42a63e74cef396868fb34d4/stubs/Authlib/authlib/jose/rfc7517/_cryptography_key.pyi#L10