### PR TITLE
Annotate 3.14+ ipaddress `version` / `max_prefixlen` as `Literal`

### DIFF
--- a/stdlib/ipaddress.pyi
+++ b/stdlib/ipaddress.pyi
@@ -109,8 +109,8 @@ class _BaseNetwork(_IPAddressBase, Generic[_A]):
 class _BaseV4:
     __slots__ = ()
     if sys.version_info >= (3, 14):
-        version: Final[Literal[4]] = 4
-        max_prefixlen: Final[Literal[32]] = 32
+        version: Final = 4
+        max_prefixlen: Final = 32
     else:
         @property
         def version(self) -> Literal[4]: ...
@@ -162,8 +162,8 @@ class IPv4Interface(IPv4Address):
 class _BaseV6:
     __slots__ = ()
     if sys.version_info >= (3, 14):
-        version: Final[Literal[6]] = 6
-        max_prefixlen: Final[Literal[128]] = 128
+        version: Final = 6
+        max_prefixlen: Final = 128
     else:
         @property
         def version(self) -> Literal[6]: ...

--- a/stdlib/ipaddress.pyi
+++ b/stdlib/ipaddress.pyi
@@ -109,8 +109,8 @@ class _BaseNetwork(_IPAddressBase, Generic[_A]):
 class _BaseV4:
     __slots__ = ()
     if sys.version_info >= (3, 14):
-        version: Final = 4
-        max_prefixlen: Final = 32
+        version: Final[Literal[4]] = 4
+        max_prefixlen: Final[Literal[32]] = 32
     else:
         @property
         def version(self) -> Literal[4]: ...
@@ -162,8 +162,8 @@ class IPv4Interface(IPv4Address):
 class _BaseV6:
     __slots__ = ()
     if sys.version_info >= (3, 14):
-        version: Final = 6
-        max_prefixlen: Final = 128
+        version: Final[Literal[6]] = 6
+        max_prefixlen: Final[Literal[128]] = 128
     else:
         @property
         def version(self) -> Literal[6]: ...

--- a/stdlib/ipaddress.pyi
+++ b/stdlib/ipaddress.pyi
@@ -109,8 +109,10 @@ class _BaseNetwork(_IPAddressBase, Generic[_A]):
 class _BaseV4:
     __slots__ = ()
     if sys.version_info >= (3, 14):
-        version: Final[Literal[4]] = 4
-        max_prefixlen: Final[Literal[32]] = 32
+        # a bare `Final` infers as `int`, which cannot narrow an
+        # `IPv4Network | IPv6Network` union (PYI064 does not account for that)
+        version: Final[Literal[4]] = 4  # noqa: PYI064
+        max_prefixlen: Final[Literal[32]] = 32  # noqa: PYI064
     else:
         @property
         def version(self) -> Literal[4]: ...
@@ -162,8 +164,10 @@ class IPv4Interface(IPv4Address):
 class _BaseV6:
     __slots__ = ()
     if sys.version_info >= (3, 14):
-        version: Final[Literal[6]] = 6
-        max_prefixlen: Final[Literal[128]] = 128
+        # a bare `Final` infers as `int`, which cannot narrow an
+        # `IPv4Network | IPv6Network` union (PYI064 does not account for that)
+        version: Final[Literal[6]] = 6  # noqa: PYI064
+        max_prefixlen: Final[Literal[128]] = 128  # noqa: PYI064
     else:
         @property
         def version(self) -> Literal[6]: ...


### PR DESCRIPTION
On 3.14+, `_BaseV4` / `_BaseV6` declare `version` and `max_prefixlen` as bare `Final`s, so they infer
as `Literal[4]?` — an inferred literal that falls back to `int` — rather than a declared `Literal[4]`.
`.version` therefore no longer narrows an `IPv4Network | IPv6Network` union, which it does on 3.13
where these are `Literal`-returning properties, and that narrowing is the only type-safe way to reach
`subnet_of` / `supernet_of` / `address_exclude`, since they take `other: Self`.

Annotate the literal types explicitly, with `# noqa: PYI064` because the bare `Final` that rule
suggests is precisely the form that loses the declared literal (pre-commit.ci autofixed it away in
0752a116c, reverted in 44bc4e1a1). Happy to drop `Final` and use plain `Literal[4]` instead if you
would rather not carry the `noqa`s, or to take this to ruff as a rule bug first.

Agent used: Claude Code (Claude Opus 5).

----

2026-08-31 (@srittau): Deferred pending discussion in python/typing#2351.
