### PR TITLE
Add comments to tkinter.Wm.wm_attributes overloads

### DIFF
--- a/stdlib/tkinter/__init__.pyi
+++ b/stdlib/tkinter/__init__.pyi
@@ -808,7 +808,6 @@ class Wm:
         def wm_attributes(self, option: Literal["-zoomed"], /) -> bool: ...
         @overload
         def wm_attributes(self, option: Literal["-type"], /) -> str: ...
-
     if sys.version_info >= (3, 13):
         # wm_attributes: Get one attribute (new variant without "-")
         @overload

--- a/stdlib/tkinter/__init__.pyi
+++ b/stdlib/tkinter/__init__.pyi
@@ -766,6 +766,8 @@ class Wm:
     ) -> tuple[int, int, int, int] | None: ...
 
     aspect = wm_aspect
+
+    # wm_attributes: Get all attributes
     if sys.version_info >= (3, 13):
         @overload
         def wm_attributes(self, *, return_python_dict: Literal[False] = False) -> tuple[Any, ...]: ...
@@ -775,6 +777,7 @@ class Wm:
         @overload
         def wm_attributes(self) -> tuple[Any, ...]: ...
 
+    # wm_attributes: Get one attribute (old variant using string that starts with "-")
     @overload
     def wm_attributes(self, option: Literal["-alpha"], /) -> float: ...
     @overload
@@ -805,7 +808,9 @@ class Wm:
         def wm_attributes(self, option: Literal["-zoomed"], /) -> bool: ...
         @overload
         def wm_attributes(self, option: Literal["-type"], /) -> str: ...
+
     if sys.version_info >= (3, 13):
+        # wm_attributes: Get one attribute (new variant without "-")
         @overload
         def wm_attributes(self, option: Literal["alpha"], /) -> float: ...
         @overload
@@ -837,6 +842,7 @@ class Wm:
             @overload
             def wm_attributes(self, option: Literal["type"], /) -> str: ...
 
+    # wm_attributes: Set an attribute (old variant using string that starts with "-")
     @overload
     def wm_attributes(self, option: str, /): ...
     @overload
@@ -868,9 +874,11 @@ class Wm:
         @overload
         def wm_attributes(self, option: Literal["-type"], value: str, /) -> Literal[""]: ...
 
+    # wm_attributes: Set multiple attributes (old variant using strings that start with "-")
     @overload
     def wm_attributes(self, option: str, value, /, *__other_option_value_pairs: Any) -> Literal[""]: ...
 
+    # wm_attributes: Set an attribute (new variant with kwarg instead of string)
     if sys.version_info >= (3, 13):
         if sys.platform == "darwin":
             @overload


### PR DESCRIPTION
It took me a while to figure out how these overloads work, so I thought I might as well add some comments. With these comments, I think I would have understood the overloads much more easily.