### PR TITLE
Add comment explaining why `typing_extensions.TypedDict` is kept distinct

### DIFF
--- a/stdlib/typing_extensions.pyi
+++ b/stdlib/typing_extensions.pyi
@@ -232,6 +232,9 @@ Literal: _SpecialForm
 
 def IntVar(name: str) -> Any: ...  # returns a new TypeVar
 
+# Kept as a distinct symbol to `typing.TypedDict` so that type checkers can more easily
+# distinguish between the two on Python 3.14, on which `typing_extensions.TypedDict`
+# exposes `__closed__` and `__extra_items__` but `typing.TypedDict` does not
 TypedDict: _SpecialForm
 
 # Internal mypy fallback type for all typed dicts (does not exist at runtime)


### PR DESCRIPTION
it would be too easy for an eager contributor to revert https://github.com/python/typeshed/commit/45313743b0c7fea31ffc389e402c87aaec13291f in the name of simplifying the stub