### PR TITLE
[oauthlib] Annotate OAuth2 client keyword arguments

### DIFF
--- a/stubs/oauthlib/@tests/test_cases/check_oauth2_clients.py
+++ b/stubs/oauthlib/@tests/test_cases/check_oauth2_clients.py
@@ -1,0 +1,13 @@
+from typing_extensions import assert_type
+
+from oauthlib.oauth2 import LegacyApplicationClient, OAuth2Token
+
+client = LegacyApplicationClient("client-id")
+
+assert_type(
+    client.prepare_request_body(
+        username="username", password="password", scope="read write", include_client_id=True, response_type="token"
+    ),
+    str,
+)
+assert_type(client.parse_request_body_response('{"access_token": "token"}'), OAuth2Token)

--- a/stubs/oauthlib/oauthlib/oauth2/rfc6749/clients/base.pyi
+++ b/stubs/oauthlib/oauthlib/oauth2/rfc6749/clients/base.pyi
@@ -106,7 +106,7 @@ class Client:
         **kwargs,
     ): ...
     def parse_request_body_response(
-        self, body: str, scope: str | set[object] | tuple[object] | list[object] | None = None, **kwargs
+        self, body: str, scope: str | set[object] | tuple[object] | list[object] | None = None, **kwargs: object
     ) -> OAuth2Token: ...
     def prepare_refresh_body(
         self,

--- a/stubs/oauthlib/oauthlib/oauth2/rfc6749/clients/legacy_application.pyi
+++ b/stubs/oauthlib/oauthlib/oauth2/rfc6749/clients/legacy_application.pyi
@@ -38,5 +38,5 @@ class LegacyApplicationClient(Client):
         client_secret: str | None = None,
         code: str | None = None,
         redirect_uri: str | None = None,
-        **kwargs,
+        **kwargs: object,
     ) -> str: ...


### PR DESCRIPTION
## Issue

Strict Pyright reports `reportUnknownMemberType` when these otherwise typed methods are accessed because their catch-all `**kwargs` parameters are unannotated:

```python
from oauthlib.oauth2 import LegacyApplicationClient

client = LegacyApplicationClient("client-id")
client.prepare_request_body(username="username", password="password")
client.parse_request_body_response('{"access_token": "token"}')
```

Annotating the keyword values as `object` keeps the signatures permissive while preventing the methods from being partially unknown.

## Changes

- Annotate `LegacyApplicationClient.prepare_request_body()` keyword values.
- Annotate `Client.parse_request_body_response()` keyword values.
- Add regression coverage for both calls and their return types.

## Tests

- `PATH="$PWD/.venv/bin:$PATH" .venv/bin/python tests/runtests.py --run-stubtest stubs/oauthlib`
- Strict downstream Pyright reproduction against the patched `oauthlib` stub path (`0 errors`)
