### PR TITLE
[rasterio] Import `Self` from `typing_extensions`

### DIFF
--- a/stubs/rasterio/rasterio/_base.pyi
+++ b/stubs/rasterio/rasterio/_base.pyi
@@ -2,8 +2,8 @@ import logging
 import os
 from collections.abc import Iterable, Sequence
 from types import TracebackType
-from typing import Any, Final, Self
-from typing_extensions import deprecated
+from typing import Any, Final
+from typing_extensions import Self, deprecated
 
 from rasterio._affine_types import Affine
 from rasterio._path import _ParsedPath, _UnparsedPath

--- a/stubs/rasterio/rasterio/_io.pyi
+++ b/stubs/rasterio/rasterio/_io.pyi
@@ -1,7 +1,7 @@
 import os
 from collections.abc import Iterator, Sequence
-from typing import Any, BinaryIO, Final, Self
-from typing_extensions import deprecated
+from typing import Any, BinaryIO, Final
+from typing_extensions import Self, deprecated
 
 import numpy as np
 from numpy.typing import DTypeLike, NDArray

--- a/stubs/rasterio/rasterio/_path.pyi
+++ b/stubs/rasterio/rasterio/_path.pyi
@@ -1,5 +1,6 @@
 import os
-from typing import Any, Final, Self
+from typing import Any, Final
+from typing_extensions import Self
 
 SCHEMES: Final[dict[str, str]]
 ARCHIVESCHEMES: Final[type[set[Any]]]

--- a/stubs/rasterio/rasterio/crs.pyi
+++ b/stubs/rasterio/rasterio/crs.pyi
@@ -1,6 +1,6 @@
 from collections.abc import Iterator, Mapping
-from typing import Any, Self
-from typing_extensions import deprecated, disjoint_base
+from typing import Any
+from typing_extensions import Self, deprecated, disjoint_base
 
 from rasterio.enums import WktVersion
 

--- a/stubs/rasterio/rasterio/env.pyi
+++ b/stubs/rasterio/rasterio/env.pyi
@@ -2,8 +2,8 @@ import logging
 import threading
 from collections.abc import Callable, Iterable
 from types import TracebackType
-from typing import Any, Final, Self, TypeVar
-from typing_extensions import deprecated
+from typing import Any, Final, TypeVar
+from typing_extensions import Self, deprecated
 
 from rasterio._env import (
     GDALDataFinder as GDALDataFinder,

--- a/stubs/rasterio/rasterio/io.pyi
+++ b/stubs/rasterio/rasterio/io.pyi
@@ -1,7 +1,7 @@
 import logging
 from types import TracebackType
-from typing import Any, Final, Self
-from typing_extensions import deprecated
+from typing import Any, Final
+from typing_extensions import Self, deprecated
 
 from numpy.typing import DTypeLike
 from rasterio._affine_types import Affine

--- a/stubs/rasterio/rasterio/rpc.pyi
+++ b/stubs/rasterio/rasterio/rpc.pyi
@@ -1,5 +1,6 @@
 from collections.abc import Sequence
-from typing import Any, Self
+from typing import Any
+from typing_extensions import Self
 
 class RPC:
     height_off: float

--- a/stubs/rasterio/rasterio/transform.pyi
+++ b/stubs/rasterio/rasterio/transform.pyi
@@ -1,6 +1,6 @@
 from collections.abc import Callable, Sequence
-from typing import Final, Literal, Self, TypeAlias, overload
-from typing_extensions import deprecated
+from typing import Final, Literal, TypeAlias, overload
+from typing_extensions import Self, deprecated
 
 from rasterio._affine_types import Affine as Affine
 from rasterio._transform import GCPTransformerBase, RPCTransformerBase

--- a/stubs/rasterio/rasterio/vrt.pyi
+++ b/stubs/rasterio/rasterio/vrt.pyi
@@ -1,5 +1,5 @@
 from types import TracebackType
-from typing import Self
+from typing_extensions import Self
 
 from rasterio._warp import WarpedVRTReaderBase
 from rasterio.transform import TransformMethodsMixin

--- a/stubs/rasterio/rasterio/windows.pyi
+++ b/stubs/rasterio/rasterio/windows.pyi
@@ -1,6 +1,6 @@
 from collections.abc import Callable, Sequence
-from typing import Any, Self, TypeAlias, overload
-from typing_extensions import deprecated
+from typing import Any, TypeAlias, overload
+from typing_extensions import Self, deprecated
 
 from numpy.typing import NDArray
 from rasterio._affine_types import Affine


### PR DESCRIPTION
The newly added rasterio stubs import `Self` from `typing`, which fails the ty checks for Python 3.10 because `typing.Self` was introduced in Python 3.11.

This is causing test failures on `main` due to a merge race: the PR that added the `rasterio` stubs (https://github.com/python/typeshed/pull/15884) was added long before we added the new ty check in CI.