### PR TITLE
[threading] Ignore Condition.locked in Python 3.15

### DIFF
--- a/stdlib/@tests/stubtest_allowlists/py315.txt
+++ b/stdlib/@tests/stubtest_allowlists/py315.txt
@@ -24,7 +24,6 @@ importlib._bootstrap_external.NamespacePath
 importlib.resources._common.package_to_anchor
 mailbox._ProxyFile.__class_getitem__
 multiprocessing.process.BaseProcess.__init__
-threading.Condition.locked
 
 # =============================================================
 # Allowlist entries that cannot or should not be fixed; >= 3.15
@@ -86,6 +85,9 @@ concurrent.interpreters._crossinterp.UnboundItem.singleton
 # object() sentinels at runtime represented by NewTypes in the stubs
 concurrent.interpreters._crossinterp.UNBOUND_ERROR
 concurrent.interpreters._crossinterp.UNBOUND_REMOVE
+
+# Condition functions are exported in __init__
+threading.Condition.locked
 
 # Assigning `__new__` causes `func` not to get recognized.
 functools.partialmethod.__new__


### PR DESCRIPTION
The entry exists since the method was added in Python 3.14: https://github.com/python/typeshed/blob/9a0198f83bc8d3ab5dc0f79989f77612df53105f/stdlib/%40tests/stubtest_allowlists/py314.txt#L24-L25
Source code: https://github.com/python/cpython/blob/f71fbc558a3051781297106f53820b04c217c13d/Lib/threading.py#L291
