### PR TITLE
Make types-networkx NumPy dependency optional

### DIFF
--- a/stubs/networkx/METADATA.toml
+++ b/stubs/networkx/METADATA.toml
@@ -1,7 +1,7 @@
 version = "3.6.1"
 upstream-repository = "https://github.com/networkx/networkx"
 # requires a version of numpy with a `py.typed` file
-dependencies = ["numpy>=1.20"]
+optional-dependencies = ["numpy>=1.20"]
 
 [tool.stubtest]
 # stub_uploader won't allow pandas-stubs in the requires field https://github.com/typeshed-internal/stub_uploader/issues/90

--- a/stubs/networkx/METADATA.toml
+++ b/stubs/networkx/METADATA.toml
@@ -1,7 +1,7 @@
 version = "3.6.1"
 upstream-repository = "https://github.com/networkx/networkx"
-# requires a version of numpy with a `py.typed` file
-optional-dependencies = ["numpy>=1.20"]
+# Requires a version of NumPy with `numpy.typing.NDArray`.
+optional-dependencies = ["numpy>=1.21"]
 
 [tool.stubtest]
 # stub_uploader won't allow pandas-stubs in the requires field https://github.com/typeshed-internal/stub_uploader/issues/90


### PR DESCRIPTION
Fixes #14760

Move NumPy from the required stub dependency list to `optional-dependencies`. This keeps pure graph users from installing NumPy transitively while retaining a discoverable `numpy` extra for users of NumPy-backed APIs.

Use NumPy 1.21 as the optional dependency floor because these stubs import `numpy.typing.NDArray`, which was introduced in 1.21. The `numpy>=2` requirement discussed in review is currently on unreleased NetworkX main; this PR targets NetworkX 3.6.1.

Validation:
- `python tests/check_typeshed_structure.py`
- `python tests/get_external_stub_requirements.py networkx`
- `pre-commit run --files stubs/networkx/METADATA.toml`

Agent used: OpenAI Codex.