### PR TITLE
Add cleanup_socket param to asyncio AbstractEventLoop.create_unix_server (3.13+)

### DIFF
--- a/stdlib/@tests/stubtest_allowlists/py313.txt
+++ b/stdlib/@tests/stubtest_allowlists/py313.txt
@@ -86,6 +86,11 @@ ntpath.join
 # Allowlist entries that cannot or should not be fixed; >= 3.13
 # =============================================================
 
+# `cleanup_socket` was added in 3.13 to the concrete `_UnixSelectorEventLoop.create_unix_server`,
+# not to the abstract `AbstractEventLoop.create_unix_server`. The stub adds it on the abstract
+# method so code typing the loop as `AbstractEventLoop` can still pass `cleanup_socket=...`. See #15742.
+asyncio.events.AbstractEventLoop.create_unix_server
+
 _pyrepl\..+  # The internal implementation of the REPL on py313+; not for public consumption
 codecs.backslashreplace_errors  # Runtime incorrectly has `self`
 codecs.ignore_errors  # Runtime incorrectly has `self`

--- a/stdlib/@tests/stubtest_allowlists/py314.txt
+++ b/stdlib/@tests/stubtest_allowlists/py314.txt
@@ -120,6 +120,11 @@ multiprocessing.managers._BaseDictProxy.__reversed__
 # Allowlist entries that cannot or should not be fixed; >= 3.13
 # =============================================================
 
+# `cleanup_socket` was added in 3.13 to the concrete `_UnixSelectorEventLoop.create_unix_server`,
+# not to the abstract `AbstractEventLoop.create_unix_server`. The stub adds it on the abstract
+# method so code typing the loop as `AbstractEventLoop` can still pass `cleanup_socket=...`. See #15742.
+asyncio.events.AbstractEventLoop.create_unix_server
+
 _pyrepl\..+  # The internal implementation of the REPL on py313+; not for public consumption
 codecs.backslashreplace_errors  # Runtime incorrectly has `self`
 codecs.ignore_errors  # Runtime incorrectly has `self`

--- a/stdlib/@tests/stubtest_allowlists/py315.txt
+++ b/stdlib/@tests/stubtest_allowlists/py315.txt
@@ -152,6 +152,11 @@ types.UnionType.__qualname__
 # Allowlist entries that cannot or should not be fixed; >= 3.13
 # =============================================================
 
+# `cleanup_socket` was added in 3.13 to the concrete `_UnixSelectorEventLoop.create_unix_server`,
+# not to the abstract `AbstractEventLoop.create_unix_server`. The stub adds it on the abstract
+# method so code typing the loop as `AbstractEventLoop` can still pass `cleanup_socket=...`. See #15742.
+asyncio.events.AbstractEventLoop.create_unix_server
+
 _pyrepl\..+  # The internal implementation of the REPL on py313+; not for public consumption
 codecs.backslashreplace_errors  # Runtime incorrectly has `self`
 codecs.ignore_errors  # Runtime incorrectly has `self`

--- a/stdlib/asyncio/events.pyi
+++ b/stdlib/asyncio/events.pyi
@@ -421,6 +421,34 @@ class AbstractEventLoop:
             ssl_handshake_timeout: float | None = None,
             ssl_shutdown_timeout: float | None = None,
         ) -> Transport | None: ...
+    else:
+        @abstractmethod
+        async def start_tls(
+            self,
+            transport: BaseTransport,
+            protocol: BaseProtocol,
+            sslcontext: ssl.SSLContext,
+            *,
+            server_side: bool = False,
+            server_hostname: str | None = None,
+            ssl_handshake_timeout: float | None = None,
+        ) -> Transport | None: ...
+
+    if sys.version_info >= (3, 13):
+        async def create_unix_server(
+            self,
+            protocol_factory: _ProtocolFactory,
+            path: StrPath | None = None,
+            *,
+            sock: socket | None = None,
+            backlog: int = 100,
+            ssl: _SSLContext = None,
+            ssl_handshake_timeout: float | None = None,
+            ssl_shutdown_timeout: float | None = None,
+            start_serving: bool = True,
+            cleanup_socket: bool = True,
+        ) -> Server: ...
+    elif sys.version_info >= (3, 11):
         async def create_unix_server(
             self,
             protocol_factory: _ProtocolFactory,
@@ -434,17 +462,6 @@ class AbstractEventLoop:
             start_serving: bool = True,
         ) -> Server: ...
     else:
-        @abstractmethod
-        async def start_tls(
-            self,
-            transport: BaseTransport,
-            protocol: BaseProtocol,
-            sslcontext: ssl.SSLContext,
-            *,
-            server_side: bool = False,
-            server_hostname: str | None = None,
-            ssl_handshake_timeout: float | None = None,
-        ) -> Transport | None: ...
         async def create_unix_server(
             self,
             protocol_factory: _ProtocolFactory,


### PR DESCRIPTION
Closes #15742.

Python 3.13 added a `cleanup_socket: bool = True` keyword-only parameter to `asyncio.loop.create_unix_server` (CPython docs: ["Changed in version 3.13: Added the cleanup_socket parameter."](https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.loop.create_unix_server)). The subclass `_UnixSelectorEventLoop.create_unix_server` in `stdlib/asyncio/unix_events.pyi` already declares this parameter for 3.13+, but `AbstractEventLoop.create_unix_server` in `stdlib/asyncio/events.pyi` does not — so callers typed against the abstract base class get a type error.

This PR splits `AbstractEventLoop.create_unix_server` out of the existing `start_tls` `if sys.version_info >= (3, 11) / else` block and gives it its own three-way version conditional:

- `>= (3, 13)` — adds `cleanup_socket: bool = True`
- `>= (3, 11)` — unchanged from previous 3.11+ signature
- `else` — unchanged pre-3.11 signature

`start_tls` keeps its existing two-way split. No behavior change for pre-3.13 versions.

I used AI assistance to identify the missing parameter location and draft the change. I have reviewed all changes myself and believe they are correct.
