### PR TITLE
[et_xmlfile] Complete the writer_cm annotation

### DIFF
--- a/stubs/et_xmlfile/et_xmlfile/xmlfile.pyi
+++ b/stubs/et_xmlfile/et_xmlfile/xmlfile.pyi
@@ -1,6 +1,6 @@
 import types
 import xml.etree.ElementTree as ET
-from collections.abc import Generator
+from collections.abc import Callable, Generator
 from contextlib import _GeneratorContextManager, contextmanager
 from typing import Any
 
@@ -9,7 +9,7 @@ class LxmlSyntaxError(Exception): ...
 class _IncrementalFileWriter:
     global_nsmap: dict[str, str]
     is_html: bool
-    def __init__(self, output_file: ET._FileWrite) -> None: ...
+    def __init__(self, output_file: Callable[[str], object]) -> None: ...
     @contextmanager
     def element(
         self,
@@ -26,7 +26,7 @@ class _IncrementalFileWriter:
 
 class xmlfile:
     encoding: str
-    writer_cm: _GeneratorContextManager[tuple[ET._FileWrite, str]] | None
+    writer_cm: _GeneratorContextManager[tuple[Callable[[str], object], str]] | None
     def __init__(
         self, output_file: ET._FileWrite, buffered: bool = False, encoding: str = "utf-8", close: bool = False
     ) -> None: ...

--- a/stubs/et_xmlfile/et_xmlfile/xmlfile.pyi
+++ b/stubs/et_xmlfile/et_xmlfile/xmlfile.pyi
@@ -1,8 +1,7 @@
 import types
 import xml.etree.ElementTree as ET
-from _typeshed import Incomplete
 from collections.abc import Generator
-from contextlib import contextmanager
+from contextlib import _GeneratorContextManager, contextmanager
 from typing import Any
 
 class LxmlSyntaxError(Exception): ...
@@ -27,7 +26,7 @@ class _IncrementalFileWriter:
 
 class xmlfile:
     encoding: str
-    writer_cm: Incomplete
+    writer_cm: _GeneratorContextManager[tuple[ET._FileWrite, str]] | None
     def __init__(
         self, output_file: ET._FileWrite, buffered: bool = False, encoding: str = "utf-8", close: bool = False
     ) -> None: ...


### PR DESCRIPTION
`xmlfile.writer_cm` was `Incomplete`. It is initialised to `None` in `__init__` and assigned the result of the `@contextmanager`-decorated `incremental_tree._get_writer` in `xmlfile.__enter__`, so its type is `_GeneratorContextManager[tuple[ET._FileWrite, str]] | None`.

The context manager yields `(write, encoding)`: the first element is passed straight to `_IncrementalFileWriter`, whose `output_file` parameter is already typed as `ET._FileWrite`, and the second is the encoding `str`.

Verified locally with stubtest, mypy, and pyright.
