### PR TITLE
[JACK-Client] Re-enable stubtest on darwin

### DIFF
--- a/stubs/JACK-Client/METADATA.toml
+++ b/stubs/JACK-Client/METADATA.toml
@@ -5,9 +5,7 @@ dependencies = ["numpy>=1.20", "types-cffi"]
 
 [tool.stubtest]
 # darwin and win32 are equivalent
-# TODO (2026-06-26): darwin temporarily disabled, see
-# https://github.com/python/typeshed/issues/15947
-ci-platforms = ["linux"]
+ci-platforms = ["darwin", "linux"]
 apt-dependencies = ["libjack-dev"]
 brew-dependencies = ["jack"]
 # No need to install on the CI. Leaving here as information for Windows contributors.


### PR DESCRIPTION
Closes #15947

The Homebrew `jack` formula (1.9.22_1) no longer depends on `berkeley-db@5`, so `libjack.dylib` loads again on macOS and `tests/stubtest_third_party.py JACK-Client` passes locally on darwin. This restores the darwin CI platform that was removed in #15948.

Agent used: Claude Code