### PR TITLE
Fix flaky hnswlib stubtest allowlist

### DIFF
--- a/stubs/hnswlib/@tests/stubtest_allowlist.txt
+++ b/stubs/hnswlib/@tests/stubtest_allowlist.txt
@@ -1,3 +1,0 @@
-# The metaclass of Index is pybind11_builtins.pybind11_type. Since pybind11 is not a
-# runtime dependency of hnswlib, we exclude Index from stubtest checks.
-hnswlib.Index

--- a/stubs/hnswlib/@tests/stubtest_allowlist.txt
+++ b/stubs/hnswlib/@tests/stubtest_allowlist.txt
@@ -1,0 +1,2 @@
+# The metaclass of Index is nondeterministically reported as pybind11_builtins.pybind11_type.
+(hnswlib.Index)?

--- a/stubs/hnswlib/@tests/stubtest_allowlist_darwin.txt
+++ b/stubs/hnswlib/@tests/stubtest_allowlist_darwin.txt
@@ -1,0 +1,2 @@
+# On macOS, the metaclass of Index is pybind11_builtins.pybind11_type.
+hnswlib.Index

--- a/stubs/hnswlib/@tests/stubtest_allowlist_darwin.txt
+++ b/stubs/hnswlib/@tests/stubtest_allowlist_darwin.txt
@@ -1,2 +1,0 @@
-# On macOS, the metaclass of Index is pybind11_builtins.pybind11_type.
-hnswlib.Index


### PR DESCRIPTION
Fixes #16100

The daily Linux job did not report the `hnswlib.Index` metaclass mismatch and therefore rejected the existing allowlist entry as unused, while the PR's fresh Linux job reproduced the mismatch. Keep the exception cross-platform, but make the regular-expression entry optional so stubtest accepts both runtime variants.

Tests:

- `PYTHONPATH=lib python3 tests/stubtest_third_party.py hnswlib -v`
- `PYTHONPATH=lib python3 tests/check_typeshed_structure.py`
- `uvx pre-commit run --files stubs/hnswlib/@tests/stubtest_allowlist.txt`
