### PR TITLE
[rasterio] Pin to 1.5.0

### DIFF
--- a/stubs/rasterio/METADATA.toml
+++ b/stubs/rasterio/METADATA.toml
@@ -1,7 +1,4 @@
-version = "1.5.*"
+version = "1.5.0"
 upstream-repository = "https://github.com/rasterio/rasterio"
 requires-python = ">=3.12"
 dependencies = ["numpy>=2", "click>=8"]
-
-[tool.stubtest]
-stubtest-dependencies = ["rasterio==1.5.*"]


### PR DESCRIPTION
Remove redundant stubtest-dependencies field