### PR TITLE
Allow IPv6 datagram protocol addresses

### DIFF
--- a/stdlib/@tests/test_cases/asyncio/check_datagram_protocol.py
+++ b/stdlib/@tests/test_cases/asyncio/check_datagram_protocol.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+import asyncio
+
+
+class IPv4DatagramProtocol(asyncio.DatagramProtocol):
+    def datagram_received(self, data: bytes, addr: tuple[str, int]) -> None: ...
+
+
+class IPv6DatagramProtocol(asyncio.DatagramProtocol):
+    def datagram_received(self, data: bytes, addr: tuple[str, int, int, int]) -> None: ...

--- a/stdlib/asyncio/protocols.pyi
+++ b/stdlib/asyncio/protocols.pyi
@@ -1,6 +1,6 @@
 from _typeshed import ReadableBuffer
 from asyncio import transports
-from typing import Any
+from socket import _RetAddress
 
 # Keep asyncio.__all__ updated with any changes to __all__ here
 __all__ = ("BaseProtocol", "Protocol", "DatagramProtocol", "SubprocessProtocol", "BufferedProtocol")
@@ -27,11 +27,10 @@ class BufferedProtocol(BaseProtocol):
 class DatagramProtocol(BaseProtocol):
     __slots__ = ()
     def connection_made(self, transport: transports.DatagramTransport) -> None: ...  # type: ignore[override]
-    # addr can be a tuple[int, int] for some unusual protocols like socket.AF_NETLINK.
-    # Use tuple[str | Any, int] to not cause typechecking issues on most usual cases.
-    # This could be improved by using tuple[AnyOf[str, int], int] if the AnyOf feature is accepted.
-    # See https://github.com/python/typing/issues/566
-    def datagram_received(self, data: bytes, addr: tuple[str | Any, int]) -> None: ...
+    # addr varies by socket family and can be a tuple[str, int, int, int] for IPv6,
+    # tuple[int, int] for some unusual protocols like socket.AF_NETLINK, or other
+    # shapes. Keep this aligned with socket.recvfrom's return address type.
+    def datagram_received(self, data: bytes, addr: _RetAddress) -> None: ...
     def error_received(self, exc: Exception) -> None: ...
 
 class SubprocessProtocol(BaseProtocol):


### PR DESCRIPTION
Summary
- Widen `asyncio.DatagramProtocol.datagram_received`'s `addr` parameter to use `socket._RetAddress`.
- Add regression coverage for IPv4 and IPv6 datagram protocol overrides.

Reproduction
- Issue #15169 reports that IPv6 datagram endpoints can pass `(host, port, flowinfo, scope_id)`, but the stub only allowed a two-item address tuple.

Root cause
- `DatagramProtocol.datagram_received` used a two-item tuple type as a practical approximation even though datagram addresses vary by socket family.
- `socket.recvfrom` already models returned addresses as `_RetAddress`, which is broad enough for IPv4, IPv6, and non-IP socket families.

Changes
- Import `socket._RetAddress` in `stdlib/asyncio/protocols.pyi`.
- Use `_RetAddress` for `DatagramProtocol.datagram_received`.
- Add `stdlib/@tests/test_cases/asyncio/check_datagram_protocol.py` with IPv4 and IPv6 override examples.

Tests
- `PATH="$PWD/.venv/bin:$PATH" pre-commit run --files stdlib/asyncio/protocols.pyi stdlib/@tests/test_cases/asyncio/check_datagram_protocol.py`
- `PATH="$PWD/.venv/bin:$PATH" .venv/bin/python tests/regr_test.py stdlib --platform darwin -p 3.10`
- `PATH="$PWD/.venv/bin:$PATH" npx pyright@1.1.410 stdlib/@tests/test_cases --pythonversion 3.10 -p pyrightconfig.testcases.json`
- `PATH="$PWD/.venv/bin:$PATH" npx pyright@1.1.410 stdlib/asyncio --pythonversion 3.10 -p pyrightconfig.stricter.json`
- `git diff --check`

Screenshots/Logs
- Not applicable; stdlib stub/test-only change.
- Note: `tests/runtests.py stdlib/asyncio` also ran locally. Its pyright/pre-commit phases passed, but stdlib stubtest failed on this local Python 3.14 environment due unrelated runtime availability/difference issues such as missing `_tkinter`, missing `_curses.BUTTON5_*`, and annotationlib differences.

AI disclosure
- Prepared with assistance from Codex.

Fixes #15169