### PR TITLE
[pika] Fix connection parameter for callbacks

### DIFF
--- a/stubs/pika/pika/adapters/asyncio_connection.pyi
+++ b/stubs/pika/pika/adapters/asyncio_connection.pyi
@@ -2,6 +2,7 @@ import asyncio
 from _typeshed import Incomplete
 from collections.abc import Callable, Sequence
 from logging import Logger
+from typing import Self
 
 from pika.adapters.base_connection import BaseConnection
 from pika.adapters.utils import io_services_utils
@@ -12,7 +13,7 @@ from pika.adapters.utils.nbio_interface import (
     AbstractIOServices,
     AbstractTimerReference,
 )
-from pika.connection import Connection, Parameters
+from pika.connection import Parameters
 
 LOGGER: Logger
 
@@ -20,9 +21,9 @@ class AsyncioConnection(BaseConnection[asyncio.AbstractEventLoop]):
     def __init__(
         self,
         parameters: Parameters | None = None,
-        on_open_callback: Callable[[Connection], object] | None = None,
-        on_open_error_callback: Callable[[Connection, BaseException], object] | None = None,
-        on_close_callback: Callable[[Connection, BaseException], object] | None = None,
+        on_open_callback: Callable[[Self], object] | None = None,
+        on_open_error_callback: Callable[[Self, BaseException], object] | None = None,
+        on_close_callback: Callable[[Self, BaseException], object] | None = None,
         custom_ioloop: asyncio.AbstractEventLoop | AbstractIOServices | None = None,
         internal_connection_workflow: bool = True,
     ) -> None: ...
@@ -30,7 +31,7 @@ class AsyncioConnection(BaseConnection[asyncio.AbstractEventLoop]):
     def create_connection(
         cls,
         connection_configs: Sequence[Parameters],
-        on_done: Callable[[Connection | AMQPConnectorException], object],
+        on_done: Callable[[Self | AMQPConnectorException], object],
         custom_ioloop: asyncio.AbstractEventLoop | None = None,
         workflow: AbstractAMQPConnectionWorkflow | None = None,
     ) -> AbstractAMQPConnectionWorkflow: ...

--- a/stubs/pika/pika/adapters/asyncio_connection.pyi
+++ b/stubs/pika/pika/adapters/asyncio_connection.pyi
@@ -2,7 +2,7 @@ import asyncio
 from _typeshed import Incomplete
 from collections.abc import Callable, Sequence
 from logging import Logger
-from typing import Self
+from typing_extensions import Self
 
 from pika.adapters.base_connection import BaseConnection
 from pika.adapters.utils import io_services_utils

--- a/stubs/pika/pika/adapters/base_connection.pyi
+++ b/stubs/pika/pika/adapters/base_connection.pyi
@@ -21,9 +21,9 @@ class BaseConnection(Connection, Generic[_IOLoop], metaclass=abc.ABCMeta):
     def __init__(
         self,
         parameters: Parameters | None,
-        on_open_callback: Callable[[Connection], object] | None,
-        on_open_error_callback: Callable[[Connection, BaseException], object] | None,
-        on_close_callback: Callable[[Connection, BaseException], object] | None,
+        on_open_callback: Callable[[Self], object] | None,
+        on_open_error_callback: Callable[[Self, BaseException], object] | None,
+        on_close_callback: Callable[[Self, BaseException], object] | None,
         nbio: AbstractIOServices,
         internal_connection_workflow: bool = True,
     ) -> None: ...
@@ -104,7 +104,7 @@ class _StreamingProtocolShim(AbstractStreamProtocol, Generic[_IOLoop]):
     def create_connection(
         cls,
         connection_configs: Sequence[Parameters],
-        on_done: Callable[[Connection | AMQPConnectorException], object],
+        on_done: Callable[[Self | AMQPConnectorException], object],
         custom_ioloop: _IOLoop | None = None,
         workflow: AbstractAMQPConnectionWorkflow | None = None,
     ) -> AbstractAMQPConnectionWorkflow: ...

--- a/stubs/pika/pika/adapters/gevent_connection.pyi
+++ b/stubs/pika/pika/adapters/gevent_connection.pyi
@@ -1,6 +1,7 @@
 from collections.abc import Callable, Sequence
 from logging import Logger
-from typing import Final, Self
+from typing import Final
+from typing_extensions import Self
 
 from gevent._types import _Loop, _TimerWatcher
 from gevent.hub import Hub

--- a/stubs/pika/pika/adapters/gevent_connection.pyi
+++ b/stubs/pika/pika/adapters/gevent_connection.pyi
@@ -1,6 +1,6 @@
 from collections.abc import Callable, Sequence
 from logging import Logger
