### PR TITLE
asyncio: add cleanup_socket to AbstractEventLoop.create_unix_server (#15742)

### DIFF
--- a/stdlib/asyncio/events.pyi
+++ b/stdlib/asyncio/events.pyi
@@ -421,18 +421,33 @@ class AbstractEventLoop:
             ssl_handshake_timeout: float | None = None,
             ssl_shutdown_timeout: float | None = None,
         ) -> Transport | None: ...
-        async def create_unix_server(
-            self,
-            protocol_factory: _ProtocolFactory,
-            path: StrPath | None = None,
-            *,
-            sock: socket | None = None,
-            backlog: int = 100,
-            ssl: _SSLContext = None,
-            ssl_handshake_timeout: float | None = None,
-            ssl_shutdown_timeout: float | None = None,
-            start_serving: bool = True,
-        ) -> Server: ...
+        if sys.version_info >= (3, 13):
+            async def create_unix_server(
+                self,
+                protocol_factory: _ProtocolFactory,
+                path: StrPath | None = None,
+                *,
+                sock: socket | None = None,
+                backlog: int = 100,
+                ssl: _SSLContext = None,
+                ssl_handshake_timeout: float | None = None,
+                ssl_shutdown_timeout: float | None = None,
+                start_serving: bool = True,
+                cleanup_socket: bool = True,
+            ) -> Server: ...
+        else:
+            async def create_unix_server(
+                self,
+                protocol_factory: _ProtocolFactory,
+                path: StrPath | None = None,
+                *,
+                sock: socket | None = None,
+                backlog: int = 100,
+                ssl: _SSLContext = None,
+                ssl_handshake_timeout: float | None = None,
+                ssl_shutdown_timeout: float | None = None,
+                start_serving: bool = True,
+            ) -> Server: ...
     else:
         @abstractmethod
         async def start_tls(


### PR DESCRIPTION
Closes #15742. Adds the `cleanup_socket: bool = True` keyword argument that Python 3.13 added to `AbstractEventLoop.create_unix_server`, mirroring the existing override on `_UnixSelectorEventLoop` in `unix_events.pyi`. Per @srittau in #15742 ("PR welcome!").