### PR TITLE
Add NamedTuple `__match_args__` attribute

### DIFF
--- a/stdlib/_typeshed/_type_checker_internals.pyi
+++ b/stdlib/_typeshed/_type_checker_internals.pyi
@@ -63,6 +63,7 @@ class TypedDictFallback(Mapping[str, object], metaclass=ABCMeta):
 class NamedTupleFallback(tuple[Any, ...]):
     _field_defaults: ClassVar[dict[str, Any]]
     _fields: ClassVar[tuple[str, ...]]
+    __match_args__: ClassVar[tuple[str, ...]] = ...
     # __orig_bases__ sometimes exists on <3.12, but not consistently
     # So we only add it to the stub on 3.12+.
     if sys.version_info >= (3, 12):

--- a/stdlib/typing.pyi
+++ b/stdlib/typing.pyi
@@ -1049,6 +1049,7 @@ if sys.version_info >= (3, 11):
 class NamedTuple(tuple[Any, ...]):
     _field_defaults: ClassVar[dict[str, Any]]
     _fields: ClassVar[tuple[str, ...]]
+    __match_args__: ClassVar[tuple[str, ...]] = ...
     # __orig_bases__ sometimes exists on <3.12, but not consistently
     # So we only add it to the stub on 3.12+.
     if sys.version_info >= (3, 12):


### PR DESCRIPTION
## Summary

Python 3.10 adds `__match_args__` to classes created by `NamedTuple`.

This adds the class variable to `_typeshed._type_checker_internals.NamedTupleFallback` and the obsolete `typing.NamedTuple` compatibility copy.

This was found while implementing `__match_args__` support for named tuples in ty: https://github.com/astral-sh/ruff/pull/25934