-from typing import Final
+from typing import Final, Self
 
 from gevent._types import _Loop, _TimerWatcher
 from gevent.hub import Hub
@@ -8,7 +8,7 @@ from pika.adapters.base_connection import BaseConnection
 from pika.adapters.utils.connection_workflow import AbstractAMQPConnectionWorkflow, AMQPConnectorException
 from pika.adapters.utils.nbio_interface import AbstractIOReference, AbstractIOServices
 from pika.adapters.utils.selector_ioloop_adapter import AbstractSelectorIOLoop, SelectorIOServicesAdapter, _SupportsCancel
-from pika.connection import Connection, Parameters
+from pika.connection import Parameters
 
 LOGGER: Logger
 
@@ -16,9 +16,9 @@ class GeventConnection(BaseConnection[_Loop]):
     def __init__(
         self,
         parameters: Parameters | None = None,
-        on_open_callback: Callable[[Connection], object] | None = None,
-        on_open_error_callback: Callable[[Connection, BaseException], object] | None = None,
-        on_close_callback: Callable[[Connection, BaseException], object] | None = None,
+        on_open_callback: Callable[[Self], object] | None = None,
+        on_open_error_callback: Callable[[Self, BaseException], object] | None = None,
+        on_close_callback: Callable[[Self, BaseException], object] | None = None,
         custom_ioloop: _Loop | AbstractIOServices | None = None,
         internal_connection_workflow: bool = True,
     ) -> None: ...
@@ -26,7 +26,7 @@ class GeventConnection(BaseConnection[_Loop]):
     def create_connection(
         cls,
         connection_configs: Sequence[Parameters],
-        on_done: Callable[[Connection | AMQPConnectorException], object],
+        on_done: Callable[[Self | AMQPConnectorException], object],
         custom_ioloop: _Loop | None = None,
         workflow: AbstractAMQPConnectionWorkflow | None = None,
     ) -> AbstractAMQPConnectionWorkflow: ...

--- a/stubs/pika/pika/adapters/select_connection.pyi
+++ b/stubs/pika/pika/adapters/select_connection.pyi
@@ -2,14 +2,14 @@ import abc
 import select
 from collections.abc import Callable, Sequence
 from logging import Logger
-from typing import ClassVar, Final, Literal, TypeAlias, TypedDict
+from typing import ClassVar, Final, Literal, Self, TypeAlias, TypedDict
 
 import pika.compat
 from pika.adapters.base_connection import BaseConnection
 from pika.adapters.utils.connection_workflow import AbstractAMQPConnectionWorkflow, AMQPConnectorException
 from pika.adapters.utils.nbio_interface import AbstractIOServices
 from pika.adapters.utils.selector_ioloop_adapter import AbstractSelectorIOLoop
-from pika.connection import Connection, Parameters
+from pika.connection import Parameters
 
 SELECT_ERROR_T: TypeAlias = OSError | IOError | InterruptedError | select.error
 
@@ -24,9 +24,9 @@ class SelectConnection(BaseConnection[IOLoop]):
     def __init__(
         self,
         parameters: Parameters | None = None,
-        on_open_callback: Callable[[Connection], object] | None = None,
-        on_open_error_callback: Callable[[Connection, BaseException], object] | None = None,
-        on_close_callback: Callable[[Connection, BaseException], object] | None = None,
+        on_open_callback: Callable[[Self], object] | None = None,
+        on_open_error_callback: Callable[[Self, BaseException], object] | None = None,
+        on_close_callback: Callable[[Self, BaseException], object] | None = None,
         custom_ioloop: IOLoop | AbstractIOServices | None = None,
         internal_connection_workflow: bool = True,
     ) -> None: ...
@@ -34,7 +34,7 @@ class SelectConnection(BaseConnection[IOLoop]):
     def create_connection(
         cls,
         connection_configs: Sequence[Parameters],
-        on_done: Callable[[Connection | AMQPConnectorException], object],
+        on_done: Callable[[Self | AMQPConnectorException], object],
         custom_ioloop: IOLoop | None = None,
         workflow: AbstractAMQPConnectionWorkflow | None = None,
     ) -> AbstractAMQPConnectionWorkflow: ...

--- a/stubs/pika/pika/adapters/select_connection.pyi
+++ b/stubs/pika/pika/adapters/select_connection.pyi
@@ -2,7 +2,8 @@ import abc
 import select
 from collections.abc import Callable, Sequence
 from logging import Logger
-from typing import ClassVar, Final, Literal, Self, TypeAlias, TypedDict
+from typing import ClassVar, Final, Literal, TypeAlias, TypedDict
+from typing_extensions import Self
 
 import pika.compat
 from pika.adapters.base_connection import BaseConnection

