### PR TITLE
Mark TypeVar/ParamSpec/TypeVarTuple 'name' as positional-only

### DIFF
--- a/stdlib/@tests/stubtest_allowlists/py310.txt
+++ b/stdlib/@tests/stubtest_allowlists/py310.txt
@@ -284,3 +284,9 @@ typing\.Annotated  # Super-special typing primitive
 # These methods have no default implementation for Python < 3.13.
 _pickle.Pickler.persistent_id
 _pickle.Unpickler.persistent_load
+
+# `name` is a positional string literal for these special forms (PEP 484 / 612);
+# the stub marks it positional-only, but the pure-Python 3.10 runtime objects
+# accept it as a keyword argument.
+typing.ParamSpec.__init__
+typing.TypeVar.__init__

--- a/stdlib/@tests/stubtest_allowlists/py311.txt
+++ b/stdlib/@tests/stubtest_allowlists/py311.txt
@@ -261,3 +261,8 @@ typing\.Annotated  # Super-special typing primitive
 # These methods have no default implementation for Python < 3.13.
 _pickle.Pickler.persistent_id
 _pickle.Unpickler.persistent_load
+
+# `name` is a positional string literal for TypeVarTuple (PEP 646); the stub
+# marks it positional-only, but the pure-Python 3.11 runtime __init__ accepts
+# it as a keyword argument.
+typing.TypeVarTuple.__init__

--- a/stdlib/typing.pyi
+++ b/stdlib/typing.pyi
@@ -375,7 +375,13 @@ class ParamSpec:
         ) -> Self: ...
     else:
         def __init__(
-            self, name: str, /, *, bound: Any | None = None, contravariant: bool = False, covariant: bool = False  # AnnotationForm
+            self,
+            name: str,
+            /,
+            *,
+            bound: Any | None = None,
+            contravariant: bool = False,
+            covariant: bool = False,  # AnnotationForm
         ) -> None: ...
 
     @property

--- a/stdlib/typing.pyi
+++ b/stdlib/typing.pyi
@@ -178,6 +178,7 @@ class TypeVar:
         def __new__(
             cls,
             name: str,
+            /,
             *constraints: Any,  # AnnotationForm
             bound: Any | None = None,  # AnnotationForm
             contravariant: bool = False,
@@ -189,6 +190,7 @@ class TypeVar:
         def __new__(
             cls,
             name: str,
+            /,
             *constraints: Any,  # AnnotationForm
             bound: Any | None = None,  # AnnotationForm
             covariant: bool = False,
@@ -199,6 +201,7 @@ class TypeVar:
         def __new__(
             cls,
             name: str,
+            /,
             *constraints: Any,  # AnnotationForm
             bound: Any | None = None,  # AnnotationForm
             covariant: bool = False,
@@ -208,6 +211,7 @@ class TypeVar:
         def __init__(
             self,
             name: str,
+            /,
             *constraints: Any,  # AnnotationForm
             bound: Any | None = None,  # AnnotationForm
             covariant: bool = False,
@@ -280,6 +284,7 @@ if sys.version_info >= (3, 11):
             def __new__(
                 cls,
                 name: str,
+                /,
                 *,
                 bound: Any | None = None,  # AnnotationForm
                 covariant: bool = False,
@@ -288,11 +293,11 @@ if sys.version_info >= (3, 11):
                 infer_variance: bool = False,
             ) -> Self: ...
         elif sys.version_info >= (3, 13):
-            def __new__(cls, name: str, *, default: Any = ...) -> Self: ...  # AnnotationForm
+            def __new__(cls, name: str, /, *, default: Any = ...) -> Self: ...  # AnnotationForm
         elif sys.version_info >= (3, 12):
-            def __new__(cls, name: str) -> Self: ...
+            def __new__(cls, name: str, /) -> Self: ...
         else:
-            def __init__(self, name: str) -> None: ...
+            def __init__(self, name: str, /) -> None: ...
 
         def __iter__(self) -> Any: ...
         def __typing_subst__(self, arg: Never, /) -> Never: ...
@@ -345,6 +350,7 @@ class ParamSpec:
         def __new__(
             cls,
             name: str,
+            /,
             *,
             bound: Any | None = None,  # AnnotationForm
             contravariant: bool = False,
@@ -356,6 +362,7 @@ class ParamSpec:
         def __new__(
             cls,
             name: str,
+            /,
             *,
             bound: Any | None = None,  # AnnotationForm
             contravariant: bool = False,
@@ -364,11 +371,11 @@ class ParamSpec:
         ) -> Self: ...
     elif sys.version_info >= (3, 11):
         def __new__(
-            cls, name: str, *, bound: Any | None = None, contravariant: bool = False, covariant: bool = False  # AnnotationForm
+            cls, name: str, /, *, bound: Any | None = None, contravariant: bool = False, covariant: bool = False  # AnnotationForm
         ) -> Self: ...
     else:
         def __init__(
-            self, name: str, *, bound: Any | None = None, contravariant: bool = False, covariant: bool = False  # AnnotationForm
+            self, name: str, /, *, bound: Any | None = None, contravariant: bool = False, covariant: bool = False  # AnnotationForm
         ) -> None: ...
 
     @property


### PR DESCRIPTION
Implements #15804.

`TypeVar`, `ParamSpec`, and `TypeVarTuple` declare `name` as positional-**or-keyword**, but every type checker (mypy, pyright, ty, pyre) requires it positionally. This is not a per-checker quirk: the typing spec (PEP 484 / 612 / 646) requires the first argument to be a string literal so the checker can bind it to the assigned variable statically, so any conformant checker must reject `name=...`. mypy core, no plugins:

```python
from typing import TypeVar
T = TypeVar(name="T")  # error: TypeVar() expects a string literal as first argument  [misc]
```

This marks `name` positional-only on every constructor overload of the three classes so the stub matches that contract. It is a no-op for type checkers (they special-case these and ignore the signature); the point is third-party tools that read typeshed as ground truth and currently suggest the type-checker-breaking `name=` form.

Scope: `NewType` and the `typing_extensions` <3.13 fallback classes are left out (introspectable runtime signatures, so they would need a stubtest-allowlist change); the >=3.13 `typing_extensions` path re-exports from `typing` and is covered transitively. On 3.10/3.11 these objects are pure-Python and introspectable, so allowlist entries are included for those versions.
