### PR TITLE
Fix tkinter.OptionMenu callback type

### DIFF
--- a/stdlib/@tests/test_cases/check_tkinter.py
+++ b/stdlib/@tests/test_cases/check_tkinter.py
@@ -24,9 +24,6 @@ def foo(x: int, y: str) -> None:
 root.after(1000, foo, 10, "lol")
 root.after(1000, foo, 10, 10)  # type: ignore
 
-tkinter.OptionMenu(root, tkinter.StringVar(), "option", command=lambda value: assert_type(value, str))
-
-
 # Font size must be integer
 label = tkinter.Label()
 label.config(font=("", 12))

--- a/stdlib/@tests/test_cases/check_tkinter.py
+++ b/stdlib/@tests/test_cases/check_tkinter.py
@@ -24,6 +24,8 @@ def foo(x: int, y: str) -> None:
 root.after(1000, foo, 10, "lol")
 root.after(1000, foo, 10, 10)  # type: ignore
 
+tkinter.OptionMenu(root, tkinter.StringVar(), "option", command=lambda value: assert_type(value, str))
+
 
 # Font size must be integer
 label = tkinter.Label()

--- a/stdlib/tkinter/__init__.pyi
+++ b/stdlib/tkinter/__init__.pyi
@@ -3905,7 +3905,7 @@ class OptionMenu(Menubutton):
             variable: StringVar,
             value: str,
             *values: str,
-            command: Callable[[StringVar], object] | None = ...,
+            command: Callable[[str], object] | None = ...,
             name: str | None = None,
         ) -> None: ...
     else:
@@ -3916,7 +3916,7 @@ class OptionMenu(Menubutton):
             variable: StringVar,
             value: str,
             *values: str,
-            command: Callable[[StringVar], object] | None = ...,
+            command: Callable[[str], object] | None = ...,
         ) -> None: ...
     # configure, config, cget are inherited from Menubutton
     # destroy and __getitem__ are overridden, signature does not change


### PR DESCRIPTION
`OptionMenu` passes the selected menu value to `_setit`, which invokes the callback with that value rather than the `StringVar`. Update both version-specific signatures to type the callback argument
  as `str`, and add a regression test for callback inference.

  CPython implementation: https://github.com/python/cpython/blob/main/Lib/tkinter/__init__.py#L4573-L4615

  Fixes #16111