--- a/stubs/pika/pika/adapters/tornado_connection.pyi
+++ b/stubs/pika/pika/adapters/tornado_connection.pyi
@@ -1,7 +1,8 @@
 from _typeshed import Incomplete
 from collections.abc import Callable, Sequence
 from logging import Logger
-from typing import Self, TypeAlias
+from typing import TypeAlias
+from typing_extensions import Self
 
 from pika.adapters.base_connection import BaseConnection
 from pika.adapters.utils.connection_workflow import AbstractAMQPConnectionWorkflow, AMQPConnectorException

--- a/stubs/pika/pika/adapters/tornado_connection.pyi
+++ b/stubs/pika/pika/adapters/tornado_connection.pyi
@@ -1,12 +1,12 @@
 from _typeshed import Incomplete
 from collections.abc import Callable, Sequence
 from logging import Logger
-from typing import TypeAlias
+from typing import Self, TypeAlias
 
 from pika.adapters.base_connection import BaseConnection
 from pika.adapters.utils.connection_workflow import AbstractAMQPConnectionWorkflow, AMQPConnectorException
 from pika.adapters.utils.nbio_interface import AbstractIOServices
-from pika.connection import Connection, Parameters
+from pika.connection import Parameters
 
 _IOLoop: TypeAlias = Incomplete  # actual type is tornado.ioloop.IOLoop
 
@@ -16,9 +16,9 @@ class TornadoConnection(BaseConnection[_IOLoop]):
     def __init__(
         self,
         parameters: Parameters | None = None,
-        on_open_callback: Callable[[Connection], object] | None = None,
-        on_open_error_callback: Callable[[Connection, BaseException], object] | None = None,
-        on_close_callback: Callable[[Connection, BaseException], object] | None = None,
+        on_open_callback: Callable[[Self], object] | None = None,
+        on_open_error_callback: Callable[[Self, BaseException], object] | None = None,
+        on_close_callback: Callable[[Self, BaseException], object] | None = None,
         custom_ioloop: _IOLoop | AbstractIOServices | None = None,
         internal_connection_workflow: bool = True,
     ) -> None: ...
@@ -26,7 +26,7 @@ class TornadoConnection(BaseConnection[_IOLoop]):
     def create_connection(
         cls,
         connection_configs: Sequence[Parameters],
-        on_done: Callable[[Connection | AMQPConnectorException], object],
+        on_done: Callable[[Self | AMQPConnectorException], object],
         custom_ioloop: _IOLoop | None = None,
         workflow: AbstractAMQPConnectionWorkflow | None = None,
     ) -> AbstractAMQPConnectionWorkflow: ...

--- a/stubs/pika/pika/adapters/twisted_connection.pyi
+++ b/stubs/pika/pika/adapters/twisted_connection.pyi
@@ -4,7 +4,8 @@
 from _typeshed import Incomplete
 from collections.abc import Callable, Iterable, Mapping
 from logging import Logger
-from typing import Generic, NamedTuple, Self, TypeVar
+from typing import Generic, NamedTuple, TypeVar
+from typing_extensions import Self
 
 from pika import amqp_object
 from pika.adapters.utils.nbio_interface import AbstractTimerReference

--- a/stubs/pika/pika/adapters/twisted_connection.pyi
+++ b/stubs/pika/pika/adapters/twisted_connection.pyi
@@ -4,7 +4,7 @@
 from _typeshed import Incomplete
 from collections.abc import Callable, Iterable, Mapping
 from logging import Logger
-from typing import Generic, NamedTuple, TypeVar
+from typing import Generic, NamedTuple, Self, TypeVar
 
 from pika import amqp_object
 from pika.adapters.utils.nbio_interface import AbstractTimerReference
@@ -137,9 +137,9 @@ class _TwistedConnectionAdapter(Connection):
     def __init__(
         self,
         parameters: Parameters | None,
-        on_open_callback: Callable[[Connection], object] | None,
-        on_open_error_callback: Callable[[Connection, BaseException], object] | None,
-        on_close_callback: Callable[[Connection, Exception], object] | None,
+        on_open_callback: Callable[[Self], object] | None,
+        on_open_error_callback: Callable[[Self, BaseException], object] | None,
+        on_close_callback: Callable[[Self, Exception], object] | None,
         custom_reactor: ReactorBase | None = None,
     ) -> None: ...
     def connection_made(self, transport: ITransport) -> None: ...


### PR DESCRIPTION
The callbacks provided to a connection get passed the connection as first argument. While this was correctly typed as `Self` in the base `Connection` class, the concrete `Connection` class was used in sub-classes. Fixed to use `Self` in sub-classes as well.