### PR TITLE
WIden parameter type accepted by `zipfile.is_zipfile` and `tarfile.is_tarfile`

### DIFF
--- a/stdlib/tarfile.pyi
+++ b/stdlib/tarfile.pyi
@@ -1,7 +1,7 @@
 import bz2
 import io
 import sys
-from _typeshed import ReadableBuffer, StrOrBytesPath, StrPath, SupportsRead, WriteableBuffer
+from _typeshed import FileDescriptorOrPath, ReadableBuffer, StrOrBytesPath, StrPath, SupportsRead, WriteableBuffer
 from builtins import list as _list  # aliases to avoid name clashes with fields named "type" or "list"
 from collections.abc import Callable, Iterable, Iterator, Mapping
 from gzip import _ReadableFileobj as _GzipReadableFileobj, _WritableFileobj as _GzipWritableFileobj
@@ -732,7 +732,7 @@ class TarFile:
 
 open = TarFile.open
 
-def is_tarfile(name: StrOrBytesPath | IO[bytes]) -> bool: ...
+def is_tarfile(name: FileDescriptorOrPath | IO[bytes]) -> bool: ...
 
 class TarError(Exception): ...
 class ReadError(TarError): ...

--- a/stdlib/zipfile/__init__.pyi
+++ b/stdlib/zipfile/__init__.pyi
@@ -1,6 +1,6 @@
 import io
 import sys
-from _typeshed import SizedBuffer, StrOrBytesPath, StrPath
+from _typeshed import FileDescriptorOrPath, SizedBuffer, StrPath
 from collections.abc import Callable, Iterable, Iterator
 from io import TextIOWrapper
 from os import PathLike
@@ -389,7 +389,7 @@ else:
         def joinpath(self, *other: StrPath) -> Path: ...
         def __truediv__(self, add: StrPath) -> Path: ...
 
-def is_zipfile(filename: StrOrBytesPath | _SupportsReadSeekTell) -> bool: ...
+def is_zipfile(filename: FileDescriptorOrPath | _SupportsReadSeekTell) -> bool: ...
 
 ZIP64_LIMIT: Final[int]
 ZIP_FILECOUNT_LIMIT: Final[int]


### PR DESCRIPTION
The functions call the built-in `open` under the hood, which accepts file descriptors.