### PR TITLE
ast: Add missing APIs for Python 3.14 and 3.15 syntax

### DIFF
--- a/stdlib/ast.pyi
+++ b/stdlib/ast.pyi
@@ -956,14 +956,27 @@ class DictComp(expr):
     else:
         value: expr
     generators: list[comprehension]
-    if sys.version_info >= (3, 13):
+    if sys.version_info >= (3, 15):
+        def __init__(
+            self, key: expr, value: expr | None = None, generators: list[comprehension] = ..., **kwargs: Unpack[_Attributes]
+        ) -> None: ...
+    elif sys.version_info >= (3, 13):
         def __init__(
             self, key: expr, value: expr, generators: list[comprehension] = ..., **kwargs: Unpack[_Attributes]
         ) -> None: ...
     else:
         def __init__(self, key: expr, value: expr, generators: list[comprehension], **kwargs: Unpack[_Attributes]) -> None: ...
 
-    if sys.version_info >= (3, 14):
+    if sys.version_info >= (3, 15):
+        def __replace__(
+            self,
+            *,
+            key: expr = ...,
+            value: expr | None = ...,
+            generators: list[comprehension] = ...,
+            **kwargs: Unpack[_Attributes],
+        ) -> Self: ...
+    elif sys.version_info >= (3, 14):
         def __replace__(
             self, *, key: expr = ..., value: expr = ..., generators: list[comprehension] = ..., **kwargs: Unpack[_Attributes]
         ) -> Self: ...
@@ -2146,6 +2159,10 @@ class NodeVisitor:
         def visit_ParamSpec(self, node: ParamSpec) -> Any: ...
         def visit_TypeVarTuple(self, node: TypeVarTuple) -> Any: ...
         def visit_TypeAlias(self, node: TypeAlias) -> Any: ...
+
+    if sys.version_info >= (3, 14):
+        def visit_TemplateStr(self, node: TemplateStr) -> Any: ...
+        def visit_Interpolation(self, node: Interpolation) -> Any: ...
 
     # visit methods for deprecated nodes
     def visit_ExtSlice(self, node: ExtSlice) -> Any: ...


### PR DESCRIPTION
Closes #15929.

Python 3.14 added the `TemplateStr` and `Interpolation` AST nodes, but the corresponding dynamically dispatched methods were missing from `NodeVisitor`.

Python 3.15 also permits dictionary unpacking in comprehensions, which represents the `DictComp.value` field as `None`. This PR therefore also updates the version-gated constructor and `__replace__` signatures to accept that representation.

For example:

```python
merged = {**mapping for mapping in mappings}
```
