### PR TITLE
Add pyproject.toml validation to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,13 @@ repos:
       - id: check-github-workflows
       - id: check-renovate
         additional_dependencies: ["json5==0.15.0"]
+  - repo: https://github.com/abravalheri/validate-pyproject
+    rev: 4b2e70d08cb2ccd26d1fba73588de41c7a5d50b7 # frozen: v0.25
+    hooks:
+      - id: validate-pyproject
+        # Renovate needs an explicit language to update additional_dependencies.
+        language: python
+        additional_dependencies: ["validate-pyproject-schema-store[all]==2026.8.15"]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # The Ruff version must match requirements-tests.txt.
     rev: c59bba8fb259db0fec2bbb77ad8ba51ea7341b56 # frozen: v0.15.20


### PR DESCRIPTION
Add [validate-pyproject](https://validate-pyproject.readthedocs.io/en/latest/) to check the contents of `pyproject.toml` files in addition to the syntax checks provided by `check-toml`, using the same hook and dependency pins as `typing_extensions`.

It validates standard project metadata and build-system settings, plus supported tool configuration through [bundled SchemaStore schemas](https://github.com/henryiii/validate-pyproject-schema-store). For example, it catches:

- Invalid project metadata, such as `version = 1` instead of a string or a malformed Python version constraint like `requires-python = "=>3.10"`.
- Incorrect build-system settings, such as `requires = "hatchling"` instead of a list of requirements.
- Misspelled tool settings and incorrect value types, such as `line-lenght = 130` under `[tool.ruff]` or `preview = "true"` instead of a boolean under `[tool.black]`.

Assisted by Codex.
