### PR TITLE
Parametrize `click.types.ParamType` as base class in `click_web.web_click_types`

### DIFF
--- a/stubs/click-web/click_web/resources/input_fields.pyi
+++ b/stubs/click-web/click_web/resources/input_fields.pyi
@@ -31,7 +31,7 @@ class FieldId:
 class NotSupported(ValueError): ...
 
 class BaseInput:
-    param_type_cls: type[click.types.ParamType] | None
+    param_type_cls: type[click.types.ParamType[Any]] | None
     ctx: click.Context
     param: click.Parameter
     command_index: int
@@ -67,13 +67,13 @@ class EmailInput(BaseInput):
     param_type_cls: type[EmailParamType]
 
 class PasswordInput(BaseInput):
-    param_type_cls: type[PasswordParamType]
+    param_type_cls: type[PasswordParamType[Any]]
 
 class TextAreaInput(BaseInput):
-    param_type_cls: type[TextAreaParamType]
+    param_type_cls: type[TextAreaParamType[Any]]
 
 class DefaultInput(BaseInput):
-    param_type_cls: type[click.ParamType]
+    param_type_cls: type[click.ParamType[Any]]
 
 INPUT_TYPES: Final[list[type[BaseInput]]]
 _DEFAULT_INPUT: Final[list[type[DefaultInput]]]

--- a/stubs/click-web/click_web/resources/input_fields.pyi
+++ b/stubs/click-web/click_web/resources/input_fields.pyi
@@ -67,10 +67,10 @@ class EmailInput(BaseInput):
     param_type_cls: type[EmailParamType]
 
 class PasswordInput(BaseInput):
-    param_type_cls: type[PasswordParamType[Any]]
+    param_type_cls: type[PasswordParamType]
 
 class TextAreaInput(BaseInput):
-    param_type_cls: type[TextAreaParamType[Any]]
+    param_type_cls: type[TextAreaParamType]
 
 class DefaultInput(BaseInput):
     param_type_cls: type[click.ParamType[Any]]

--- a/stubs/click-web/click_web/web_click_types.pyi
+++ b/stubs/click-web/click_web/web_click_types.pyi
@@ -9,10 +9,10 @@ class EmailParamType(click.ParamType[str]):
     EMAIL_REGEX: ClassVar[re.Pattern[str]]
     def convert(self, value: str, param: click.Parameter | None, ctx: click.Context | None) -> str: ...
 
-class PasswordParamType(click.ParamType[_T]):
+class PasswordParamType(click.ParamType[Any]):
     def convert(self, value: _T, param: click.Parameter | None, ctx: click.Context | None) -> _T: ...
 
-class TextAreaParamType(click.ParamType[_T]):
+class TextAreaParamType(click.ParamType[Any]):
     def convert(self, value: _T, param: click.Parameter | None, ctx: click.Context | None) -> _T: ...
 
 EMAIL_TYPE: EmailParamType

--- a/stubs/click-web/click_web/web_click_types.pyi
+++ b/stubs/click-web/click_web/web_click_types.pyi
@@ -5,14 +5,14 @@ import click
 
 _T = TypeVar("_T")
 
-class EmailParamType(click.ParamType):
+class EmailParamType(click.ParamType[str]):
     EMAIL_REGEX: ClassVar[re.Pattern[str]]
     def convert(self, value: str, param: click.Parameter | None, ctx: click.Context | None) -> str: ...
 
-class PasswordParamType(click.ParamType):
+class PasswordParamType(click.ParamType[_T]):
     def convert(self, value: _T, param: click.Parameter | None, ctx: click.Context | None) -> _T: ...
 
-class TextAreaParamType(click.ParamType):
+class TextAreaParamType(click.ParamType[_T]):
     def convert(self, value: _T, param: click.Parameter | None, ctx: click.Context | None) -> _T: ...
 
 EMAIL_TYPE: EmailParamType

--- a/stubs/click-web/click_web/web_click_types.pyi
+++ b/stubs/click-web/click_web/web_click_types.pyi
@@ -1,5 +1,5 @@
 import re
-from typing import ClassVar, TypeVar
+from typing import Any, ClassVar, TypeVar
 
 import click
 


### PR DESCRIPTION
I saw that the workflows for my other PR, particularly those from pyright, were failing because this file was annotated incompletely.