### PR TITLE
Simplify some GitHub workflows

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -123,18 +123,14 @@ jobs:
         with:
           repository: typeshed-internal/stub_uploader
           path: stub_uploader
-      - uses: actions/setup-python@v6
-        with:
-          # Keep in sync with stub_uploader's check_scripts.yml workflow.
-          python-version: "3.13"
       - uses: astral-sh/setup-uv@v7
         with:
           version-file: "typeshed/requirements-tests.txt"
       - name: Run tests
         run: |
           cd stub_uploader
-          uv pip install -r requirements.txt --system
-          python -m pytest tests
+          # Keep Python version in sync with stub_uploader's check_scripts.yml workflow.
+          uv run --python=3.13 --no-project --with-requirements=requirements.txt -m pytest tests
 
   # https://github.community/t/run-github-actions-job-only-if-previous-job-has-failed/174786/2
   create-issue-on-failure:

--- a/.github/workflows/meta_tests.yml
+++ b/.github/workflows/meta_tests.yml
@@ -36,14 +36,17 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.13"
       - uses: astral-sh/setup-uv@v7
         with:
           version-file: "requirements-tests.txt"
-      - run: uv pip install -r requirements-tests.txt --system
-      - run: python ./tests/typecheck_typeshed.py --platform=${{ matrix.platform }}
+      - run: |
+          uv run \
+          --python=3.13 \
+          --no-project \
+          --with-requirements=requirements-tests.txt \
+          ./tests/typecheck_typeshed.py \
+          --platform=${{ matrix.platform }}
+
   pyright:
     name: Check scripts and tests with pyright
     runs-on: ubuntu-latest
@@ -67,14 +70,12 @@ jobs:
           python-platform: ${{ matrix.python-platform }}
           python-version: "3.10" # Oldest version supported for running scripts and tests
           project: ./pyrightconfig.scripts_and_tests.json
+
   stubsabot-dry-run:
     name: Stubsabot dry run
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.13"
       - uses: astral-sh/setup-uv@v7
         with:
           version-file: "requirements-tests.txt"
@@ -82,5 +83,10 @@ jobs:
         run: |
           git config --global user.name stubsabot
           git config --global user.email '<>'
-      - run: uv pip install -r requirements-tests.txt --system
-      - run: python scripts/stubsabot.py --action-level local
+      - run: |
+          uv run \
+          --python=3.13 \
+          --no-project \
+          --with-requirements=requirements-tests.txt \
+          scripts/stubsabot.py \
+          --action-level=local

--- a/.github/workflows/stubsabot.yml
+++ b/.github/workflows/stubsabot.yml
@@ -24,9 +24,6 @@ jobs:
           # use an ssh key so that checks automatically run on stubsabot PRs
           ssh-key: ${{ secrets.STUBSABOT_SSH_PRIVATE_KEY }}
           fetch-depth: 0
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.13"
       - uses: astral-sh/setup-uv@v7
         with:
           version-file: "requirements-tests.txt"
@@ -34,10 +31,15 @@ jobs:
         run: |
           git config --global user.name stubsabot
           git config --global user.email '<>'
-      - name: Install dependencies
-        run: uv pip install -r requirements-tests.txt --system
       - name: Run stubsabot
-        run: GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} python scripts/stubsabot.py --action-level everything
+        run: |
+          GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
+          uv run \
+          --python=3.13 \
+          --no-project \
+          --with-requirements=requirements-tests.txt \
+          scripts/stubsabot.py \
+          --action-level=everything
 
   # https://github.community/t/run-github-actions-job-only-if-previous-job-has-failed/174786/2
   create-issue-on-failure:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,14 +27,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.13"
       - uses: astral-sh/setup-uv@v7
         with:
           version-file: "requirements-tests.txt"
-      - run: uv pip install -r requirements-tests.txt --system
-      - run: python ./tests/check_typeshed_structure.py
+      - run: |
+          uv run \
+          --python=3.13 \
+          --no-project \
+          --with-requirements=requirements-tests.txt \
+          ./tests/check_typeshed_structure.py
 
   mypy:
     name: "mypy: Check stubs"
@@ -69,14 +70,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.14"
       - uses: astral-sh/setup-uv@v7
         with:
           version-file: "requirements-tests.txt"
-      - run: uv pip install -r requirements-tests.txt --system
-      - run: python ./tests/regr_test.py --all --verbosity QUIET
+      - run: |
+          uv run \
+          --python=3.14 \
+          --no-project \
+          --with-requirements=requirements-tests.txt \
+          ./tests/regr_test.py \
+          --all \
+          --verbosity=QUIET
 
   pyright:
     name: "pyright: Run test cases"
@@ -156,15 +160,10 @@ jobs:
         with:
           repository: typeshed-internal/stub_uploader
           path: stub_uploader
-      - uses: actions/setup-python@v6
-        with:
-          # Keep in sync with stub_uploader's check_scripts.yml workflow.
-          python-version: "3.13"
       - uses: astral-sh/setup-uv@v7
         with:
           version-file: "typeshed/requirements-tests.txt"
       - name: Run tests
         run: |
           cd stub_uploader
-          uv pip install -r requirements.txt --system
-          python -m pytest tests
+          uv run --python=3.13 --no-project --with-requirements=requirements.txt -m pytest tests


### PR DESCRIPTION
Remove `setup-python` steps in various jobs that are already using uv. uv is capable of installing Python itself; getting rid of the unnecessary step means there's one less step that could go wrong when running the job