### PR TITLE
Subclassing TTLCache[KT, VT] loses generic type inference on instantiation

### DIFF
--- a/stubs/cachetools/@tests/test_cases/check_cachetools.py
+++ b/stubs/cachetools/@tests/test_cases/check_cachetools.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 from collections.abc import Hashable
-from typing import Any
+from typing import Any, TypeVar
 from typing_extensions import assert_type
 
-from cachetools import LRUCache, cached, keys as cachekeys
+from cachetools import LRUCache, TTLCache, cached, keys as cachekeys
 from cachetools.func import fifo_cache, lfu_cache, lru_cache, rr_cache, ttl_cache
+
+_KT = TypeVar("_KT")
+_VT = TypeVar("_VT")
 
 # Tests for cachetools.cached
 
@@ -102,3 +105,14 @@ assert_type(k3, tuple[Hashable, ...])
 
 k4 = cachekeys.typedmethodkey(inst, 2)
 assert_type(k4, tuple[Hashable, ...])
+
+
+class TestTTLCache(TTLCache[_KT, _VT]):
+    def popitem(self) -> tuple[_KT, _VT]:
+        key, value = super().popitem()
+        return key, value
+
+
+TTL_inst: TestTTLCache[Any, Any] = TestTTLCache(maxsize=128, ttl=600)
+
+assert_type(TTL_inst, TestTTLCache[Any, Any])

--- a/stubs/cachetools/cachetools/__init__.pyi
+++ b/stubs/cachetools/cachetools/__init__.pyi
@@ -66,8 +66,10 @@ class _TimedCache(Cache[_KT, _VT], Generic[_KT, _VT, _TT]):
 class TTLCache(_TimedCache[_KT, _VT, _TT]):
     @overload
     def __init__(
-        self: TTLCache[_KT2, _VT2, float], maxsize: float, ttl: float, *, getsizeof: Callable[[_VT2], float] | None = None
+        self: TTLCache[_KT2, _VT2, float], maxsize: float, ttl: float, *, getsizeof: Callable[[_VT2], float]
     ) -> None: ...
+    @overload
+    def __init__(self: TTLCache[_KT2, _VT2, float], maxsize: float, ttl: float, *, getsizeof: None = None) -> None: ...
     @overload
     def __init__(
         self,


### PR DESCRIPTION
Closes: #15798

Splitted overload for `__init__` in `TTLCache` to make `getsizeof` None in one case, as was requested in the issue. Also added test, that checks whether or not there is a third implicit type parameter. However, I'm not sure about this one, mb I had to work with `timer` arument?