### PR TITLE
[yt-dlp] Remove unused websockets dependency

### DIFF
--- a/stubs/yt-dlp/METADATA.toml
+++ b/stubs/yt-dlp/METADATA.toml
@@ -1,3 +1,2 @@
 version = "2026.7.4"
 upstream-repository = "https://github.com/yt-dlp/yt-dlp"
-dependencies = ["websockets"]


### PR DESCRIPTION
websockets is not imported anywhere in the yt-dlp stubs; it was a leftover from the initial stub PR (#14216). Splitting out from #16084 per reviewer's suggestion.