### PR TITLE
Direct Claude towards AGENTS.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
Our `AGENTS.md` file contains clear guidance that most PRs to typeshed don't need regression tests, but we still see lots of (clearly agentic-driven) PRs that unnecessarily include them. I think one reason for this might be that Anthropic models don't look at AGENTS.md by default -- you have to manually point them towards AGENTS.md by adding a CLAUDE.md that looks like this. See https://code.claude.com/docs/en/memory#agents-md