### PR TITLE
Update tqdm.utils.envwrap

### DIFF
--- a/stubs/tqdm/tqdm/utils.pyi
+++ b/stubs/tqdm/tqdm/utils.pyi
@@ -54,5 +54,9 @@ class CallbackIOWrapper(ObjectWrapper):
 def disp_len(data: str) -> int: ...
 def disp_trim(data: str, length: int) -> str: ...
 def envwrap(
-    name: str, app: str = "", types: Mapping[str, Callable[[Incomplete], Incomplete]] | None = None, is_method: bool = False
+    name: str,
+    app: str = "",
+    types: Mapping[str, Callable[[Incomplete], Incomplete]] | None = None,
+    is_method: bool = False,
+    convert_config: bool = True,
 ) -> Callable[[Callable[_P, _R]], Callable[_P, _R]]: ...


### PR DESCRIPTION
Closes #16350.

Adds the `convert_config` parameter exposed by tqdm 4.70.0 when its supported extras install `envwrap`.

Agent used: OpenAI Codex.