### PR TITLE
Check stdlib/venv with pyrefly

### DIFF
--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -3,6 +3,10 @@
 # `respect-type-ignore-comments` setting in ty.toml.
 enabled-ignores = ["pyrefly"]
 
+# pyrefly excludes "**/venv/**/*" by default, which matches "stdlib/venv",
+# a proper stdlib module. We change this to only match ".venv" directories.
+project-excludes = ["**/__pycache__", "**/.venv/**", "**/.[!/.]*/**"]
+
 # These imports are intentionally optional and are also ignored by mypy and pyright.
 ignore-missing-imports = [
     "branca",

--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -6,6 +6,7 @@ enabled-ignores = ["pyrefly"]
 # pyrefly excludes "**/venv/**/*" by default, which matches "stdlib/venv",
 # a proper stdlib module.
 project-excludes = ["**/__pycache__", "**/.[!/.]*/**"]
+disable-project-excludes-heuristics = true
 
 # These imports are intentionally optional and are also ignored by mypy and pyright.
 ignore-missing-imports = [

--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -4,8 +4,8 @@
 enabled-ignores = ["pyrefly"]
 
 # pyrefly excludes "**/venv/**/*" by default, which matches "stdlib/venv",
-# a proper stdlib module. We change this to only match ".venv" directories.
-project-excludes = ["**/__pycache__", "**/.venv/**", "**/.[!/.]*/**"]
+# a proper stdlib module.
+project-excludes = ["**/__pycache__", "**/.[!/.]*/**"]
 
 # These imports are intentionally optional and are also ignored by mypy and pyright.
 ignore-missing-imports = [


### PR DESCRIPTION
Fixes the following warning when running the pyrefly checks:

> WARN Skipping include pattern `/home/runner/work/typeshed/typeshed/stdlib/venv/__init__.pyi` because it is matched by `project-excludes` or an ignore file.