### PR TITLE
Set `tool.black.exclude` so that `stdlib/venv` is not excluded when "manually" invoking Black

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,9 +11,28 @@ target-version = ["py310"]
 skip-magic-trailing-comma = true
 preview = true
 
+# Override `exclude` so that the `stdlib/venv` directory is not excluded
+# if you invoke Black "manually" (not using pre-commit). `venv` is one of
+# the directories that Black excludes by default if `tool.black.exclude`
+# is not set. See https://black.readthedocs.io/en/stable/usage_and_configuration/the_basics.html#exclude
+exclude = '''
+/(
+    \.env|
+    \.venv|
+    env|
+    \.git|
+    \.mypy_cache
+)/
+'''
+
 [tool.ruff]
 line-length = 130
 fix = true
+
+# Override `exclude` so that the `stdlib/venv` directory is not excluded
+# if you invoke Ruff "manually" (not using pre-commit). `venv` is one of
+# the directories that Ruff excludes by default if `tool.ruff.exclude`
+# is not set. See https://docs.astral.sh/ruff/configuration/
 exclude = [
     # virtual environment
     ".env",


### PR DESCRIPTION
If you don't set `tool.black.exclude`, Black by default ignores everything listed in your `.gitignore` file _and_ ignores a hardcoded list of regex patterns. This is documented [here](https://black.readthedocs.io/en/stable/usage_and_configuration/the_basics.html#exclude). One of those regex patterns is `venv`, so if you run `uvx black stdlib/venv` in this repo, Black currently does this:

```
% uvx black stdlib/venv
No Python files are present to be formatted. Nothing to do 😴
```

Now, that actually doesn't matter much for CI in this repo right now, because we run Black in CI via pre-commit, which passes all files to be formatted as positional arguments when it invokes Black. Explicitly passed positional _files_ are formatted by Black even if the whole directory matches an exclude pattern:

```
% uvx black stdlib/venv/__init__.pyi
All done! ✨ 🍰 ✨
1 file left unchanged.
```

So Black _has_ been enforced in CI anyway for typeshed because of the specific way we've been invoking it. Still, it seems weird that, right now, exactly which files are formatted depends on exactly how you're invoking Black. This PR therefore adds a `tool.black.exclude` setting so that this is consistent however you invoke Black. It has the same exclusions as the `tool.ruff.exclude` setting we already specify in our `pyproject.toml` file.

This problem has existed since https://github.com/python/typeshed/commit/1f1bc6f27c5bb4891bd8129bede153052a96bae3, when typeshed replaced its `tool.black.exclude` setting with a `tool.black.force-exclude` setting! The reason why I noticed it now is that I was investigating why some of the docstrings in Ruff's codemodded version of typeshed have [apparently quite bad formatting](https://github.com/astral-sh/ruff/blob/c8b63fcf950e4cdca19fcf1d1dea7bd1576301b8/crates/ty_vendored/vendor/typeshed/stdlib/venv/__init__.pyi#L77-L169). The reason is that we [format the stubs after codemodding them](https://github.com/astral-sh/ruff/blob/c8b63fcf950e4cdca19fcf1d1dea7bd1576301b8/.github/workflows/sync_typeshed.yaml#L210-L213) using `uvx black --config=<typeshed pyproject.toml file>`, and typeshed's pyproject.toml file doesn't specify `tool.black.exclude`, so in Ruff's CI we were just falling back to Black's default exclude patterns too. If necessary, I can just fix this problem in Ruff's CI, but I figured that it's quite confusing to have Black work differently in typeshed depending on how it's invoked, so it might be better to fix the problem over here.

(We use Black to format the stubs in Ruff's CI so that we minimize spurious differences with the upstream stubs; formatting the codemodded stubs with Ruff would increase the risk of that.)