### PR TITLE
convert `callable` assignment to re-export

### DIFF
--- a/stubs/six/@tests/stubtest_allowlist.txt
+++ b/stubs/six/@tests/stubtest_allowlist.txt
@@ -27,6 +27,3 @@ six.Module_six_moves_urllib_robotparser
 
 # Belongs to `django.utils.six`
 six.iterlists
-
-# Unclear problems
-six.callable

--- a/stubs/six/six/__init__.pyi
+++ b/stubs/six/six/__init__.pyi
@@ -1,9 +1,8 @@
-import builtins
 import operator
 import types
 import unittest
 from _typeshed import IdentityFunction, SupportsGetItem, Unused
-from builtins import next as next
+from builtins import callable as callable, next as next
 from collections.abc import Callable, ItemsView, Iterable, Iterator as _Iterator, KeysView, Mapping, ValuesView
 from functools import wraps as wraps
 from importlib.util import spec_from_loader as spec_from_loader
@@ -31,8 +30,6 @@ text_type = str
 binary_type = bytes
 
 MAXSIZE: int
-
-callable = builtins.callable
 
 def get_unbound_function(unbound: types.FunctionType) -> types.FunctionType: ...
 


### PR DESCRIPTION
This is a small cleanup I noticed was possible while editing #16051