### PR TITLE
Add cleanup_socket to AbstractEventLoop create_unix_server

### DIFF
--- a/stdlib/@tests/stubtest_allowlists/py313.txt
+++ b/stdlib/@tests/stubtest_allowlists/py313.txt
@@ -104,6 +104,10 @@ codecs.replace_errors  # Runtime incorrectly has `self`
 codecs.strict_errors  # Runtime incorrectly has `self`
 codecs.xmlcharrefreplace_errors  # Runtime incorrectly has `self`
 
+# The concrete Unix event loop accepts this Python 3.13 parameter, but the
+# abstract runtime signature has not been updated.
+asyncio.events.AbstractEventLoop.create_unix_server  # parameter `cleanup_socket`
+
 # These multiprocessing proxy methods have *args, **kwargs signatures at runtime,
 # But have more precise (accurate) signatures in the stub
 multiprocessing.managers._BaseDictProxy.__iter__

--- a/stdlib/@tests/stubtest_allowlists/py314.txt
+++ b/stdlib/@tests/stubtest_allowlists/py314.txt
@@ -138,6 +138,10 @@ codecs.replace_errors  # Runtime incorrectly has `self`
 codecs.strict_errors  # Runtime incorrectly has `self`
 codecs.xmlcharrefreplace_errors  # Runtime incorrectly has `self`
 
+# The concrete Unix event loop accepts this Python 3.13 parameter, but the
+# abstract runtime signature has not been updated.
+asyncio.events.AbstractEventLoop.create_unix_server  # parameter `cleanup_socket`
+
 # These multiprocessing proxy methods have *args, **kwargs signatures at runtime,
 # But have more precise (accurate) signatures in the stub
 multiprocessing.managers._BaseDictProxy.__iter__

--- a/stdlib/@tests/stubtest_allowlists/py315.txt
+++ b/stdlib/@tests/stubtest_allowlists/py315.txt
@@ -138,6 +138,10 @@ codecs.replace_errors  # Runtime incorrectly has `self`
 codecs.strict_errors  # Runtime incorrectly has `self`
 codecs.xmlcharrefreplace_errors  # Runtime incorrectly has `self`
 
+# The concrete Unix event loop accepts this Python 3.13 parameter, but the
+# abstract runtime signature has not been updated.
+asyncio.events.AbstractEventLoop.create_unix_server  # parameter `cleanup_socket`
+
 # These multiprocessing proxy methods have *args, **kwargs signatures at runtime,
 # but have more precise (accurate) signatures in the stub.
 multiprocessing.managers._BaseDictProxy.__iter__

--- a/stdlib/@tests/test_cases/asyncio/check_events-py313.py
+++ b/stdlib/@tests/test_cases/asyncio/check_events-py313.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import asyncio
+import sys
+from collections.abc import Callable
+
+if sys.version_info >= (3, 13):
+
+    async def check_abstract_event_loop_create_unix_server_cleanup_socket(
+        loop: asyncio.AbstractEventLoop, protocol_factory: Callable[[], asyncio.Protocol]
+    ) -> None:
+        await loop.create_unix_server(protocol_factory, cleanup_socket=False)

--- a/stdlib/asyncio/events.pyi
+++ b/stdlib/asyncio/events.pyi
@@ -422,18 +422,33 @@ class AbstractEventLoop:
             ssl_handshake_timeout: float | None = None,
             ssl_shutdown_timeout: float | None = None,
         ) -> Transport | None: ...
-        async def create_unix_server(
-            self,
-            protocol_factory: _ProtocolFactory,
-            path: StrPath | None = None,
-            *,
-            sock: socket | None = None,
-            backlog: int = 100,
-            ssl: _SSLContext = None,
-            ssl_handshake_timeout: float | None = None,
-            ssl_shutdown_timeout: float | None = None,
-            start_serving: bool = True,
-        ) -> Server: ...
+        if sys.version_info >= (3, 13):
+            async def create_unix_server(
+                self,
+                protocol_factory: _ProtocolFactory,
+                path: StrPath | None = None,
+                *,
+                sock: socket | None = None,
+                backlog: int = 100,
+                ssl: _SSLContext = None,
+                ssl_handshake_timeout: float | None = None,
+                ssl_shutdown_timeout: float | None = None,
+                start_serving: bool = True,
+                cleanup_socket: bool = True,
+            ) -> Server: ...
+        else:
+            async def create_unix_server(
+                self,
+                protocol_factory: _ProtocolFactory,
+                path: StrPath | None = None,
+                *,
+                sock: socket | None = None,
+                backlog: int = 100,
+                ssl: _SSLContext = None,
+                ssl_handshake_timeout: float | None = None,
+                ssl_shutdown_timeout: float | None = None,
+                start_serving: bool = True,
+            ) -> Server: ...
     else:
         @abstractmethod
         async def start_tls(


### PR DESCRIPTION
Fixes #15742.

`asyncio.unix_events._UnixSelectorEventLoop.create_unix_server` already includes the Python 3.13 `cleanup_socket` keyword, but `asyncio.events.AbstractEventLoop.create_unix_server` did not. This adds the Python 3.13+ keyword there so code typed as `AbstractEventLoop` can call the API without a false-positive type error.

The abstract runtime signature still lacks the keyword, so the versioned stubtest allowlists document that mismatch while keeping the concrete Unix event-loop signature checked.

Checks run:

- `PYTHONPATH=lib /Volumes/STOREJET/2/Dependencies/typeshed-venv/bin/python tests/regr_test.py stdlib --python-version 3.13`
- `PYTHONPATH=lib /Volumes/STOREJET/2/Dependencies/typeshed-venv/bin/python tests/regr_test.py stdlib --python-version 3.12`
- `PYTHONPATH=lib /Volumes/STOREJET/2/Dependencies/typeshed-venv/bin/python tests/mypy_test.py stdlib/asyncio --python-version 3.13`
- `PYTHONPATH=lib /Volumes/STOREJET/2/Dependencies/typeshed-venv/bin/python tests/pyright_test.py stdlib/asyncio/events.pyi`
- `PYTHONPATH=lib /Volumes/STOREJET/2/Dependencies/typeshed-venv/bin/python tests/check_typeshed_structure.py`
- `PYTHONPATH=lib /Volumes/STOREJET/2/Dependencies/typeshed-venv/bin/python -m mypy.stubtest --show-traceback --strict-type-check-only --custom-typeshed-dir . --ignore-unused-allowlist --allowlist stdlib/@tests/stubtest_allowlists/common.txt --allowlist stdlib/@tests/stubtest_allowlists/darwin.txt --allowlist stdlib/@tests/stubtest_allowlists/py314.txt --allowlist stdlib/@tests/stubtest_allowlists/darwin-py314.txt asyncio.events asyncio.unix_events`
- `/Volumes/STOREJET/2/Dependencies/typeshed-venv/bin/python -m ruff format --check stdlib/asyncio/events.pyi stdlib/@tests/test_cases/asyncio/check_events-py313.py`
- `git diff --check`

Note: `tests/runtests.py stdlib/asyncio --python-version 3.13` reached successful mypy/pyright/regression/structure checks locally, but the all-in-one run was not fully usable in this external-volume checkout: pre-commit hook installation generated AppleDouble `._*.dist-info` metadata in its hook venv, and full stdlib stubtest also reports unrelated local Python 3.14 runtime mismatches outside asyncio (`_curses`, `annotationlib`, `pyexpat`).
