### PR TITLE
Remove `__name__` property from `LazyImportType`

### DIFF
--- a/stdlib/types.pyi
+++ b/stdlib/types.pyi
@@ -610,8 +610,6 @@ if sys.version_info >= (3, 15):
 
     @final
     class LazyImportType:
-        @property
-        def __name__(self) -> str: ...
         def resolve(self) -> Any: ...
 
 @final


### PR DESCRIPTION
Fixes https://github.com/python/typeshed/issues/16343.