### PR TITLE
[typing] Add missing `qualname` parameter annotation to `TypeAliasType.__new__`

### DIFF
--- a/stdlib/typing.pyi
+++ b/stdlib/typing.pyi
@@ -1207,6 +1207,7 @@ if sys.version_info >= (3, 12):
             def __qualname__(self) -> str: ...
         else:
             def __new__(cls, name: str, value: Any, *, type_params: tuple[_TypeParameter, ...] = ()) -> Self: ...
+
         @property
         def __value__(self) -> Any: ...  # AnnotationForm
         @property

--- a/stdlib/typing.pyi
+++ b/stdlib/typing.pyi
@@ -1199,7 +1199,14 @@ if sys.version_info >= (3, 12):
 
     @final
     class TypeAliasType:
-        def __new__(cls, name: str, value: Any, *, type_params: tuple[_TypeParameter, ...] = ()) -> Self: ...
+        if sys.version_info >= (3, 15):
+            def __new__(
+                cls, name: str, value: Any, *, type_params: tuple[_TypeParameter, ...] = (), qualname: str | None = None
+            ) -> Self: ...
+            @property
+            def __qualname__(self) -> str: ...
+        else:
+            def __new__(cls, name: str, value: Any, *, type_params: tuple[_TypeParameter, ...] = ()) -> Self: ...
         @property
         def __value__(self) -> Any: ...  # AnnotationForm
         @property
@@ -1208,9 +1215,6 @@ if sys.version_info >= (3, 12):
         def __parameters__(self) -> tuple[Any, ...]: ...  # AnnotationForm
         @property
         def __name__(self) -> str: ...
-        if sys.version_info >= (3, 15):
-            @property
-            def __qualname__(self) -> str: ...
         # It's writable on types, but not on instances of TypeAliasType.
         @property
         def __module__(self) -> str | None: ...  # type: ignore[override]


### PR DESCRIPTION
Wasn't mentioned in https://github.com/python/typeshed/pull/15725.
Part of the user-visible changes made to `TypeAliasType` in 3.15.