### PR TITLE
Fix return type of `tkinter.Text.search_all()`

### DIFF
--- a/stdlib/tkinter/__init__.pyi
+++ b/stdlib/tkinter/__init__.pyi
@@ -3646,7 +3646,7 @@ class Text(Widget, XView, YView):
             nolinestop: bool | None = None,
             overlap: bool | None = None,
             strictlimits: bool | None = None,
-        ) -> tuple[str, ...]: ...
+        ) -> tuple[_tkinter.Tcl_Obj, ...]: ...
     else:
         def search(
             self,


### PR DESCRIPTION
It returns a tuple of `_tkinter.Tcl_Obj`:

```
akuli@Akuli-Desktop ~/sourcestuff/Python-3.15.0b1 $ ./python 
Python 3.15.0b1 (main, May 11 2026, 17:35:51) [GCC 14.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import tkinter
>>> t = tkinter.Text()
>>> t.pack()
>>> t.insert('end', 'hello world test thingy hello test')
>>> t.search_all('t', '1.0')
(<textindex object: '1.12'>, <textindex object: '1.15'>, <textindex object: '1.17'>, <textindex object: '1.30'>, <textindex object: '1.33'>)
>>> list(map(type,_))
[<class '_tkinter.Tcl_Obj'>, <class '_tkinter.Tcl_Obj'>, <class '_tkinter.Tcl_Obj'>, <class '_tkinter.Tcl_Obj'>, <class '_tkinter.Tcl_Obj'>]
```