### PR TITLE
_operator: Accept readable buffers in _compare_digest

### DIFF
--- a/stdlib/_operator.pyi
+++ b/stdlib/_operator.pyi
@@ -13,7 +13,7 @@ from _typeshed import (
 )
 from collections.abc import Callable, Container, Iterable, MutableMapping, MutableSequence, Sequence
 from operator import attrgetter as attrgetter, itemgetter as itemgetter, methodcaller as methodcaller
-from typing import Any, AnyStr, ParamSpec, Protocol, SupportsAbs, SupportsIndex, TypeAlias, TypeVar, overload, type_check_only
+from typing import Any, ParamSpec, Protocol, SupportsAbs, SupportsIndex, TypeAlias, TypeVar, overload, type_check_only
 from typing_extensions import TypeIs
 
 _R = TypeVar("_R")
@@ -154,7 +154,7 @@ if sys.version_info >= (3, 11):
 @overload
 def _compare_digest(a: ReadableBuffer, b: ReadableBuffer, /) -> bool: ...
 @overload
-def _compare_digest(a: AnyStr, b: AnyStr, /) -> bool: ...
+def _compare_digest(a: str, b: str, /) -> bool: ...
 
 if sys.version_info >= (3, 14):
     def is_none(a: object, /) -> TypeIs[None]: ...

--- a/stdlib/_operator.pyi
+++ b/stdlib/_operator.pyi
@@ -1,5 +1,6 @@
 import sys
 from _typeshed import (
+    ReadableBuffer,
     SupportsAdd,
     SupportsGetItem,
     SupportsMod,
@@ -150,6 +151,9 @@ def ixor(a, b, /): ...
 if sys.version_info >= (3, 11):
     def call(obj: Callable[_P, _R], /, *args: _P.args, **kwargs: _P.kwargs) -> _R: ...
 
+@overload
+def _compare_digest(a: ReadableBuffer, b: ReadableBuffer, /) -> bool: ...
+@overload
 def _compare_digest(a: AnyStr, b: AnyStr, /) -> bool: ...
 
 if sys.version_info >= (3, 14):


### PR DESCRIPTION
Closes #15617

Accepts arbitrary readable buffer combinations in _operator._compare_digest, matching runtime behavior and _hashlib.compare_digest.

AI assistance: Codex was used to implement and verify this change.