### PR TITLE
[CI] Fix mypy_primer comment

### DIFF
--- a/.github/workflows/mypy_primer_comment.yml
+++ b/.github/workflows/mypy_primer_comment.yml
@@ -3,7 +3,7 @@ name: mypy_primer (comment)
 on:
   workflow_run:
     workflows:
-      - Run mypy_primer
+      - mypy_primer
     types:
       - completed
 


### PR DESCRIPTION
Because for some unfathomable reason they think that triggering by name instead of file name was a good idea.