### PR TITLE
Fix hnswlib SIGILL in stubtest by building without `-march=native`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -235,6 +235,12 @@ when running stubtest. For example: `mypy-plugins = ["mypy_django_plugin.main"]`
 * `mypy-plugins-config` (default: `{}`): A dictionary mapping plugin names to their
 configuration dictionaries for use by mypy plugins. For example:
 `mypy-plugins-config = {"django-stubs" = {"django_settings_module" = "@tests.django_settings"}}`
+* `install-environment` (default: `{}`): A dictionary of environment variables
+  to set while `pip install`ing the package and its dependencies for stubtest.
+  Useful for packages that read build-time options from the environment, for
+  example to disable CPU-specific compiler flags that do not survive CI's
+  shared wheel cache. For example:
+  `install-environment = { HNSWLIB_NO_NATIVE = "1" }`
 
 `*-dependencies` are usually packages needed to `pip install` the implementation
 distribution.

--- a/lib/ts_utils/metadata.py
+++ b/lib/ts_utils/metadata.py
@@ -53,6 +53,10 @@ def _is_nested_dict(obj: object) -> TypeGuard[dict[str, dict[str, Any]]]:
     return isinstance(obj, dict) and all(isinstance(k, str) and isinstance(v, dict) for k, v in obj.items())
 
 
+def _is_dict_of_strings(obj: object) -> TypeGuard[dict[str, str]]:
+    return isinstance(obj, dict) and all(isinstance(k, str) and isinstance(v, str) for k, v in obj.items())
+
+
 @functools.cache
 def get_oldest_supported_python() -> str:
     with PYPROJECT_PATH.open("rb") as config:
@@ -85,6 +89,7 @@ class StubtestSettings:
     stubtest_dependencies: list[str]
     mypy_plugins: list[str]
     mypy_plugins_config: dict[str, dict[str, Any]]
+    install_environment: dict[str, str]
 
     def system_requirements_for_platform(self, platform: str) -> list[str]:
         assert platform in _STUBTEST_PLATFORM_MAPPING, f"Unrecognised platform {platform!r}"
@@ -110,6 +115,7 @@ def read_stubtest_settings(distribution: str) -> StubtestSettings:
     stubtest_dependencies: object = data.get("stubtest-dependencies", [])
     mypy_plugins: object = data.get("mypy-plugins", [])
     mypy_plugins_config: object = data.get("mypy-plugins-config", {})
+    install_environment: object = data.get("install-environment", {})
 
     assert type(skip) is bool
     assert type(ignore_missing_stub) is bool
@@ -124,6 +130,7 @@ def read_stubtest_settings(distribution: str) -> StubtestSettings:
     assert _is_list_of_strings(stubtest_dependencies)
     assert _is_list_of_strings(mypy_plugins)
     assert _is_nested_dict(mypy_plugins_config)
+    assert _is_dict_of_strings(install_environment)
 
     unrecognised_platforms = set(ci_platforms) - _STUBTEST_PLATFORM_MAPPING.keys()
     assert not unrecognised_platforms, f"Unrecognised ci-platforms specified for {distribution!r}: {unrecognised_platforms}"
@@ -152,6 +159,7 @@ def read_stubtest_settings(distribution: str) -> StubtestSettings:
         stubtest_dependencies=stubtest_dependencies,
         mypy_plugins=mypy_plugins,
         mypy_plugins_config=mypy_plugins_config,
+        install_environment=install_environment,
     )
 
 
@@ -227,6 +235,7 @@ _KNOWN_METADATA_TOOL_FIELDS: Final = {
         "stubtest-dependencies",
         "mypy-plugins",
         "mypy-plugins-config",
+        "install-environment",
     }
 }
 _DIST_NAME_RE: Final = re.compile(r"^[a-z0-9]([a-z0-9._-]*[a-z0-9])?$", re.IGNORECASE)

--- a/stubs/hnswlib/METADATA.toml
+++ b/stubs/hnswlib/METADATA.toml
@@ -4,6 +4,8 @@ upstream-repository = "https://github.com/nmslib/hnswlib"
 dependencies = ["numpy>=1.21"]
 
 [tool.stubtest]
