### PR TITLE
Add type stubs for `scp` package

### DIFF
--- a/stubs/scp/METADATA.toml
+++ b/stubs/scp/METADATA.toml
@@ -1,0 +1,3 @@
+version = "0.15.*"
+upstream-repository = "https://github.com/jbardin/scp.py"
+dependencies = ["types-paramiko"]

--- a/stubs/scp/scp.pyi
+++ b/stubs/scp/scp.pyi
@@ -1,7 +1,7 @@
 from collections.abc import Callable, Iterable
 from pathlib import PurePath
 from types import TracebackType
-from typing import IO, Final, Literal, TypeAlias
+from typing import Final, Literal, Protocol, TypeAlias, type_check_only
 from typing_extensions import Self
 
 from paramiko.channel import Channel
@@ -14,6 +14,12 @@ PATH_TYPES: Final[tuple[type[str], type[bytes], type[PurePath]]]
 bytes_sep: Final[bytes]
 
 PathTypes: TypeAlias = str | bytes | PurePath
+
+@type_check_only
+class _PutFOReader(Protocol):
+    def read(self, size: int, /) -> str | bytes | bytearray: ...
+    def tell(self) -> int: ...
+    def seek(self, offset: int, whence: Literal[0, 2], /) -> object: ...
 
 def asbytes(s: PathTypes) -> bytes: ...
 def asunicode(s: bytes | str) -> str: ...
@@ -49,9 +55,7 @@ class SCPClient:
         recursive: bool = False,
         preserve_times: bool = False,
     ) -> None: ...
-    def putfo(
-        self, fl: IO[str] | IO[bytes], remote_path: PathTypes, mode: str | bytes = "0644", size: int | None = None
-    ) -> None: ...
+    def putfo(self, fl: _PutFOReader, remote_path: PathTypes, mode: str | bytes = "0644", size: int | None = None) -> None: ...
     def get(
         self,
         remote_path: PathTypes | Iterable[PathTypes],

--- a/stubs/scp/scp.pyi
+++ b/stubs/scp/scp.pyi
@@ -1,0 +1,79 @@
+from collections.abc import Callable, Iterable
+from pathlib import PurePath
+from types import TracebackType
+from typing import IO, Final, Literal, TypeAlias
+from typing_extensions import Self
+
+from paramiko.channel import Channel
+from paramiko.transport import Transport
+
+__version__: Final[str]
+
+SCP_COMMAND: Final = b"scp"
+PATH_TYPES: Final[tuple[type[str], type[bytes], type[PurePath]]]
+bytes_sep: Final[bytes]
+
+PathTypes: TypeAlias = str | bytes | PurePath
+
+def asbytes(s: PathTypes) -> bytes: ...
+def asunicode(s: bytes | str) -> str: ...
+def asunicode_win(s: bytes | str) -> str: ...
+
+class SCPClient:
+    transport: Transport
+    buff_size: int
+    socket_timeout: float | None
+    channel: Channel | None
+    preserve_times: bool
+    sanitize: Callable[[bytes], bytes]
+    peername: tuple[str, int]
+    scp_command: bytes
+    def __init__(
+        self,
+        transport: Transport,
+        buff_size: int = 16384,
+        socket_timeout: float | None = 10.0,
+        progress: Callable[[str | bytes, int, int], None] | None = None,
+        progress4: Callable[[str | bytes, int, int, tuple[str, int]], None] | None = None,
+        sanitize: Callable[[bytes], bytes] | Literal[False] = ...,
+        limit_bw: int | None = None,
+    ) -> None: ...
+    def __enter__(self) -> Self: ...
+    def __exit__(
+        self, type: type[BaseException] | None, value: BaseException | None, traceback: TracebackType | None
+    ) -> None: ...
+    def put(
+        self,
+        files: PathTypes | Iterable[PathTypes],
+        remote_path: PathTypes = b".",
+        recursive: bool = False,
+        preserve_times: bool = False,
+    ) -> None: ...
+    def putfo(
+        self, fl: IO[str] | IO[bytes], remote_path: PathTypes, mode: str | bytes = "0644", size: int | None = None
+    ) -> None: ...
+    def get(
+        self,
+        remote_path: PathTypes | Iterable[PathTypes],
+        local_path: PathTypes = "",
+        recursive: bool = False,
+        preserve_times: bool = False,
+    ) -> None: ...
+    def close(self) -> None: ...
+
+class SCPException(Exception): ...
+
+def put(
+    transport: Transport,
+    files: PathTypes | Iterable[PathTypes],
+    remote_path: PathTypes = b".",
+    recursive: bool = False,
+    preserve_times: bool = False,
+) -> None: ...
+def get(
+    transport: Transport,
+    remote_path: PathTypes | Iterable[PathTypes],
+    local_path: PathTypes = "",
+    recursive: bool = False,
+    preserve_times: bool = False,
+) -> None: ...


### PR DESCRIPTION
This PR implements type stubs for the `scp` package:
- Repository: https://github.com/jbardin/scp.py
- PyPI project: https://pypi.org/project/scp/

Also see #15913.

As this is my first contribution to typeshed, I have a few questions regarding the implementation:
- I don't quite get `# undocumented` comments: what "documented" refers to in this context? Is it about docstrings mentions or some type information _(I mean when documentation is a small `README.md`, like in this case)_? 
  - Is it generally necessary to add these comments?
- Is it OK to use `IO[str] | IO[bytes]` instead of `IO[AnyStr]` for [`.putfo()`](https://github.com/jbardin/scp.py/blob/master/scp.py#L214)? Since `AnyStr` is being phased out and there is no strict need for generic behavior here, using a union seems cleaner.
- Are there any recommendations about `import X` versus `from X import Y`? I couldn't find a consistent pattern in the existing stubs :)