### PR TITLE
add type hints for authlib.common.language

### DIFF
--- a/stubs/Authlib/authlib/common/language.pyi
+++ b/stubs/Authlib/authlib/common/language.pyi
@@ -1,4 +1,5 @@
-from typing import Final, Pattern
+from re import Pattern
+from typing import Final
 
 _LANGUAGE_TAG_RE: Final[Pattern[str]]
 

--- a/stubs/Authlib/authlib/common/language.pyi
+++ b/stubs/Authlib/authlib/common/language.pyi
@@ -1,0 +1,5 @@
+from typing import Final, Pattern
+
+_LANGUAGE_TAG_RE: Final[Pattern[str]]
+
+def is_valid_language_tag(tag: str) -> bool: ...


### PR DESCRIPTION
- Add Final[Pattern[str]] for _LANGUAGE_TAG_RE constant
- Add type hints for is_valid_language_tag(tag: str) -> bool

[authlib.common.language](https://github.com/authlib/authlib/blob/main/authlib/common/language.py)