### PR TITLE
[reportlab] Use TypedDict with Unpack for BaseDocTemplate kwargs

### DIFF
--- a/stubs/reportlab/reportlab/platypus/doctemplate.pyi
+++ b/stubs/reportlab/reportlab/platypus/doctemplate.pyi
@@ -1,8 +1,8 @@
 from _typeshed import Incomplete
 from abc import abstractmethod
 from collections.abc import Callable
-from typing import IO, Any, Literal, Protocol, TypeAlias, type_check_only
-from typing_extensions import Self
+from typing import IO, Any, Literal, Protocol, TypeAlias, TypedDict, type_check_only
+from typing_extensions import Self, Unpack
 
 from reportlab.pdfgen.canvas import Canvas
 from reportlab.platypus.flowables import Flowable
@@ -181,6 +181,54 @@ class PageAccumulator:
     def pageEndAction(self, canv: Canvas, doc: BaseDocTemplate) -> None: ...
     def onDrawStr(self, value: object, *args) -> _OnDrawStr: ...
 
+@type_check_only
+class _DocTemplateKwargs(TypedDict, total=False):
+    pagesize: Incomplete
+    pageTemplates: list[PageTemplate]
+    showBoundary: Incomplete
+    width: float
+    height: float
+    leftMargin: float
+    rightMargin: float
+    topMargin: float
+    bottomMargin: float
+    allowSplitting: Incomplete
+    title: Incomplete | None
+    author: Incomplete | None
+    subject: Incomplete | None
+    creator: Incomplete | None
+    producer: Incomplete | None
+    keywords: list[Incomplete]
+    invariant: Incomplete | None
+    pageCompression: Incomplete | None
+    rotation: Incomplete
+    encrypt: Incomplete | None
+    cropMarks: Incomplete | None
+    enforceColorSpace: Incomplete | None
+    displayDocTitle: Incomplete | None
+    lang: Incomplete | None
+    initialFontName: Incomplete | None
+    initialFontSize: Incomplete | None
+    initialLeading: Incomplete | None
+    cropBox: Incomplete | None
+    artBox: Incomplete | None
+    trimBox: Incomplete | None
+    bleedBox: Incomplete | None
+    keepTogetherClass: type[Flowable]
+    hideToolbar: Incomplete | None
+    hideMenubar: Incomplete | None
+    hideWindowUI: Incomplete | None
+    fitWindow: Incomplete | None
+    centerWindow: Incomplete | None
+    nonFullScreenPageMode: Incomplete | None
+    direction: Incomplete | None
+    viewArea: Incomplete | None
+    viewClip: Incomplete | None
+    printArea: Incomplete | None
+    printClip: Incomplete | None
+    printScaling: Incomplete | None
+    duplex: Incomplete | None
+
 class BaseDocTemplate:
     filename: Incomplete
     pagesize: Incomplete
@@ -233,8 +281,7 @@ class BaseDocTemplate:
     page: int
     frame: Frame
     canv: Canvas
-    # TODO: Use TypedDict with Unpack for **kw
-    def __init__(self, filename: str | IO[bytes], **kw) -> None: ...
+    def __init__(self, filename: str | IO[bytes], **kw: Unpack[_DocTemplateKwargs]) -> None: ...
     def setPageCallBack(self, func: Callable[[int], object] | None) -> None: ...
     def setProgressCallBack(self, func: Callable[[str, int], object] | None) -> None: ...
     def clean_hanging(self) -> None: ...


### PR DESCRIPTION
You are a senior Typeshed contributor working on the ReportLab stubs.

## Objective

Resolve the remaining `TODO: Use TypedDict with Unpack for **kw` in:

    stubs/reportlab/reportlab/platypus/doctemplate.pyi

by replacing the untyped `**kw` parameter in `BaseDocTemplate.__init__` with a precise `TypedDict` using PEP 692 `Unpack`.

This is a stub-only typing improvement. Do not modify runtime behavior or public APIs.

---

# Phase 1 — Investigation

Inspect:

- stubs/reportlab/reportlab/platypus/doctemplate.pyi
- The corresponding ReportLab runtime implementation of `BaseDocTemplate`
- Any related ReportLab stubs defining `PageTemplate`, `Flowable`, or shared aliases

Before making changes:

1. Enumerate every keyword argument accepted by `BaseDocTemplate.__init__`.
2. Verify default values and optionality.
3. Confirm which attributes are assigned directly from `**kw`.
4. Reuse existing types where available instead of introducing new aliases.
5. Preserve existing Typeshed style and naming conventions.

Do not infer unsupported keyword arguments.

---

# Phase 2 -Introduce TypedDict

Import:

- `TypedDict` from `typing`
- `Unpack` from `typing_extensions`

Create:

```python
@type_check_only
class _DocTemplateKwargs(TypedDict, total=False):
    ...