### PR TITLE
`set_lazy_imports_filter`'s first arg (`importing_module`) can be `None`

### DIFF
--- a/stdlib/sys/__init__.pyi
+++ b/stdlib/sys/__init__.pyi
@@ -10,7 +10,7 @@ from typing_extensions import LiteralString, deprecated
 
 _T = TypeVar("_T")
 _LazyImportMode: TypeAlias = Literal["normal", "all", "none"]
-_LazyImportFilter: TypeAlias = Callable[[str, str, tuple[str, ...] | None], bool]
+_LazyImportFilter: TypeAlias = Callable[[str | None, str, tuple[str, ...] | None], bool]
 
 # see https://github.com/python/typeshed/issues/8513#issue-1333671093 for the rationale behind this alias
 _ExitCode: TypeAlias = str | int | None


### PR DESCRIPTION
In real world scenario (see https://github.com/Toufool/AutoSplit/commit/ba2e3d4f4dcc9d97b78e7830fc4ec72cc86c3076#diff-37d213d547553f3e9f803b055881175eebb3b15caf26baec90775d81be0389f0 where I was playing around with the new lazy import filtering API) I've hit the first arg being `None`. I think from exec'd/embedded code (e.g. shiboken6's signature bootstrap)

Weirdly, this is not documented: https://docs.python.org/3.15/library/sys.html#sys.set_lazy_imports_filter
I've considered `| MaybeNone`, but this is already advanced usage, may as well be correct and let advanced users account for this edge case.