### PR TITLE
gh-15769: Make string.templatelib.Interpolation generic

### DIFF
--- a/stdlib/string/templatelib.pyi
+++ b/stdlib/string/templatelib.pyi
@@ -1,24 +1,24 @@
 from collections.abc import Iterator
 from types import GenericAlias
-from typing import Any, Literal, TypeVar, final, overload
+from typing import Any, Generic, Literal, TypeVar, final, overload
 
 _T = TypeVar("_T")
 
 @final
 class Template:  # TODO: consider making `Template` generic on `TypeVarTuple`
     strings: tuple[str, ...]
-    interpolations: tuple[Interpolation, ...]
+    interpolations: tuple[Interpolation[Any], ...]
 
-    def __new__(cls, *args: str | Interpolation) -> Template: ...
-    def __iter__(self) -> Iterator[str | Interpolation]: ...
+    def __new__(cls, *args: str | Interpolation[Any]) -> Template: ...
+    def __iter__(self) -> Iterator[str | Interpolation[Any]]: ...
     def __add__(self, other: Template, /) -> Template: ...
     def __class_getitem__(cls, item: Any, /) -> GenericAlias: ...
     @property
     def values(self) -> tuple[Any, ...]: ...  # Tuple of interpolation values, which can have any type
 
 @final
-class Interpolation:
-    value: Any  # TODO: consider making `Interpolation` generic in runtime
+class Interpolation(Generic[_T]):
+    value: _T
     expression: str
     conversion: Literal["a", "r", "s"] | None
     format_spec: str
@@ -26,8 +26,8 @@ class Interpolation:
     __match_args__ = ("value", "expression", "conversion", "format_spec")
 
     def __new__(
-        cls, value: Any, expression: str = "", conversion: Literal["a", "r", "s"] | None = None, format_spec: str = ""
-    ) -> Interpolation: ...
+        cls, value: _T, expression: str = "", conversion: Literal["a", "r", "s"] | None = None, format_spec: str = ""
+    ) -> Interpolation[_T]: ...
     def __class_getitem__(cls, item: Any, /) -> GenericAlias: ...
 
 @overload


### PR DESCRIPTION
Resolves #15769. Allows `Interpolation` instances constructed with `__new__` to be parameterized. Instances constructed implicitly via t-strings are unaffected; support could be added at a later date once `Template` parameterization is more feasible.