### PR TITLE
Improve lib2to3 future_features annotation

### DIFF
--- a/stdlib/lib2to3/pytree.pyi
+++ b/stdlib/lib2to3/pytree.pyi
@@ -1,4 +1,4 @@
-from _typeshed import Incomplete, SupportsGetItem, SupportsLenAndGetItem, Unused
+from _typeshed import SupportsGetItem, SupportsLenAndGetItem, Unused
 from abc import abstractmethod
 from collections.abc import Iterable, Iterator, MutableSequence
 from typing import ClassVar, Final, TypeAlias
@@ -48,7 +48,7 @@ class Base:
 class Node(Base):
     fixers_applied: MutableSequence[BaseFix] | None
     # Is Unbound until set in refactor.RefactoringTool
-    future_features: frozenset[Incomplete]
+    future_features: frozenset[str]
     # Is Unbound until set in pgen2.parse.Parser.pop
     used_names: set[str]
     def __init__(


### PR DESCRIPTION
Part of #14031.

`RefactoringTool` populates `Node.future_features` from `_detect_future_features`, which collects tokenizer `NAME` values and returns a `frozenset`. This narrows the placeholder element type from `Incomplete` to `str` and removes the unused import.

Validation:

- focused `tests/runtests.py stdlib/lib2to3`: pre-commit, structure, strict Pyright, ty, mypy, and both regression suites passed
- direct detector probe returned `frozenset({'annotations', 'generator_stop'})` with `str` elements
- global and module-specific stubtest failures reproduced identically on untouched `origin/main`; none reference `future_features`
