### PR TITLE
Fix type of ssl.Options.OP_ALL

### DIFF
--- a/stdlib/ssl.pyi
+++ b/stdlib/ssl.pyi
@@ -141,7 +141,7 @@ PROTOCOL_TLS_CLIENT: Final = _SSLMethod.PROTOCOL_TLS_CLIENT
 PROTOCOL_TLS_SERVER: Final = _SSLMethod.PROTOCOL_TLS_SERVER
 
 class Options(enum.IntFlag):
-    OP_ALL: int
+    OP_ALL = ...
     OP_NO_SSLv2 = 0
     OP_NO_SSLv3 = 33554432
     OP_NO_TLSv1 = 67108864


### PR DESCRIPTION
Closes #16378

`Options.OP_ALL` was declared as `OP_ALL: int` (since #15589, because its runtime value differs between OpenSSL builds), which makes type checkers treat it as a non-member attribute of type `int` rather than an enum member. So `Options.OP_ALL` is not assignable to `Options`, unlike every other flag in the class.

Per the typing spec for enums in stubs, a member whose value we don't want to pin can be declared as `OP_ALL = ...`, as suggested by @srittau in the issue. That's what this PR does.

Verified locally with the issue's reproducer (`--custom-typeshed-dir` pointing at this branch):

- mypy 2.3.0: before → `Revealed type is "int"` + `Argument 1 to "f" has incompatible type "int"; expected "Options"`; after → `Revealed type is "Literal[ssl.Options.OP_ALL]?"`, no errors.
- pyright 1.1.411: after → `Type of "Options.OP_ALL" is "Literal[Options.OP_ALL]"`, 0 errors.
- `stubtest ssl` (py3.11, linux allowlists): no issues, same as main.
- `tests/mypy_test.py stdlib/ssl.pyi -p 3.11 -p 3.13`: success.
