### PR TITLE
Add config alias for tkinter.Misc

### DIFF
--- a/stdlib/@tests/stubtest_allowlists/common.txt
+++ b/stdlib/@tests/stubtest_allowlists/common.txt
@@ -13,6 +13,9 @@ tarfile.TarInfo.__slots__  # it's a big dictionary at runtime and the dictionary
 # TODO: Modules that exist at runtime, but are missing from stubs
 # ===============================================================
 
+turtledemo
+turtledemo\..+
+
 
 # ======================================================================
 # Modules that exist at runtime, but are deliberately missing from stubs

--- a/stdlib/@tests/stubtest_allowlists/common.txt
+++ b/stdlib/@tests/stubtest_allowlists/common.txt
@@ -13,16 +13,6 @@ tarfile.TarInfo.__slots__  # it's a big dictionary at runtime and the dictionary
 # TODO: Modules that exist at runtime, but are missing from stubs
 # ===============================================================
 
-turtledemo
-turtledemo\..+
-
-
-# ======================================================================
-# TODO: Module members that exist at runtime, but are missing from stubs
-# ======================================================================
-
-tkinter.Misc.config
-
 
 # ======================================================================
 # Modules that exist at runtime, but are deliberately missing from stubs

--- a/stdlib/tkinter/__init__.pyi
+++ b/stdlib/tkinter/__init__.pyi
@@ -679,8 +679,7 @@ class Misc:
     def __getitem__(self, key: str) -> Any: ...
     def cget(self, key: str) -> Any: ...
     def configure(self, cnf: Any = None) -> Any: ...
-    # TODO: config is an alias of configure, but adding that here creates
-    # conflict with the type of config in the subclasses. See #13149
+    config = configure
 
 class CallWrapper:
     func: Incomplete


### PR DESCRIPTION
I didn't add this initially because it confused mypy, but let's see what CI and primer say.