### PR TITLE
[http] Update Cookie type hints

### DIFF
--- a/stdlib/http/cookiejar.pyi
+++ b/stdlib/http/cookiejar.pyi
@@ -129,7 +129,7 @@ class Cookie:
     domain_initial_dot: bool
     def __init__(
         self,
-        version: int | None,
+        version: int | str | None,
         name: str,
         value: str | None,  # undocumented
         port: str | None,
@@ -140,7 +140,7 @@ class Cookie:
         path: str,
         path_specified: bool,
         secure: bool,
-        expires: int | None,
+        expires: float | str | None,
         discard: bool,
         comment: str | None,
         comment_url: str | None,


### PR DESCRIPTION
The Cookie class's `__init__` method accepts a string for both the `version` and the `expires` parameters (https://github.com/python/cpython/blob/31c81e6ee3b1c874a807ea161182b83c6c607713/Lib/http/cookiejar.py#L776) so this should probably be reflected here.