-# TODO: stubtest fails on Linux because it gets killed with a SIGILL
-# for unknown reasons. See https://github.com/python/typeshed/issues/16100
-ci-platforms = ["darwin"]
+# hnswlib is source-only and compiles with -march=native by default. CI
+# restores pip's wheel cache across runners with different CPUs, so a wheel
+# built on one machine can SIGILL on the next. See
+# https://github.com/python/typeshed/issues/16100
+install-environment = { HNSWLIB_NO_NATIVE = "1" }

--- a/tests/stubtest_third_party.py
+++ b/tests/stubtest_third_party.py
@@ -91,8 +91,12 @@ def run_stubtest(dist: Path, *, verbose: bool = False, ci_platforms_only: bool =
             dists_to_install[:] = dists_to_install[1:]
 
         pip_cmd = [pip_exe, "install", *dists_to_install]
+        # Some packages read environment variables at build time, e.g. to
+        # opt out of CPU-specific compiler flags. See `install-environment`
+        # in CONTRIBUTING.md.
+        pip_env = os.environ | stubtest_settings.install_environment
         try:
-            subprocess.run(pip_cmd, check=True, capture_output=True)
+            subprocess.run(pip_cmd, env=pip_env, check=True, capture_output=True)
         except subprocess.CalledProcessError as e:
             print_command_failure("Failed to install", e)
             return False


### PR DESCRIPTION
Fixes #16100. Reverts the darwin-only workaround from #16125 so hnswlib is tested on Linux again.

### What was happening

hnswlib is source-only and its `setup.py` adds `-march=native` on unix. CI restores pip's wheel cache across runners, keyed only on `requirements-tests.txt` and `stubs/**/METADATA.toml`. So a wheel compiled on one `ubuntu-latest` host gets restored onto another with a different CPU, and the first unsupported vector instruction is a SIGILL. That accounts for every symptom in the issue: exit `-4`, empty output (it dies on import before stubtest prints anything), passing locally (you build and run on one machine), and passing on darwin (uniform hardware).

I did not want to rest this on the build flags alone, so I pulled the logs for the three consecutive daily runs around the first failure. Same runner image (`ubuntu-24.04 20260720.247.2`) on all three, so the only variable is the physical host:

| date | hnswlib step | outcome | cache |
|---|---|---|---|
| 07-27 | **25.27 s** | success | hit, 630 MB |
| 07-28 | **5.82 s** | SIGILL | hit, 702 MB |
| 07-29 | **8.89 s** | success | hit, 716 MB |

A clean source build of hnswlib takes about 25 s (I timed 25 s locally on Apple Silicon too), so 07-27 compiled fresh. 5.82 s and 8.89 s are far too fast for a compile: both runs used a cached wheel built on some earlier host. On 07-28 that host's instruction set did not match; on 07-29 it did. Same cached artifact, different CPU, different result.

### The fix

hnswlib provides an `HNSWLIB_NO_NATIVE` opt-out in `setup.py`. `stubtest_third_party.py` ran `pip install` without an `env=`, and there was no per-distribution way to set one, so this adds a general `[tool.stubtest] install-environment` key (a table of environment variables applied to the pip install step), documents it in CONTRIBUTING.md, and uses it for hnswlib. I made it general rather than special-casing hnswlib since any source-only package with CPU-specific flags has the same exposure.

Because `stubs/**/METADATA.toml` is in the cache key, changing hnswlib's METADATA.toml also rotates the cache, so no stale native wheel can be restored after this merges.

### Verification

- Built hnswlib with `pip -v` with and without the variable: without it, `-march=native` appears in the actual `c++` compile commands; with it, the flag is gone.
- Ran `tests/stubtest_third_party.py hnswlib` end to end through the patched code: `hnswlib... (44.51 s) success`, a full source build.
- Wrapped `subprocess.run` to confirm the env actually reaches pip: `HNSWLIB_NO_NATIVE=1` is present for hnswlib and absent for an unrelated distribution (`six`).
- `read_stubtest_settings("hnswlib")` parses to `{"HNSWLIB_NO_NATIVE": "1"}` and `ci_platforms` falls back to the default `["linux"]`.
- `check_typeshed_structure.py`, `typecheck_typeshed.py` (mypy `--strict` on `tests/` and `scripts/`, linux 3.13), black, flake8, and ruff check all pass.