### PR TITLE
Override `__int__` and `__index__` for `bool` in `builtins.pyi`

### DIFF
--- a/stdlib/builtins.pyi
+++ b/stdlib/builtins.pyi
@@ -1060,6 +1060,16 @@ class memoryview(Sequence[_I]):
 class bool(int):
     def __new__(cls, o: object = False, /) -> Self: ...
 
+    @overload
+    def __int__(self: Literal[True]) -> Literal[1]: ...
+    @overload
+    def __int__(self: Literal[False]) -> Literal[0]: ...
+
+    @overload
+    def __index__(self: Literal[True]) -> Literal[1]: ...
+    @overload
+    def __index__(self: Literal[False]) -> Literal[0]: ...
+
     # The following overloads could be represented more elegantly with a TypeVar("_B", bool, int),
     # however mypy has a bug regarding TypeVar constraints (https://github.com/python/mypy/issues/11880).
     @overload


### PR DESCRIPTION
Such that the fact that they only return `1` for `True` and `0` for `False` may be represented without violating the Liskov Substitution Principle. This change is motivated by astral-sh/ty#4048, from which I learnt no type checker supports the inference of the value of booleans in integer operation context, but that may be fixable by a stub-side modification.