### PR TITLE
Improve Renovate configuration, add pre-commit hooks to validate Renovate configuration

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,7 +2,14 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "dependencyDashboard": true,
   "suppressNotifications": ["prEditedNotification"],
-  "extends": ["config:recommended", "helpers:pinGitHubActionDigests"],
+  "extends": [
+    "config:recommended",
+    "schedule:monthly",
+    "helpers:pinGitHubActionDigestsToSemver",
+    "replacements:all",
+    "abandonments:recommended"
+  ],
+  "configMigration": true,
   "labels": ["bot: dependencies"],
   "rebaseLabel": ["bot: rebase"],
   "semanticCommits": "disabled",
@@ -15,7 +22,13 @@
   "pre-commit": {
     "enabled": true
   },
+  "minimumReleaseAge": "7 days",
   "packageRules": [
+    {
+      // Pin versions already in use without waiting for the upgrade cooldown.
+      "matchUpdateTypes": ["pinDigest"],
+      "minimumReleaseAge": null
+    },
     {
       groupName: "GitHub Actions",
       matchManagers: ["github-actions"],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,7 +4,6 @@
   "suppressNotifications": ["prEditedNotification"],
   "extends": [
     "config:recommended",
-    "schedule:monthly",
     "helpers:pinGitHubActionDigestsToSemver",
     "replacements:all",
     "abandonments:recommended"

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,7 +11,7 @@
   ],
   "configMigration": true,
   "labels": ["bot: dependencies"],
-  "rebaseLabel": ["bot: rebase"],
+  "rebaseLabel": "bot: rebase",
   "semanticCommits": "disabled",
   "separateMajorMinor": false,
   "prHourlyLimit": 10,

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,12 @@ repos:
       - id: mixed-line-ending
         args: [--fix=lf]
       - id: check-case-conflict
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 12e63946db2c5cfcc9030fac21c3883ba88c6ed8 # frozen: 0.38.0
+    hooks:
+      - id: check-github-workflows
+      - id: check-renovate
+        additional_dependencies: ["json5==0.15.0"]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # The Ruff version must match requirements-tests.txt.
     rev: c59bba8fb259db0fec2bbb77ad8ba51ea7341b56 # frozen: v0.15.20


### PR DESCRIPTION
Make Renovate's dependency updates more conservative and add schema validation for repository configuration.

- Set a [seven-day minimum release age](https://docs.renovatebot.com/configuration-options/#minimumreleaseage), exempting [initial digest pins](https://docs.renovatebot.com/configuration-options/#packagerulesmatchupdatetypes).
- Use [SemVer-based GitHub Action digest pinning](https://docs.renovatebot.com/presets-helpers/#helperspingithubactiondigeststosemver)
- Include [package replacement rules](https://docs.renovatebot.com/presets-replacements/#replacementsall) and [recommended abandonment detection](https://docs.renovatebot.com/presets-abandonments/#abandonmentsrecommended), and enable [configuration migration PRs](https://docs.renovatebot.com/configuration-options/#configmigration).

This PR also fixes a schema error that was already present on `main`: [`rebaseLabel`](https://docs.renovatebot.com/configuration-options/#rebaselabel) should be a string, not an array. To prevent this issue from happening again in the future, I added the [`check-renovate`](https://check-jsonschema.readthedocs.io/en/latest/precommit_usage.html#check-renovate) pre-commit hook, and added the [`check-github-workflows`](https://check-jsonschema.readthedocs.io/en/latest/precommit_usage.html#check-github-workflows) hook from the same repo. We have both hooks enabled already on `typing_extensions`.