### PR TITLE
typing: make Protocol definition reflect runtime

### DIFF
--- a/stdlib/@tests/stubtest_allowlists/common.txt
+++ b/stdlib/@tests/stubtest_allowlists/common.txt
@@ -396,7 +396,6 @@ typing.type_check_only  # typing decorator that is not available at runtime
 # Details of runtime definition don't need to be in stubs
 typing._Final
 typing._Final.__init_subclass__
-typing\.Protocol
 typing(_extensions)?\._TypedDict
 typing(_extensions)?\.Any.*
 typing(_extensions)?\.TypedDict

--- a/stdlib/@tests/stubtest_allowlists/py314.txt
+++ b/stdlib/@tests/stubtest_allowlists/py314.txt
@@ -156,7 +156,6 @@ multiprocessing.managers._BaseDictProxy.values
 # To match `dict`, we lie about the runtime, but use overloads to match the correct behavior
 types.MappingProxyType.get
 
-typing_extensions.Protocol  # Super-special typing primitive
 
 
 # =============================================================

--- a/stdlib/@tests/stubtest_allowlists/py315.txt
+++ b/stdlib/@tests/stubtest_allowlists/py315.txt
@@ -129,7 +129,6 @@ multiprocessing.managers._BaseDictProxy.values
 # To match `dict`, we lie about the runtime, but use overloads to match the correct behavior.
 types.MappingProxyType.get
 
-typing_extensions.Protocol  # Super-special typing primitive
 
 copy.replace  # Cannot have keyword-only ParamSpec
 

--- a/stdlib/typing.pyi
+++ b/stdlib/typing.pyi
@@ -238,7 +238,6 @@ class _SpecialForm(_Final):
     def __ror__(self, other: Any) -> _SpecialForm: ...
 
 Union: _SpecialForm
-Protocol: _SpecialForm
 Callable: _SpecialForm
 Type: _SpecialForm
 NoReturn: _SpecialForm
@@ -471,6 +470,11 @@ class _Generic:
     def __class_getitem__(cls, args: TypeVar | ParamSpec | tuple[TypeVar | ParamSpec, ...]) -> _Final: ...
 
 Generic: type[_Generic]
+
+@type_check_only
+class _Protocol: ...
+
+Protocol: type[_Protocol]
 
 class _ProtocolMeta(ABCMeta):
     if sys.version_info >= (3, 12):

--- a/stdlib/typing_extensions.pyi
+++ b/stdlib/typing_extensions.pyi
@@ -215,12 +215,15 @@ _T_contra = _TypeVar("_T_contra", contravariant=True)
 if sys.version_info < (3, 15):
     def no_type_check_decorator(decorator: _F) -> _F: ...
 
+@type_check_only
+class _Protocol: ...
+
 # Do not import (and re-export) Protocol or runtime_checkable from
 # typing module because type checkers need to be able to distinguish
 # typing.Protocol and typing_extensions.Protocol so they can properly
 # warn users about potential runtime exceptions when using typing.Protocol
 # on older versions of Python.
-Protocol: _SpecialForm
+Protocol: type[_Protocol]
 
 def runtime_checkable(cls: _TC) -> _TC: ...
 


### PR DESCRIPTION
Follow-up to #14583, which moved `Generic` from `_SpecialForm` to `type[_Generic]` and named `Protocol` as a future candidate for the same treatment. See python/mypy#21940.

Declare `class _Protocol` and use `type[_Protocol]` for `typing.Protocol` and `typing_extensions.Protocol`, mirroring `Generic`; remove the stubtest allowlist entries this makes unnecessary.

Agent used: ZCode (GLM)
