### PR TITLE
Use SupportsItems for the urllib.request.Request headers parameter

### DIFF
--- a/stdlib/urllib/request.pyi
+++ b/stdlib/urllib/request.pyi
@@ -1,6 +1,6 @@
 import ssl
 import sys
-from _typeshed import ReadableBuffer, StrOrBytesPath, SupportsRead
+from _typeshed import ReadableBuffer, StrOrBytesPath, SupportsItems, SupportsRead
 from collections.abc import Callable, Iterable, Mapping, MutableMapping, Sequence
 from email.message import Message
 from http.client import HTTPConnection, HTTPMessage, HTTPResponse
@@ -139,7 +139,7 @@ class Request:
         self,
         url: str,
         data: _DataType = None,
-        headers: MutableMapping[str, str] = {},
+        headers: SupportsItems[str, str] = {},
         origin_req_host: str | None = None,
         unverifiable: bool = False,
         method: str | None = None,


### PR DESCRIPTION
`Request.__init__` only calls `.items()` on `headers`. It copies the pairs into a new dict, so the argument does not need to be mutable:

```python
class Request:

    def __init__(self, url, data=None, headers={},
                 origin_req_host=None, unverifiable=False,
                 method=None):
        self.full_url = url
        self.headers = {}
        self.unredirected_hdrs = {}
        self._data = None
        self.data = data
        self._tunnel_host = None
        for key, value in headers.items():
            self.add_header(key, value)
```

`add_header` assigns into that new dict, not into the argument:

```python
    def add_header(self, key, val):
        # useful for something like authentication
        self.headers[key.capitalize()] = val
```

The documentation agrees that only the pairs matter: "headers should be a dictionary, and will be treated as if `add_header()` was called with each key and value as arguments."

So the current annotation rejects a `Mapping[str, str]` argument that works at runtime.

The parameter received this type in #6969, which widened `headers` from `dict[str, str]` to `MutableMapping[str, str]` on both the attribute and the parameter. The issue behind that change, #6963, asked only about the attribute, which does need item assignment. The parameter changed with it.

`SupportsItems` states what the implementation requires, and typeshed already uses it for the same constructor shape:

```python
# stdlib/graphlib.pyi
def __init__(self, graph: SupportsItems[_T, Iterable[_T]]) -> None: ...

# stdlib/http/cookies.pyi
class BaseCookie(dict[str, Morsel[_T]], Generic[_T]):
    def __init__(self, input: str | SupportsItems[str, str | Morsel[Any]] | None = None) -> None: ...
```

The `headers` attribute keeps `MutableMapping[str, str]`.

`Mapping[str, str]` also fixes the report, if you prefer the more familiar type in the signature.

I checked the change with pyright 1.1.411 and mypy against a patched checkout. `Mapping[str, str]` now passes. `dict[str, str]` and `MutableMapping[str, str]` still pass, `list[tuple[str, str]]` is still rejected, and item assignment on `request.headers` still type-checks.

From the bug report [PY-71141](https://youtrack.jetbrains.com/issue/PY-71141)
