### PR TITLE
Add Python 3.15 TypedDict attributes

### DIFF
--- a/stdlib/_typeshed/_type_checker_internals.pyi
+++ b/stdlib/_typeshed/_type_checker_internals.pyi
@@ -28,6 +28,10 @@ class TypedDictFallback(Mapping[str, object], metaclass=ABCMeta):
     if sys.version_info >= (3, 13):
         __readonly_keys__: ClassVar[frozenset[str]]
         __mutable_keys__: ClassVar[frozenset[str]]
+    if sys.version_info >= (3, 15):
+        # PEP 728
+        __closed__: ClassVar[bool | None]
+        __extra_items__: ClassVar[Any]  # AnnotationForm
 
     def copy(self) -> typing_extensions.Self: ...
     # Using Never so that only calls using mypy plugin hook that specialize the signature

--- a/stdlib/_typeshed/_type_checker_internals.pyi
+++ b/stdlib/_typeshed/_type_checker_internals.pyi
@@ -5,6 +5,7 @@
 import sys
 import typing_extensions
 from _collections_abc import dict_items, dict_keys, dict_values
+from _typeshed import AnnotationForm
 from abc import ABCMeta
 from collections.abc import Awaitable, Generator, Iterable, Mapping
 from typing import Any, ClassVar, Generic, TypeVar, overload
@@ -31,7 +32,7 @@ class TypedDictFallback(Mapping[str, object], metaclass=ABCMeta):
     if sys.version_info >= (3, 15):
         # PEP 728
         __closed__: ClassVar[bool | None]
-        __extra_items__: ClassVar[Any]  # AnnotationForm
+        __extra_items__: ClassVar[AnnotationForm]
 
     def copy(self) -> typing_extensions.Self: ...
     # Using Never so that only calls using mypy plugin hook that specialize the signature

--- a/stdlib/typing.pyi
+++ b/stdlib/typing.pyi
@@ -1082,6 +1082,10 @@ class _TypedDict(Mapping[str, object], metaclass=ABCMeta):
     if sys.version_info >= (3, 13):
         __readonly_keys__: ClassVar[frozenset[str]]
         __mutable_keys__: ClassVar[frozenset[str]]
+    if sys.version_info >= (3, 15):
+        # PEP 728
+        __closed__: ClassVar[bool | None]
+        __extra_items__: ClassVar[Any]  # AnnotationForm
 
     def copy(self) -> typing_extensions.Self: ...
     # Using Never so that only calls using mypy plugin hook that specialize the signature


### PR DESCRIPTION
## Summary

Python 3.15's PEP 728 implementation adds `__closed__` and `__extra_items__` to classes created by `TypedDict`.

This adds those version-gated class variables to `_typeshed._type_checker_internals.TypedDictFallback` and the obsolete `typing._TypedDict` compatibility copy.

This was found while implementing PEP 728 support in ty: https://github.com/astral-sh/ruff/pull/25591#discussion_r3384239314
