### PR TITLE
Fix aiofiles NamedTemporaryFile name type

### DIFF
--- a/stubs/aiofiles/@tests/test_cases/check_tempfile.py
+++ b/stubs/aiofiles/@tests/test_cases/check_tempfile.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from typing_extensions import assert_type
+
+from aiofiles.tempfile import NamedTemporaryFile
+
+
+async def check_named_temporary_file_name() -> None:
+    async with NamedTemporaryFile() as binary_file:
+        assert_type(binary_file.name, str)
+
+    async with NamedTemporaryFile(mode="w+") as text_file:
+        assert_type(text_file.name, str)

--- a/stubs/aiofiles/aiofiles/tempfile/__init__.pyi
+++ b/stubs/aiofiles/aiofiles/tempfile/__init__.pyi
@@ -11,11 +11,31 @@ from _typeshed import (
 )
 from asyncio import AbstractEventLoop
 from concurrent.futures import Executor
-from typing import AnyStr, Literal, overload
+from typing import AnyStr, Literal, overload, type_check_only
 
 from ..base import AiofilesContextManager
 from ..threadpool.binary import AsyncBufferedIOBase, AsyncBufferedReader, AsyncFileIO
 from ..threadpool.text import AsyncTextIOWrapper
+
+@type_check_only
+class _NamedAsyncTextIOWrapper(AsyncTextIOWrapper):
+    @property
+    def name(self) -> str: ...
+
+@type_check_only
+class _NamedAsyncFileIO(AsyncFileIO):
+    @property
+    def name(self) -> str: ...
+
+@type_check_only
+class _NamedAsyncBufferedReader(AsyncBufferedReader):
+    @property
+    def name(self) -> str: ...
+
+@type_check_only
+class _NamedAsyncBufferedIOBase(AsyncBufferedIOBase):
+    @property
+    def name(self) -> str: ...
 
 # Text mode: always returns AsyncTextIOWrapper
 @overload
@@ -89,7 +109,7 @@ if sys.version_info >= (3, 12):
         delete_on_close: bool = True,
         loop: AbstractEventLoop | None = None,
         executor: Executor | None = None,
-    ) -> AiofilesContextManager[AsyncTextIOWrapper]: ...
+    ) -> AiofilesContextManager[_NamedAsyncTextIOWrapper]: ...
 
     # Unbuffered binary: returns a FileIO
     @overload
@@ -105,7 +125,7 @@ if sys.version_info >= (3, 12):
         delete_on_close: bool = True,
         loop: AbstractEventLoop | None = None,
         executor: Executor | None = None,
-    ) -> AiofilesContextManager[AsyncFileIO]: ...
+    ) -> AiofilesContextManager[_NamedAsyncFileIO]: ...
 
     # Buffered binary reading/updating: AsyncBufferedReader
     @overload
@@ -121,7 +141,7 @@ if sys.version_info >= (3, 12):
         delete_on_close: bool = True,
         loop: AbstractEventLoop | None = None,
         executor: Executor | None = None,
-    ) -> AiofilesContextManager[AsyncBufferedReader]: ...
+    ) -> AiofilesContextManager[_NamedAsyncBufferedReader]: ...
 
     # Buffered binary writing: AsyncBufferedIOBase
     @overload
@@ -137,7 +157,7 @@ if sys.version_info >= (3, 12):
         delete_on_close: bool = True,
         loop: AbstractEventLoop | None = None,
         executor: Executor | None = None,
-    ) -> AiofilesContextManager[AsyncBufferedIOBase]: ...
+    ) -> AiofilesContextManager[_NamedAsyncBufferedIOBase]: ...
 else:
     # Text mode: always returns AsyncTextIOWrapper
     @overload
@@ -152,7 +172,7 @@ else:
         delete: bool = True,
         loop: AbstractEventLoop | None = None,
         executor: Executor | None = None,
-    ) -> AiofilesContextManager[AsyncTextIOWrapper]: ...
+    ) -> AiofilesContextManager[_NamedAsyncTextIOWrapper]: ...
 
     # Unbuffered binary: returns a FileIO
     @overload
@@ -167,7 +187,7 @@ else:
         delete: bool = True,
         loop: AbstractEventLoop | None = None,
         executor: Executor | None = None,
-    ) -> AiofilesContextManager[AsyncFileIO]: ...
+    ) -> AiofilesContextManager[_NamedAsyncFileIO]: ...
 
     # Buffered binary reading/updating: AsyncBufferedReader
     @overload
@@ -182,7 +202,7 @@ else:
         delete: bool = True,
         loop: AbstractEventLoop | None = None,
         executor: Executor | None = None,
-    ) -> AiofilesContextManager[AsyncBufferedReader]: ...
+    ) -> AiofilesContextManager[_NamedAsyncBufferedReader]: ...
 
     # Buffered binary writing: AsyncBufferedIOBase
     @overload
@@ -197,7 +217,7 @@ else:
         delete: bool = True,
         loop: AbstractEventLoop | None = None,
         executor: Executor | None = None,
-    ) -> AiofilesContextManager[AsyncBufferedIOBase]: ...
+    ) -> AiofilesContextManager[_NamedAsyncBufferedIOBase]: ...
 
 # Text mode: always returns AsyncTextIOWrapper
 @overload


### PR DESCRIPTION
Fixes #13551.

`aiofiles.tempfile.NamedTemporaryFile()` always creates a named temporary file, so its async file object exposes `name` as a string path. The generic aiofiles async file wrappers still keep the broader `FileDescriptorOrPath` type for other call sites, but the `NamedTemporaryFile()` overloads now return named wrapper variants that narrow `name` to `str`.

Validation:

- `/Volumes/STOREJET/2/Dependencies/typeshed-venv/bin/python tests/regr_test.py aiofiles --python-version 3.13 --verbosity NORMAL`
- `/Volumes/STOREJET/2/Dependencies/typeshed-venv/bin/python tests/mypy_test.py stubs/aiofiles --python-version 3.13`
- `/Volumes/STOREJET/2/Dependencies/typeshed-venv/bin/python tests/check_typeshed_structure.py`
- `NPM_CONFIG_CACHE=/Volumes/STOREJET/Documents/OSC/repos/typeshed-aiofiles-name/.npm-cache /Volumes/STOREJET/2/Dependencies/typeshed-venv/bin/python tests/pyright_test.py stubs/aiofiles/aiofiles/tempfile/__init__.pyi`
- `git diff --check`
