### PR TITLE
Make typed_subpart_iterator generic over Message

### DIFF
--- a/stdlib/email/iterators.pyi
+++ b/stdlib/email/iterators.pyi
@@ -1,11 +1,14 @@
 from _typeshed import SupportsWrite
 from collections.abc import Iterator
 from email.message import Message
+from typing import TypeVar
+
+_T = TypeVar("_T", bound=Message)
 
 __all__ = ["body_line_iterator", "typed_subpart_iterator", "walk"]
 
 def body_line_iterator(msg: Message, decode: bool = False) -> Iterator[str]: ...
-def typed_subpart_iterator(msg: Message, maintype: str = "text", subtype: str | None = None) -> Iterator[str]: ...
+def typed_subpart_iterator(msg: _T, maintype: str = "text", subtype: str | None = None) -> Iterator[_T]: ...
 def walk(self: Message) -> Iterator[Message]: ...
 
 # We include the seemingly private function because it is documented in the stdlib documentation.


### PR DESCRIPTION
Fixes #15809 

As was mentioned in [issue](https://github.com/python/typeshed/issues/15809), made typed_subpart_iterator generic over Message

