### PR TITLE
[_typeshed] Add `SupportsGet`

### DIFF
--- a/stdlib/_typeshed/__init__.pyi
+++ b/stdlib/_typeshed/__init__.pyi
@@ -162,11 +162,13 @@ class SupportsTrunc(Protocol):
 
 # The second and third overload could technically be combined, but splitting
 # them works better with some type checkers.
-class SupportsGet(Protocol[_KT_contra, _VT_co]):# type: ignore[misc] # Covariant type as parameter
+class SupportsGet(Protocol[_KT_contra, _VT_co]):  # type: ignore[misc] # Covariant type as parameter
     @overload
     def get(self, key: _KT_contra, /) -> _VT_co | None: ...
     @overload
-    def get(self, key: _KT_contra, default: _VT_co, /) -> _VT_co: ...  # pyright: ignore[reportGeneralTypeIssues] # Covariant type as parameter
+    def get(
+        self, key: _KT_contra, default: _VT_co, /
+    ) -> _VT_co: ...  # pyright: ignore[reportGeneralTypeIssues] # Covariant type as parameter
     @overload
     def get(self, key: _KT_contra, default: _T, /) -> _VT_co | _T: ...
 

--- a/stdlib/_typeshed/__init__.pyi
+++ b/stdlib/_typeshed/__init__.pyi
@@ -197,6 +197,8 @@ class SupportsItemAccess(Protocol[_KT_contra, _VT]):
     def __setitem__(self, key: _KT_contra, value: _VT, /) -> None: ...
     def __delitem__(self, key: _KT_contra, /) -> None: ...
 
+# Path and file handling
+
 StrPath: TypeAlias = str | PathLike[str]  # stable
 BytesPath: TypeAlias = bytes | PathLike[bytes]  # stable
 GenericPath: TypeAlias = AnyStr | PathLike[AnyStr]

--- a/stdlib/_typeshed/__init__.pyi
+++ b/stdlib/_typeshed/__init__.pyi
@@ -167,8 +167,8 @@ class SupportsGet(Protocol[_KT_contra, _VT_co]):  # type: ignore[misc] # Covaria
     def get(self, key: _KT_contra, /) -> _VT_co | None: ...
     @overload
     def get(
-        self, key: _KT_contra, default: _VT_co, /
-    ) -> _VT_co: ...  # pyright: ignore[reportGeneralTypeIssues] # Covariant type as parameter
+        self, key: _KT_contra, default: _VT_co, /  # type: ignore[misc] # pyright: ignore[reportGeneralTypeIssues] # Covariant type as parameter
+    ) -> _VT_co: ...
     @overload
     def get(self, key: _KT_contra, default: _T, /) -> _VT_co | _T: ...
 

--- a/stdlib/_typeshed/__init__.pyi
+++ b/stdlib/_typeshed/__init__.pyi
@@ -162,11 +162,11 @@ class SupportsTrunc(Protocol):
 
 # The second and third overload could technically be combined, but splitting
 # them works better with some type checkers.
-class SupportsGet(Protocol[_KT_contra, _VT_co]):
+class SupportsGet(Protocol[_KT_contra, _VT_co]):# type: ignore[misc] # Covariant type as parameter
     @overload
     def get(self, key: _KT_contra, /) -> _VT_co | None: ...
     @overload
-    def get(self, key: _KT_contra, default: _VT_co, /) -> _VT_co: ...  # type: ignore[misc] # pyright: ignore[reportGeneralTypeIssues] # Covariant type as parameter
+    def get(self, key: _KT_contra, default: _VT_co, /) -> _VT_co: ...  # pyright: ignore[reportGeneralTypeIssues] # Covariant type as parameter
     @overload
     def get(self, key: _KT_contra, default: _T, /) -> _VT_co | _T: ...
 

--- a/stdlib/_typeshed/__init__.pyi
+++ b/stdlib/_typeshed/__init__.pyi
@@ -160,6 +160,16 @@ class SupportsTrunc(Protocol):
 
 # Mapping-like protocols
 
+# The second and third overload could technically be combined, but splitting
+# them works better with some type checkers.
+class SupportsGet(Protocol[_KT_contra, _VT_co]):
+    @overload
+    def get(self, key: _KT_contra, /) -> _VT_co | None: ...
+    @overload
+    def get(self, key: _KT_contra, default: _VT_co, /) -> _VT_co: ...  # type: ignore[misc] # pyright: ignore[reportGeneralTypeIssues] # Covariant type as parameter
+    @overload
+    def get(self, key: _KT_contra, default: _T, /) -> _VT_co | _T: ...
+
 # stable
 class SupportsItems(Protocol[_KT_co, _VT_co]):
     def items(self) -> AbstractSet[tuple[_KT_co, _VT_co]]: ...


### PR DESCRIPTION
Commonly useful protocol. This also allows us to document the `__get__` annotations in a central place.