### PR TITLE
[protobuf] Bump to 7.35.1

### DIFF
--- a/stubs/protobuf/METADATA.toml
+++ b/stubs/protobuf/METADATA.toml
@@ -1,8 +1,8 @@
 # Using an exact number in the specifier for scripts/sync_protobuf/google_protobuf.py
 # When updating, also re-run the script
-version = "~=7.34.1"
+version = "~=7.35.1"
 upstream-repository = "https://github.com/protocolbuffers/protobuf"
-extra-description = "Partially generated using [mypy-protobuf==3.6.0](https://github.com/nipunn1313/mypy-protobuf/tree/v3.6.0) and libprotoc 34.1 on [protobuf v34.1](https://github.com/protocolbuffers/protobuf/releases/tag/v34.1) (python `protobuf==7.34.1`)."
+extra-description = "Partially generated using [mypy-protobuf==3.6.0](https://github.com/nipunn1313/mypy-protobuf/tree/v3.6.0) and libprotoc 35.1 on [protobuf v35.1](https://github.com/protocolbuffers/protobuf/releases/tag/v35.1) (python `protobuf==7.35.1`)."
 partial-stub = true
 
 [tool.stubtest]

--- a/stubs/protobuf/google/protobuf/any_pb2.pyi
+++ b/stubs/protobuf/google/protobuf/any_pb2.pyi
@@ -46,88 +46,33 @@ class Any(google.protobuf.message.Message, google.protobuf.internal.well_known_t
     """`Any` contains an arbitrary serialized protocol buffer message along with a
     URL that describes the type of the serialized message.
 
-    Protobuf library provides support to pack/unpack Any values in the form
-    of utility functions or additional generated methods of the Any type.
+    In its binary encoding, an `Any` is an ordinary message; but in other wire
+    forms like JSON, it has a special encoding. The format of the type URL is
+    described on the `type_url` field.
 
-    Example 1: Pack and unpack a message in C++.
+    Protobuf APIs provide utilities to interact with `Any` values:
 
-        Foo foo = ...;
-        Any any;
-        any.PackFrom(foo);
-        ...
-        if (any.UnpackTo(&foo)) {
-          ...
-        }
+    - A 'pack' operation accepts a message and constructs a generic `Any` wrapper
+      around it.
+    - An 'unpack' operation reads the content of an `Any` message, either into an
+      existing message or a new one. Unpack operations must check the type of the
+      value they unpack against the declared `type_url`.
+    - An 'is' operation decides whether an `Any` contains a message of the given
+      type, i.e. whether it can 'unpack' that type.
 
-    Example 2: Pack and unpack a message in Java.
+    The JSON format representation of an `Any` follows one of these cases:
 
-        Foo foo = ...;
-        Any any = Any.pack(foo);
-        ...
-        if (any.is(Foo.class)) {
-          foo = any.unpack(Foo.class);
-        }
-        // or ...
-        if (any.isSameTypeAs(Foo.getDefaultInstance())) {
-          foo = any.unpack(Foo.getDefaultInstance());
-        }
+    - For types without special-cased JSON encodings, the JSON format
+      representation of the `Any` is the same as that of the message, with an
+      additional `@type` field which contains the type URL.
+    - For types with special-cased JSON encodings (typically called 'well-known'
+      types, listed in https://protobuf.dev/programming-guides/json/#any), the
+      JSON format representation has a key `@type` which contains the type URL
+      and a key `value` which contains the JSON-serialized value.
 
-     Example 3: Pack and unpack a message in Python.
-
-        foo = Foo(...)
-        any = Any()
-        any.Pack(foo)
-        ...
-        if any.Is(Foo.DESCRIPTOR):
-          any.Unpack(foo)
-          ...
-
-     Example 4: Pack and unpack a message in Go
-
-         foo := &pb.Foo{...}
-         any, err := anypb.New(foo)
-         if err != nil {
-           ...
-         }
-         ...
-         foo := &pb.Foo{}
-         if err := any.UnmarshalTo(foo); err != nil {
-           ...
-         }
-
-    The pack methods provided by protobuf library will by default use
-    'type.googleapis.com/full.type.name' as the type URL and the unpack
-    methods only use the fully qualified type name after the last '/'
-    in the type URL, for example "foo.bar.com/x/y.z" will yield type
-    name "y.z".
-
-    JSON
-    ====
-    The JSON representation of an `Any` value uses the regular
-    representation of the deserialized, embedded message, with an
-    additional field `@type` which contains the type URL. Example:
-
-        package google.profile;
-        message Person {
-          string first_name = 1;
-          string last_name = 2;
-        }
-
-        {
-          "@type": "type.googleapis.com/google.profile.Person",
-          "firstName": <string>,
-          "lastName": <string>
-        }
-
-    If the embedded message type is well-known and has a custom JSON
-    representation, that representation will be embedded adding a field
-    `value` which holds the custom JSON in addition to the `@type`
-    field. Example (for message [google.protobuf.Duration][]):
-
-        {
-          "@type": "type.googleapis.com/google.protobuf.Duration",
-          "value": "1.212s"
-        }
+    The text format representation of an `Any` is like a message with one field
+    whose name is the type URL in brackets. For example, an `Any` containing a
+    `foo.Bar` message may be written `[type.googleapis.com/foo.Bar] { a: 2 }`.
     """
 
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
@@ -135,37 +80,38 @@ class Any(google.protobuf.message.Message, google.protobuf.internal.well_known_t
     TYPE_URL_FIELD_NUMBER: builtins.int
     VALUE_FIELD_NUMBER: builtins.int
     type_url: builtins.str
-    """A URL/resource name that uniquely identifies the type of the serialized
-    protocol buffer message. This string must contain at least
-    one "/" character. The last segment of the URL's path must represent
-    the fully qualified name of the type (as in
-    `path/google.protobuf.Duration`). The name should be in a canonical form
-    (e.g., leading "." is not accepted).
+    """Identifies the type of the serialized Protobuf message with a URI reference
+    consisting of a prefix ending in a slash and the fully-qualified type name.
 
-    In practice, teams usually precompile into the binary all types that they
-    expect it to use in the context of Any. However, for URLs which use the
-    scheme `http`, `https`, or no scheme, one can optionally set up a type
-    server that maps type URLs to message definitions as follows:
+    Example: type.googleapis.com/google.protobuf.StringValue
 
-    * If no scheme is provided, `https` is assumed.
-    * An HTTP GET on the URL must yield a [google.protobuf.Type][]
-      value in binary format, or produce an error.
-    * Applications are allowed to cache lookup results based on the
-      URL, or have them precompiled into a binary to avoid any
-      lookup. Therefore, binary compatibility needs to be preserved
-      on changes to types. (Use versioned type names to manage
-      breaking changes.)
+    This string must contain at least one `/` character, and the content after
+    the last `/` must be the fully-qualified name of the type in canonical
+    form, without a leading dot. Do not write a scheme on these URI references
+    so that clients do not attempt to contact them.
 
-    Note: this functionality is not currently available in the official
-    protobuf release, and it is not used for type URLs beginning with
-    type.googleapis.com. As of May 2023, there are no widely used type server
-    implementations and no plans to implement one.
+    The prefix is arbitrary and Protobuf implementations are expected to
+    simply strip off everything up to and including the last `/` to identify
+    the type. `type.googleapis.com/` is a common default prefix that some
+    legacy implementations require. This prefix does not indicate the origin of
+    the type, and URIs containing it are not expected to respond to any
+    requests.
 
-    Schemes other than `http`, `https` (or the empty scheme) might be
-    used with implementation specific semantics.
+    All type URL strings must be legal URI references with the additional
+    restriction (for the text format) that the content of the reference
+    must consist only of alphanumeric characters, percent-encoded escapes, and
+    characters in the following set (not including the outer backticks):
+    `/-.~_!$&()*+,;=`. Despite our allowing percent encodings, implementations
+    should not unescape them to prevent confusion with existing parsers. For
+    example, `type.googleapis.com%2FFoo` should be rejected.
+
+    In the original design of `Any`, the possibility of launching a type
+    resolution service at these type URLs was considered but Protobuf never
+    implemented one and considers contacting these URLs to be problematic and
+    a potential security issue. Do not attempt to contact type URLs.
     """
     value: builtins.bytes
-    """Must be a valid serialized protocol buffer of the above specified type."""
+    """Holds a Protobuf serialization of the type described by type_url."""
     def __init__(self, *, type_url: builtins.str | None = ..., value: builtins.bytes | None = ...) -> None: ...
     def ClearField(self, field_name: typing.Literal["type_url", b"type_url", "value", b"value"]) -> None: ...
 

--- a/stubs/protobuf/google/protobuf/descriptor_pb2.pyi
+++ b/stubs/protobuf/google/protobuf/descriptor_pb2.pyi
@@ -52,6 +52,9 @@ class _EditionEnumTypeWrapper(google.protobuf.internal.enum_type_wrapper._EnumTy
     comparison.
     """
     EDITION_2024: _Edition.ValueType  # 1001
+    EDITION_2026: _Edition.ValueType  # 1002
+    EDITION_UNSTABLE: _Edition.ValueType  # 9999
+    """A placeholder edition for developing and testing unscheduled features."""
     EDITION_1_TEST_ONLY: _Edition.ValueType  # 1
     """Placeholder editions for testing feature resolution.  These should not be
     used or relied on outside of tests.
@@ -88,6 +91,9 @@ should not be depended on, but they will always be time-ordered for easy
 comparison.
 """
 EDITION_2024: Edition.ValueType  # 1001
+EDITION_2026: Edition.ValueType  # 1002
+EDITION_UNSTABLE: Edition.ValueType  # 9999
+"""A placeholder edition for developing and testing unscheduled features."""
 EDITION_1_TEST_ONLY: Edition.ValueType  # 1
 """Placeholder editions for testing feature resolution.  These should not be
 used or relied on outside of tests.
@@ -1649,6 +1655,7 @@ class FieldOptions(google.protobuf.message.Message):
         EDITION_DEPRECATED_FIELD_NUMBER: builtins.int
         DEPRECATION_WARNING_FIELD_NUMBER: builtins.int
         EDITION_REMOVED_FIELD_NUMBER: builtins.int
+        REMOVAL_ERROR_FIELD_NUMBER: builtins.int
         edition_introduced: global___Edition.ValueType
         """The edition that this feature was first available in.  In editions
         earlier than this one, the default assigned to EDITION_LEGACY will be
@@ -1667,6 +1674,10 @@ class FieldOptions(google.protobuf.message.Message):
         this one, the last default assigned will be used, and proto files will
         not be able to override it.
         """
+        removal_error: builtins.str
+        """The removal error text if this feature is used after the edition it was
+        removed in.
+        """
         def __init__(
             self,
             *,
@@ -1674,6 +1685,7 @@ class FieldOptions(google.protobuf.message.Message):
             edition_deprecated: global___Edition.ValueType | None = ...,
             deprecation_warning: builtins.str | None = ...,
             edition_removed: global___Edition.ValueType | None = ...,
+            removal_error: builtins.str | None = ...,
         ) -> None: ...
         def HasField(
             self,
@@ -1686,6 +1698,8 @@ class FieldOptions(google.protobuf.message.Message):
                 b"edition_introduced",
                 "edition_removed",
                 b"edition_removed",
+                "removal_error",
+                b"removal_error",
             ],
         ) -> builtins.bool: ...
         def ClearField(
@@ -1699,6 +1713,8 @@ class FieldOptions(google.protobuf.message.Message):
                 b"edition_introduced",
                 "edition_removed",
                 b"edition_removed",
+                "removal_error",
+                b"removal_error",
             ],
         ) -> None: ...
 
@@ -2460,11 +2476,13 @@ class FeatureSet(google.protobuf.message.Message):
         ENFORCE_NAMING_STYLE_UNKNOWN: FeatureSet._EnforceNamingStyle.ValueType  # 0
         STYLE2024: FeatureSet._EnforceNamingStyle.ValueType  # 1
         STYLE_LEGACY: FeatureSet._EnforceNamingStyle.ValueType  # 2
+        STYLE2026: FeatureSet._EnforceNamingStyle.ValueType  # 3
 
     class EnforceNamingStyle(_EnforceNamingStyle, metaclass=_EnforceNamingStyleEnumTypeWrapper): ...
     ENFORCE_NAMING_STYLE_UNKNOWN: FeatureSet.EnforceNamingStyle.ValueType  # 0
     STYLE2024: FeatureSet.EnforceNamingStyle.ValueType  # 1
     STYLE_LEGACY: FeatureSet.EnforceNamingStyle.ValueType  # 2
+    STYLE2026: FeatureSet.EnforceNamingStyle.ValueType  # 3
 
     @typing.final
     class VisibilityFeature(google.protobuf.message.Message):

--- a/stubs/protobuf/google/protobuf/field_mask_pb2.pyi
+++ b/stubs/protobuf/google/protobuf/field_mask_pb2.pyi
@@ -157,24 +157,22 @@ class FieldMask(google.protobuf.message.Message, google.protobuf.internal.well_k
     An implementation may provide options to override this default behavior for
     repeated and message fields.
 
-    In order to reset a field's value to the default, the field must
-    be in the mask and set to the default value in the provided resource.
-    Hence, in order to reset all fields of a resource, provide a default
-    instance of the resource and set all fields in the mask, or do
-    not provide a mask as described below.
+    Note that libraries which implement FieldMask resolution have various
+    different behaviors in the face of empty masks or the special "*" mask.
+    When implementing a service you should confirm these cases have the
+    appropriate behavior in the underlying FieldMask library that you desire,
+    and you may need to special case those cases in your application code if
+    the underlying field mask library behavior differs from your intended
+    service semantics.
 
-    If a field mask is not present on update, the operation applies to
-    all fields (as if a field mask of all fields has been specified).
-    Note that in the presence of schema evolution, this may mean that
-    fields the client does not know and has therefore not filled into
-    the request will be reset to their default. If this is unwanted
-    behavior, a specific service may require a client to always specify
-    a field mask, producing an error if not.
+    Update methods implementing https://google.aip.dev/134
+    - MUST support the special value * meaning "full replace"
+    - MUST treat an omitted field mask as "replace fields which are present".
 
-    As with get operations, the location of the resource which
-    describes the updated values in the request message depends on the
-    operation kind. In any case, the effect of the field mask is
-    required to be honored by the API.
+    Other methods implementing https://google.aip.dev/157
+    - SHOULD support the special value "*" to mean "get all".
+    - MUST treat an omitted field mask to mean "get all", unless otherwise
+    documented.
 
     ## Considerations for HTTP REST
 

--- a/stubs/protobuf/google/protobuf/json_format.pyi
+++ b/stubs/protobuf/google/protobuf/json_format.pyi
@@ -19,6 +19,8 @@ def MessageToJson(
     descriptor_pool: DescriptorPool | None = None,
     ensure_ascii: bool = True,
     always_print_fields_with_no_presence: bool = False,
+    *,
+    unquote_int64_if_possible: bool = False,
 ) -> str: ...
 def MessageToDict(
     message: Message,
@@ -26,6 +28,8 @@ def MessageToDict(
     preserving_proto_field_name: bool = False,
     use_integers_for_enums: bool = False,
     descriptor_pool: DescriptorPool | None = None,
+    *,
+    unquote_int64_if_possible: bool = False,
 ) -> dict[str, Any]: ...
 def Parse(
     text: bytes | str,

--- a/stubs/protobuf/google/protobuf/struct_pb2.pyi
+++ b/stubs/protobuf/google/protobuf/struct_pb2.pyi
@@ -60,10 +60,15 @@ class _NullValueEnumTypeWrapper(google.protobuf.internal.enum_type_wrapper._Enum
     """Null value."""
 
 class NullValue(_NullValue, metaclass=_NullValueEnumTypeWrapper):
-    """`NullValue` is a singleton enumeration to represent the null value for the
-    `Value` type union.
+    """Represents a JSON `null`.
 
-    The JSON representation for `NullValue` is JSON `null`.
+    `NullValue` is a sentinel, using an enum with only one value to represent
+    the null value for the `Value` type union.
+
+    A field of type `NullValue` with any value other than `0` is considered
+    invalid. Most ProtoJSON serializers will emit a Value with a `null_value` set
+    as a JSON `null` regardless of the integer value, and so will round trip to
+    a `0` value.
     """
 
 NULL_VALUE: NullValue.ValueType  # 0
@@ -72,14 +77,19 @@ global___NullValue = NullValue
 
 @typing.final
 class Struct(google.protobuf.message.Message, google.protobuf.internal.well_known_types.Struct):
-    """`Struct` represents a structured data value, consisting of fields
-    which map to dynamically typed values. In some languages, `Struct`
-    might be supported by a native representation. For example, in
-    scripting languages like JS a struct is represented as an
-    object. The details of that representation are described together
-    with the proto support for the language.
+    """Represents a JSON object.
 
-    The JSON representation for `Struct` is JSON object.
+    An unordered key-value map, intending to perfectly capture the semantics of a
+    JSON object. This enables parsing any arbitrary JSON payload as a message
+    field in ProtoJSON format.
+
+    This follows RFC 8259 guidelines for interoperable JSON: notably this type
+    cannot represent large Int64 values or `NaN`/`Infinity` numbers,
+    since the JSON format generally does not support those values in its number
+    type.
+
+    If you do not intend to parse arbitrary JSON into your message, a custom
+    typed message should be preferred instead of using this type.
     """
 
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
@@ -109,12 +119,12 @@ global___Struct = Struct
 
 @typing.final
 class Value(google.protobuf.message.Message):
-    """`Value` represents a dynamically typed value which can be either
+    """Represents a JSON value.
+
+    `Value` represents a dynamically typed value which can be either
     null, a number, a string, a boolean, a recursive struct value, or a
     list of values. A producer of value is expected to set one of these
-    variants. Absence of any variant indicates an error.
-
-    The JSON representation for `Value` is JSON value.
+    variants. Absence of any variant is an invalid state.
     """
 
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
@@ -126,20 +136,24 @@ class Value(google.protobuf.message.Message):
     STRUCT_VALUE_FIELD_NUMBER: builtins.int
     LIST_VALUE_FIELD_NUMBER: builtins.int
     null_value: global___NullValue.ValueType
-    """Represents a null value."""
+    """Represents a JSON `null`."""
     number_value: builtins.float
-    """Represents a double value."""
+    """Represents a JSON number. Must not be `NaN`, `Infinity` or
+    `-Infinity`, since those are not supported in JSON. This also cannot
+    represent large Int64 values, since JSON format generally does not
+    support them in its number type.
+    """
     string_value: builtins.str
-    """Represents a string value."""
+    """Represents a JSON string."""
     bool_value: builtins.bool
-    """Represents a boolean value."""
+    """Represents a JSON boolean (`true` or `false` literal in JSON)."""
     @property
     def struct_value(self) -> global___Struct:
-        """Represents a structured value."""
+        """Represents a JSON object."""
 
     @property
     def list_value(self) -> global___ListValue:
-        """Represents a repeated `Value`."""
+        """Represents a JSON array."""
 
     def __init__(
         self,
@@ -197,10 +211,7 @@ global___Value = Value
 
 @typing.final
 class ListValue(google.protobuf.message.Message, google.protobuf.internal.well_known_types.ListValue):
-    """`ListValue` is a wrapper around a repeated field of values.
-
-    The JSON representation for `ListValue` is JSON array.
-    """
+    """Represents a JSON array."""
 
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 

--- a/stubs/protobuf/google/protobuf/text_format.pyi
+++ b/stubs/protobuf/google/protobuf/text_format.pyi
@@ -138,6 +138,7 @@ def Parse(
     allow_field_number: bool = False,
     descriptor_pool: DescriptorPool | None = None,
     allow_unknown_field: bool = False,
+    max_recursion_depth: int | None = None,
 ) -> _M: ...
 def Merge(
     text: str | bytes,
@@ -146,6 +147,7 @@ def Merge(
     allow_field_number: bool = False,
     descriptor_pool: DescriptorPool | None = None,
     allow_unknown_field: bool = False,
+    max_recursion_depth: int | None = None,
 ) -> _M: ...
 def MergeLines(
     lines: Iterable[str | bytes],
@@ -154,6 +156,7 @@ def MergeLines(
     allow_field_number: bool = False,
     descriptor_pool: DescriptorPool | None = None,
     allow_unknown_field: bool = False,
+    max_recursion_depth: int | None = None,
 ) -> _M: ...
 
 class _Parser:
@@ -161,12 +164,15 @@ class _Parser:
     allow_field_number: bool
     descriptor_pool: DescriptorPool | None
     allow_unknown_field: bool
+    max_recursion_depth: int | None
+    recursion_depth: int
     def __init__(
         self,
         allow_unknown_extension: bool = False,
         allow_field_number: bool = False,
         descriptor_pool: DescriptorPool | None = None,
         allow_unknown_field: bool = False,
+        max_recursion_depth: int | None = None,
     ) -> None: ...
     def ParseLines(self, lines: Iterable[str | bytes], message: _M) -> _M: ...
     def MergeLines(self, lines: Iterable[str | bytes], message: _M) -> _M: ...

--- a/stubs/protobuf/google/protobuf/timestamp_pb2.pyi
+++ b/stubs/protobuf/google/protobuf/timestamp_pb2.pyi
@@ -115,8 +115,8 @@ class Timestamp(google.protobuf.message.Message, google.protobuf.internal.well_k
     {hour}, {min}, and {sec} are zero-padded to two digits each. The fractional
     seconds, which can go up to 9 digits (i.e. up to 1 nanosecond resolution),
     are optional. The "Z" suffix indicates the timezone ("UTC"); the timezone
-    is required. A proto3 JSON serializer should always use UTC (as indicated by
-    "Z") when printing the Timestamp type and a proto3 JSON parser should be
+    is required. A ProtoJSON serializer should always use UTC (as indicated by
+    "Z") when printing the Timestamp type and a ProtoJSON parser should be
     able to accept both UTC and other timezones (as indicated by an offset).
 
     For example, "2017-01-15T01:30:15.01Z" encodes 15.01 seconds past
@@ -139,14 +139,15 @@ class Timestamp(google.protobuf.message.Message, google.protobuf.internal.well_k
     SECONDS_FIELD_NUMBER: builtins.int
     NANOS_FIELD_NUMBER: builtins.int
     seconds: builtins.int
-    """Represents seconds of UTC time since Unix epoch
-    1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
-    9999-12-31T23:59:59Z inclusive.
+    """Represents seconds of UTC time since Unix epoch 1970-01-01T00:00:00Z. Must
+    be between -62135596800 and 253402300799 inclusive (which corresponds to
+    0001-01-01T00:00:00Z to 9999-12-31T23:59:59Z).
     """
     nanos: builtins.int
-    """Non-negative fractions of a second at nanosecond resolution. Negative
-    second values with fractions must still have non-negative nanos values
-    that count forward in time. Must be from 0 to 999,999,999
+    """Non-negative fractions of a second at nanosecond resolution. This field is
+    the nanosecond portion of the duration, not an alternative to seconds.
+    Negative second values with fractions must still have non-negative nanos
+    values that count forward in time. Must be between 0 and 999,999,999
     inclusive.
     """
     def __init__(self, *, seconds: builtins.int | None = ..., nanos: builtins.int | None = ...) -> None: ...


### PR DESCRIPTION
Closes #15811

Regenerates the `*_pb2.pyi` stubs with `scripts/sync_protobuf/google_protobuf.py` on protobuf v35.1 (libprotoc 35.1, mypy-protobuf 3.6.0 to match the previous generation, since the 5.x output changes the whole stub style and trips Y015 after black), and adds the new `unquote_int64_if_possible` keyword to `json_format.MessageToDict`/`MessageToJson` and `max_recursion_depth` to `text_format.Parse`/`Merge`/`MergeLines`/`_Parser`.

Agent used: Claude Code