### PR TITLE
[stdlib] add sys._framework

### DIFF
--- a/stdlib/sys/__init__.pyi
+++ b/stdlib/sys/__init__.pyi
@@ -42,6 +42,7 @@ excepthook: Callable[[type[BaseException], BaseException, TracebackType | None],
 exec_prefix: str
 executable: str
 float_repr_style: Literal["short", "legacy"]
+_framework: str  # empty string on non-macOS platforms
 hexversion: int
 last_type: type[BaseException] | None
 last_value: BaseException | None


### PR DESCRIPTION
I noticed that ty fails to recognize this attribute.

It doesn't appear to be a public API, so I'm not 100% sure it's a fit for here. However, a global GH search shows a decent amount of usage of it:

https://github.com/search?q=language%3Apython+%22sys._framework%22&type=code

Ref: https://github.com/astral-sh/ty-vscode/pull/533/files#r3816508735