### PR TITLE
Use optional-dependencies for third-party packages

### DIFF
--- a/stubs/Deprecated/METADATA.toml
+++ b/stubs/Deprecated/METADATA.toml
@@ -1,3 +1,2 @@
 version = "~=1.3.1"
 upstream-repository = "https://github.com/laurent-laporte-pro/deprecated"
-dependencies = []

--- a/stubs/Flask-SocketIO/METADATA.toml
+++ b/stubs/Flask-SocketIO/METADATA.toml
@@ -1,3 +1,3 @@
 version = "5.6.*"
-dependencies = ["Flask>=0.9"]
 upstream-repository = "https://github.com/miguelgrinberg/flask-socketio"
+dependencies = ["Flask>=0.9"]

--- a/stubs/Pygments/METADATA.toml
+++ b/stubs/Pygments/METADATA.toml
@@ -1,6 +1,6 @@
 version = "2.20.*"
 upstream-repository = "https://github.com/pygments/pygments"
-dependencies = ["types-docutils"]
+optional-dependencies = ["types-docutils"]
 partial-stub = true
 
 [tool.stubtest]

--- a/stubs/bleach/METADATA.toml
+++ b/stubs/bleach/METADATA.toml
@@ -1,6 +1,6 @@
 version = "6.4.*"
-dependencies = ["types-html5lib"]
 upstream-repository = "https://github.com/mozilla/bleach"
+dependencies = ["types-html5lib"]
 
 [tool.stubtest]
 extras = ["css"]

--- a/stubs/click-log/METADATA.toml
+++ b/stubs/click-log/METADATA.toml
@@ -1,3 +1,3 @@
 version = "0.4.*"
-dependencies = ["click>=8.0.0"]
 upstream-repository = "https://github.com/click-contrib/click-log"
+dependencies = ["click>=8.0.0"]

--- a/stubs/click-web/METADATA.toml
+++ b/stubs/click-web/METADATA.toml
@@ -1,3 +1,3 @@
 version = "0.8.*"
-dependencies = ["click>=8.0.0", "Flask>=2.3.2"]
 upstream-repository = "https://github.com/fredrik-corneliusson/click-web"
+dependencies = ["click>=8.0.0", "Flask>=2.3.2"]

--- a/stubs/docker/METADATA.toml
+++ b/stubs/docker/METADATA.toml
@@ -1,3 +1,4 @@
 version = "7.2.*"
 upstream-repository = "https://github.com/docker/docker-py"
-dependencies = ["types-paramiko", "types-requests", "urllib3>=2"]
+dependencies = ["types-requests", "urllib3>=2"]
+optional-dependencies = ["types-paramiko"]

--- a/stubs/geopandas/METADATA.toml
+++ b/stubs/geopandas/METADATA.toml
@@ -1,7 +1,7 @@
-# Requires a version of numpy with a `py.typed` file
 version = "1.1.4"
-dependencies = ["numpy>=1.20", "pandas-stubs", "types-shapely", "pyproj"]
 upstream-repository = "https://github.com/geopandas/geopandas"
+# Requires a version of numpy with a `py.typed` file
+dependencies = ["numpy>=1.20", "pandas-stubs", "types-shapely", "pyproj"]
 
 [tool.stubtest]
 # libproj-dev and proj-bin are required to build pyproj if wheels for the

--- a/stubs/gunicorn/METADATA.toml
+++ b/stubs/gunicorn/METADATA.toml
@@ -1,6 +1,6 @@
 version = "26.0.0"
 upstream-repository = "https://github.com/benoitc/gunicorn"
-dependencies = ["types-gevent"]
+optional-dependencies = ["types-gevent"]
 
 [tool.stubtest]
 supported-platforms = ["linux", "darwin"]

--- a/stubs/hnswlib/METADATA.toml
+++ b/stubs/hnswlib/METADATA.toml
@@ -1,4 +1,4 @@
 version = "0.8.*"
+upstream-repository = "https://github.com/nmslib/hnswlib"
 # Requires a version of numpy with a `py.typed` file
 dependencies = ["numpy>=1.21"]
-upstream-repository = "https://github.com/nmslib/hnswlib"

--- a/stubs/pony/METADATA.toml
+++ b/stubs/pony/METADATA.toml
@@ -1,3 +1,3 @@
 version = "0.7.*"
 upstream-repository = "https://github.com/ponyorm/pony"
-dependencies = ["types-psycopg2", "types-PyMySQL"]
+optional-dependencies = ["types-psycopg2", "types-PyMySQL"]

--- a/stubs/pyogrio/METADATA.toml
+++ b/stubs/pyogrio/METADATA.toml
@@ -1,4 +1,5 @@
 version = "0.13.*"
-# Requires a version of numpy with a `py.typed` file
-dependencies = ["numpy>=1.20", "types-geopandas"]
 upstream-repository = "https://github.com/geopandas/pyogrio"
+# Requires a version of numpy with a `py.typed` file
+dependencies = ["numpy>=1.20"]
+optional-dependencies = ["types-geopandas"]

--- a/stubs/seaborn/METADATA.toml
+++ b/stubs/seaborn/METADATA.toml
@@ -1,4 +1,4 @@
 version = "0.13.2"
+upstream-repository = "https://github.com/mwaskom/seaborn"
 # Requires a version of numpy and matplotlib with a `py.typed` file
 dependencies = ["matplotlib>=3.8", "numpy>=1.20", "pandas-stubs"]
-upstream-repository = "https://github.com/mwaskom/seaborn"

--- a/stubs/shapely/METADATA.toml
+++ b/stubs/shapely/METADATA.toml
@@ -1,4 +1,4 @@
 version = "2.1.*"
+upstream-repository = "https://github.com/shapely/shapely"
 # Requires a version of numpy with a `py.typed` file
 dependencies = ["numpy>=1.20"]
-upstream-repository = "https://github.com/shapely/shapely"

--- a/stubs/tqdm/METADATA.toml
+++ b/stubs/tqdm/METADATA.toml
@@ -1,6 +1,6 @@
 version = "4.69.*"
 upstream-repository = "https://github.com/tqdm/tqdm"
-dependencies = ["types-requests"]
+optional-dependencies = ["types-requests"]
 
 [tool.stubtest]
 extras = ["slack", "telegram"]


### PR DESCRIPTION
* tqdm: https://github.com/tqdm/tqdm/blob/master/pyproject.toml
* pyogrio: https://github.com/geopandas/pyogrio/blob/main/pyproject.toml
* docker: https://github.com/docker/docker-py/blob/main/pyproject.toml
* pygments: https://github.com/pygments/pygments/blob/master/pyproject.toml
* gunicorn: https://github.com/benoitc/gunicorn/blob/master/pyproject.toml
* pony: https://github.com/ponyorm/pony/blob/main/setup.py

I left some dependencies in the `dependencies` field because they appeared to be used fairly frequently throughout the typeshed stubs. For example, `numpy` is used by `stubs/networkx/`, even though it's only an [optional dependency](https://github.com/networkx/networkx/blob/main/pyproject.toml) of `networkx`.