### PR TITLE
Fix annotation for inspect.BoundArguments.arguments

### DIFF
--- a/stdlib/inspect.pyi
+++ b/stdlib/inspect.pyi
@@ -3,7 +3,6 @@ import enum
 import sys
 import types
 from _typeshed import AnnotationForm, StrPath
-from collections import OrderedDict
 from collections.abc import AsyncGenerator, Awaitable, Callable, Coroutine, Generator, Mapping, Sequence, Set as AbstractSet
 from types import (
     AsyncGeneratorType,
@@ -468,14 +467,14 @@ class Parameter:
 
 class BoundArguments:
     __slots__ = ("arguments", "_signature", "__weakref__")
-    arguments: OrderedDict[str, Any]
+    arguments: dict[str, Any]
     @property
     def args(self) -> tuple[Any, ...]: ...
     @property
     def kwargs(self) -> dict[str, Any]: ...
     @property
     def signature(self) -> Signature: ...
-    def __init__(self, signature: Signature, arguments: OrderedDict[str, Any]) -> None: ...
+    def __init__(self, signature: Signature, arguments: dict[str, Any]) -> None: ...
     def apply_defaults(self) -> None: ...
     def __eq__(self, other: object) -> bool: ...
     __hash__: ClassVar[None]  # type: ignore[assignment]


### PR DESCRIPTION
Fixes a minor issue in the annotations for the `inspect.BoundArguments` class reported in https://github.com/python/typeshed/issues/15832.

@JelleZijlstra 