### PR TITLE
[importlib] Update SourceLoader.source_to_code method

### DIFF
--- a/stdlib/@tests/stubtest_allowlists/py315.txt
+++ b/stdlib/@tests/stubtest_allowlists/py315.txt
@@ -3,8 +3,6 @@
 # ============================================
 
 _frozen_importlib_external.PathFinder.discover
-_frozen_importlib_external.SourceFileLoader.source_to_code
-_frozen_importlib_external.SourceLoader.source_to_code
 dataclasses.MISSING
 dataclasses._MISSING_TYPE
 dataclasses.field

--- a/stdlib/_frozen_importlib_external.pyi
+++ b/stdlib/_frozen_importlib_external.pyi
@@ -101,9 +101,24 @@ class SourceLoader(_LoaderBasics):
     def set_data(self, path: str, data: bytes) -> None: ...
     def get_source(self, fullname: str) -> str | None: ...
     def path_stats(self, path: str) -> Mapping[str, Any]: ...
-    def source_to_code(
-        self, data: ReadableBuffer | str | _ast.Module | _ast.Expression | _ast.Interactive, path: bytes | StrPath
-    ) -> types.CodeType: ...
+    if sys.version_info >= (3, 15):
+        def source_to_code(
+            self,
+            data: ReadableBuffer | str | _ast.Module | _ast.Expression | _ast.Interactive,
+            path: bytes | StrPath,
+            fullname: str | None = None,
+            *,
+            _optimize: int = -1,
+        ) -> types.CodeType: ...
+    else:
+        def source_to_code(
+            self,
+            data: ReadableBuffer | str | _ast.Module | _ast.Expression | _ast.Interactive,
+            path: bytes | StrPath,
+            *,
+            _optimize: int = -1,
+        ) -> types.CodeType: ...
+
     def get_code(self, fullname: str) -> types.CodeType | None: ...
 
 class FileLoader:
@@ -120,13 +135,6 @@ class FileLoader:
 class SourceFileLoader(importlib.abc.FileLoader, FileLoader, importlib.abc.SourceLoader, SourceLoader):  # type: ignore[misc]  # incompatible method arguments in base classes
     def set_data(self, path: str, data: ReadableBuffer, *, _mode: int = 0o666) -> None: ...
     def path_stats(self, path: str) -> Mapping[str, Any]: ...
-    def source_to_code(  # type: ignore[override]  # incompatible with InspectLoader.source_to_code
-        self,
-        data: ReadableBuffer | str | _ast.Module | _ast.Expression | _ast.Interactive,
-        path: bytes | StrPath,
-        *,
-        _optimize: int = -1,
-    ) -> types.CodeType: ...
 
 class SourcelessFileLoader(importlib.abc.FileLoader, FileLoader, _LoaderBasics):
     def get_code(self, fullname: str) -> types.CodeType | None: ...


### PR DESCRIPTION
* Add `fullname` param to `source_to_code` methdos in Python 3.15
* Move `source_to_code` definition to `SourceLoader` (parent of `SourceFileLoader`) (fix #13880)