### PR TITLE
[typing] Remove keyword arguments for NamedTuple in Python 3.15

### DIFF
--- a/stdlib/_typeshed/_type_checker_internals.pyi
+++ b/stdlib/_typeshed/_type_checker_internals.pyi
@@ -69,13 +69,16 @@ class NamedTupleFallback(tuple[Any, ...]):
     if sys.version_info >= (3, 12):
         __orig_bases__: ClassVar[tuple[Any, ...]]
 
-    @overload
-    def __init__(self, typename: str, fields: Iterable[tuple[str, Any]], /) -> None: ...
-    @overload
-    @typing_extensions.deprecated(
-        "Creating a typing.NamedTuple using keyword arguments is deprecated and support will be removed in Python 3.15"
-    )
-    def __init__(self, typename: str, fields: None = None, /, **kwargs: Any) -> None: ...
+    if sys.version_info >= (3, 15):
+        def __init__(self, typename: str, fields: Iterable[tuple[str, Any]], /) -> None: ...
+    else:
+        @overload
+        def __init__(self, typename: str, fields: Iterable[tuple[str, Any]], /) -> None: ...
+        @overload
+        @typing_extensions.deprecated(
+            "Creating a typing.NamedTuple using keyword arguments is deprecated; support removed in Python 3.15"
+        )
+        def __init__(self, typename: str, fields: None = None, /, **kwargs: Any) -> None: ...
 
     @classmethod
     def _make(cls, iterable: Iterable[Any]) -> typing_extensions.Self: ...

--- a/stdlib/typing.pyi
+++ b/stdlib/typing.pyi
@@ -1055,11 +1055,14 @@ class NamedTuple(tuple[Any, ...]):
     if sys.version_info >= (3, 12):
         __orig_bases__: ClassVar[tuple[Any, ...]]
 
-    @overload
-    def __init__(self, typename: str, fields: Iterable[tuple[str, Any]], /) -> None: ...
-    @overload
-    @deprecated("Creating a typing.NamedTuple using keyword arguments is deprecated and support will be removed in Python 3.15")
-    def __init__(self, typename: str, fields: None = None, /, **kwargs: Any) -> None: ...
+    if sys.version_info >= (3, 15):
+        def __init__(self, typename: str, fields: Iterable[tuple[str, Any]], /) -> None: ...
+    else:
+        @overload
+        def __init__(self, typename: str, fields: Iterable[tuple[str, Any]], /) -> None: ...
+        @overload
+        @deprecated("Creating a typing.NamedTuple using keyword arguments is deprecated; support removed in Python 3.15")
+        def __init__(self, typename: str, fields: None = None, /, **kwargs: Any) -> None: ...
 
     @final
     @classmethod


### PR DESCRIPTION
Source: https://github.com/python/cpython/pull/133822