### PR TITLE
Allow None return from    grpc.aio.ServerInterceptor.intercept_service

### DIFF
--- a/stubs/grpcio/@tests/test_cases/check_server_interceptor.py
+++ b/stubs/grpcio/@tests/test_cases/check_server_interceptor.py
@@ -26,9 +26,9 @@ grpc.server(interceptors=[NoopInterceptor()], thread_pool=ThreadPoolExecutor())
 class NoopAioInterceptor(grpc.aio.ServerInterceptor):
     async def intercept_service(
         self,
-        continuation: Callable[[grpc.HandlerCallDetails], Awaitable[grpc.RpcMethodHandler[RequestT, ResponseT]]],
+        continuation: Callable[[grpc.HandlerCallDetails], Awaitable[grpc.RpcMethodHandler[RequestT, ResponseT] | None]],
         handler_call_details: grpc.HandlerCallDetails,
-    ) -> grpc.RpcMethodHandler[RequestT, ResponseT]:
+    ) -> grpc.RpcMethodHandler[RequestT, ResponseT] | None:
         return await continuation(handler_call_details)
 
 

--- a/stubs/grpcio/grpc/aio/__init__.pyi
+++ b/stubs/grpcio/grpc/aio/__init__.pyi
@@ -375,12 +375,15 @@ class ServerInterceptor(metaclass=abc.ABCMeta):
     # This method (not the class) is generic over _TRequest and _TResponse
     # and the types must satisfy the no-op implementation of
     # `return await continuation(handler_call_details)`.
+    # The return is Optional: per the runtime docstring, an interceptor
+    # may return None to signal that the RPC is not serviced, and the
+    # continuation propagates that None down the chain.
     @abc.abstractmethod
     async def intercept_service(
         self,
-        continuation: Callable[[HandlerCallDetails], Awaitable[RpcMethodHandler[_TRequest, _TResponse]]],
+        continuation: Callable[[HandlerCallDetails], Awaitable[RpcMethodHandler[_TRequest, _TResponse] | None]],
         handler_call_details: HandlerCallDetails,
-    ) -> RpcMethodHandler[_TRequest, _TResponse]: ...
+    ) -> RpcMethodHandler[_TRequest, _TResponse] | None: ...
 
 # Multi-Callable Interfaces:
 


### PR DESCRIPTION
## Summary
Update the type hints for `grpc.aio.ServerInterceptor.intercept_service` and its `continuation` parameter to allow returning `None`. Specifically, the return type and the inner `Awaitable` are widened to `RpcMethodHandler[_TRequest, _TResponse] | None`.

## Motivation
The [runtime docstring](https://github.com/grpc/grpc/blob/a5a3cc8321d2c90a4e9694f07caf1ff6679468b0/src/python/grpcio/grpc/aio/_interceptor.py#L90) for `grpc.aio.ServerInterceptor.intercept_service` explicitly documents `None` as a valid return value to signal that an RPC is not being serviced:

> **Returns**: An RpcMethodHandler with which the RPC may be serviced if the interceptor chooses to service this RPC, or **None otherwise**.

Because the interceptor chain propagates `None` end-to-end (each link's `continuation` returns whatever the next interceptor returned), the inner `Awaitable` must also admit `None`. With the current stubs, subclasses that honour the documented contract are forced to use `# type: ignore[override]` to widen the override. This PR eliminates that friction.

## Precedent
This change aligns the async stubs with their synchronous counterpart. The sync stub (`stubs/grpcio/grpc/__init__.pyi`, lines 506-510, see [here](https://github.com/Rhadamanthus1/typeshed/blob/6e3b4fab79197c668dd94918ce88e74b9c96ccbe/stubs/grpcio/grpc/__init__.pyi#L506)) already correctly declares both positions as `RpcMethodHandler[_TRequest, _TResponse] | None`:

```python
class ServerInterceptor(abc.ABC):
    @abc.abstractmethod
    def intercept_service(
        self,
        continuation: Callable[[HandlerCallDetails], RpcMethodHandler[_TRequest, _TResponse] | None],
        handler_call_details: HandlerCallDetails,
    ) -> RpcMethodHandler[_TRequest, _TResponse] | None: ...
```

## Changes

* `stubs/grpcio/grpc/aio/__init__.pyi`:
  * Widened the `Awaitable[...]` and the return type of `ServerInterceptor.intercept_service` to include `None`.
  * Added a short inline comment explaining the optional return type.