### PR TITLE
[grpcio] Fix AioRpcError.trailing_metadata and Metadata iteration

### DIFF
--- a/stubs/grpcio/@tests/test_cases/check_aio.py
+++ b/stubs/grpcio/@tests/test_cases/check_aio.py
@@ -17,9 +17,8 @@ grpc.aio.server(interceptors=server_interceptors)
 async def metadata() -> None:
     metadata = await cast(grpc.aio.Call, None).initial_metadata()
     assert_type(metadata["foo"], grpc.aio._MetadataValue)
-    for k in metadata:
-        assert_type(k, str)
-
-    for k, v in metadata.items():
-        assert_type(k, str)
-        assert_type(v, grpc.aio._MetadataValue)
+    # grpc.aio.Metadata is a Collection that iterates as (key, value) tuples,
+    # not a Mapping that iterates bare keys.
+    for key, value in metadata:
+        assert_type(key, str)
+        assert_type(value, grpc.aio._MetadataValue)

--- a/stubs/grpcio/grpc/aio/__init__.pyi
+++ b/stubs/grpcio/grpc/aio/__init__.pyi
@@ -1,7 +1,18 @@
 import abc
 import asyncio
-from _typeshed import Incomplete
-from collections.abc import AsyncIterable, AsyncIterator, Awaitable, Callable, Generator, Iterable, Iterator, Mapping, Sequence
+from _typeshed import Incomplete, MaybeNone
+from collections.abc import (
+    AsyncIterable,
+    AsyncIterator,
+    Awaitable,
+    Callable,
+    Collection,
+    Generator,
+    Iterable,
+    Iterator,
+    Mapping,
+    Sequence,
+)
 from concurrent import futures
 from types import TracebackType
 from typing import Any, Generic, NoReturn, TypeAlias, TypeVar, overload, type_check_only
@@ -41,7 +52,10 @@ class AioRpcError(RpcError):
         debug_error_string: str | None = None,
     ) -> None: ...
     def debug_error_string(self) -> str: ...
-    def initial_metadata(self) -> Metadata: ...
+    def initial_metadata(self) -> Metadata | MaybeNone: ...
+    # AioRpcError returns the async Metadata, overriding the synchronous
+    # grpc.RpcError.trailing_metadata() -> tuple[_Metadatum, ...].
+    def trailing_metadata(self) -> Metadata | MaybeNone: ...  # type: ignore[override]
 
 # Create Client:
 
@@ -445,7 +459,7 @@ _MetadatumType: TypeAlias = tuple[_MetadataKey, _MetadataValue]
 _MetadataType: TypeAlias = Metadata | Sequence[_MetadatumType]
 _T = TypeVar("_T")
 
-class Metadata(Mapping[_MetadataKey, _MetadataValue]):
+class Metadata(Collection[_MetadatumType]):
     def __init__(self, *args: tuple[_MetadataKey, _MetadataValue]) -> None: ...
     @classmethod
     def from_tuple(cls, raw_metadata: tuple[_MetadataKey, _MetadataValue]) -> Metadata: ...
@@ -455,7 +469,7 @@ class Metadata(Mapping[_MetadataKey, _MetadataValue]):
     def __setitem__(self, key: _MetadataKey, value: _MetadataValue) -> None: ...
     def __delitem__(self, key: _MetadataKey) -> None: ...
     def delete_all(self, key: _MetadataKey) -> None: ...
-    def __iter__(self) -> Iterator[_MetadataKey]: ...
+    def __iter__(self) -> Iterator[_MetadatumType]: ...
 
     @overload
     def get(self, key: _MetadataKey, default: None = None) -> _MetadataValue | None: ...


### PR DESCRIPTION
I encountered a typing issue when using `grpc.aio` and figured I would write a PR to solve it at source.

Two related fixes to the async (`grpc.aio`) metadata types:

1. **`AioRpcError.trailing_metadata()`** inherited the synchronous
   `RpcError.trailing_metadata() -> tuple[_Metadatum, ...]`, but at runtime returns a
   `grpc.aio.Metadata`
   ([`_call.py`](https://github.com/grpc/grpc/blob/master/src/python/grpcio/grpc/aio/_call.py)).
   Added the override.

2. **`grpc.aio.Metadata`** was modelled as a `Mapping`, but the runtime class is a
   `Collection` that iterates `(key, value)` tuples
   ([`_metadata.py`](https://github.com/grpc/grpc/blob/master/src/python/grpcio/grpc/aio/_metadata.py)).
   Re-based on `Collection[_MetadatumType]` with an item-yielding `__iter__`; keyed
   access (`m[key]`, `m.get(...)`) is unchanged.

Together these let `for key, value in err.trailing_metadata()` type-check — it
previously errored with "`_Metadatum` is not iterable".

```python
import grpc.aio

def reason(err: grpc.aio.AioRpcError) -> None:
    for key, value in err.trailing_metadata():  # before: error "_Metadatum is not iterable"
...
```

```pycon
>>> import grpc
>>> from grpc.aio import Metadata, AioRpcError
>>> m = Metadata(("x-request-id", "abc"))
>>> [type(x).__name__ for x in m]            # iterates items, not keys
['tuple']
>>> err = AioRpcError(grpc.StatusCode.NOT_FOUND, Metadata(), m)
>>> type(err.trailing_metadata()).__name__   # not tuple[_Metadatum, ...]
'Metadata'
```

Please let me know if I've overlooked something in the contribution process.