### PR TITLE
[stdlib] Update `asyncio.run` to accept `Awaitable` from 3.14

### DIFF
--- a/stdlib/asyncio/runners.pyi
+++ b/stdlib/asyncio/runners.pyi
@@ -27,7 +27,12 @@ if sys.version_info >= (3, 11):
         else:
             def run(self, coro: Coroutine[Any, Any, _T], *, context: Context | None = None) -> _T: ...
 
-if sys.version_info >= (3, 12):
+if sys.version_info >= (3, 14):
+    def run(
+        main: Awaitable[_T], *, debug: bool | None = None, loop_factory: Callable[[], AbstractEventLoop] | None = None
+    ) -> _T: ...
+
+elif sys.version_info >= (3, 12):
     def run(
         main: Coroutine[Any, Any, _T], *, debug: bool | None = None, loop_factory: Callable[[], AbstractEventLoop] | None = None
     ) -> _T: ...


### PR DESCRIPTION
This applies the same patch as https://github.com/python/typeshed/pull/15046 to `asyncio.run` given that the [CPython change](https://github.com/python/cpython/commit/1229cb8c1412d37cf3206eab407f03e21d602cbd) is for both `asyncio.run` (function) and `asyncio.Runner.run` (method).